### PR TITLE
Quantize CosyVoice DiT to 4-bit, compile DiT & Mimi decoder

### DIFF
--- a/Sources/CosyVoiceTTS/Configuration.swift
+++ b/Sources/CosyVoiceTTS/Configuration.swift
@@ -42,6 +42,8 @@ public struct CosyVoiceDiTConfig: Codable, Sendable {
     public var spkDim: Int = 80
     public var staticChunkSize: Int = 50
     public var freqEmbedDim: Int = 256
+    public var groupSize: Int = 64
+    public var bits: Int = 4
 
     /// Feedforward network dimension: dim * ffMult
     public var ffDim: Int { dim * ffMult }

--- a/Sources/CosyVoiceTTS/WeightLoading.swift
+++ b/Sources/CosyVoiceTTS/WeightLoading.swift
@@ -122,13 +122,13 @@ public enum CosyVoiceWeightLoader {
         // SinusoidalPositionEmbedding has no learnable parameters.
         // TimestepEmbedding: sin_embed (no params) -> linear1 -> SiLU -> linear2
         // Python keys: time_embed.time_mlp.0 (linear1), time_embed.time_mlp.2 (linear2)
-        CommonWeightLoader.applyLinearWeights(
+        CommonWeightLoader.applyQuantizedLinearWeights(
             to: dit.timeEmbed.linear1, prefix: "\(prefix).time_embed.time_mlp.0", from: weights)
-        CommonWeightLoader.applyLinearWeights(
+        CommonWeightLoader.applyQuantizedLinearWeights(
             to: dit.timeEmbed.linear2, prefix: "\(prefix).time_embed.time_mlp.2", from: weights)
 
         // Input embedding: projection + causal conv position embedding
-        CommonWeightLoader.applyLinearWeights(
+        CommonWeightLoader.applyQuantizedLinearWeights(
             to: dit.inputEmbed.proj, prefix: "\(prefix).input_embed.proj", from: weights)
 
         // Conv position embedding: two grouped Conv1d layers
@@ -147,33 +147,33 @@ public enum CosyVoiceWeightLoader {
             let blockPrefix = "\(prefix).transformer_blocks.\(i)"
 
             // AdaLN attention norm: projects timestep embedding to 6 modulation params
-            CommonWeightLoader.applyLinearWeights(
+            CommonWeightLoader.applyQuantizedLinearWeights(
                 to: block.attnNorm.linear, prefix: "\(blockPrefix).attn_norm.linear", from: weights)
 
             // Self-attention (full attention, not GQA)
             // Python keys use to_q, to_k, to_v, to_out.0
-            CommonWeightLoader.applyLinearWeights(
+            CommonWeightLoader.applyQuantizedLinearWeights(
                 to: block.attn.toQ, prefix: "\(blockPrefix).attn.to_q", from: weights)
-            CommonWeightLoader.applyLinearWeights(
+            CommonWeightLoader.applyQuantizedLinearWeights(
                 to: block.attn.toK, prefix: "\(blockPrefix).attn.to_k", from: weights)
-            CommonWeightLoader.applyLinearWeights(
+            CommonWeightLoader.applyQuantizedLinearWeights(
                 to: block.attn.toV, prefix: "\(blockPrefix).attn.to_v", from: weights)
-            CommonWeightLoader.applyLinearWeights(
+            CommonWeightLoader.applyQuantizedLinearWeights(
                 to: block.attn.toOut, prefix: "\(blockPrefix).attn.to_out.0", from: weights)
 
             // Feedforward: GELU(tanh) MLP
             // Python keys: ff.ff.0.0 (linear1 after GELU wrapper), ff.ff.2 (linear2)
-            CommonWeightLoader.applyLinearWeights(
+            CommonWeightLoader.applyQuantizedLinearWeights(
                 to: block.ff.linear1, prefix: "\(blockPrefix).ff.ff.0.0", from: weights)
-            CommonWeightLoader.applyLinearWeights(
+            CommonWeightLoader.applyQuantizedLinearWeights(
                 to: block.ff.linear2, prefix: "\(blockPrefix).ff.ff.2", from: weights)
         }
 
         // Final adaptive norm: projects to 2 modulation params (scale + shift)
-        CommonWeightLoader.applyLinearWeights(
+        CommonWeightLoader.applyQuantizedLinearWeights(
             to: dit.normOut.linear, prefix: "\(prefix).norm_out.linear", from: weights)
 
-        // Output projection: model dim -> mel dim
+        // Output projection: model dim -> mel dim (NOT quantized: 80 % 64 != 0)
         CommonWeightLoader.applyLinearWeights(
             to: dit.projOut, prefix: "\(prefix).proj_out", from: weights)
     }


### PR DESCRIPTION
## Summary
- **4-bit quantize CosyVoice DiT** flow model: all Linear → QuantizedLinear (159 layers), `flow.safetensors` reduced 634MB → 186MB (3.4x)
- **Compile DiT** forward pass (`shapeless=false`) — 22-layer transformer fused across 10 ODE steps
- **Compile Mimi codec decoder** (`shapeless=false`) — reuses graph across decode chunks
- **Remove redundant `eval()`** in CosyVoice LLM loop
- **Add `--quantize-dit`** flag to conversion script

## Benchmarks (M2 Max, release)

| Engine | Metric | Value |
|--------|--------|-------|
| CosyVoice | RTF | 0.65 |
| CosyVoice | Flow | ~680ms (10 steps) |
| CosyVoice | HiFi-GAN | ~291ms |
| Qwen3-TTS | RTF | 0.56 |
| Qwen3-TTS | Talker | 39ms/step |

## Test plan
- [x] `swift build` compiles
- [x] CosyVoice CLI: synthesize + verbose timing
- [x] ASR round-trip: "The quick brown fox..." matches for both engines
- [x] Quantized `flow.safetensors` uploaded to `aufklarer/CosyVoice3-0.5B-MLX-4bit`