### PR TITLE
Optimize TTS latency: compile DiT, Mimi decoder, remove eval

### DIFF
--- a/Sources/CosyVoiceTTS/LLM.swift
+++ b/Sources/CosyVoiceTTS/LLM.swift
@@ -497,7 +497,6 @@ public class CosyVoiceLLM: Module {
             // Forward single token through transformer
             let (stepLogits, newCache) = executeStep(
                 embeds: tokenEmbed, offset: prefixLen + step, cache: currentCache)
-            eval(stepLogits, newCache)
             currentCache = newCache
 
             // Sample next token (ignore EOS until min_len reached)


### PR DESCRIPTION
## Summary
- **Compile CosyVoice DiT** flow matching forward pass (22-layer transformer, ~330 Metal kernel dispatches × 10 ODE steps) with `compile(shapeless: false)` — shapes constant across steps, so steps 2-10 reuse fused graph
- **Compile Qwen3-TTS Mimi codec decoder** with `compile(shapeless: false)` — most chunks share shape `[1,16,35]`, graph reused across decode chunks
- **Remove redundant `eval()`** in CosyVoice LLM generation loop — `.item()` in `sampleToken` already forces evaluation of the computation graph
- **Add `--quantize-dit` flag** to `convert_cosyvoice3.py` — prep for future 4-bit DiT quantization (Swift-side QuantizedLinear deferred)

## Benchmarks (M2 Max, release build)

| Engine | Metric | Value |
|--------|--------|-------|
| CosyVoice | RTF | 0.45-0.49 |
| CosyVoice | LLM | 12.2ms/token |
| CosyVoice | Flow | ~493ms (10 steps) |
| CosyVoice | HiFi-GAN | ~139ms |
| Qwen3-TTS | RTF | 0.56 |
| Qwen3-TTS | Talker | 39ms/step |
| Qwen3-TTS | Codec decode | 105ms |

Both engines faster than real-time. Compilation benefits compound in persistent processes (server/streaming use cases) where compiled graphs are reused across multiple generations.

## Test plan
- [x] `swift build` compiles without errors
- [x] `swift test` passes (E2E TTS→ASR round-trip)
- [x] CosyVoice CLI: synthesize + verbose timing
- [x] Qwen3-TTS CLI: synthesize + timing
- [x] ASR round-trip: "The quick brown fox..." matches for both engines