### PR TITLE
Fix streaming TTS quality and add CustomVoice speakers

### DIFF
--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -542,8 +542,8 @@ public class Qwen3TTSModel {
                         text: text, langId: langId, speakerTokenId: speakerTokenId,
                         tokenizer: tokenizer, sampling: sampling, chunkSize: chunkSize)
 
-                    let decodeChunkSize = 18
-                    let leftContextSize = 8
+                    let decodeChunkSize = 25
+                    let leftContextSize = 10
                     let samplesPerFrame = 1920
                     let numCodeGroups = self.config.codePredictor.numCodeGroups
 
@@ -782,7 +782,8 @@ public class Qwen3TTSModel {
         }
 
         let flatCodes: [Int32] = decodeInput.flatMap { $0 }
-        let codesArray = MLXArray(flatCodes).reshaped([1, numCodeGroups, decodeInput.count])
+        // flatMap gives [T, 16] row-major; reshape to [1, T, 16] then transpose to [1, 16, T]
+        let codesArray = MLXArray(flatCodes).reshaped([1, decodeInput.count, numCodeGroups]).transposed(0, 2, 1)
         let waveform = codecDecoder.chunkedDecode(codes: codesArray)
         let flat = waveform.squeezed()
         eval(flat)


### PR DESCRIPTION
## Summary

- **Fix streaming TTS audio quality**: codec array was transposed (`[T,16]` frame-major reshaped as `[1,16,T]` codebook-major), producing garbled audio. Fixed by reshaping to `[1,T,16]` then transposing to `[1,16,T]`.
- **Align streaming chunk params** with decoder defaults (18/8 → 25/10)
- **Add streaming quality round-trip test**: synthesize via standard and streaming paths, verify both produce ASR-recognizable speech

## Test plan

- [x] 11/11 TTSE2ETests passed (including 3 streaming tests)
- [x] 23/23 unit tests passed
- [x] CLI streaming test: RTF 0.61, first chunk in 1.27s
- [x] Streaming ASR round-trip: 5/5 expected words matched (was 0/5 before fix)