### PR TITLE
Add SpeechVAD: VAD, speaker diarization, and speaker embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Tests/**/test_audio_roundtrip.wav
 
 # Blog drafts
 blog/
+docs/blog-*.md

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,10 @@ let package = Package(
             name: "PersonaPlex",
             targets: ["PersonaPlex"]
         ),
+        .library(
+            name: "SpeechVAD",
+            targets: ["SpeechVAD"]
+        ),
         .executable(
             name: "audio",
             targets: ["AudioCLI"]
@@ -85,12 +89,21 @@ let package = Package(
             ]
         ),
         .target(
+            name: "SpeechVAD",
+            dependencies: [
+                "AudioCommon",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+            ]
+        ),
+        .target(
             name: "AudioCLILib",
             dependencies: [
                 "Qwen3ASR",
                 "Qwen3TTS",
                 "CosyVoiceTTS",
                 "PersonaPlex",
+                "SpeechVAD",
                 "AudioCommon",
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
@@ -118,6 +131,14 @@ let package = Package(
         .testTarget(
             name: "CosyVoiceTTSTests",
             dependencies: ["CosyVoiceTTS", "AudioCommon"]
+        ),
+        .testTarget(
+            name: "SpeechVADTests",
+            dependencies: [
+                "SpeechVAD",
+                "AudioCommon",
+                .product(name: "MLX", package: "mlx-swift"),
+            ]
         ),
         .testTarget(
             name: "AudioCLITests",

--- a/Sources/AudioCLILib/AudioCLI.swift
+++ b/Sources/AudioCLILib/AudioCLI.swift
@@ -9,6 +9,10 @@ public struct AudioCLI: ParsableCommand {
             AlignCommand.self,
             SpeakCommand.self,
             RespondCommand.self,
+            VadCommand.self,
+            VadStreamCommand.self,
+            DiarizeCommand.self,
+            EmbedSpeakerCommand.self,
         ]
     )
 

--- a/Sources/AudioCLILib/DiarizeCommand.swift
+++ b/Sources/AudioCLILib/DiarizeCommand.swift
@@ -1,0 +1,144 @@
+import Foundation
+import ArgumentParser
+import SpeechVAD
+import AudioCommon
+
+public struct DiarizeCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "diarize",
+        abstract: "Identify speakers and their speech segments in audio"
+    )
+
+    @Argument(help: "Audio file to analyze (WAV, any sample rate)")
+    public var audioFile: String
+
+    @Option(name: .long, help: "Clustering distance threshold (0.0-2.0)")
+    public var threshold: Float = DiarizationConfig.default.clusteringThreshold
+
+    @Option(name: .long, help: "Maximum number of speakers (0 = auto)")
+    public var maxSpeakers: Int = 0
+
+    @Option(name: .long, help: "Enrollment audio for target speaker extraction")
+    public var targetSpeaker: String?
+
+    @Flag(name: .long, help: "Output as JSON")
+    public var json: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        try runAsync {
+            print("Loading audio: \(audioFile)")
+            let audio = try AudioFileLoader.load(
+                url: URL(fileURLWithPath: audioFile), targetSampleRate: 16000)
+            let duration = formatDuration(audio.count, sampleRate: 16000)
+            print("  Loaded \(audio.count) samples (\(duration)s)")
+
+            let config = DiarizationConfig(
+                clusteringThreshold: threshold,
+                maxSpeakers: maxSpeakers
+            )
+
+            print("Loading diarization models...")
+            let pipeline = try await DiarizationPipeline.fromPretrained(
+                progressHandler: reportProgress
+            )
+
+            if let enrollmentFile = targetSpeaker {
+                // Speaker extraction mode
+                print("Loading enrollment audio: \(enrollmentFile)")
+                let enrollAudio = try AudioFileLoader.load(
+                    url: URL(fileURLWithPath: enrollmentFile), targetSampleRate: 16000)
+
+                print("Extracting target speaker embedding...")
+                let targetEmb = pipeline.embeddingModel.embed(
+                    audio: enrollAudio, sampleRate: 16000)
+
+                print("Extracting target speaker segments...")
+                let start = Date()
+                let segments = pipeline.extractSpeaker(
+                    audio: audio, sampleRate: 16000,
+                    targetEmbedding: targetEmb, config: config
+                )
+                let elapsed = Date().timeIntervalSince(start)
+
+                if json {
+                    printSpeechJSON(segments)
+                } else {
+                    if segments.isEmpty {
+                        print("Target speaker not found.")
+                    } else {
+                        for seg in segments {
+                            let s = String(format: "%.2f", seg.startTime)
+                            let e = String(format: "%.2f", seg.endTime)
+                            let d = String(format: "%.2f", seg.duration)
+                            print("Target: [\(s)s - \(e)s] (\(d)s)")
+                        }
+                        let totalSpeech = segments.reduce(Float(0)) { $0 + $1.duration }
+                        print("\n\(segments.count) segment(s), \(String(format: "%.2f", totalSpeech))s total")
+                    }
+                    print("Extraction took \(String(format: "%.2f", elapsed))s")
+                }
+            } else {
+                // Full diarization mode
+                print("Running diarization...")
+                let start = Date()
+                let result = pipeline.diarize(
+                    audio: audio, sampleRate: 16000, config: config)
+                let elapsed = Date().timeIntervalSince(start)
+
+                if json {
+                    printDiarizeJSON(result)
+                } else {
+                    if result.segments.isEmpty {
+                        print("No speech detected.")
+                    } else {
+                        for seg in result.segments {
+                            let s = String(format: "%.2f", seg.startTime)
+                            let e = String(format: "%.2f", seg.endTime)
+                            let d = String(format: "%.2f", seg.duration)
+                            print("Speaker \(seg.speakerId): [\(s)s - \(e)s] (\(d)s)")
+                        }
+                        print("\n--- \(result.numSpeakers) speaker(s) ---")
+                    }
+                    print("Diarization took \(String(format: "%.2f", elapsed))s")
+                }
+            }
+        }
+    }
+
+    private func printDiarizeJSON(_ result: DiarizationResult) {
+        var items = [[String: Any]]()
+        for seg in result.segments {
+            items.append([
+                "start": Double(String(format: "%.3f", seg.startTime))!,
+                "end": Double(String(format: "%.3f", seg.endTime))!,
+                "duration": Double(String(format: "%.3f", seg.duration))!,
+                "speaker": seg.speakerId,
+            ])
+        }
+        let output: [String: Any] = [
+            "segments": items,
+            "num_speakers": result.numSpeakers,
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: output, options: .prettyPrinted),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+    }
+
+    private func printSpeechJSON(_ segments: [SpeechSegment]) {
+        var items = [[String: Any]]()
+        for seg in segments {
+            items.append([
+                "start": Double(String(format: "%.3f", seg.startTime))!,
+                "end": Double(String(format: "%.3f", seg.endTime))!,
+                "duration": Double(String(format: "%.3f", seg.duration))!,
+            ])
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: items, options: .prettyPrinted),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+    }
+}

--- a/Sources/AudioCLILib/EmbedSpeakerCommand.swift
+++ b/Sources/AudioCLILib/EmbedSpeakerCommand.swift
@@ -1,0 +1,55 @@
+import Foundation
+import ArgumentParser
+import SpeechVAD
+import AudioCommon
+
+public struct EmbedSpeakerCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "embed-speaker",
+        abstract: "Extract a 256-dim speaker embedding from audio"
+    )
+
+    @Argument(help: "Audio file containing speaker voice (WAV, any sample rate)")
+    public var audioFile: String
+
+    @Flag(name: .long, help: "Output as JSON")
+    public var json: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        try runAsync {
+            print("Loading audio: \(audioFile)")
+            let audio = try AudioFileLoader.load(
+                url: URL(fileURLWithPath: audioFile), targetSampleRate: 16000)
+            let duration = formatDuration(audio.count, sampleRate: 16000)
+            print("  Loaded \(audio.count) samples (\(duration)s)")
+
+            print("Loading speaker embedding model...")
+            let model = try await WeSpeakerModel.fromPretrained(
+                progressHandler: reportProgress
+            )
+
+            print("Extracting speaker embedding...")
+            let start = Date()
+            let embedding = model.embed(audio: audio, sampleRate: 16000)
+            let elapsed = Date().timeIntervalSince(start)
+
+            if json {
+                let embStrings = embedding.map { String(format: "%.6f", $0) }
+                print("{\"embedding\": [\(embStrings.joined(separator: ", "))], \"dimension\": \(embedding.count)}")
+            } else {
+                // Print summary statistics
+                let minVal = embedding.min() ?? 0
+                let maxVal = embedding.max() ?? 0
+                let norm = sqrt(embedding.reduce(Float(0)) { $0 + $1 * $1 })
+
+                print("Embedding dimension: \(embedding.count)")
+                print("L2 norm: \(String(format: "%.4f", norm))")
+                print("Range: [\(String(format: "%.4f", minVal)), \(String(format: "%.4f", maxVal))]")
+                print("First 8 values: \(embedding.prefix(8).map { String(format: "%.4f", $0) }.joined(separator: ", "))")
+                print("Extraction took \(String(format: "%.2f", elapsed))s")
+            }
+        }
+    }
+}

--- a/Sources/AudioCLILib/VadCommand.swift
+++ b/Sources/AudioCLILib/VadCommand.swift
@@ -1,0 +1,99 @@
+import Foundation
+import ArgumentParser
+import SpeechVAD
+import AudioCommon
+
+public struct VadCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "vad",
+        abstract: "Detect speech segments using pyannote Voice Activity Detection"
+    )
+
+    @Argument(help: "Audio file to analyze (WAV, any sample rate)")
+    public var audioFile: String
+
+    @Option(name: .shortAndLong, help: "Model ID on HuggingFace")
+    public var model: String = PyannoteVADModel.defaultModelId
+
+    @Option(name: .long, help: "Onset threshold (speech start)")
+    public var onset: Float = VADConfig.default.onset
+
+    @Option(name: .long, help: "Offset threshold (speech end)")
+    public var offset: Float = VADConfig.default.offset
+
+    @Option(name: .long, help: "Minimum speech duration in seconds")
+    public var minSpeech: Float = VADConfig.default.minSpeechDuration
+
+    @Option(name: .long, help: "Minimum silence duration in seconds")
+    public var minSilence: Float = VADConfig.default.minSilenceDuration
+
+    @Flag(name: .long, help: "Output as JSON")
+    public var json: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        try runAsync {
+            print("Loading audio: \(audioFile)")
+            let audio = try AudioFileLoader.load(
+                url: URL(fileURLWithPath: audioFile), targetSampleRate: 16000)
+            let duration = formatDuration(audio.count, sampleRate: 16000)
+            print("  Loaded \(audio.count) samples (\(duration)s)")
+
+            let vadConfig = VADConfig(
+                onset: onset,
+                offset: offset,
+                minSpeechDuration: minSpeech,
+                minSilenceDuration: minSilence,
+                windowDuration: VADConfig.default.windowDuration,
+                stepRatio: VADConfig.default.stepRatio
+            )
+
+            print("Loading VAD model: \(model)")
+            let vad = try await PyannoteVADModel.fromPretrained(
+                modelId: model,
+                vadConfig: vadConfig,
+                progressHandler: reportProgress
+            )
+
+            print("Detecting speech segments...")
+            let start = Date()
+            let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
+            let elapsed = Date().timeIntervalSince(start)
+
+            if json {
+                printJSON(segments)
+            } else {
+                if segments.isEmpty {
+                    print("No speech detected.")
+                } else {
+                    for seg in segments {
+                        let s = String(format: "%.2f", seg.startTime)
+                        let e = String(format: "%.2f", seg.endTime)
+                        let d = String(format: "%.2f", seg.duration)
+                        print("[\(s)s - \(e)s] (\(d)s)")
+                    }
+
+                    let totalSpeech = segments.reduce(Float(0)) { $0 + $1.duration }
+                    print("\n\(segments.count) segment(s), \(String(format: "%.2f", totalSpeech))s total speech")
+                }
+                print("Detection took \(String(format: "%.2f", elapsed))s")
+            }
+        }
+    }
+
+    private func printJSON(_ segments: [SpeechSegment]) {
+        var items = [[String: Any]]()
+        for seg in segments {
+            items.append([
+                "start": Double(String(format: "%.3f", seg.startTime))!,
+                "end": Double(String(format: "%.3f", seg.endTime))!,
+                "duration": Double(String(format: "%.3f", seg.duration))!,
+            ])
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: items, options: .prettyPrinted),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+    }
+}

--- a/Sources/AudioCLILib/VadStreamCommand.swift
+++ b/Sources/AudioCLILib/VadStreamCommand.swift
@@ -1,0 +1,140 @@
+import Foundation
+import ArgumentParser
+import SpeechVAD
+import AudioCommon
+
+public struct VadStreamCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "vad-stream",
+        abstract: "Detect speech segments using streaming Silero VAD (32ms chunks)"
+    )
+
+    @Argument(help: "Audio file to analyze (WAV, any sample rate)")
+    public var audioFile: String
+
+    @Option(name: .shortAndLong, help: "Model ID on HuggingFace")
+    public var model: String = SileroVADModel.defaultModelId
+
+    @Option(name: .long, help: "Onset threshold (speech start)")
+    public var onset: Float = VADConfig.sileroDefault.onset
+
+    @Option(name: .long, help: "Offset threshold (speech end)")
+    public var offset: Float = VADConfig.sileroDefault.offset
+
+    @Option(name: .long, help: "Minimum speech duration in seconds")
+    public var minSpeech: Float = VADConfig.sileroDefault.minSpeechDuration
+
+    @Option(name: .long, help: "Minimum silence duration in seconds")
+    public var minSilence: Float = VADConfig.sileroDefault.minSilenceDuration
+
+    @Flag(name: .long, help: "Output as JSON")
+    public var json: Bool = false
+
+    public init() {}
+
+    public func run() throws {
+        try runAsync {
+            print("Loading audio: \(audioFile)")
+            let audio = try AudioFileLoader.load(
+                url: URL(fileURLWithPath: audioFile), targetSampleRate: 16000)
+            let duration = formatDuration(audio.count, sampleRate: 16000)
+            print("  Loaded \(audio.count) samples (\(duration)s)")
+
+            print("Loading Silero VAD model: \(model)")
+            let vadModel = try await SileroVADModel.fromPretrained(
+                modelId: model,
+                progressHandler: reportProgress
+            )
+
+            let vadConfig = VADConfig(
+                onset: onset,
+                offset: offset,
+                minSpeechDuration: minSpeech,
+                minSilenceDuration: minSilence,
+                windowDuration: VADConfig.sileroDefault.windowDuration,
+                stepRatio: VADConfig.sileroDefault.stepRatio
+            )
+
+            let processor = StreamingVADProcessor(model: vadModel, config: vadConfig)
+
+            print("Processing in 32ms chunks...")
+            let start = Date()
+            var allEvents = [VADEvent]()
+
+            // Process audio in 512-sample chunks (simulating real-time streaming)
+            let chunkSize = SileroVADModel.chunkSize
+            var offset = 0
+
+            while offset + chunkSize <= audio.count {
+                let chunk = Array(audio[offset ..< (offset + chunkSize)])
+                let events = processor.process(samples: chunk)
+                for event in events {
+                    if !json { printEvent(event) }
+                }
+                allEvents.append(contentsOf: events)
+                offset += chunkSize
+            }
+
+            // Handle remaining samples
+            if offset < audio.count {
+                let remaining = Array(audio[offset...])
+                let events = processor.process(samples: remaining)
+                for event in events {
+                    if !json { printEvent(event) }
+                }
+                allEvents.append(contentsOf: events)
+            }
+
+            // Flush any pending segment
+            let flushEvents = processor.flush()
+            for event in flushEvents {
+                if !json { printEvent(event) }
+            }
+            allEvents.append(contentsOf: flushEvents)
+
+            let elapsed = Date().timeIntervalSince(start)
+
+            if json {
+                printJSON(allEvents)
+            } else {
+                // Summary
+                let segments = allEvents.compactMap { event -> SpeechSegment? in
+                    if case .speechEnded(let seg) = event { return seg }
+                    return nil
+                }
+                let totalSpeech = segments.reduce(Float(0)) { $0 + $1.duration }
+                print("\n\(segments.count) segment(s), \(String(format: "%.2f", totalSpeech))s total speech")
+                print("Processing took \(String(format: "%.3f", elapsed))s (\(String(format: "%.0f", Double(audio.count) / 16000.0 / elapsed))x real-time)")
+            }
+        }
+    }
+
+    private func printEvent(_ event: VADEvent) {
+        switch event {
+        case .speechStarted(let time):
+            print("[\(String(format: "%.2f", time))s] Speech started")
+        case .speechEnded(let seg):
+            let d = String(format: "%.2f", seg.duration)
+            print("[\(String(format: "%.2f", seg.endTime))s] Speech ended (\(d)s)")
+        }
+    }
+
+    private func printJSON(_ events: [VADEvent]) {
+        let segments = events.compactMap { event -> SpeechSegment? in
+            if case .speechEnded(let seg) = event { return seg }
+            return nil
+        }
+        var items = [[String: Any]]()
+        for seg in segments {
+            items.append([
+                "start": Double(String(format: "%.3f", seg.startTime))!,
+                "end": Double(String(format: "%.3f", seg.endTime))!,
+                "duration": Double(String(format: "%.3f", seg.duration))!,
+            ])
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: items, options: .prettyPrinted),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+    }
+}

--- a/Sources/AudioCommon/Protocols.swift
+++ b/Sources/AudioCommon/Protocols.swift
@@ -86,3 +86,68 @@ public protocol SpeechToSpeechModel: AnyObject {
     /// Generate response audio from input audio with streaming output
     func respondStream(userAudio: [Float]) -> AsyncThrowingStream<AudioChunk, Error>
 }
+
+// MARK: - Voice Activity Detection
+
+/// A time segment where speech was detected.
+public struct SpeechSegment: Sendable {
+    /// Start time in seconds
+    public let startTime: Float
+    /// End time in seconds
+    public let endTime: Float
+
+    public init(startTime: Float, endTime: Float) {
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+
+    /// Duration in seconds
+    public var duration: Float { endTime - startTime }
+}
+
+/// A model that detects speech activity regions in audio.
+public protocol VoiceActivityDetectionModel: AnyObject {
+    /// Expected input sample rate in Hz
+    var inputSampleRate: Int { get }
+    /// Detect speech segments in audio
+    func detectSpeech(audio: [Float], sampleRate: Int) -> [SpeechSegment]
+}
+
+// MARK: - Speaker Diarization
+
+/// A speech segment with an assigned speaker identity.
+public struct DiarizedSegment: Sendable {
+    /// Start time in seconds
+    public let startTime: Float
+    /// End time in seconds
+    public let endTime: Float
+    /// Speaker identifier (0-based)
+    public let speakerId: Int
+
+    public init(startTime: Float, endTime: Float, speakerId: Int) {
+        self.startTime = startTime
+        self.endTime = endTime
+        self.speakerId = speakerId
+    }
+
+    /// Duration in seconds
+    public var duration: Float { endTime - startTime }
+}
+
+/// A model that produces speaker embeddings from audio.
+public protocol SpeakerEmbeddingModel: AnyObject {
+    /// Expected input sample rate in Hz
+    var inputSampleRate: Int { get }
+    /// Embedding vector dimension
+    var embeddingDimension: Int { get }
+    /// Extract a speaker embedding from audio
+    func embed(audio: [Float], sampleRate: Int) -> [Float]
+}
+
+/// A model that assigns speaker identities to speech segments.
+public protocol SpeakerDiarizationModel: AnyObject {
+    /// Expected input sample rate in Hz
+    var inputSampleRate: Int { get }
+    /// Diarize audio into speaker-labeled segments
+    func diarize(audio: [Float], sampleRate: Int) -> [DiarizedSegment]
+}

--- a/Sources/SpeechVAD/BiLSTM.swift
+++ b/Sources/SpeechVAD/BiLSTM.swift
@@ -1,0 +1,100 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// A single LSTM layer with updatable parameters.
+///
+/// Uses `var` properties so they can be loaded via `update(parameters:)`.
+/// Parameter keys match MLX convention: `Wx` (input→hidden), `Wh` (hidden→hidden), `bias`.
+class LSTMLayer: Module {
+    let hiddenSize: Int
+
+    @ParameterInfo(key: "Wx") var wx: MLXArray
+    @ParameterInfo(key: "Wh") var wh: MLXArray
+    var bias: MLXArray
+
+    init(inputSize: Int, hiddenSize: Int) {
+        self.hiddenSize = hiddenSize
+        let scale = 1.0 / Foundation.sqrt(Float(hiddenSize))
+        self._wx.wrappedValue = MLXRandom.uniform(low: -scale, high: scale, [4 * hiddenSize, inputSize])
+        self._wh.wrappedValue = MLXRandom.uniform(low: -scale, high: scale, [4 * hiddenSize, hiddenSize])
+        self.bias = MLXRandom.uniform(low: -scale, high: scale, [4 * hiddenSize])
+    }
+
+    /// Process a sequence.
+    /// - Parameter x: `[batch, seq_len, input_size]`
+    /// - Returns: `[batch, seq_len, hidden_size]`
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Project all timesteps at once: [B, L, 4H]
+        let projected = addMM(bias, x, wx.T)
+
+        let seqLen = x.dim(-2)
+        var hidden: MLXArray? = nil
+        var cell: MLXArray? = nil
+        var allHidden = [MLXArray]()
+
+        for t in 0 ..< seqLen {
+            var ifgo = projected[.ellipsis, t, 0...]
+            if let h = hidden {
+                ifgo = ifgo + matmul(h, wh.T)
+            }
+
+            let pieces = split(ifgo, parts: 4, axis: -1)
+            let i = sigmoid(pieces[0])
+            let f = sigmoid(pieces[1])
+            let g = tanh(pieces[2])
+            let o = sigmoid(pieces[3])
+
+            if let c = cell {
+                cell = f * c + i * g
+            } else {
+                cell = i * g
+            }
+            hidden = o * tanh(cell!)
+
+            allHidden.append(hidden!)
+        }
+
+        return stacked(allHidden, axis: -2)
+    }
+}
+
+/// Container for LSTM layers (enables module parameter tree: `layers.0`, `layers.1`, etc.)
+class LSTMStack: Module {
+    let layers: [LSTMLayer]
+
+    init(layers: [LSTMLayer]) {
+        self.layers = layers
+    }
+}
+
+/// Run bidirectional LSTM across multiple layers.
+///
+/// For each layer, runs forward LSTM on the sequence and backward LSTM on the
+/// reversed sequence, then concatenates outputs along the feature dimension.
+///
+/// - Parameters:
+///   - x: `[batch, seq_len, features]`
+///   - fwd: forward LSTM stack
+///   - bwd: backward LSTM stack
+/// - Returns: `[batch, seq_len, 2 * hidden_size]`
+func runBiLSTM(_ x: MLXArray, fwd: LSTMStack, bwd: LSTMStack) -> MLXArray {
+    var input = x
+
+    for i in 0 ..< fwd.layers.count {
+        // Forward direction
+        let fwdOut = fwd.layers[i](input)
+
+        // Backward direction: reverse → process → reverse back
+        let seqLen = input.dim(-2)
+        let indices = MLXArray(Array((0 ..< seqLen).reversed()))
+        let reversed = input.take(indices, axis: -2)
+        let bwdOutRev = bwd.layers[i](reversed)
+        let bwdOut = bwdOutRev.take(indices, axis: -2)
+
+        // Concatenate along feature dimension
+        input = concatenated([fwdOut, bwdOut], axis: -1)
+    }
+
+    return input
+}

--- a/Sources/SpeechVAD/Configuration.swift
+++ b/Sources/SpeechVAD/Configuration.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Model configuration for pyannote PyanNet segmentation.
+public struct SegmentationConfig {
+    /// Audio sample rate in Hz
+    public let sampleRate: Int
+
+    /// SincNet filter counts per layer
+    public let sincnetFilters: [Int]
+    /// SincNet kernel sizes per layer
+    public let sincnetKernelSizes: [Int]
+    /// SincNet strides per layer
+    public let sincnetStrides: [Int]
+    /// SincNet max-pool kernel sizes per layer
+    public let sincnetPoolSizes: [Int]
+
+    /// LSTM hidden size (per direction; output is 2x for bidirectional)
+    public let lstmHiddenSize: Int
+    /// Number of LSTM layers
+    public let lstmNumLayers: Int
+
+    /// Linear layer hidden size
+    public let linearHiddenSize: Int
+    /// Number of linear layers (before classifier)
+    public let linearNumLayers: Int
+
+    /// Number of output classes (powerset)
+    public let numClasses: Int
+
+    /// Default configuration for pyannote/segmentation-3.0
+    public static let `default` = SegmentationConfig(
+        sampleRate: 16000,
+        sincnetFilters: [80, 60, 60],
+        sincnetKernelSizes: [251, 5, 5],
+        sincnetStrides: [10, 1, 1],
+        sincnetPoolSizes: [3, 3, 3],
+        lstmHiddenSize: 128,
+        lstmNumLayers: 4,
+        linearHiddenSize: 128,
+        linearNumLayers: 2,
+        numClasses: 7
+    )
+}
+
+/// VAD pipeline configuration with default hysteresis thresholds.
+public struct VADConfig {
+    /// Onset threshold (speech starts when probability exceeds this)
+    public var onset: Float
+    /// Offset threshold (speech ends when probability drops below this)
+    public var offset: Float
+    /// Minimum speech duration in seconds
+    public var minSpeechDuration: Float
+    /// Minimum silence duration in seconds
+    public var minSilenceDuration: Float
+    /// Analysis window duration in seconds
+    public var windowDuration: Float
+    /// Step ratio for sliding window (fraction of window)
+    public var stepRatio: Float
+
+    public init(
+        onset: Float, offset: Float,
+        minSpeechDuration: Float, minSilenceDuration: Float,
+        windowDuration: Float, stepRatio: Float
+    ) {
+        self.onset = onset
+        self.offset = offset
+        self.minSpeechDuration = minSpeechDuration
+        self.minSilenceDuration = minSilenceDuration
+        self.windowDuration = windowDuration
+        self.stepRatio = stepRatio
+    }
+
+    /// Default pyannote VAD thresholds
+    public static let `default` = VADConfig(
+        onset: 0.767,
+        offset: 0.377,
+        minSpeechDuration: 0.136,
+        minSilenceDuration: 0.067,
+        windowDuration: 10.0,
+        stepRatio: 0.1
+    )
+
+    /// Default Silero VAD thresholds (streaming-optimized)
+    public static let sileroDefault = VADConfig(
+        onset: 0.5,
+        offset: 0.35,
+        minSpeechDuration: 0.25,
+        minSilenceDuration: 0.1,
+        windowDuration: 0.032,
+        stepRatio: 1.0
+    )
+}

--- a/Sources/SpeechVAD/DiarizationPipeline.swift
+++ b/Sources/SpeechVAD/DiarizationPipeline.swift
@@ -1,0 +1,464 @@
+import Foundation
+import MLX
+import AudioCommon
+
+// MARK: - Configuration
+
+/// Configuration for speaker diarization.
+public struct DiarizationConfig {
+    /// Onset threshold for speaker activity
+    public var onset: Float
+    /// Offset threshold for speaker activity
+    public var offset: Float
+    /// Minimum speech segment duration in seconds
+    public var minSpeechDuration: Float
+    /// Minimum silence duration between segments in seconds
+    public var minSilenceDuration: Float
+    /// Clustering distance threshold (cosine distance, 0-2 range)
+    public var clusteringThreshold: Float
+    /// Maximum number of speakers (0 = automatic)
+    public var maxSpeakers: Int
+
+    public init(
+        onset: Float = 0.5,
+        offset: Float = 0.3,
+        minSpeechDuration: Float = 0.3,
+        minSilenceDuration: Float = 0.15,
+        clusteringThreshold: Float = 0.5,
+        maxSpeakers: Int = 0
+    ) {
+        self.onset = onset
+        self.offset = offset
+        self.minSpeechDuration = minSpeechDuration
+        self.minSilenceDuration = minSilenceDuration
+        self.clusteringThreshold = clusteringThreshold
+        self.maxSpeakers = maxSpeakers
+    }
+
+    public static let `default` = DiarizationConfig()
+}
+
+// MARK: - Result
+
+/// Result of speaker diarization.
+public struct DiarizationResult: Sendable {
+    /// Diarized speech segments with speaker IDs
+    public let segments: [DiarizedSegment]
+    /// Number of distinct speakers found
+    public let numSpeakers: Int
+    /// Centroid embedding for each speaker (speaker ID → 256-dim embedding)
+    public let speakerEmbeddings: [[Float]]
+
+    public init(segments: [DiarizedSegment], numSpeakers: Int, speakerEmbeddings: [[Float]]) {
+        self.segments = segments
+        self.numSpeakers = numSpeakers
+        self.speakerEmbeddings = speakerEmbeddings
+    }
+}
+
+// MARK: - Pipeline
+
+/// Speaker diarization pipeline: segmentation → embedding → clustering.
+///
+/// Three-stage pipeline:
+/// 1. **Segmentation**: Pyannote segmentation on 10s sliding windows → per-speaker local segments
+/// 2. **Embedding**: For each local segment, crop audio → mel → WeSpeaker → 256-dim embedding
+/// 3. **Clustering**: Agglomerative clustering on embeddings → global speaker IDs
+///
+/// ```swift
+/// let pipeline = try await DiarizationPipeline.fromPretrained()
+/// let result = pipeline.diarize(audio: samples, sampleRate: 16000)
+/// for seg in result.segments {
+///     print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
+/// }
+/// ```
+public final class DiarizationPipeline {
+
+    /// Pyannote segmentation model
+    let segmentationModel: SegmentationModel
+
+    /// Segmentation config
+    let segConfig: SegmentationConfig
+
+    /// WeSpeaker embedding model
+    public let embeddingModel: WeSpeakerModel
+
+    init(
+        segmentationModel: SegmentationModel,
+        segConfig: SegmentationConfig,
+        embeddingModel: WeSpeakerModel
+    ) {
+        self.segmentationModel = segmentationModel
+        self.segConfig = segConfig
+        self.embeddingModel = embeddingModel
+    }
+
+    /// Load pre-trained models for diarization.
+    ///
+    /// Downloads both the pyannote segmentation model and WeSpeaker embedding model.
+    ///
+    /// - Parameters:
+    ///   - segModelId: HuggingFace model ID for segmentation
+    ///   - embModelId: HuggingFace model ID for speaker embeddings
+    ///   - progressHandler: callback for download progress
+    /// - Returns: ready-to-use diarization pipeline
+    public static func fromPretrained(
+        segModelId: String = PyannoteVADModel.defaultModelId,
+        embModelId: String = WeSpeakerModel.defaultModelId,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> DiarizationPipeline {
+        progressHandler?(0.0, "Downloading segmentation model...")
+
+        // Load segmentation model
+        let segCacheDir = try HuggingFaceDownloader.getCacheDirectory(for: segModelId)
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: segModelId,
+            to: segCacheDir,
+            progressHandler: { progress in
+                progressHandler?(progress * 0.4, "Downloading segmentation weights...")
+            }
+        )
+
+        let segConfig = SegmentationConfig.default
+        let segModel = SegmentationModel(config: segConfig)
+        try SegmentationWeightLoader.loadWeights(model: segModel, from: segCacheDir)
+
+        progressHandler?(0.4, "Downloading speaker embedding model...")
+
+        // Load embedding model
+        let embModel = try await WeSpeakerModel.fromPretrained(
+            modelId: embModelId,
+            progressHandler: { progress, status in
+                progressHandler?(0.4 + progress * 0.5, status)
+            }
+        )
+
+        progressHandler?(1.0, "Ready")
+
+        return DiarizationPipeline(
+            segmentationModel: segModel,
+            segConfig: segConfig,
+            embeddingModel: embModel
+        )
+    }
+
+    /// Run speaker diarization on audio.
+    ///
+    /// - Parameters:
+    ///   - audio: PCM Float32 audio samples
+    ///   - sampleRate: sample rate of the input audio
+    ///   - config: diarization configuration
+    /// - Returns: diarization result with speaker-labeled segments
+    public func diarize(
+        audio: [Float],
+        sampleRate: Int,
+        config: DiarizationConfig = .default
+    ) -> DiarizationResult {
+        let samples: [Float]
+        if sampleRate != segConfig.sampleRate {
+            samples = resample(audio, from: sampleRate, to: segConfig.sampleRate)
+        } else {
+            samples = audio
+        }
+
+        // Stage 1: Segmentation — get per-speaker local segments from sliding windows
+        let localSegments = runSegmentation(samples: samples, config: config)
+
+        guard !localSegments.isEmpty else {
+            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        }
+
+        // Stage 2: Embedding — extract speaker embedding for each local segment
+        var embeddings = [[Float]]()
+        for seg in localSegments {
+            let startSample = max(0, Int(seg.startTime * Float(segConfig.sampleRate)))
+            let endSample = min(samples.count, Int(seg.endTime * Float(segConfig.sampleRate)))
+
+            guard endSample > startSample else {
+                embeddings.append([Float](repeating: 0, count: embeddingModel.embeddingDimension))
+                continue
+            }
+
+            let cropAudio = Array(samples[startSample..<endSample])
+            let emb = embeddingModel.embed(audio: cropAudio, sampleRate: segConfig.sampleRate)
+            embeddings.append(emb)
+        }
+
+        // Stage 3: Clustering — assign global speaker IDs
+        let (clusterIds, centroids) = agglomerativeClustering(
+            embeddings: embeddings,
+            threshold: config.clusteringThreshold,
+            maxClusters: config.maxSpeakers > 0 ? config.maxSpeakers : Int.max
+        )
+
+        // Build diarized segments
+        var diarizedSegments = [DiarizedSegment]()
+        for (i, seg) in localSegments.enumerated() {
+            diarizedSegments.append(DiarizedSegment(
+                startTime: seg.startTime,
+                endTime: seg.endTime,
+                speakerId: clusterIds[i]
+            ))
+        }
+
+        // Merge adjacent segments with same speaker and short gaps
+        let merged = mergeAdjacentSegments(
+            diarizedSegments,
+            minSilence: config.minSilenceDuration
+        )
+
+        let numSpeakers = Set(clusterIds).count
+
+        return DiarizationResult(
+            segments: merged,
+            numSpeakers: numSpeakers,
+            speakerEmbeddings: centroids
+        )
+    }
+
+    /// Extract segments of a target speaker from audio.
+    ///
+    /// Given a reference embedding (from `WeSpeakerModel.embed()`), finds the
+    /// speaker with highest cosine similarity and returns their segments.
+    ///
+    /// - Parameters:
+    ///   - audio: PCM Float32 audio samples
+    ///   - sampleRate: sample rate of the input audio
+    ///   - targetEmbedding: 256-dim reference embedding of the target speaker
+    ///   - config: diarization configuration
+    /// - Returns: speech segments belonging to the target speaker
+    public func extractSpeaker(
+        audio: [Float],
+        sampleRate: Int,
+        targetEmbedding: [Float],
+        config: DiarizationConfig = .default
+    ) -> [SpeechSegment] {
+        let result = diarize(audio: audio, sampleRate: sampleRate, config: config)
+
+        guard result.numSpeakers > 0 else { return [] }
+
+        // Find speaker with highest cosine similarity to target
+        var bestSpeaker = 0
+        var bestSimilarity: Float = -1
+
+        for (i, centroid) in result.speakerEmbeddings.enumerated() {
+            let sim = WeSpeakerModel.cosineSimilarity(centroid, targetEmbedding)
+            if sim > bestSimilarity {
+                bestSimilarity = sim
+                bestSpeaker = i
+            }
+        }
+
+        return result.segments
+            .filter { $0.speakerId == bestSpeaker }
+            .map { SpeechSegment(startTime: $0.startTime, endTime: $0.endTime) }
+    }
+
+    // MARK: - Stage 1: Segmentation
+
+    private func runSegmentation(
+        samples: [Float],
+        config: DiarizationConfig
+    ) -> [(startTime: Float, endTime: Float, localSpeaker: Int)] {
+        let vadConfig = VADConfig.default
+        let pipeline = VADPipeline(
+            config: vadConfig,
+            sampleRate: segConfig.sampleRate,
+            framesPerChunk: 589
+        )
+
+        let positions = pipeline.windowPositions(numSamples: samples.count)
+        guard !positions.isEmpty else { return [] }
+
+        let windowSamples = Int(vadConfig.windowDuration * Float(segConfig.sampleRate))
+        let frameDuration = vadConfig.windowDuration / Float(589)
+
+        var allSegments = [(startTime: Float, endTime: Float, localSpeaker: Int)]()
+
+        for (start, end) in positions {
+            var window = Array(samples[start..<end])
+            if window.count < windowSamples {
+                window.append(contentsOf: [Float](repeating: 0, count: windowSamples - window.count))
+            }
+
+            // Run segmentation: [1, 1, samples] → [1, frames, 7]
+            let input = MLXArray(window).reshaped(1, 1, windowSamples)
+            let posteriors = segmentationModel(input)
+
+            // Decode powerset to per-speaker: [1, frames, 3]
+            let speakerProbs = PowersetDecoder.speakerProbabilities(from: posteriors)
+            eval(speakerProbs)
+
+            let windowStartTime = Float(start) / Float(segConfig.sampleRate)
+
+            // Extract segments for each local speaker
+            for spk in 0..<3 {
+                let probs = speakerProbs[0, 0..., spk].asArray(Float.self)
+
+                let segments = PowersetDecoder.binarize(
+                    probs: probs,
+                    onset: config.onset,
+                    offset: config.offset,
+                    frameDuration: frameDuration
+                )
+
+                for seg in segments {
+                    let absStart = windowStartTime + seg.startTime
+                    let absEnd = windowStartTime + seg.endTime
+                    let duration = absEnd - absStart
+
+                    if duration >= config.minSpeechDuration {
+                        allSegments.append((absStart, absEnd, spk))
+                    }
+                }
+            }
+        }
+
+        // Sort by start time
+        return allSegments.sorted { $0.startTime < $1.startTime }
+    }
+
+    // MARK: - Stage 3: Agglomerative Clustering
+
+    private func agglomerativeClustering(
+        embeddings: [[Float]],
+        threshold: Float,
+        maxClusters: Int
+    ) -> (clusterIds: [Int], centroids: [[Float]]) {
+        let n = embeddings.count
+        guard n > 0 else { return ([], []) }
+        if n == 1 { return ([0], embeddings) }
+
+        // Initialize: each embedding is its own cluster
+        var clusterAssignment = Array(0..<n)
+        var centroids = embeddings
+        var activeClusterIds = Set(0..<n)
+
+        while activeClusterIds.count > 1 {
+            // Find closest pair of clusters
+            var bestDist: Float = Float.infinity
+            var bestI = -1
+            var bestJ = -1
+
+            let activeList = Array(activeClusterIds).sorted()
+            for ai in 0..<activeList.count {
+                for aj in (ai + 1)..<activeList.count {
+                    let ci = activeList[ai]
+                    let cj = activeList[aj]
+                    let dist = cosineDistance(centroids[ci], centroids[cj])
+                    if dist < bestDist {
+                        bestDist = dist
+                        bestI = ci
+                        bestJ = cj
+                    }
+                }
+            }
+
+            // Stop if minimum distance exceeds threshold
+            if bestDist > threshold { break }
+
+            // Stop if we've reached max clusters
+            if activeClusterIds.count <= maxClusters { break }
+
+            // Merge bestJ into bestI
+            let membersI = clusterAssignment.enumerated().filter { $0.element == bestI }.map(\.offset)
+            let membersJ = clusterAssignment.enumerated().filter { $0.element == bestJ }.map(\.offset)
+
+            // Update centroid (average linkage)
+            let totalMembers = membersI.count + membersJ.count
+            var newCentroid = [Float](repeating: 0, count: embeddings[0].count)
+            for idx in membersI + membersJ {
+                for d in 0..<newCentroid.count {
+                    newCentroid[d] += embeddings[idx][d]
+                }
+            }
+            for d in 0..<newCentroid.count {
+                newCentroid[d] /= Float(totalMembers)
+            }
+
+            // L2 normalize centroid
+            var norm: Float = 0
+            for d in 0..<newCentroid.count { norm += newCentroid[d] * newCentroid[d] }
+            norm = sqrt(norm + 1e-10)
+            for d in 0..<newCentroid.count { newCentroid[d] /= norm }
+
+            centroids[bestI] = newCentroid
+
+            // Reassign members of bestJ to bestI
+            for idx in membersJ {
+                clusterAssignment[idx] = bestI
+            }
+            activeClusterIds.remove(bestJ)
+        }
+
+        // Remap cluster IDs to contiguous 0-based
+        let uniqueClusters = Array(Set(clusterAssignment)).sorted()
+        var remap = [Int: Int]()
+        for (newId, oldId) in uniqueClusters.enumerated() {
+            remap[oldId] = newId
+        }
+
+        let remappedIds = clusterAssignment.map { remap[$0]! }
+        let finalCentroids = uniqueClusters.map { centroids[$0] }
+
+        return (remappedIds, finalCentroids)
+    }
+
+    private func cosineDistance(_ a: [Float], _ b: [Float]) -> Float {
+        return 1.0 - WeSpeakerModel.cosineSimilarity(a, b)
+    }
+
+    // MARK: - Segment Merging
+
+    private func mergeAdjacentSegments(
+        _ segments: [DiarizedSegment],
+        minSilence: Float
+    ) -> [DiarizedSegment] {
+        guard !segments.isEmpty else { return [] }
+
+        var merged = [DiarizedSegment]()
+        var current = segments[0]
+
+        for i in 1..<segments.count {
+            let next = segments[i]
+            let gap = next.startTime - current.endTime
+
+            if next.speakerId == current.speakerId && gap < minSilence {
+                current = DiarizedSegment(
+                    startTime: current.startTime,
+                    endTime: next.endTime,
+                    speakerId: current.speakerId
+                )
+            } else {
+                merged.append(current)
+                current = next
+            }
+        }
+        merged.append(current)
+
+        return merged
+    }
+
+    // MARK: - Resampling
+
+    private func resample(_ audio: [Float], from sourceSR: Int, to targetSR: Int) -> [Float] {
+        guard sourceSR != targetSR else { return audio }
+        let ratio = Double(targetSR) / Double(sourceSR)
+        let outputLen = Int(Double(audio.count) * ratio)
+        var output = [Float](repeating: 0, count: outputLen)
+
+        for i in 0..<outputLen {
+            let srcPos = Double(i) / ratio
+            let srcIdx = Int(srcPos)
+            let frac = Float(srcPos - Double(srcIdx))
+
+            if srcIdx + 1 < audio.count {
+                output[i] = audio[srcIdx] * (1 - frac) + audio[srcIdx + 1] * frac
+            } else if srcIdx < audio.count {
+                output[i] = audio[srcIdx]
+            }
+        }
+
+        return output
+    }
+}

--- a/Sources/SpeechVAD/PowersetDecoder.swift
+++ b/Sources/SpeechVAD/PowersetDecoder.swift
@@ -1,0 +1,70 @@
+import MLX
+
+/// Decodes pyannote's 7-class powerset output to per-speaker probabilities.
+///
+/// The 7 powerset classes represent all possible speaker combinations
+/// for up to 3 speakers:
+/// - 0: non-speech
+/// - 1: speaker 1 alone
+/// - 2: speaker 2 alone
+/// - 3: speaker 3 alone
+/// - 4: speakers 1+2 overlap
+/// - 5: speakers 1+3 overlap
+/// - 6: speakers 2+3 overlap
+enum PowersetDecoder {
+
+    /// Convert 7-class powerset posteriors to per-speaker probabilities.
+    ///
+    /// Each speaker's probability is the sum of all classes where that speaker
+    /// is active (alone or in overlap).
+    ///
+    /// - Parameter posteriors: `[batch, frames, 7]` softmax probabilities
+    /// - Returns: `[batch, frames, 3]` per-speaker probabilities
+    static func speakerProbabilities(from posteriors: MLXArray) -> MLXArray {
+        // spk1: alone(1) + with_spk2(4) + with_spk3(5)
+        let spk1 = posteriors[0..., 0..., 1] + posteriors[0..., 0..., 4] + posteriors[0..., 0..., 5]
+        // spk2: alone(2) + with_spk1(4) + with_spk3(6)
+        let spk2 = posteriors[0..., 0..., 2] + posteriors[0..., 0..., 4] + posteriors[0..., 0..., 6]
+        // spk3: alone(3) + with_spk1(5) + with_spk2(6)
+        let spk3 = posteriors[0..., 0..., 3] + posteriors[0..., 0..., 5] + posteriors[0..., 0..., 6]
+        return stacked([spk1, spk2, spk3], axis: -1)
+    }
+
+    /// Apply hysteresis binarization to per-speaker probabilities.
+    ///
+    /// - Parameters:
+    ///   - probs: per-frame probabilities for one speaker `[frames]`
+    ///   - onset: threshold to start a segment
+    ///   - offset: threshold to end a segment
+    ///   - frameDuration: duration of one frame in seconds
+    /// - Returns: array of (startTime, endTime) tuples
+    static func binarize(
+        probs: [Float],
+        onset: Float,
+        offset: Float,
+        frameDuration: Float
+    ) -> [(startTime: Float, endTime: Float)] {
+        var segments = [(startTime: Float, endTime: Float)]()
+        var inSpeech = false
+        var speechStart: Float = 0
+
+        for (i, prob) in probs.enumerated() {
+            let time = Float(i) * frameDuration
+
+            if !inSpeech && prob >= onset {
+                inSpeech = true
+                speechStart = time
+            } else if inSpeech && prob < offset {
+                inSpeech = false
+                segments.append((speechStart, time))
+            }
+        }
+
+        if inSpeech {
+            let endTime = Float(probs.count) * frameDuration
+            segments.append((speechStart, endTime))
+        }
+
+        return segments
+    }
+}

--- a/Sources/SpeechVAD/Segmentation.swift
+++ b/Sources/SpeechVAD/Segmentation.swift
@@ -1,0 +1,97 @@
+import MLX
+import MLXNN
+
+/// PyanNet segmentation model: SincNet → BiLSTM → Linear → Classifier.
+///
+/// Produces per-frame powerset class probabilities for up to 3 speakers.
+/// Output classes (7): non-speech, spk1, spk2, spk3, spk1+2, spk1+3, spk2+3
+///
+/// Weight keys at model level:
+/// ```
+/// sincnet.{conv, norm, wav_norm}.*
+/// lstm_fwd.layers.{i}.{Wx, Wh, bias}
+/// lstm_bwd.layers.{i}.{Wx, Wh, bias}
+/// linear.{0,1}.{weight, bias}
+/// classifier.{weight, bias}
+/// ```
+class SegmentationModel: Module {
+    let config: SegmentationConfig
+
+    let sincnet: SincNet
+
+    /// Forward and backward LSTM stacks (at top level for weight loading)
+    @ModuleInfo(key: "lstm_fwd") var lstmFwd: LSTMStack
+    @ModuleInfo(key: "lstm_bwd") var lstmBwd: LSTMStack
+
+    let linear: [Linear]
+    let classifier: Linear
+
+    init(config: SegmentationConfig = .default) {
+        self.config = config
+
+        self.sincnet = SincNet(config: config)
+
+        // Build LSTM stacks
+        let sincnetOutputDim = config.sincnetFilters.last!  // 60
+        var fwdLayers = [LSTMLayer]()
+        var bwdLayers = [LSTMLayer]()
+        for i in 0 ..< config.lstmNumLayers {
+            let inSize = (i == 0) ? sincnetOutputDim : config.lstmHiddenSize * 2
+            fwdLayers.append(LSTMLayer(inputSize: inSize, hiddenSize: config.lstmHiddenSize))
+            bwdLayers.append(LSTMLayer(inputSize: inSize, hiddenSize: config.lstmHiddenSize))
+        }
+
+        // Linear layers with LeakyReLU
+        let lstmOutputDim = config.lstmHiddenSize * 2  // 256 (bidirectional)
+        var layers = [Linear]()
+        for i in 0 ..< config.linearNumLayers {
+            let inDim = (i == 0) ? lstmOutputDim : config.linearHiddenSize
+            layers.append(Linear(inDim, config.linearHiddenSize))
+        }
+        self.linear = layers
+
+        self.classifier = Linear(config.linearHiddenSize, config.numClasses)
+
+        // Set @ModuleInfo properties after all stored properties
+        self._lstmFwd.wrappedValue = LSTMStack(layers: fwdLayers)
+        self._lstmBwd.wrappedValue = LSTMStack(layers: bwdLayers)
+    }
+
+    /// Run segmentation on audio.
+    /// - Parameter waveform: `[batch, 1, samples]` (mono, 16kHz)
+    /// - Returns: `[batch, num_frames, num_classes]` class probabilities
+    func callAsFunction(_ waveform: MLXArray) -> MLXArray {
+        // SincNet: [B, 1, T] → [B, 60, ~293]
+        var x = sincnet(waveform)
+
+        // Transpose for LSTM: [B, 60, L] → [B, L, 60]
+        x = x.transposed(0, 2, 1)
+
+        // BiLSTM: [B, L, 60] → [B, L, 256]
+        x = runBiLSTM(x, fwd: lstmFwd, bwd: lstmBwd)
+
+        // Linear layers with LeakyReLU
+        for layer in linear {
+            x = layer(x)
+            x = leakyRelu(x)
+        }
+
+        // Classifier + softmax: [B, L, 7]
+        x = classifier(x)
+        x = softmax(x, axis: -1)
+
+        return x
+    }
+
+    /// Extract speech probability from powerset output.
+    ///
+    /// Classes: [non-speech, spk1, spk2, spk3, spk1+2, spk1+3, spk2+3]
+    /// Speech probability = 1 - P(non-speech).
+    ///
+    /// - Parameter posteriors: `[batch, frames, 7]`
+    /// - Returns: `[batch, frames]` speech probability per frame
+    static func speechProbability(from posteriors: MLXArray) -> MLXArray {
+        let nonSpeech = posteriors[0..., 0..., 0]
+        return 1.0 - nonSpeech
+    }
+}

--- a/Sources/SpeechVAD/SileroModel.swift
+++ b/Sources/SpeechVAD/SileroModel.swift
@@ -1,0 +1,186 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Silero VAD v5 neural network: STFT → Encoder → LSTM → Decoder.
+///
+/// Processes 512-sample audio chunks (32ms @ 16kHz) with 64 samples of context
+/// prepended from the previous chunk. The STFT uses a pre-computed DFT basis
+/// stored as Conv1d weights.
+///
+/// Architecture:
+/// ```
+/// Input: 576 samples (64 context + 512 new)
+///   → ReflectionPad(right=64) → 640 samples
+///   → STFT Conv1d(1→258, k=256, s=128) → 4 frames × 258
+///   → Magnitude: √(real² + imag²) → 4 × 129
+///   → Encoder: 4× Conv1d+ReLU → 1 × 128
+///   → LSTM(128→128, 1 layer) → hidden state [B, 128]
+///   → ReLU → Conv1d(128→1, k=1) → Sigmoid → probability
+/// ```
+///
+/// Weight keys:
+/// ```
+/// stft.weight                 [258, 256, 1]
+/// encoder.{0-3}.weight        Conv1d weights
+/// encoder.{0-3}.bias          Conv1d biases
+/// lstm.{Wx, Wh, bias}         LSTM parameters
+/// decoder.{weight, bias}      Final Conv1d
+/// ```
+class SileroVADNetwork: Module {
+
+    // STFT: pre-computed DFT basis as Conv1d (no bias)
+    @ModuleInfo(key: "stft") var stft: Conv1d
+
+    // Encoder: 4 Conv1d + ReLU
+    let encoder: [Conv1d]
+
+    // LSTM: 128→128, 1 layer (reuses LSTMLayer for parameter structure)
+    @ModuleInfo(key: "lstm") var lstm: LSTMLayer
+
+    // Decoder: Conv1d(128→1, k=1)
+    @ModuleInfo(key: "decoder") var decoder: Conv1d
+
+    override init() {
+        // STFT: filter_length=256, hop_length=128, 1→258 channels (129 real + 129 imag)
+        self._stft.wrappedValue = Conv1d(
+            inputChannels: 1, outputChannels: 258, kernelSize: 256,
+            stride: 128, bias: false)
+
+        // Encoder
+        self.encoder = [
+            Conv1d(inputChannels: 129, outputChannels: 128, kernelSize: 3, stride: 1, padding: 1),
+            Conv1d(inputChannels: 128, outputChannels: 64, kernelSize: 3, stride: 2, padding: 1),
+            Conv1d(inputChannels: 64, outputChannels: 64, kernelSize: 3, stride: 2, padding: 1),
+            Conv1d(inputChannels: 64, outputChannels: 128, kernelSize: 3, stride: 1, padding: 1),
+        ]
+
+        // LSTM: input_size=128, hidden_size=128
+        self._lstm.wrappedValue = LSTMLayer(inputSize: 128, hiddenSize: 128)
+
+        // Decoder: 128→1 with kernel=1
+        self._decoder.wrappedValue = Conv1d(
+            inputChannels: 128, outputChannels: 1, kernelSize: 1)
+    }
+
+    /// Forward pass for a single chunk.
+    ///
+    /// - Parameters:
+    ///   - samples: `[B, T]` raw audio (576 samples: 64 context + 512 new)
+    ///   - h: LSTM hidden state `[1, B, 128]` or nil for initial state
+    ///   - c: LSTM cell state `[1, B, 128]` or nil for initial state
+    /// - Returns: `(probability [B], new_h [1, B, 128], new_c [1, B, 128])`
+    func forward(_ samples: MLXArray, h: MLXArray?, c: MLXArray?) -> (MLXArray, MLXArray, MLXArray) {
+        // [B, T] → [B, T, 1] for channels-last Conv1d
+        var x = samples.expandedDimensions(axis: -1)
+
+        // Reflection padding: 64 samples on the RIGHT side only
+        // (matching Silero's pad(input, [0, 64], "reflect"))
+        x = reflectionPadRight(x, padding: 64)
+
+        // STFT via Conv1d: [B, 640, 1] → [B, 4, 258]
+        x = stft(x)
+
+        // Split real/imaginary and compute magnitude
+        let real = x[0..., 0..., ..<129]
+        let imag = x[0..., 0..., 129...]
+        x = sqrt(real * real + imag * imag)  // [B, 4, 129]
+
+        // Encoder: 4× Conv1d + ReLU → [B, 1, 128]
+        for conv in encoder {
+            x = relu(conv(x))
+        }
+
+        // LSTM with explicit h/c state
+        // Encoder output is [B, 1, 128] — single timestep
+        let (newH, newC) = lstmForward(x, h: h, c: c)
+
+        // Decoder: use LSTM hidden state h, not full sequence output
+        // h: [1, B, 128] → [B, 128] → [B, 1, 128] for Conv1d
+        let hForDecoder = newH.squeezed(axis: 0).expandedDimensions(axis: 1)
+
+        // ReLU → Conv1d(128→1, k=1) → Sigmoid
+        let prob = sigmoid(decoder(relu(hForDecoder)))  // [B, 1, 1]
+
+        return (prob.squeezed(axes: [1, 2]), newH, newC)
+    }
+
+    /// Run LSTM with explicit hidden/cell state for streaming.
+    ///
+    /// Accesses LSTMLayer's parameters directly (Wx, Wh, bias) rather than
+    /// calling its `callAsFunction`, which doesn't support stateful operation.
+    ///
+    /// Returns (new_h [1, B, H], new_c [1, B, H])
+    private func lstmForward(
+        _ x: MLXArray, h: MLXArray?, c: MLXArray?
+    ) -> (MLXArray, MLXArray) {
+        // Project all timesteps: [B, T, 4*H]
+        let projected = addMM(lstm.bias, x, lstm.wx.T)
+        let seqLen = x.dim(-2)
+
+        // Squeeze state from [1, B, H] to [B, H]
+        var hidden = h?.squeezed(axis: 0)
+        var cell = c?.squeezed(axis: 0)
+
+        for t in 0 ..< seqLen {
+            var ifgo = projected[0..., t, 0...]
+            if let h = hidden {
+                ifgo = ifgo + matmul(h, lstm.wh.T)
+            }
+
+            let pieces = split(ifgo, parts: 4, axis: -1)
+            let i = sigmoid(pieces[0])
+            let f = sigmoid(pieces[1])
+            let g = tanh(pieces[2])
+            let o = sigmoid(pieces[3])
+
+            if let c = cell {
+                cell = f * c + i * g
+            } else {
+                cell = i * g
+            }
+            hidden = o * tanh(cell!)
+        }
+
+        let newH = hidden!.expandedDimensions(axis: 0)  // [1, B, H]
+        let newC = cell!.expandedDimensions(axis: 0)  // [1, B, H]
+
+        return (newH, newC)
+    }
+}
+
+// MARK: - Reflection Padding
+
+/// Right-only reflection padding for 1D data in channels-last format `[B, T, C]`.
+///
+/// Matches Silero's `F.pad(input, [0, 64], mode='reflect')`.
+/// For input `[a, b, c, d, e]` with padding=2: `[a, b, c, d, e, d, c]`
+func reflectionPadRight(_ x: MLXArray, padding: Int) -> MLXArray {
+    let T = x.dim(1)
+    guard padding > 0, T > padding else { return x }
+
+    // Right: reflect indices [T-2, T-3, ..., T-1-padding]
+    let rightIndices = MLXArray(Array(stride(from: T - 2, through: T - 1 - padding, by: -1)))
+    let rightPad = x.take(rightIndices, axis: 1)
+
+    return concatenated([x, rightPad], axis: 1)
+}
+
+/// Symmetric reflection padding for 1D data in channels-last format `[B, T, C]`.
+///
+/// Pads the time dimension by reflecting values at both boundaries.
+/// For input `[a, b, c, d, e]` with padding=2: `[c, b, a, b, c, d, e, d, c]`
+func reflectionPad1d(_ x: MLXArray, padding: Int) -> MLXArray {
+    let T = x.dim(1)
+    guard padding > 0, T > padding else { return x }
+
+    // Left: reflect indices [padding, padding-1, ..., 1]
+    let leftIndices = MLXArray(Array(stride(from: padding, through: 1, by: -1)))
+    let leftPad = x.take(leftIndices, axis: 1)
+
+    // Right: reflect indices [T-2, T-3, ..., T-1-padding]
+    let rightIndices = MLXArray(Array(stride(from: T - 2, through: T - 1 - padding, by: -1)))
+    let rightPad = x.take(rightIndices, axis: 1)
+
+    return concatenated([leftPad, x, rightPad], axis: 1)
+}

--- a/Sources/SpeechVAD/SileroVAD.swift
+++ b/Sources/SpeechVAD/SileroVAD.swift
@@ -1,0 +1,216 @@
+import Foundation
+import MLX
+import AudioCommon
+
+/// Streaming Voice Activity Detection using Silero VAD v5.
+///
+/// A lightweight (~260K params) VAD model that processes 512-sample chunks
+/// (32ms @ 16kHz) with sub-millisecond latency. Carries LSTM state across
+/// chunks for streaming operation.
+///
+/// ```swift
+/// let vad = try await SileroVADModel.fromPretrained()
+///
+/// // Streaming: process one chunk at a time
+/// let prob = vad.processChunk(samples512)  // → 0.0...1.0
+///
+/// // Batch: detect all speech segments
+/// let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+/// ```
+public final class SileroVADModel {
+
+    /// The neural network
+    let network: SileroVADNetwork
+
+    /// LSTM hidden state (carried across chunks)
+    private var h: MLXArray?
+    /// LSTM cell state (carried across chunks)
+    private var c: MLXArray?
+    /// Context buffer: last 64 samples from previous chunk
+    private var context: [Float]
+
+    /// Default HuggingFace model ID
+    public static let defaultModelId = "aufklarer/Silero-VAD-v5-MLX"
+
+    /// Number of audio samples per chunk (32ms @ 16kHz)
+    public static let chunkSize = 512
+
+    /// Number of context samples prepended from previous chunk
+    public static let contextSize = 64
+
+    /// Expected input sample rate
+    public static let sampleRate = 16000
+
+    init(network: SileroVADNetwork) {
+        self.network = network
+        self.context = [Float](repeating: 0, count: Self.contextSize)
+    }
+
+    /// Process a single 512-sample audio chunk and return speech probability.
+    ///
+    /// Maintains internal LSTM state across calls. Call `resetState()` between
+    /// different audio streams.
+    ///
+    /// - Parameter samples: exactly 512 PCM Float32 samples at 16kHz
+    /// - Returns: speech probability in `[0, 1]`
+    public func processChunk(_ samples: [Float]) -> Float {
+        precondition(samples.count == Self.chunkSize,
+                     "Chunk must be \(Self.chunkSize) samples, got \(samples.count)")
+
+        // Prepend 64-sample context from previous chunk
+        let fullSamples = context + samples
+
+        // Save last 64 samples as context for next chunk
+        context = Array(samples.suffix(Self.contextSize))
+
+        // Run network: [1, 576] → probability
+        let input = MLXArray(fullSamples).reshaped(1, fullSamples.count)
+        let (prob, newH, newC) = network.forward(input, h: h, c: c)
+
+        h = newH
+        c = newC
+
+        eval(prob)
+        return prob.item(Float.self)
+    }
+
+    /// Reset LSTM and context state.
+    ///
+    /// Call this between processing different audio streams to prevent
+    /// state leakage.
+    public func resetState() {
+        h = nil
+        c = nil
+        context = [Float](repeating: 0, count: Self.contextSize)
+    }
+
+    /// Detect speech segments in complete audio (batch mode).
+    ///
+    /// Processes the entire audio in 512-sample chunks, collects per-chunk
+    /// probabilities, then applies hysteresis thresholding and duration filtering.
+    ///
+    /// - Parameters:
+    ///   - audio: PCM Float32 audio samples
+    ///   - sampleRate: sample rate of input audio (resampled to 16kHz if needed)
+    ///   - config: VAD configuration (defaults to Silero-tuned thresholds)
+    /// - Returns: array of speech segments with start/end times in seconds
+    public func detectSpeech(
+        audio: [Float],
+        sampleRate: Int,
+        config: VADConfig = .sileroDefault
+    ) -> [SpeechSegment] {
+        let samples: [Float]
+        if sampleRate != Self.sampleRate {
+            samples = resample(audio, from: sampleRate, to: Self.sampleRate)
+        } else {
+            samples = audio
+        }
+
+        resetState()
+
+        // Collect per-chunk probabilities
+        var probs = [Float]()
+        var offset = 0
+
+        while offset + Self.chunkSize <= samples.count {
+            let chunk = Array(samples[offset ..< (offset + Self.chunkSize)])
+            probs.append(processChunk(chunk))
+            offset += Self.chunkSize
+        }
+
+        // Handle remaining samples with zero-padding
+        if offset < samples.count {
+            var lastChunk = Array(samples[offset...])
+            lastChunk.append(contentsOf: [Float](repeating: 0, count: Self.chunkSize - lastChunk.count))
+            probs.append(processChunk(lastChunk))
+        }
+
+        guard !probs.isEmpty else { return [] }
+
+        // Use VADPipeline for hysteresis binarization.
+        // Set windowDuration = probs.count * chunkDuration so frameDuration = 0.032s
+        let chunkDuration: Float = Float(Self.chunkSize) / Float(Self.sampleRate)
+        let batchPipeline = VADPipeline(
+            config: VADConfig(
+                onset: config.onset,
+                offset: config.offset,
+                minSpeechDuration: config.minSpeechDuration,
+                minSilenceDuration: config.minSilenceDuration,
+                windowDuration: Float(probs.count) * chunkDuration,
+                stepRatio: 1.0
+            ),
+            sampleRate: Self.sampleRate,
+            framesPerChunk: probs.count
+        )
+
+        return batchPipeline.binarize(probs: probs)
+    }
+
+    /// Load a pre-trained Silero VAD model from HuggingFace.
+    ///
+    /// Downloads model weights on first use, then caches locally at
+    /// `~/Library/Caches/qwen3-speech/aufklarer_Silero-VAD-v5-MLX/`.
+    ///
+    /// - Parameters:
+    ///   - modelId: HuggingFace model ID
+    ///   - progressHandler: callback for download progress
+    /// - Returns: ready-to-use VAD model
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> SileroVADModel {
+        progressHandler?(0.0, "Downloading model...")
+
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: cacheDir,
+            progressHandler: { progress in
+                progressHandler?(progress * 0.8, "Downloading weights...")
+            }
+        )
+
+        progressHandler?(0.8, "Loading model...")
+
+        let network = SileroVADNetwork()
+        try SileroWeightLoader.loadWeights(model: network, from: cacheDir)
+
+        progressHandler?(1.0, "Ready")
+
+        return SileroVADModel(network: network)
+    }
+
+    /// Simple linear resampling.
+    private func resample(_ audio: [Float], from sourceSR: Int, to targetSR: Int) -> [Float] {
+        guard sourceSR != targetSR else { return audio }
+        let ratio = Double(targetSR) / Double(sourceSR)
+        let outputLen = Int(Double(audio.count) * ratio)
+        var output = [Float](repeating: 0, count: outputLen)
+
+        for i in 0 ..< outputLen {
+            let srcPos = Double(i) / ratio
+            let srcIdx = Int(srcPos)
+            let frac = Float(srcPos - Double(srcIdx))
+
+            if srcIdx + 1 < audio.count {
+                output[i] = audio[srcIdx] * (1 - frac) + audio[srcIdx + 1] * frac
+            } else if srcIdx < audio.count {
+                output[i] = audio[srcIdx]
+            }
+        }
+
+        return output
+    }
+}
+
+// MARK: - VoiceActivityDetectionModel
+
+extension SileroVADModel: VoiceActivityDetectionModel {
+    public var inputSampleRate: Int { Self.sampleRate }
+
+    /// Protocol conformance — uses default Silero config.
+    public func detectSpeech(audio: [Float], sampleRate: Int) -> [SpeechSegment] {
+        detectSpeech(audio: audio, sampleRate: sampleRate, config: .sileroDefault)
+    }
+}

--- a/Sources/SpeechVAD/SileroWeightLoading.swift
+++ b/Sources/SpeechVAD/SileroWeightLoading.swift
@@ -1,0 +1,35 @@
+import Foundation
+import MLX
+import MLXNN
+import AudioCommon
+
+/// Weight loading for the Silero VAD v5 model.
+///
+/// Loads from safetensors files produced by `scripts/convert_silero_vad.py`.
+/// The conversion script transposes Conv1d weights and sums LSTM biases,
+/// so loading is a straightforward parameter tree update.
+enum SileroWeightLoader {
+
+    /// Load weights from a directory containing model.safetensors.
+    static func loadWeights(
+        model: SileroVADNetwork,
+        from directory: URL
+    ) throws {
+        let weightsURL = directory.appendingPathComponent("model.safetensors")
+
+        guard FileManager.default.fileExists(atPath: weightsURL.path) else {
+            throw WeightLoadingError.noWeightsFound(directory)
+        }
+
+        let weights = try MLX.loadArrays(url: weightsURL)
+
+        // Build nested parameter tree from flat keys
+        let parameters = ModuleParameters.unflattened(weights)
+
+        // Apply to model
+        try model.update(parameters: parameters, verify: .noUnusedKeys)
+
+        // Materialize all parameters
+        MLX.eval(model.parameters())
+    }
+}

--- a/Sources/SpeechVAD/SincNet.swift
+++ b/Sources/SpeechVAD/SincNet.swift
@@ -1,0 +1,129 @@
+import MLX
+import MLXNN
+
+/// SincNet feature extractor: 3 conv+pool+norm+activation layers.
+///
+/// The first conv layer uses pre-computed sinc bandpass filters (computed during
+/// weight conversion). At runtime, all three layers are standard Conv1d.
+///
+/// All data flows in MLX channels-last format: `[batch, length, channels]`.
+///
+/// Architecture:
+///   InstanceNorm(1) → Conv1d(1,80,k=251,s=10) → |·| → MaxPool(3,3) → InstanceNorm(80) → LeakyReLU
+///   → Conv1d(80,60,k=5) → MaxPool(3,3) → InstanceNorm(60) → LeakyReLU
+///   → Conv1d(60,60,k=5) → MaxPool(3,3) → InstanceNorm(60) → LeakyReLU
+class SincNet: Module {
+    /// Input waveform normalization
+    @ModuleInfo(key: "wav_norm") var wavNorm: InstanceNorm
+
+    /// Three conv layers (first is pre-computed sinc filterbank)
+    let conv: [Conv1d]
+
+    /// Instance norm after each conv+pool
+    let norm: [InstanceNorm]
+
+    init(config: SegmentationConfig) {
+        let filters = config.sincnetFilters
+        let kernels = config.sincnetKernelSizes
+        let strides = config.sincnetStrides
+
+        // Build conv layers: input channels are [1, 80, 60]
+        let inputChannels = [1] + Array(filters.dropLast())
+        self.conv = zip(zip(inputChannels, filters), zip(kernels, strides)).map { arg in
+            let ((inC, outC), (k, s)) = arg
+            return Conv1d(inputChannels: inC, outputChannels: outC, kernelSize: k, stride: s)
+        }
+
+        self.norm = filters.map { InstanceNorm(dimensions: $0) }
+
+        self._wavNorm.wrappedValue = InstanceNorm(dimensions: 1)
+    }
+
+    /// Forward pass.
+    /// - Parameter x: `[batch, 1, samples]` raw waveform (channels-first, transposed internally)
+    /// - Returns: `[batch, channels, frames]` feature frames (channels-first for LSTM transpose)
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Convert from [B, C, T] to MLX channels-last [B, T, C]
+        var out = x.transposed(0, 2, 1)
+
+        // Normalize input waveform: [B, T, 1]
+        out = wavNorm(out)
+
+        for i in 0 ..< conv.count {
+            // Conv1d: [B, T, Cin] → [B, T', Cout]
+            out = conv[i](out)
+
+            // First layer uses abs() (sinc filterbank — energy)
+            if i == 0 {
+                out = abs(out)
+            }
+
+            // MaxPool1d(3, stride=3) — pool over time (axis -2)
+            out = maxPool1d(out, kernelSize: 3, stride: 3)
+
+            // InstanceNorm + LeakyReLU
+            out = norm[i](out)
+            out = leakyRelu(out)
+        }
+
+        // Convert back to [B, C, T] for downstream compatibility
+        return out.transposed(0, 2, 1)
+    }
+}
+
+/// Instance normalization for 1D data (channels-last format).
+///
+/// Input shape: `[batch, length, channels]`
+/// Normalizes over the length dimension per-channel, with learnable affine.
+class InstanceNorm: Module {
+    let dimensions: Int
+    var weight: MLXArray
+    var bias: MLXArray
+
+    init(dimensions: Int) {
+        self.dimensions = dimensions
+        self.weight = MLXArray.ones([dimensions])
+        self.bias = MLXArray.zeros([dimensions])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // x: [B, L, C] — normalize over L dimension (axis 1)
+        let mean = x.mean(axis: 1, keepDims: true)
+        let variance = x.variance(axis: 1, keepDims: true)
+        let eps: Float = 1e-5
+        let normalized = (x - mean) * rsqrt(variance + eps)
+        // Scale and shift: weight and bias are [C], broadcast naturally over [B, L, C]
+        return normalized * weight + bias
+    }
+}
+
+/// 1D max pooling for channels-last data.
+///
+/// Input: `[batch, length, channels]` — pools over the length dimension (axis -2).
+///
+/// - Parameters:
+///   - x: `[batch, length, channels]`
+///   - kernelSize: pooling window
+///   - stride: pooling stride
+/// - Returns: `[batch, floor((length - kernelSize) / stride) + 1, channels]`
+func maxPool1d(_ x: MLXArray, kernelSize: Int, stride: Int) -> MLXArray {
+    let length = x.dim(-2)  // time/length axis
+    let outLen = (length - kernelSize) / stride + 1
+
+    // Collect slices for each position in the kernel
+    var slices = [MLXArray]()
+    for k in 0 ..< kernelSize {
+        // Take every stride-th element starting at offset k along time axis
+        let slice = x[0..., .stride(from: k, to: k + outLen * stride, by: stride), 0...]
+        slices.append(slice)
+    }
+
+    // Stack along new axis and take max: [B, outLen, C, kernelSize] → [B, outLen, C]
+    let stacked = MLX.stacked(slices, axis: -1)
+    return stacked.max(axis: -1)
+}
+
+/// LeakyReLU activation.
+func leakyRelu(_ x: MLXArray, negativeSlope: Float = 0.01) -> MLXArray {
+    maximum(x, x * negativeSlope)
+}

--- a/Sources/SpeechVAD/SpeechVAD+Protocols.swift
+++ b/Sources/SpeechVAD/SpeechVAD+Protocols.swift
@@ -1,0 +1,21 @@
+import AudioCommon
+
+// MARK: - VoiceActivityDetectionModel
+
+extension PyannoteVADModel: VoiceActivityDetectionModel {
+    public var inputSampleRate: Int { segConfig.sampleRate }
+}
+
+// MARK: - SpeakerEmbeddingModel
+
+extension WeSpeakerModel: SpeakerEmbeddingModel {}
+
+// MARK: - SpeakerDiarizationModel
+
+extension DiarizationPipeline: SpeakerDiarizationModel {
+    public var inputSampleRate: Int { segConfig.sampleRate }
+
+    public func diarize(audio: [Float], sampleRate: Int) -> [DiarizedSegment] {
+        diarize(audio: audio, sampleRate: sampleRate, config: .default).segments
+    }
+}

--- a/Sources/SpeechVAD/SpeechVAD.swift
+++ b/Sources/SpeechVAD/SpeechVAD.swift
@@ -1,0 +1,154 @@
+import Foundation
+import MLX
+import AudioCommon
+
+/// Voice Activity Detection using pyannote PyanNet segmentation.
+///
+/// Detects speech regions in audio using a sliding-window segmentation model
+/// with hysteresis thresholding and duration filtering.
+///
+/// ```swift
+/// let vad = try await PyannoteVADModel.fromPretrained()
+/// let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+/// for seg in segments {
+///     print("Speech: \(seg.startTime)s - \(seg.endTime)s")
+/// }
+/// ```
+public final class PyannoteVADModel {
+    /// The segmentation model
+    let model: SegmentationModel
+
+    /// VAD pipeline configuration
+    public let vadConfig: VADConfig
+
+    /// Segmentation model configuration
+    public let segConfig: SegmentationConfig
+
+    /// Default HuggingFace model ID
+    public static let defaultModelId = "aufklarer/Pyannote-Segmentation-MLX"
+
+    init(model: SegmentationModel, segConfig: SegmentationConfig, vadConfig: VADConfig) {
+        self.model = model
+        self.segConfig = segConfig
+        self.vadConfig = vadConfig
+    }
+
+    /// Load a pre-trained VAD model from HuggingFace.
+    ///
+    /// Downloads model weights on first use, then caches locally.
+    ///
+    /// - Parameters:
+    ///   - modelId: HuggingFace model ID
+    ///   - vadConfig: VAD pipeline configuration (thresholds, durations)
+    ///   - progressHandler: callback for download progress
+    /// - Returns: ready-to-use VAD model
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        vadConfig: VADConfig = .default,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> PyannoteVADModel {
+        progressHandler?(0.0, "Downloading model...")
+
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: cacheDir,
+            progressHandler: { progress in
+                progressHandler?(progress * 0.8, "Downloading weights...")
+            }
+        )
+
+        progressHandler?(0.8, "Loading model...")
+
+        let segConfig = SegmentationConfig.default
+        let model = SegmentationModel(config: segConfig)
+
+        try SegmentationWeightLoader.loadWeights(model: model, from: cacheDir)
+
+        progressHandler?(1.0, "Ready")
+
+        return PyannoteVADModel(model: model, segConfig: segConfig, vadConfig: vadConfig)
+    }
+
+    /// Detect speech segments in audio.
+    ///
+    /// - Parameters:
+    ///   - audio: PCM Float32 audio samples
+    ///   - sampleRate: sample rate of the input audio (will resample to 16kHz if needed)
+    /// - Returns: array of speech segments with start/end times in seconds
+    public func detectSpeech(audio: [Float], sampleRate: Int) -> [SpeechSegment] {
+        let samples: [Float]
+        if sampleRate != segConfig.sampleRate {
+            samples = resample(audio, from: sampleRate, to: segConfig.sampleRate)
+        } else {
+            samples = audio
+        }
+
+        let pipeline = VADPipeline(
+            config: vadConfig,
+            sampleRate: segConfig.sampleRate,
+            framesPerChunk: 589
+        )
+
+        let positions = pipeline.windowPositions(numSamples: samples.count)
+
+        guard !positions.isEmpty else { return [] }
+
+        let windowSamples = Int(vadConfig.windowDuration * Float(segConfig.sampleRate))
+
+        // Run segmentation on each window
+        var windowProbs = [[Float]]()
+
+        for (start, end) in positions {
+            // Extract window, zero-pad if needed
+            var window = Array(samples[start ..< end])
+            if window.count < windowSamples {
+                window.append(contentsOf: [Float](repeating: 0, count: windowSamples - window.count))
+            }
+
+            // Run model: [1, 1, samples] → [1, frames, 7]
+            let input = MLXArray(window).reshaped(1, 1, windowSamples)
+            let posteriors = model(input)
+
+            // Extract speech probability: [1, frames] → [frames]
+            let speechProb = SegmentationModel.speechProbability(from: posteriors)
+            eval(speechProb)
+
+            let probArray = speechProb[0].asArray(Float.self)
+            windowProbs.append(probArray)
+        }
+
+        // Aggregate overlapping windows
+        let aggregated = pipeline.aggregateFrames(
+            windowProbs: windowProbs,
+            positions: positions,
+            numSamples: samples.count
+        )
+
+        // Binarize with hysteresis
+        return pipeline.binarize(probs: aggregated)
+    }
+
+    /// Simple linear resampling.
+    private func resample(_ audio: [Float], from sourceSR: Int, to targetSR: Int) -> [Float] {
+        guard sourceSR != targetSR else { return audio }
+        let ratio = Double(targetSR) / Double(sourceSR)
+        let outputLen = Int(Double(audio.count) * ratio)
+        var output = [Float](repeating: 0, count: outputLen)
+
+        for i in 0 ..< outputLen {
+            let srcPos = Double(i) / ratio
+            let srcIdx = Int(srcPos)
+            let frac = Float(srcPos - Double(srcIdx))
+
+            if srcIdx + 1 < audio.count {
+                output[i] = audio[srcIdx] * (1 - frac) + audio[srcIdx + 1] * frac
+            } else if srcIdx < audio.count {
+                output[i] = audio[srcIdx]
+            }
+        }
+
+        return output
+    }
+}

--- a/Sources/SpeechVAD/StreamingVADProcessor.swift
+++ b/Sources/SpeechVAD/StreamingVADProcessor.swift
@@ -1,0 +1,208 @@
+import Foundation
+import AudioCommon
+
+/// Events emitted by the streaming VAD processor.
+public enum VADEvent: Sendable {
+    /// Speech has been detected and confirmed (duration ≥ minSpeechDuration).
+    case speechStarted(time: Float)
+    /// Speech has ended (silence ≥ minSilenceDuration).
+    case speechEnded(segment: SpeechSegment)
+}
+
+/// Event-driven streaming VAD processor.
+///
+/// Wraps a `SileroVADModel` to provide event-based speech detection.
+/// Accepts audio samples of any length, buffers them into 512-sample chunks,
+/// runs the model, and applies hysteresis with duration filtering via a
+/// four-state machine.
+///
+/// ```swift
+/// let model = try await SileroVADModel.fromPretrained()
+/// let processor = StreamingVADProcessor(model: model)
+///
+/// // Feed audio samples (any length)
+/// let events = processor.process(samples: audioBuffer)
+/// for event in events {
+///     switch event {
+///     case .speechStarted(let time):
+///         print("Speech started at \(time)s")
+///     case .speechEnded(let segment):
+///         print("Speech: \(segment.startTime)s - \(segment.endTime)s")
+///     }
+/// }
+///
+/// // At end of stream, flush any pending segment
+/// let finalEvents = processor.flush()
+/// ```
+public final class StreamingVADProcessor {
+
+    private let model: SileroVADModel
+    private let config: VADConfig
+    private let chunkDuration: Float  // seconds per chunk (0.032)
+
+    /// Buffer for accumulating samples until we have a full chunk
+    private var buffer: [Float] = []
+    /// Number of chunks processed so far
+    private var chunkCount: Int = 0
+
+    /// State machine for hysteresis + duration filtering
+    private enum State {
+        /// No speech detected
+        case silence
+        /// Onset threshold crossed, waiting for minSpeechDuration
+        case pendingSpeech(startTime: Float)
+        /// Speech confirmed and speechStarted emitted
+        case speech(startTime: Float)
+        /// Offset threshold crossed, waiting for minSilenceDuration
+        case pendingSilence(speechStart: Float, silenceStart: Float)
+    }
+
+    private var state: State = .silence
+
+    /// Create a streaming VAD processor.
+    ///
+    /// - Parameters:
+    ///   - model: Silero VAD model instance
+    ///   - config: VAD configuration (thresholds, durations)
+    public init(model: SileroVADModel, config: VADConfig = .sileroDefault) {
+        self.model = model
+        self.config = config
+        self.chunkDuration = Float(SileroVADModel.chunkSize) / Float(SileroVADModel.sampleRate)
+    }
+
+    /// Feed audio samples and get VAD events back.
+    ///
+    /// Samples are buffered internally. Events are emitted as soon as the
+    /// state machine confirms speech start/end with the configured thresholds
+    /// and duration constraints.
+    ///
+    /// - Parameter samples: PCM Float32 samples at 16kHz (any length)
+    /// - Returns: zero or more VAD events
+    public func process(samples: [Float]) -> [VADEvent] {
+        buffer.append(contentsOf: samples)
+        var events = [VADEvent]()
+
+        while buffer.count >= SileroVADModel.chunkSize {
+            let chunk = Array(buffer.prefix(SileroVADModel.chunkSize))
+            buffer.removeFirst(SileroVADModel.chunkSize)
+
+            let prob = model.processChunk(chunk)
+            let time = Float(chunkCount) * chunkDuration
+            chunkCount += 1
+
+            events.append(contentsOf: processProb(prob, time: time))
+        }
+
+        return events
+    }
+
+    /// Flush any pending speech segment at end of stream.
+    ///
+    /// Call this when the audio stream ends to close any open speech segment.
+    ///
+    /// - Returns: zero or more final VAD events
+    public func flush() -> [VADEvent] {
+        // Process any remaining buffered samples (zero-padded)
+        var events = [VADEvent]()
+        if !buffer.isEmpty {
+            var lastChunk = buffer
+            lastChunk.append(contentsOf: [Float](repeating: 0, count: SileroVADModel.chunkSize - lastChunk.count))
+            buffer.removeAll()
+
+            let prob = model.processChunk(lastChunk)
+            let time = Float(chunkCount) * chunkDuration
+            chunkCount += 1
+            events.append(contentsOf: processProb(prob, time: time))
+        }
+
+        let endTime = Float(chunkCount) * chunkDuration
+
+        // Close any open state
+        switch state {
+        case .silence:
+            break
+        case .pendingSpeech(let startTime):
+            // Check if pending speech meets minimum duration
+            if endTime - startTime >= config.minSpeechDuration {
+                events.append(.speechStarted(time: startTime))
+                events.append(.speechEnded(segment: SpeechSegment(
+                    startTime: startTime, endTime: endTime)))
+            }
+        case .speech(let startTime):
+            events.append(.speechEnded(segment: SpeechSegment(
+                startTime: startTime, endTime: endTime)))
+        case .pendingSilence(let speechStart, let silenceStart):
+            // End at the silence start point
+            events.append(.speechEnded(segment: SpeechSegment(
+                startTime: speechStart, endTime: silenceStart)))
+        }
+
+        state = .silence
+        return events
+    }
+
+    /// Reset all state (model + processor).
+    ///
+    /// Call between processing different audio streams.
+    public func reset() {
+        buffer.removeAll()
+        chunkCount = 0
+        state = .silence
+        model.resetState()
+    }
+
+    /// Current time position in seconds.
+    public var currentTime: Float {
+        Float(chunkCount) * chunkDuration
+    }
+
+    // MARK: - State Machine
+
+    private func processProb(_ prob: Float, time: Float) -> [VADEvent] {
+        var events = [VADEvent]()
+        let nextTime = time + chunkDuration
+
+        switch state {
+        case .silence:
+            if prob >= config.onset {
+                state = .pendingSpeech(startTime: time)
+            }
+
+        case .pendingSpeech(let startTime):
+            if prob < config.offset {
+                // False alarm — speech too brief, return to silence
+                state = .silence
+            } else if nextTime - startTime >= config.minSpeechDuration {
+                // Speech confirmed
+                events.append(.speechStarted(time: startTime))
+                state = .speech(startTime: startTime)
+            }
+            // else: still pending, keep waiting
+
+        case .speech(let startTime):
+            if prob < config.offset {
+                // Speech may be ending
+                state = .pendingSilence(speechStart: startTime, silenceStart: time)
+            }
+
+        case .pendingSilence(let speechStart, let silenceStart):
+            if prob >= config.onset {
+                // Speech resumed — cancel silence
+                state = .speech(startTime: speechStart)
+            } else if nextTime - silenceStart >= config.minSilenceDuration {
+                // Silence confirmed — emit speechEnded
+                events.append(.speechEnded(segment: SpeechSegment(
+                    startTime: speechStart, endTime: silenceStart)))
+                // Check if new speech is starting
+                if prob >= config.onset {
+                    state = .pendingSpeech(startTime: time)
+                } else {
+                    state = .silence
+                }
+            }
+            // else: still waiting for silence confirmation
+        }
+
+        return events
+    }
+}

--- a/Sources/SpeechVAD/VADPipeline.swift
+++ b/Sources/SpeechVAD/VADPipeline.swift
@@ -1,0 +1,181 @@
+import Foundation
+import MLX
+import AudioCommon
+
+/// VAD pipeline: sliding window segmentation → aggregation → binarization.
+///
+/// Processes audio in overlapping 10-second windows, runs the segmentation model
+/// on each window, aggregates overlapping frame predictions, then applies
+/// hysteresis thresholding and duration filtering to produce speech segments.
+public struct VADPipeline {
+
+    /// Configuration for the pipeline
+    public let config: VADConfig
+
+    /// Sample rate expected by the segmentation model
+    public let sampleRate: Int
+
+    /// Number of output frames per 10s chunk (from the segmentation model)
+    public let framesPerChunk: Int
+
+    public init(config: VADConfig = .default, sampleRate: Int = 16000, framesPerChunk: Int = 589) {
+        self.config = config
+        self.sampleRate = sampleRate
+        self.framesPerChunk = framesPerChunk
+    }
+
+    /// Duration of one frame in seconds.
+    public var frameDuration: Float {
+        config.windowDuration / Float(framesPerChunk)
+    }
+
+    // MARK: - Sliding Window
+
+    /// Generate sliding window positions for the given audio length.
+    /// - Parameter numSamples: total audio samples
+    /// - Returns: array of (start, end) sample indices
+    func windowPositions(numSamples: Int) -> [(start: Int, end: Int)] {
+        let windowSamples = Int(config.windowDuration * Float(sampleRate))
+        let stepSamples = Int(config.windowDuration * config.stepRatio * Float(sampleRate))
+
+        guard numSamples > 0 else { return [] }
+
+        // If audio is shorter than one window, just use one window (zero-padded)
+        if numSamples <= windowSamples {
+            return [(0, numSamples)]
+        }
+
+        var positions = [(start: Int, end: Int)]()
+        var start = 0
+        while start + windowSamples <= numSamples {
+            positions.append((start, start + windowSamples))
+            start += stepSamples
+        }
+        // Handle the last partial window
+        if positions.isEmpty || positions.last!.end < numSamples {
+            positions.append((numSamples - windowSamples, numSamples))
+        }
+
+        return positions
+    }
+
+    // MARK: - Frame Aggregation
+
+    /// Aggregate overlapping frame-level speech probabilities from multiple windows.
+    ///
+    /// Each window produces `framesPerChunk` frames. Overlapping regions are
+    /// averaged across windows.
+    ///
+    /// - Parameters:
+    ///   - windowProbs: array of per-window speech probability arrays (each `framesPerChunk` long)
+    ///   - positions: corresponding window positions (sample indices)
+    ///   - numSamples: total audio length in samples
+    /// - Returns: aggregated speech probability per frame for the entire audio
+    func aggregateFrames(
+        windowProbs: [[Float]],
+        positions: [(start: Int, end: Int)],
+        numSamples: Int
+    ) -> [Float] {
+        let totalDuration = Float(numSamples) / Float(sampleRate)
+        let numFrames = Int(ceil(totalDuration / frameDuration))
+
+        guard numFrames > 0 else { return [] }
+
+        var sumProbs = [Float](repeating: 0, count: numFrames)
+        var counts = [Float](repeating: 0, count: numFrames)
+
+        for (windowIdx, (start, _)) in positions.enumerated() {
+            let probs = windowProbs[windowIdx]
+            let windowStartTime = Float(start) / Float(sampleRate)
+
+            for (frameIdx, prob) in probs.enumerated() {
+                let frameTime = windowStartTime + Float(frameIdx) * frameDuration
+                let globalFrame = Int(frameTime / frameDuration)
+
+                if globalFrame >= 0 && globalFrame < numFrames {
+                    sumProbs[globalFrame] += prob
+                    counts[globalFrame] += 1
+                }
+            }
+        }
+
+        // Average where we have overlapping windows
+        return zip(sumProbs, counts).map { sum, count in
+            count > 0 ? sum / count : 0
+        }
+    }
+
+    // MARK: - Binarization (Hysteresis Thresholding)
+
+    /// Apply hysteresis thresholding to speech probabilities.
+    ///
+    /// Speech starts when probability exceeds `onset` and ends when it drops
+    /// below `offset`. This two-threshold approach prevents rapid toggling.
+    ///
+    /// - Parameter probs: per-frame speech probabilities
+    /// - Returns: array of `SpeechSegment` with start/end times
+    public func binarize(probs: [Float]) -> [SpeechSegment] {
+        var segments = [SpeechSegment]()
+        var inSpeech = false
+        var speechStart: Float = 0
+
+        for (i, prob) in probs.enumerated() {
+            let time = Float(i) * frameDuration
+
+            if !inSpeech && prob >= config.onset {
+                inSpeech = true
+                speechStart = time
+            } else if inSpeech && prob < config.offset {
+                inSpeech = false
+                let segment = SpeechSegment(startTime: speechStart, endTime: time)
+                segments.append(segment)
+            }
+        }
+
+        // Close any open segment
+        if inSpeech {
+            let endTime = Float(probs.count) * frameDuration
+            segments.append(SpeechSegment(startTime: speechStart, endTime: endTime))
+        }
+
+        return filterDurations(segments)
+    }
+
+    // MARK: - Duration Filtering
+
+    /// Filter segments by minimum speech and silence durations.
+    ///
+    /// 1. Remove speech segments shorter than `minSpeechDuration`
+    /// 2. Merge segments separated by silence shorter than `minSilenceDuration`
+    func filterDurations(_ segments: [SpeechSegment]) -> [SpeechSegment] {
+        guard !segments.isEmpty else { return [] }
+
+        // Filter short speech segments
+        let filtered = segments.filter { $0.duration >= config.minSpeechDuration }
+
+        guard !filtered.isEmpty else { return [] }
+
+        // Merge segments separated by short silence
+        var merged = [SpeechSegment]()
+        var current = filtered[0]
+
+        for i in 1 ..< filtered.count {
+            let next = filtered[i]
+            let gap = next.startTime - current.endTime
+
+            if gap < config.minSilenceDuration {
+                // Merge: extend current segment
+                current = SpeechSegment(
+                    startTime: current.startTime,
+                    endTime: next.endTime
+                )
+            } else {
+                merged.append(current)
+                current = next
+            }
+        }
+        merged.append(current)
+
+        return merged
+    }
+}

--- a/Sources/SpeechVAD/WeSpeaker.swift
+++ b/Sources/SpeechVAD/WeSpeaker.swift
@@ -1,0 +1,133 @@
+import Foundation
+import MLX
+import AudioCommon
+
+/// Speaker embedding model using WeSpeaker ResNet34-LM.
+///
+/// Produces 256-dimensional L2-normalized speaker embeddings from audio.
+/// Uses 80-dim log-mel features at 16kHz.
+///
+/// ```swift
+/// let model = try await WeSpeakerModel.fromPretrained()
+/// let embedding = model.embed(audio: samples, sampleRate: 16000)
+/// // embedding: [Float] of length 256
+/// ```
+public final class WeSpeakerModel {
+
+    /// The ResNet34 network
+    let network: WeSpeakerNetwork
+
+    /// Mel feature extractor
+    let melExtractor: MelFeatureExtractor
+
+    /// Default HuggingFace model ID
+    public static let defaultModelId = "aufklarer/WeSpeaker-ResNet34-LM-MLX"
+
+    /// Embedding dimension
+    public let embeddingDimension: Int = 256
+
+    /// Expected input sample rate
+    public let inputSampleRate: Int = 16000
+
+    init(network: WeSpeakerNetwork) {
+        self.network = network
+        self.melExtractor = MelFeatureExtractor()
+    }
+
+    /// Load a pre-trained speaker embedding model from HuggingFace.
+    ///
+    /// Downloads model weights on first use, then caches locally.
+    ///
+    /// - Parameters:
+    ///   - modelId: HuggingFace model ID
+    ///   - progressHandler: callback for download progress
+    /// - Returns: ready-to-use speaker embedding model
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> WeSpeakerModel {
+        progressHandler?(0.0, "Downloading speaker embedding model...")
+
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: cacheDir,
+            progressHandler: { progress in
+                progressHandler?(progress * 0.8, "Downloading weights...")
+            }
+        )
+
+        progressHandler?(0.8, "Loading model...")
+
+        let network = WeSpeakerNetwork()
+        try WeSpeakerWeightLoader.loadWeights(model: network, from: cacheDir)
+
+        progressHandler?(1.0, "Ready")
+
+        return WeSpeakerModel(network: network)
+    }
+
+    /// Extract a 256-dimensional speaker embedding from audio.
+    ///
+    /// - Parameters:
+    ///   - audio: PCM Float32 audio samples
+    ///   - sampleRate: sample rate of the input audio
+    /// - Returns: 256-dim L2-normalized speaker embedding
+    public func embed(audio: [Float], sampleRate: Int) -> [Float] {
+        let samples: [Float]
+        if sampleRate != inputSampleRate {
+            samples = resample(audio, from: sampleRate, to: inputSampleRate)
+        } else {
+            samples = audio
+        }
+
+        // Extract mel features: [T, 80]
+        let mel = melExtractor.extract(samples)
+
+        // Add batch and channel dims: [1, T, 80, 1]
+        let input = mel.reshaped(1, mel.dim(0), mel.dim(1), 1)
+
+        // Forward pass: [1, 256]
+        let emb = network(input)
+        eval(emb)
+
+        return emb[0].asArray(Float.self)
+    }
+
+    /// Compute cosine similarity between two embeddings.
+    public static func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
+        guard a.count == b.count, !a.isEmpty else { return 0 }
+        var dot: Float = 0
+        var normA: Float = 0
+        var normB: Float = 0
+        for i in 0..<a.count {
+            dot += a[i] * b[i]
+            normA += a[i] * a[i]
+            normB += b[i] * b[i]
+        }
+        let denom = sqrt(normA) * sqrt(normB)
+        return denom > 0 ? dot / denom : 0
+    }
+
+    private func resample(_ audio: [Float], from sourceSR: Int, to targetSR: Int) -> [Float] {
+        guard sourceSR != targetSR else { return audio }
+        let ratio = Double(targetSR) / Double(sourceSR)
+        let outputLen = Int(Double(audio.count) * ratio)
+        var output = [Float](repeating: 0, count: outputLen)
+
+        for i in 0..<outputLen {
+            let srcPos = Double(i) / ratio
+            let srcIdx = Int(srcPos)
+            let frac = Float(srcPos - Double(srcIdx))
+
+            if srcIdx + 1 < audio.count {
+                output[i] = audio[srcIdx] * (1 - frac) + audio[srcIdx + 1] * frac
+            } else if srcIdx < audio.count {
+                output[i] = audio[srcIdx]
+            }
+        }
+
+        return output
+    }
+}

--- a/Sources/SpeechVAD/WeSpeakerModel.swift
+++ b/Sources/SpeechVAD/WeSpeakerModel.swift
@@ -1,0 +1,159 @@
+import MLX
+import MLXNN
+
+/// ResNet BasicBlock with BN fused into Conv2d.
+///
+/// Each block has two 3×3 Conv2d layers with bias (fused BatchNorm).
+/// Shortcut Conv2d(1×1) is added when stride≠1 or channels change.
+class BasicBlock: Module {
+    let conv1: Conv2d
+    let conv2: Conv2d
+    let shortcut: Conv2d?
+    let stride: Int
+
+    init(inChannels: Int, outChannels: Int, stride: Int = 1) {
+        self.stride = stride
+
+        self.conv1 = Conv2d(
+            inputChannels: inChannels, outputChannels: outChannels,
+            kernelSize: 3, stride: IntOrPair(arrayLiteral: stride, stride),
+            padding: 1, bias: true
+        )
+        self.conv2 = Conv2d(
+            inputChannels: outChannels, outputChannels: outChannels,
+            kernelSize: 3, stride: 1, padding: 1, bias: true
+        )
+
+        if stride != 1 || inChannels != outChannels {
+            self.shortcut = Conv2d(
+                inputChannels: inChannels, outputChannels: outChannels,
+                kernelSize: 1, stride: IntOrPair(arrayLiteral: stride, stride),
+                padding: 0, bias: true
+            )
+        } else {
+            self.shortcut = nil
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var out = relu(conv1(x))
+        out = conv2(out)
+
+        let residual: MLXArray
+        if let shortcut {
+            residual = shortcut(x)
+        } else {
+            residual = x
+        }
+
+        return relu(out + residual)
+    }
+}
+
+/// WeSpeaker ResNet34 speaker embedding network (BN-fused).
+///
+/// Architecture:
+/// ```
+/// Input: [B, T, 80, 1] mel spectrogram
+/// → Conv2d(1→32, k=3, p=1) + ReLU
+/// → Layer1: 3× BasicBlock(32→32)
+/// → Layer2: 4× BasicBlock(32→64, s=2)
+/// → Layer3: 6× BasicBlock(64→128, s=2)
+/// → Layer4: 3× BasicBlock(128→256, s=2)
+/// → Statistics Pooling: mean + std → [B, 5120]
+/// → Linear(5120→256) → L2 normalize
+/// Output: [B, 256] speaker embedding
+/// ```
+class WeSpeakerNetwork: Module {
+    let conv1: Conv2d
+    let layer1: [BasicBlock]
+    let layer2: [BasicBlock]
+    let layer3: [BasicBlock]
+    let layer4: [BasicBlock]
+    let embedding: Linear
+
+    override init() {
+        self.conv1 = Conv2d(
+            inputChannels: 1, outputChannels: 32,
+            kernelSize: 3, stride: 1, padding: 1, bias: true
+        )
+
+        // Layer1: 3 blocks, 32→32
+        var blocks1 = [BasicBlock]()
+        for _ in 0..<3 {
+            blocks1.append(BasicBlock(inChannels: 32, outChannels: 32))
+        }
+        self.layer1 = blocks1
+
+        // Layer2: 4 blocks, 32→64, first stride=2
+        var blocks2 = [BasicBlock]()
+        for i in 0..<4 {
+            blocks2.append(BasicBlock(
+                inChannels: i == 0 ? 32 : 64,
+                outChannels: 64,
+                stride: i == 0 ? 2 : 1
+            ))
+        }
+        self.layer2 = blocks2
+
+        // Layer3: 6 blocks, 64→128, first stride=2
+        var blocks3 = [BasicBlock]()
+        for i in 0..<6 {
+            blocks3.append(BasicBlock(
+                inChannels: i == 0 ? 64 : 128,
+                outChannels: 128,
+                stride: i == 0 ? 2 : 1
+            ))
+        }
+        self.layer3 = blocks3
+
+        // Layer4: 3 blocks, 128→256, first stride=2
+        var blocks4 = [BasicBlock]()
+        for i in 0..<3 {
+            blocks4.append(BasicBlock(
+                inChannels: i == 0 ? 128 : 256,
+                outChannels: 256,
+                stride: i == 0 ? 2 : 1
+            ))
+        }
+        self.layer4 = blocks4
+
+        // Pooling output: T/8 * 10 * 256 → mean+std → 2 * 10 * 256 = 5120
+        self.embedding = Linear(5120, 256)
+    }
+
+    /// Forward pass.
+    /// - Parameter mel: `[B, T, 80, 1]` mel spectrogram (channels-last)
+    /// - Returns: `[B, 256]` L2-normalized speaker embedding
+    func callAsFunction(_ mel: MLXArray) -> MLXArray {
+        // mel: [B, T, 80, 1]
+        var x = relu(conv1(mel))
+
+        // ResNet layers
+        for block in layer1 { x = block(x) }
+        for block in layer2 { x = block(x) }
+        for block in layer3 { x = block(x) }
+        for block in layer4 { x = block(x) }
+        // x: [B, T/8, 10, 256]
+
+        // Reshape for statistics pooling: [B, T/8, 10 * 256] = [B, T/8, 2560]
+        let B = x.dim(0)
+        let T = x.dim(1)
+        x = x.reshaped(B, T, -1)
+
+        // Statistics pooling: mean + std over time → [B, 5120]
+        let mean = x.mean(axis: 1)  // [B, 2560]
+        let variance = x.variance(axis: 1)  // [B, 2560]
+        let std = sqrt(variance + 1e-10)
+        let pooled = concatenated([mean, std], axis: -1)  // [B, 5120]
+
+        // Embedding projection
+        var emb = embedding(pooled)  // [B, 256]
+
+        // L2 normalize
+        let norm = sqrt((emb * emb).sum(axis: -1, keepDims: true) + 1e-10)
+        emb = emb / norm
+
+        return emb
+    }
+}

--- a/Sources/SpeechVAD/WeSpeakerWeightLoading.swift
+++ b/Sources/SpeechVAD/WeSpeakerWeightLoading.swift
@@ -1,0 +1,32 @@
+import Foundation
+import MLX
+import MLXNN
+import AudioCommon
+
+/// Weight loading for the WeSpeaker ResNet34-LM speaker embedding model.
+///
+/// Loads from safetensors files produced by `scripts/convert_wespeaker.py`.
+/// The conversion script fuses BatchNorm into Conv2d and transposes weights,
+/// so loading is a straightforward parameter tree update.
+enum WeSpeakerWeightLoader {
+
+    /// Load weights from a directory containing model.safetensors.
+    static func loadWeights(
+        model: WeSpeakerNetwork,
+        from directory: URL
+    ) throws {
+        let weightsURL = directory.appendingPathComponent("model.safetensors")
+
+        guard FileManager.default.fileExists(atPath: weightsURL.path) else {
+            throw WeightLoadingError.noWeightsFound(directory)
+        }
+
+        let weights = try MLX.loadArrays(url: weightsURL)
+
+        let parameters = ModuleParameters.unflattened(weights)
+
+        try model.update(parameters: parameters, verify: .noUnusedKeys)
+
+        MLX.eval(model.parameters())
+    }
+}

--- a/Sources/SpeechVAD/WeightLoading.swift
+++ b/Sources/SpeechVAD/WeightLoading.swift
@@ -1,0 +1,36 @@
+import Foundation
+import MLX
+import MLXNN
+import AudioCommon
+
+/// Weight loading for the PyanNet segmentation model.
+///
+/// Loads from safetensors files produced by `scripts/convert_pyannote.py`.
+/// The conversion script pre-computes sinc filters and transposes Conv1d weights,
+/// so loading is a straightforward parameter tree update.
+enum SegmentationWeightLoader {
+
+    /// Load weights from a directory containing model.safetensors.
+    static func loadWeights(
+        model: SegmentationModel,
+        from directory: URL
+    ) throws {
+        let weightsURL = directory.appendingPathComponent("model.safetensors")
+
+        guard FileManager.default.fileExists(atPath: weightsURL.path) else {
+            throw WeightLoadingError.noWeightsFound(directory)
+        }
+
+        let weights = try MLX.loadArrays(url: weightsURL)
+
+        // The conversion script produces keys matching our module structure directly.
+        // Use ModuleParameters.unflattened to build the nested parameter tree.
+        let parameters = ModuleParameters.unflattened(weights)
+
+        // Apply to model
+        try model.update(parameters: parameters, verify: .noUnusedKeys)
+
+        // Evaluate all parameters to ensure they're materialized
+        MLX.eval(model.parameters())
+    }
+}

--- a/Tests/SpeechVADTests/SileroVADTests.swift
+++ b/Tests/SpeechVADTests/SileroVADTests.swift
@@ -1,0 +1,377 @@
+import XCTest
+import MLX
+@testable import SpeechVAD
+import AudioCommon
+
+final class SileroVADTests: XCTestCase {
+
+    // MARK: - Configuration Tests
+
+    func testSileroDefaultVADConfig() {
+        let config = VADConfig.sileroDefault
+        XCTAssertEqual(config.onset, 0.5, accuracy: 0.001)
+        XCTAssertEqual(config.offset, 0.35, accuracy: 0.001)
+        XCTAssertEqual(config.minSpeechDuration, 0.25, accuracy: 0.001)
+        XCTAssertEqual(config.minSilenceDuration, 0.1, accuracy: 0.001)
+    }
+
+    // MARK: - Model Shape Tests (random weights, no download)
+
+    func testSileroNetworkForwardShape() {
+        let network = SileroVADNetwork()
+
+        // 576 samples = 64 context + 512 new
+        let input = MLXRandom.normal([1, 576])
+        let (prob, h, c) = network.forward(input, h: nil, c: nil)
+        eval(prob, h, c)
+
+        // Probability should be a scalar per batch element
+        XCTAssertEqual(prob.shape, [1])
+
+        // LSTM state: [1, batch, 128]
+        XCTAssertEqual(h.shape, [1, 1, 128])
+        XCTAssertEqual(c.shape, [1, 1, 128])
+
+        // Probability should be in [0, 1] (sigmoid output)
+        let p = prob.item(Float.self)
+        XCTAssertGreaterThanOrEqual(p, 0.0)
+        XCTAssertLessThanOrEqual(p, 1.0)
+    }
+
+    func testSileroNetworkStatefulLSTM() {
+        let network = SileroVADNetwork()
+
+        let input1 = MLXRandom.normal([1, 576])
+        let input2 = MLXRandom.normal([1, 576])
+
+        // First forward: no state
+        let (prob1, h1, c1) = network.forward(input1, h: nil, c: nil)
+        eval(prob1, h1, c1)
+
+        // Second forward: with state from first (different input)
+        let (prob2, h2, c2) = network.forward(input2, h: h1, c: c1)
+        eval(prob2, h2, c2)
+
+        // State should be different between calls (LSTM updates)
+        let h1val = h1[0, 0, 0].item(Float.self)
+        let h2val = h2[0, 0, 0].item(Float.self)
+        // With random weights and different inputs, states will differ
+        XCTAssertNotEqual(h1val, h2val, accuracy: 1e-6,
+                          "LSTM state should change between calls")
+    }
+
+    func testReflectionPad1d() {
+        // Test reflection padding: [1, 2, 3, 4, 5] with padding=2
+        // Expected: [3, 2, 1, 2, 3, 4, 5, 4, 3]
+        let x = MLXArray([Float](arrayLiteral: 1, 2, 3, 4, 5)).reshaped(1, 5, 1)
+        let padded = reflectionPad1d(x, padding: 2)
+        eval(padded)
+
+        XCTAssertEqual(padded.shape, [1, 9, 1])
+
+        let values = padded.squeezed().asArray(Float.self)
+        XCTAssertEqual(values, [3, 2, 1, 2, 3, 4, 5, 4, 3])
+    }
+
+    // MARK: - SileroVADModel Tests (random weights)
+
+    func testProcessChunk() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+
+        let samples = [Float](repeating: 0, count: SileroVADModel.chunkSize)
+        let prob = model.processChunk(samples)
+
+        XCTAssertGreaterThanOrEqual(prob, 0.0)
+        XCTAssertLessThanOrEqual(prob, 1.0)
+    }
+
+    func testProcessChunkPrecondition() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+
+        // Wrong chunk size should trigger precondition
+        // (Can't test precondition failure in XCTest without crashing)
+        // Just verify correct size works
+        let samples = [Float](repeating: 0, count: 512)
+        let prob = model.processChunk(samples)
+        XCTAssertGreaterThanOrEqual(prob, 0.0)
+    }
+
+    func testResetState() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+
+        // Process a chunk to populate state
+        let samples = [Float](repeating: 0.1, count: 512)
+        _ = model.processChunk(samples)
+
+        // Reset
+        model.resetState()
+
+        // Process same chunk again — should produce same result as fresh model
+        let prob1 = model.processChunk(samples)
+
+        let model2 = SileroVADModel(network: network)
+        let prob2 = model2.processChunk(samples)
+
+        // Both should be equal since state was reset
+        XCTAssertEqual(prob1, prob2, accuracy: 1e-5)
+    }
+
+    func testDetectSpeechWithRandomWeights() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+
+        // 5 seconds of silence at 16kHz
+        let audio = [Float](repeating: 0, count: 80000)
+        let segments = model.detectSpeech(audio: audio, sampleRate: 16000)
+
+        // With random weights, verify no crash and valid segments
+        for seg in segments {
+            XCTAssertGreaterThanOrEqual(seg.startTime, 0)
+            XCTAssertGreaterThan(seg.endTime, seg.startTime)
+        }
+    }
+
+    // MARK: - StreamingVADProcessor Tests
+
+    func testStreamingProcessorNoSpeech() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+
+        // Use very high onset to ensure no false positives
+        let config = VADConfig(
+            onset: 0.99, offset: 0.98,
+            minSpeechDuration: 0.25, minSilenceDuration: 0.1,
+            windowDuration: 0.032, stepRatio: 1.0
+        )
+        let processor = StreamingVADProcessor(model: model, config: config)
+
+        let silence = [Float](repeating: 0, count: 16000)  // 1 second
+        let events = processor.process(samples: silence)
+        let flushEvents = processor.flush()
+
+        // With onset=0.99 and silence input, should get no speech events
+        let speechStarts = (events + flushEvents).filter {
+            if case .speechStarted = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(speechStarts.isEmpty, "Should not detect speech in silence with high threshold")
+    }
+
+    func testStreamingProcessorBuffering() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+        let config = VADConfig.sileroDefault
+        let processor = StreamingVADProcessor(model: model, config: config)
+
+        // Feed less than one chunk
+        let shortSamples = [Float](repeating: 0, count: 100)
+        let events = processor.process(samples: shortSamples)
+
+        // Should buffer, no events yet (not enough for a chunk)
+        XCTAssertTrue(events.isEmpty, "Should buffer samples until chunk is complete")
+    }
+
+    func testStreamingProcessorReset() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+        let processor = StreamingVADProcessor(model: model, config: .sileroDefault)
+
+        // Process some audio
+        let samples = [Float](repeating: 0, count: 1024)
+        _ = processor.process(samples: samples)
+
+        // Reset
+        processor.reset()
+
+        // Current time should be 0
+        XCTAssertEqual(processor.currentTime, 0.0)
+    }
+
+    func testStreamingProcessorFlushEmptyState() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+        let processor = StreamingVADProcessor(model: model, config: .sileroDefault)
+
+        // Flush with no data
+        let events = processor.flush()
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testStreamingProcessorChunkTiming() {
+        let network = SileroVADNetwork()
+        let model = SileroVADModel(network: network)
+        let processor = StreamingVADProcessor(model: model, config: .sileroDefault)
+
+        // Process exactly 2 chunks (1024 samples = 64ms)
+        let samples = [Float](repeating: 0, count: 1024)
+        _ = processor.process(samples: samples)
+
+        // After 2 chunks, current time should be ~0.064s
+        XCTAssertEqual(processor.currentTime, 0.064, accuracy: 0.001)
+    }
+
+    // MARK: - VADEvent Tests
+
+    func testVADEventSendable() {
+        // Verify VADEvent conforms to Sendable (compile-time check)
+        let event: VADEvent = .speechStarted(time: 1.0)
+        let _: any Sendable = event
+        XCTAssertTrue(true)  // If this compiles, Sendable conformance works
+    }
+
+    // MARK: - E2E Integration Test (requires real weights)
+
+    func testE2EWithRealWeights() async throws {
+        let model = try await SileroVADModel.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+        XCTAssertGreaterThan(samples.count, 0)
+
+        // Batch mode
+        let segments = model.detectSpeech(audio: samples, sampleRate: sampleRate)
+
+        // Should detect speech in the test audio (speech is around 5-8.5s)
+        XCTAssertGreaterThanOrEqual(segments.count, 1,
+                                     "Should detect at least 1 speech segment")
+
+        if let seg = segments.first {
+            // Speech region is approximately 5.16s - 8.44s
+            XCTAssertGreaterThan(seg.startTime, 3.0,
+                                 "Speech should start after 3s (got \(seg.startTime))")
+            XCTAssertLessThan(seg.startTime, 7.0,
+                              "Speech should start before 7s (got \(seg.startTime))")
+            XCTAssertGreaterThan(seg.endTime, 7.0,
+                                 "Speech should end after 7s (got \(seg.endTime))")
+            XCTAssertLessThan(seg.endTime, 10.0,
+                              "Speech should end before 10s (got \(seg.endTime))")
+        }
+    }
+
+    func testE2EStreamingWithRealWeights() async throws {
+        let model = try await SileroVADModel.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Resample to 16kHz if needed
+        let audio: [Float]
+        if sampleRate != 16000 {
+            // Simple linear resample
+            let ratio = 16000.0 / Double(sampleRate)
+            let outLen = Int(Double(samples.count) * ratio)
+            audio = (0 ..< outLen).map { i in
+                let src = Double(i) / ratio
+                let idx = Int(src)
+                let frac = Float(src - Double(idx))
+                if idx + 1 < samples.count {
+                    return samples[idx] * (1 - frac) + samples[idx + 1] * frac
+                }
+                return idx < samples.count ? samples[idx] : 0
+            }
+        } else {
+            audio = samples
+        }
+
+        // Streaming mode
+        let processor = StreamingVADProcessor(model: model)
+        var allEvents = [VADEvent]()
+
+        // Feed in 512-sample chunks
+        var offset = 0
+        while offset + 512 <= audio.count {
+            let chunk = Array(audio[offset ..< offset + 512])
+            allEvents.append(contentsOf: processor.process(samples: chunk))
+            offset += 512
+        }
+        if offset < audio.count {
+            allEvents.append(contentsOf: processor.process(samples: Array(audio[offset...])))
+        }
+        allEvents.append(contentsOf: processor.flush())
+
+        // Should detect at least one speech segment
+        let segments = allEvents.compactMap { event -> SpeechSegment? in
+            if case .speechEnded(let seg) = event { return seg }
+            return nil
+        }
+        XCTAssertGreaterThanOrEqual(segments.count, 1,
+                                     "Streaming should detect at least 1 speech segment")
+
+        // Verify segment is in the right ballpark
+        if let seg = segments.first {
+            XCTAssertGreaterThan(seg.duration, 1.0,
+                                 "Speech segment should be at least 1s")
+        }
+    }
+
+    func testE2EPerChunkProbabilities() async throws {
+        let model = try await SileroVADModel.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Resample to 16kHz
+        let audio: [Float]
+        if sampleRate != 16000 {
+            let ratio = 16000.0 / Double(sampleRate)
+            let outLen = Int(Double(samples.count) * ratio)
+            audio = (0 ..< outLen).map { i in
+                let src = Double(i) / ratio
+                let idx = Int(src)
+                let frac = Float(src - Double(idx))
+                if idx + 1 < samples.count {
+                    return samples[idx] * (1 - frac) + samples[idx + 1] * frac
+                }
+                return idx < samples.count ? samples[idx] : 0
+            }
+        } else {
+            audio = samples
+        }
+
+        // Collect per-chunk probabilities
+        model.resetState()
+        var probs = [Float]()
+        var offset = 0
+        while offset + 512 <= audio.count {
+            let chunk = Array(audio[offset ..< offset + 512])
+            probs.append(model.processChunk(chunk))
+            offset += 512
+        }
+
+        // Verify probabilities are in valid range
+        for (i, p) in probs.enumerated() {
+            XCTAssertGreaterThanOrEqual(p, 0.0, "Prob at chunk \(i) should be >= 0")
+            XCTAssertLessThanOrEqual(p, 1.0, "Prob at chunk \(i) should be <= 1")
+        }
+
+        // The speech region (~5.16-8.44s) corresponds to chunks ~161-263 (at 32ms each)
+        // There should be high probabilities in that range
+        let speechStart = 5.0 / 0.032  // ~156
+        let speechEnd = 8.5 / 0.032    // ~265
+
+        if probs.count > Int(speechEnd) {
+            let speechProbs = probs[Int(speechStart) ..< min(Int(speechEnd), probs.count)]
+            let maxProb = speechProbs.max() ?? 0
+            XCTAssertGreaterThan(maxProb, 0.3,
+                                 "Should have high probability during speech region")
+        }
+
+        print("Per-chunk probabilities: \(probs.count) chunks")
+        print("Max prob: \(probs.max() ?? 0)")
+    }
+}

--- a/Tests/SpeechVADTests/SpeechVADTests.swift
+++ b/Tests/SpeechVADTests/SpeechVADTests.swift
@@ -1,0 +1,326 @@
+import XCTest
+import MLX
+@testable import SpeechVAD
+import AudioCommon
+
+final class SpeechVADTests: XCTestCase {
+
+    // MARK: - Configuration Tests
+
+    func testDefaultSegmentationConfig() {
+        let config = SegmentationConfig.default
+        XCTAssertEqual(config.sampleRate, 16000)
+        XCTAssertEqual(config.sincnetFilters, [80, 60, 60])
+        XCTAssertEqual(config.sincnetKernelSizes, [251, 5, 5])
+        XCTAssertEqual(config.sincnetStrides, [10, 1, 1])
+        XCTAssertEqual(config.sincnetPoolSizes, [3, 3, 3])
+        XCTAssertEqual(config.lstmHiddenSize, 128)
+        XCTAssertEqual(config.lstmNumLayers, 4)
+        XCTAssertEqual(config.linearHiddenSize, 128)
+        XCTAssertEqual(config.linearNumLayers, 2)
+        XCTAssertEqual(config.numClasses, 7)
+    }
+
+    func testDefaultVADConfig() {
+        let config = VADConfig.default
+        XCTAssertEqual(config.onset, 0.767, accuracy: 0.001)
+        XCTAssertEqual(config.offset, 0.377, accuracy: 0.001)
+        XCTAssertEqual(config.minSpeechDuration, 0.136, accuracy: 0.001)
+        XCTAssertEqual(config.minSilenceDuration, 0.067, accuracy: 0.001)
+        XCTAssertEqual(config.windowDuration, 10.0, accuracy: 0.001)
+        XCTAssertEqual(config.stepRatio, 0.1, accuracy: 0.001)
+    }
+
+    // MARK: - SpeechSegment Tests
+
+    func testSpeechSegmentDuration() {
+        let seg = SpeechSegment(startTime: 1.5, endTime: 3.7)
+        XCTAssertEqual(seg.duration, 2.2, accuracy: 0.001)
+    }
+
+    // MARK: - Pipeline Windowing Tests
+
+    func testWindowPositionsSingleWindow() {
+        let pipeline = VADPipeline(sampleRate: 16000)
+        // 5 seconds < 10 second window
+        let positions = pipeline.windowPositions(numSamples: 80000)
+        XCTAssertEqual(positions.count, 1)
+        XCTAssertEqual(positions[0].start, 0)
+        XCTAssertEqual(positions[0].end, 80000)
+    }
+
+    func testWindowPositionsMultipleWindows() {
+        let pipeline = VADPipeline(sampleRate: 16000)
+        // 30 seconds of audio
+        let numSamples = 480000
+        let positions = pipeline.windowPositions(numSamples: numSamples)
+
+        // Window = 160000 samples (10s), step = 16000 samples (1s)
+        // Should have multiple overlapping windows
+        XCTAssertGreaterThan(positions.count, 1)
+
+        // First window starts at 0
+        XCTAssertEqual(positions[0].start, 0)
+
+        // All windows should be within bounds
+        for pos in positions {
+            XCTAssertGreaterThanOrEqual(pos.start, 0)
+            XCTAssertLessThanOrEqual(pos.end, numSamples)
+        }
+
+        // Last window should cover the end
+        XCTAssertEqual(positions.last!.end, numSamples)
+    }
+
+    func testWindowPositionsEmpty() {
+        let pipeline = VADPipeline(sampleRate: 16000)
+        let positions = pipeline.windowPositions(numSamples: 0)
+        XCTAssertTrue(positions.isEmpty)
+    }
+
+    // MARK: - Binarization Tests
+
+    func testBinarizeAllSilence() {
+        let pipeline = VADPipeline()
+        let probs = [Float](repeating: 0.1, count: 293)
+        let segments = pipeline.binarize(probs: probs)
+        XCTAssertTrue(segments.isEmpty)
+    }
+
+    func testBinarizeAllSpeech() {
+        let pipeline = VADPipeline()
+        let probs = [Float](repeating: 0.9, count: 293)
+        let segments = pipeline.binarize(probs: probs)
+        // Should produce one long segment
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].startTime, 0.0, accuracy: 0.05)
+    }
+
+    func testBinarizeSpeechInMiddle() {
+        let pipeline = VADPipeline()
+        var probs = [Float](repeating: 0.1, count: 293)
+        // Speech from frame 50 to 200
+        for i in 50 ..< 200 {
+            probs[i] = 0.9
+        }
+        let segments = pipeline.binarize(probs: probs)
+        XCTAssertEqual(segments.count, 1)
+        // Verify the segment covers roughly the right region
+        XCTAssertGreaterThan(segments[0].startTime, 0.5)
+        XCTAssertLessThan(segments[0].endTime, 8.0)
+    }
+
+    func testBinarizeHysteresis() {
+        // Test that brief dips below onset but above offset don't split segments
+        let pipeline = VADPipeline()
+        var probs = [Float](repeating: 0.5, count: 293) // above offset, below onset
+        // Speech onset
+        for i in 20 ..< 50 {
+            probs[i] = 0.9
+        }
+        // Brief dip (still above offset)
+        for i in 50 ..< 55 {
+            probs[i] = 0.5  // above offset (0.377), below onset (0.767)
+        }
+        // Speech continues
+        for i in 55 ..< 100 {
+            probs[i] = 0.9
+        }
+        // End: drop below offset
+        for i in 100 ..< 120 {
+            probs[i] = 0.1
+        }
+
+        let segments = pipeline.binarize(probs: probs)
+        // Should be one continuous segment (the dip doesn't cross offset)
+        XCTAssertEqual(segments.count, 1)
+    }
+
+    func testMinDurationFiltering() {
+        let config = VADConfig(
+            onset: 0.5,
+            offset: 0.3,
+            minSpeechDuration: 1.0,  // 1 second minimum
+            minSilenceDuration: 0.5,
+            windowDuration: 10.0,
+            stepRatio: 0.1
+        )
+        let pipeline = VADPipeline(config: config)
+
+        // Very short speech burst (only 3 frames = ~0.1s)
+        var probs = [Float](repeating: 0.1, count: 293)
+        for i in 50 ..< 53 {
+            probs[i] = 0.9
+        }
+        let segments = pipeline.binarize(probs: probs)
+        // Should be filtered out (too short)
+        XCTAssertTrue(segments.isEmpty)
+    }
+
+    func testMinSilenceMerging() {
+        let config = VADConfig(
+            onset: 0.5,
+            offset: 0.3,
+            minSpeechDuration: 0.0,  // no minimum
+            minSilenceDuration: 2.0,  // 2 second minimum silence
+            windowDuration: 10.0,
+            stepRatio: 0.1
+        )
+        let pipeline = VADPipeline(config: config)
+
+        var probs = [Float](repeating: 0.1, count: 293)
+        // Two speech segments separated by a short gap
+        for i in 20 ..< 80 {
+            probs[i] = 0.9
+        }
+        for i in 80 ..< 85 {  // ~0.17s gap — shorter than 2s min silence
+            probs[i] = 0.1
+        }
+        for i in 85 ..< 150 {
+            probs[i] = 0.9
+        }
+        let segments = pipeline.binarize(probs: probs)
+        // Should be merged into one segment
+        XCTAssertEqual(segments.count, 1)
+    }
+
+    // MARK: - Model Shape Tests (random weights, no download)
+
+    func testSegmentationModelOutputShape() {
+        // 10s of audio at 16kHz = 160000 samples
+        let config = SegmentationConfig.default
+        let model = SegmentationModel(config: config)
+
+        let input = MLXRandom.normal([1, 1, 160000])
+        let output = model(input)
+        eval(output)
+
+        // Should produce [1, 589, 7] for 10s @ 16kHz with padding=0
+        XCTAssertEqual(output.shape[0], 1)     // batch
+        XCTAssertEqual(output.shape[2], 7)     // classes
+        // 160000 → SincConv(k=251,s=10): 15975 → Pool(3,3): 5325
+        // → Conv(k=5): 5321 → Pool(3,3): 1773 → Conv(k=5): 1769 → Pool(3,3): 589
+        XCTAssertEqual(output.shape[1], 589)
+
+        // Softmax: each frame's class probs should sum to ~1
+        let frameSum = output[0, 0].sum().item(Float.self)
+        XCTAssertEqual(frameSum, 1.0, accuracy: 0.01)
+    }
+
+    func testSpeechProbabilityExtraction() {
+        // Create fake posteriors: [1, 10, 7]
+        let posteriors = MLXRandom.uniform(low: 0.0, high: 1.0, [1, 10, 7])
+        let normalized = posteriors / posteriors.sum(axis: -1, keepDims: true)
+        let speechProb = SegmentationModel.speechProbability(from: normalized)
+        eval(speechProb)
+
+        XCTAssertEqual(speechProb.shape, [1, 10])
+        // Speech prob should be 1 - P(non-speech), so in [0, 1]
+        let values = speechProb[0].asArray(Float.self)
+        for v in values {
+            XCTAssertGreaterThanOrEqual(v, 0.0)
+            XCTAssertLessThanOrEqual(v, 1.0)
+        }
+    }
+
+    func testSincNetOutputShape() {
+        let config = SegmentationConfig.default
+        let sincnet = SincNet(config: config)
+
+        let input = MLXRandom.normal([1, 1, 160000])
+        let output = sincnet(input)
+        eval(output)
+
+        // SincNet: [1, 1, 160000] → [1, 60, ~293]
+        XCTAssertEqual(output.shape[0], 1)
+        XCTAssertEqual(output.shape[1], 60)
+        XCTAssertGreaterThan(output.shape[2], 200)
+    }
+
+    func testBiLSTMOutputShape() {
+        let fwdLayers = [LSTMLayer(inputSize: 60, hiddenSize: 128)]
+        let bwdLayers = [LSTMLayer(inputSize: 60, hiddenSize: 128)]
+        let fwd = LSTMStack(layers: fwdLayers)
+        let bwd = LSTMStack(layers: bwdLayers)
+
+        let input = MLXRandom.normal([1, 50, 60])
+        let output = runBiLSTM(input, fwd: fwd, bwd: bwd)
+        eval(output)
+
+        // BiLSTM: [1, 50, 60] → [1, 50, 256]
+        XCTAssertEqual(output.shape, [1, 50, 256])
+    }
+
+    func testDetectSpeechWithRandomWeights() {
+        // Full pipeline test with random weights (won't detect real speech,
+        // but verifies the pipeline runs end-to-end without crashes)
+        let segConfig = SegmentationConfig.default
+        let vadConfig = VADConfig.default
+        let model = SegmentationModel(config: segConfig)
+
+        let vadModel = PyannoteVADModel(
+            model: model, segConfig: segConfig, vadConfig: vadConfig)
+
+        // 5s of random audio at 16kHz
+        let audio = [Float](repeating: 0, count: 80000)
+        let segments = vadModel.detectSpeech(audio: audio, sampleRate: 16000)
+
+        // With random weights, might or might not detect "speech" — just verify no crash
+        // and segments are valid
+        for seg in segments {
+            XCTAssertGreaterThanOrEqual(seg.startTime, 0)
+            XCTAssertGreaterThan(seg.endTime, seg.startTime)
+        }
+    }
+
+    // MARK: - E2E Integration Test (requires real weights)
+
+    func testE2EWithRealWeights() async throws {
+        // Load the real pre-trained model
+        let vadModel = try await PyannoteVADModel.fromPretrained()
+
+        // Load the test audio file
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+        XCTAssertGreaterThan(samples.count, 0)
+
+        // Run VAD
+        let segments = vadModel.detectSpeech(audio: samples, sampleRate: sampleRate)
+
+        // Should detect exactly one speech segment (matches Python pyannote output)
+        XCTAssertEqual(segments.count, 1, "Expected 1 speech segment, got \(segments.count)")
+
+        if let seg = segments.first {
+            // Python pyannote: [5.16s - 8.40s]
+            // Swift:           [5.16s - 8.44s] (within ~0.05s tolerance)
+            XCTAssertEqual(seg.startTime, 5.16, accuracy: 0.1,
+                           "Start time should be ~5.16s (got \(seg.startTime))")
+            XCTAssertEqual(seg.endTime, 8.42, accuracy: 0.1,
+                           "End time should be ~8.40-8.44s (got \(seg.endTime))")
+            XCTAssertGreaterThan(seg.duration, 3.0)
+            XCTAssertLessThan(seg.duration, 4.0)
+        }
+    }
+
+    // MARK: - Frame Aggregation Tests
+
+    func testAggregateFramesSingleWindow() {
+        let pipeline = VADPipeline(sampleRate: 16000)
+        let probs: [Float] = (0 ..< 293).map { Float($0) / 293.0 }
+        let positions = [(start: 0, end: 160000)]
+
+        let aggregated = pipeline.aggregateFrames(
+            windowProbs: [probs],
+            positions: positions,
+            numSamples: 160000
+        )
+
+        XCTAssertGreaterThan(aggregated.count, 0)
+        // First frame should be near 0, last near 1
+        XCTAssertLessThan(aggregated[0], 0.1)
+    }
+}

--- a/Tests/SpeechVADTests/WeSpeakerTests.swift
+++ b/Tests/SpeechVADTests/WeSpeakerTests.swift
@@ -1,0 +1,522 @@
+import XCTest
+import MLX
+@testable import SpeechVAD
+import AudioCommon
+
+final class WeSpeakerTests: XCTestCase {
+
+    // MARK: - Configuration Tests
+
+    func testDiarizationConfigDefault() {
+        let config = DiarizationConfig.default
+        XCTAssertEqual(config.onset, 0.5, accuracy: 0.001)
+        XCTAssertEqual(config.offset, 0.3, accuracy: 0.001)
+        XCTAssertEqual(config.minSpeechDuration, 0.3, accuracy: 0.001)
+        XCTAssertEqual(config.clusteringThreshold, 0.5, accuracy: 0.001)
+        XCTAssertEqual(config.maxSpeakers, 0)
+    }
+
+    func testDiarizedSegmentDuration() {
+        let seg = DiarizedSegment(startTime: 1.0, endTime: 3.5, speakerId: 0)
+        XCTAssertEqual(seg.duration, 2.5, accuracy: 0.001)
+        XCTAssertEqual(seg.speakerId, 0)
+    }
+
+    // MARK: - PowersetDecoder Tests
+
+    func testPowersetDecoderShape() {
+        // Uniform posteriors: [1, 10, 7]
+        let posteriors = MLXArray.ones([1, 10, 7]) / 7.0
+        let speakerProbs = PowersetDecoder.speakerProbabilities(from: posteriors)
+        eval(speakerProbs)
+
+        XCTAssertEqual(speakerProbs.shape, [1, 10, 3])
+    }
+
+    func testPowersetDecoderValues() {
+        // Create known posteriors: only class 1 (spk1 alone) is active
+        var data = [Float](repeating: 0, count: 7)
+        data[1] = 1.0  // spk1 alone
+        let posteriors = MLXArray(data, [1, 1, 7])
+
+        let speakerProbs = PowersetDecoder.speakerProbabilities(from: posteriors)
+        eval(speakerProbs)
+
+        let probs = speakerProbs[0, 0].asArray(Float.self)
+        XCTAssertEqual(probs[0], 1.0, accuracy: 0.001)  // spk1 active
+        XCTAssertEqual(probs[1], 0.0, accuracy: 0.001)  // spk2 inactive
+        XCTAssertEqual(probs[2], 0.0, accuracy: 0.001)  // spk3 inactive
+    }
+
+    func testPowersetDecoderOverlap() {
+        // Class 4 (spk1+2 overlap) is active
+        var data = [Float](repeating: 0, count: 7)
+        data[4] = 1.0  // spk1+2
+        let posteriors = MLXArray(data, [1, 1, 7])
+
+        let speakerProbs = PowersetDecoder.speakerProbabilities(from: posteriors)
+        eval(speakerProbs)
+
+        let probs = speakerProbs[0, 0].asArray(Float.self)
+        XCTAssertEqual(probs[0], 1.0, accuracy: 0.001)  // spk1 active
+        XCTAssertEqual(probs[1], 1.0, accuracy: 0.001)  // spk2 active
+        XCTAssertEqual(probs[2], 0.0, accuracy: 0.001)  // spk3 inactive
+    }
+
+    func testPowersetBinarize() {
+        let probs: [Float] = [0.1, 0.1, 0.8, 0.9, 0.9, 0.2, 0.1]
+        let segments = PowersetDecoder.binarize(
+            probs: probs, onset: 0.5, offset: 0.3, frameDuration: 1.0
+        )
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].startTime, 2.0, accuracy: 0.01)
+        XCTAssertEqual(segments[0].endTime, 5.0, accuracy: 0.01)
+    }
+
+    // MARK: - MelFeatureExtractor Tests
+
+    func testMelExtractorShape() {
+        let extractor = MelFeatureExtractor()
+        // 1 second of silence at 16kHz
+        let audio = [Float](repeating: 0, count: 16000)
+        let mel = extractor.extract(audio)
+        eval(mel)
+
+        // T = (16000 + 400 - 400) / 160 + 1 = 101 frames
+        XCTAssertEqual(mel.shape[1], 80)
+        XCTAssertGreaterThan(mel.shape[0], 90)
+        XCTAssertLessThan(mel.shape[0], 110)
+    }
+
+    func testMelExtractorNonZero() {
+        let extractor = MelFeatureExtractor()
+        // Random audio
+        var audio = [Float](repeating: 0, count: 16000)
+        for i in 0..<audio.count {
+            audio[i] = Float.random(in: -0.5...0.5)
+        }
+        let mel = extractor.extract(audio)
+        eval(mel)
+
+        // Should have non-zero values for non-silent audio
+        let maxVal = mel.max().item(Float.self)
+        XCTAssertGreaterThan(maxVal, -20.0)  // log scale, not -inf
+    }
+
+    // MARK: - WeSpeaker Model Shape Tests (random weights)
+
+    func testResNet34OutputShape() {
+        let network = WeSpeakerNetwork()
+
+        // 2 seconds of mel features: T≈101 frames, 80 mel bins
+        let mel = MLXRandom.normal([1, 101, 80, 1])
+        let output = network(mel)
+        eval(output)
+
+        // Should produce [1, 256]
+        XCTAssertEqual(output.shape, [1, 256])
+    }
+
+    func testResNet34L2Normalized() {
+        let network = WeSpeakerNetwork()
+
+        let mel = MLXRandom.normal([1, 101, 80, 1])
+        let output = network(mel)
+        eval(output)
+
+        // L2 norm should be approximately 1.0
+        let norm = sqrt((output * output).sum(axis: -1)).item(Float.self)
+        XCTAssertEqual(norm, 1.0, accuracy: 0.01)
+    }
+
+    func testBasicBlockSameChannels() {
+        let block = BasicBlock(inChannels: 32, outChannels: 32)
+        let x = MLXRandom.normal([1, 100, 80, 32])
+        let out = block(x)
+        eval(out)
+
+        // Same channels, no stride → same spatial dims
+        XCTAssertEqual(out.shape, [1, 100, 80, 32])
+    }
+
+    func testBasicBlockDownsample() {
+        let block = BasicBlock(inChannels: 32, outChannels: 64, stride: 2)
+        let x = MLXRandom.normal([1, 100, 80, 32])
+        let out = block(x)
+        eval(out)
+
+        // Stride 2 → halved spatial dims, doubled channels
+        XCTAssertEqual(out.shape, [1, 50, 40, 64])
+    }
+
+    // MARK: - Cosine Similarity Tests
+
+    func testCosineSimilaritySame() {
+        let a: [Float] = [1, 0, 0, 0]
+        let sim = WeSpeakerModel.cosineSimilarity(a, a)
+        XCTAssertEqual(sim, 1.0, accuracy: 0.001)
+    }
+
+    func testCosineSimilarityOpposite() {
+        let a: [Float] = [1, 0, 0, 0]
+        let b: [Float] = [-1, 0, 0, 0]
+        let sim = WeSpeakerModel.cosineSimilarity(a, b)
+        XCTAssertEqual(sim, -1.0, accuracy: 0.001)
+    }
+
+    func testCosineSimilarityOrthogonal() {
+        let a: [Float] = [1, 0, 0, 0]
+        let b: [Float] = [0, 1, 0, 0]
+        let sim = WeSpeakerModel.cosineSimilarity(a, b)
+        XCTAssertEqual(sim, 0.0, accuracy: 0.001)
+    }
+
+    // MARK: - DiarizationResult Tests
+
+    func testDiarizationResultInit() {
+        let segments = [
+            DiarizedSegment(startTime: 0.0, endTime: 1.0, speakerId: 0),
+            DiarizedSegment(startTime: 1.5, endTime: 3.0, speakerId: 1),
+        ]
+        let embeddings = [[Float](repeating: 0.1, count: 256), [Float](repeating: -0.1, count: 256)]
+        let result = DiarizationResult(segments: segments, numSpeakers: 2, speakerEmbeddings: embeddings)
+
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.numSpeakers, 2)
+        XCTAssertEqual(result.speakerEmbeddings.count, 2)
+    }
+
+    // MARK: - E2E Integration Test (requires real weights)
+
+    func testE2EEmbedding() async throws {
+        let model = try await WeSpeakerModel.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+        XCTAssertGreaterThan(samples.count, 0)
+
+        let embedding = model.embed(audio: samples, sampleRate: sampleRate)
+
+        // Should be 256-dim
+        XCTAssertEqual(embedding.count, 256)
+
+        // Should be L2 normalized (norm ≈ 1.0)
+        let norm = sqrt(embedding.reduce(Float(0)) { $0 + $1 * $1 })
+        XCTAssertEqual(norm, 1.0, accuracy: 0.01)
+
+        // Same audio should produce similar embedding (consistency check)
+        let embedding2 = model.embed(audio: samples, sampleRate: sampleRate)
+        let similarity = WeSpeakerModel.cosineSimilarity(embedding, embedding2)
+        XCTAssertEqual(similarity, 1.0, accuracy: 0.001)
+    }
+
+    func testE2EDiarization() async throws {
+        let pipeline = try await DiarizationPipeline.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+        let result = pipeline.diarize(audio: samples, sampleRate: sampleRate, config: .default)
+
+        // Should detect at least one speaker segment
+        XCTAssertGreaterThan(result.segments.count, 0)
+        XCTAssertGreaterThanOrEqual(result.numSpeakers, 1)
+
+        // All segments should have valid times
+        for seg in result.segments {
+            XCTAssertGreaterThanOrEqual(seg.startTime, 0)
+            XCTAssertGreaterThan(seg.endTime, seg.startTime)
+            XCTAssertGreaterThanOrEqual(seg.speakerId, 0)
+            XCTAssertLessThan(seg.speakerId, result.numSpeakers)
+        }
+
+        // Should have centroid for each speaker
+        XCTAssertEqual(result.speakerEmbeddings.count, result.numSpeakers)
+        for emb in result.speakerEmbeddings {
+            XCTAssertEqual(emb.count, 256)
+        }
+    }
+
+    // MARK: - E2E: Single Speaker Detection
+
+    func testE2ESingleSpeakerAudio() async throws {
+        let pipeline = try await DiarizationPipeline.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Test audio has a single speaker — with maxSpeakers=1, pipeline should detect 1
+        let config = DiarizationConfig(maxSpeakers: 1)
+        let result = pipeline.diarize(audio: samples, sampleRate: sampleRate, config: config)
+        XCTAssertEqual(result.numSpeakers, 1,
+                       "maxSpeakers=1 should force 1 speaker, got \(result.numSpeakers)")
+
+        // All segments should be speaker 0
+        for seg in result.segments {
+            XCTAssertEqual(seg.speakerId, 0)
+        }
+
+        // Segments should cover the speech region
+        XCTAssertGreaterThan(result.segments.count, 0)
+    }
+
+    // MARK: - E2E: Speaker Extraction
+
+    func testE2ESpeakerExtraction() async throws {
+        let pipeline = try await DiarizationPipeline.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Use same audio as enrollment (target speaker IS the speaker)
+        let targetEmb = pipeline.embeddingModel.embed(audio: samples, sampleRate: sampleRate)
+        XCTAssertEqual(targetEmb.count, 256)
+
+        let extracted = pipeline.extractSpeaker(
+            audio: samples, sampleRate: sampleRate,
+            targetEmbedding: targetEmb
+        )
+
+        // Should extract at least one segment matching the target speaker
+        XCTAssertGreaterThan(extracted.count, 0,
+                             "Should extract segments matching the target speaker")
+
+        // Extracted segments should be in the speech region (~5-8.5s)
+        for seg in extracted {
+            XCTAssertGreaterThanOrEqual(seg.startTime, 0)
+            XCTAssertGreaterThan(seg.endTime, seg.startTime)
+            XCTAssertGreaterThan(seg.duration, 0.1)
+        }
+    }
+
+    // MARK: - E2E: Embedding Subsegment Consistency
+
+    func testE2EEmbeddingSubsegments() async throws {
+        let model = try await WeSpeakerModel.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Embed the full audio
+        let fullEmb = model.embed(audio: samples, sampleRate: sampleRate)
+
+        // Embed just the speech region (~5-8.5s)
+        let startSample = Int(5.0 * Float(sampleRate))
+        let endSample = min(Int(8.5 * Float(sampleRate)), samples.count)
+        let speechRegion = Array(samples[startSample..<endSample])
+
+        let speechEmb = model.embed(audio: speechRegion, sampleRate: sampleRate)
+
+        // Same speaker in both — cosine similarity should be positive
+        // Full audio includes silence which affects the embedding, so threshold is relaxed
+        let similarity = WeSpeakerModel.cosineSimilarity(fullEmb, speechEmb)
+        XCTAssertGreaterThan(similarity, 0.2,
+                             "Full audio and speech region embeddings should be positively correlated (got \(similarity))")
+    }
+
+    // MARK: - E2E: Protocol Conformance
+
+    func testE2EProtocolConformance() async throws {
+        let pipeline = try await DiarizationPipeline.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Test through SpeakerDiarizationModel protocol
+        let diarizationModel: any SpeakerDiarizationModel = pipeline
+        let segments = diarizationModel.diarize(audio: samples, sampleRate: sampleRate)
+        XCTAssertGreaterThan(segments.count, 0)
+        for seg in segments {
+            XCTAssertGreaterThanOrEqual(seg.speakerId, 0)
+            XCTAssertGreaterThan(seg.endTime, seg.startTime)
+        }
+
+        // Test through SpeakerEmbeddingModel protocol
+        let embModel: any SpeakerEmbeddingModel = pipeline.embeddingModel
+        XCTAssertEqual(embModel.embeddingDimension, 256)
+        XCTAssertEqual(embModel.inputSampleRate, 16000)
+
+        let emb = embModel.embed(audio: samples, sampleRate: sampleRate)
+        XCTAssertEqual(emb.count, 256)
+        let norm = sqrt(emb.reduce(Float(0)) { $0 + $1 * $1 })
+        XCTAssertEqual(norm, 1.0, accuracy: 0.01)
+    }
+
+    // MARK: - E2E: VAD Cross-Validation
+
+    func testE2EVADCrossValidation() async throws {
+        let pyannote = try await PyannoteVADModel.fromPretrained()
+        let silero = try await SileroVADModel.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Both models should detect speech in the same region
+        let pyannoteSegs = pyannote.detectSpeech(audio: samples, sampleRate: sampleRate)
+        let sileroSegs = silero.detectSpeech(audio: samples, sampleRate: sampleRate)
+
+        XCTAssertGreaterThan(pyannoteSegs.count, 0, "Pyannote should detect speech")
+        XCTAssertGreaterThan(sileroSegs.count, 0, "Silero should detect speech")
+
+        // Both should detect speech starting roughly in 4-7s range
+        if let pySeg = pyannoteSegs.first, let siSeg = sileroSegs.first {
+            XCTAssertEqual(pySeg.startTime, siSeg.startTime, accuracy: 2.0,
+                           "Pyannote (\(pySeg.startTime)s) and Silero (\(siSeg.startTime)s) start times should be within 2s")
+            XCTAssertEqual(pySeg.endTime, siSeg.endTime, accuracy: 2.0,
+                           "Pyannote (\(pySeg.endTime)s) and Silero (\(siSeg.endTime)s) end times should be within 2s")
+        }
+
+        // Both through VoiceActivityDetectionModel protocol
+        let models: [any VoiceActivityDetectionModel] = [pyannote, silero]
+        for model in models {
+            let segs = model.detectSpeech(audio: samples, sampleRate: sampleRate)
+            XCTAssertGreaterThan(segs.count, 0)
+        }
+    }
+
+    // MARK: - E2E: Mel Feature Extractor on Real Audio
+
+    func testE2EMelFeatures() async throws {
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Resample to 16kHz if needed
+        let audio16k: [Float]
+        if sampleRate != 16000 {
+            let ratio = Double(16000) / Double(sampleRate)
+            let outLen = Int(Double(samples.count) * ratio)
+            audio16k = (0..<outLen).map { i in
+                let src = Double(i) / ratio
+                let idx = Int(src)
+                let frac = Float(src - Double(idx))
+                if idx + 1 < samples.count {
+                    return samples[idx] * (1 - frac) + samples[idx + 1] * frac
+                }
+                return idx < samples.count ? samples[idx] : 0
+            }
+        } else {
+            audio16k = samples
+        }
+
+        let extractor = MelFeatureExtractor()
+        let mel = extractor.extract(audio16k)
+        eval(mel)
+
+        // Shape: [T, 80]
+        XCTAssertEqual(mel.shape[1], 80, "Mel should have 80 bins")
+        XCTAssertGreaterThan(mel.shape[0], 0, "Should have at least 1 frame")
+
+        // Expected frames: (numSamples + 400 - 400) / 160 + 1
+        let expectedFrames = (audio16k.count / 160) + 1
+        XCTAssertEqual(mel.shape[0], expectedFrames, accuracy: 5,
+                       "Frame count should match expected")
+
+        // Mel values should be in reasonable log range (not NaN/Inf)
+        let maxVal = mel.max().item(Float.self)
+        let minVal = mel.min().item(Float.self)
+        XCTAssertFalse(maxVal.isNaN, "Mel max should not be NaN")
+        XCTAssertFalse(minVal.isNaN, "Mel min should not be NaN")
+        XCTAssertFalse(maxVal.isInfinite, "Mel max should not be Inf")
+        XCTAssertGreaterThan(maxVal, -30.0, "Mel max should be above -30 (log scale)")
+    }
+
+    // MARK: - E2E: Diarization with Custom Config
+
+    func testE2EDiarizationCustomConfig() async throws {
+        let pipeline = try await DiarizationPipeline.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Force max 1 speaker
+        let config = DiarizationConfig(maxSpeakers: 1)
+        let result = pipeline.diarize(audio: samples, sampleRate: sampleRate, config: config)
+
+        XCTAssertEqual(result.numSpeakers, 1,
+                       "maxSpeakers=1 should force single speaker, got \(result.numSpeakers)")
+        XCTAssertGreaterThan(result.segments.count, 0)
+
+        // All segments should be speaker 0 when forced to 1 speaker
+        for seg in result.segments {
+            XCTAssertEqual(seg.speakerId, 0)
+        }
+
+        // Force max 2 speakers — should produce at most 2
+        let config2 = DiarizationConfig(maxSpeakers: 2)
+        let result2 = pipeline.diarize(audio: samples, sampleRate: sampleRate, config: config2)
+        XCTAssertLessThanOrEqual(result2.numSpeakers, 2,
+                                  "maxSpeakers=2 should produce at most 2 speakers, got \(result2.numSpeakers)")
+    }
+
+    // MARK: - E2E: Embedding Different Audio Produces Different Embeddings
+
+    func testE2EEmbeddingDifferentAudio() async throws {
+        let model = try await WeSpeakerModel.fromPretrained()
+
+        let audioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("Test audio file not found")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        // Embed real audio
+        let realEmb = model.embed(audio: samples, sampleRate: sampleRate)
+
+        // Embed random noise (simulating a different "speaker")
+        var noise = [Float](repeating: 0, count: 32000)  // 2s @ 16kHz
+        for i in 0..<noise.count {
+            noise[i] = Float.random(in: -0.5...0.5)
+        }
+        let noiseEmb = model.embed(audio: noise, sampleRate: 16000)
+
+        // Both should be 256-dim and normalized
+        XCTAssertEqual(realEmb.count, 256)
+        XCTAssertEqual(noiseEmb.count, 256)
+
+        let realNorm = sqrt(realEmb.reduce(Float(0)) { $0 + $1 * $1 })
+        let noiseNorm = sqrt(noiseEmb.reduce(Float(0)) { $0 + $1 * $1 })
+        XCTAssertEqual(realNorm, 1.0, accuracy: 0.01)
+        XCTAssertEqual(noiseNorm, 1.0, accuracy: 0.01)
+
+        // Real speech vs noise should have low similarity
+        let similarity = WeSpeakerModel.cosineSimilarity(realEmb, noiseEmb)
+        XCTAssertLessThan(similarity, 0.8,
+                          "Speech vs noise should not be highly similar (got \(similarity))")
+    }
+}

--- a/docs/silero-vad.md
+++ b/docs/silero-vad.md
@@ -1,0 +1,140 @@
+# Silero VAD v5: Streaming Voice Activity Detection
+
+## Overview
+
+Silero VAD v5 is a lightweight (~309K params, ~1.2 MB) voice activity detection model designed for real-time streaming. It processes 512-sample audio chunks (32ms @ 16kHz) and outputs a speech probability between 0 and 1, carrying LSTM state across chunks.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  SileroVADModel                                                 │
+│                                                                 │
+│  Input: 512 samples (32ms @ 16kHz)                              │
+│    │                                                            │
+│    ├── Prepend 64-sample context from previous chunk → 576      │
+│    │                                                            │
+│    ├── ReflectionPad(right=64) → 640 samples                    │
+│    ├── STFT Conv1d(1→258, k=256, s=128) → 4 frames × 258       │
+│    ├── Magnitude: √(real² + imag²) → 4 × 129                   │
+│    │                                                            │
+│    ├── Encoder:                                                 │
+│    │   Conv1d(129→128, k=3, s=1, p=1) → 4 × 128   ─ ReLU      │
+│    │   Conv1d(128→ 64, k=3, s=2, p=1) → 2 ×  64   ─ ReLU      │
+│    │   Conv1d( 64→ 64, k=3, s=2, p=1) → 1 ×  64   ─ ReLU      │
+│    │   Conv1d( 64→128, k=3, s=1, p=1) → 1 × 128   ─ ReLU      │
+│    │                                                            │
+│    ├── LSTM(128→128, 1 layer) ─── h,c state carried ──→        │
+│    │                                                            │
+│    ├── Decoder: ReLU → Conv1d(128→1, k=1) → Sigmoid            │
+│    │                                                            │
+│  Output: speech probability [0, 1]                              │
+│  State: h (1,1,128), c (1,1,128), context (64 samples)         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## STFT
+
+The STFT is implemented as a Conv1d with a pre-computed DFT basis matrix stored as weights (no learnable parameters). At inference it's a single convolution followed by magnitude extraction:
+
+1. **Pad**: Reflect 64 samples on the right only (`F.pad(x, [0, 64], "reflect")`)
+2. **Conv1d**: 258 output channels (129 real + 129 imaginary), kernel=256, stride=128
+3. **Magnitude**: Split channels at 129, compute `√(real² + imag²)` → 129 frequency bins × 4 frames
+
+The asymmetric right-only padding (not symmetric) is critical — it produces 4 STFT frames from 576 input samples, which the encoder reduces to a single feature vector.
+
+## Encoder
+
+Four Conv1d layers with ReLU activations progressively reduce the temporal dimension from 4 frames to 1:
+
+| Layer | Channels | Kernel | Stride | Padding | Output Frames |
+|-------|----------|--------|--------|---------|---------------|
+| 0 | 129 → 128 | 3 | 1 | 1 | 4 |
+| 1 | 128 → 64 | 3 | 2 | 1 | 2 |
+| 2 | 64 → 64 | 3 | 2 | 1 | 1 |
+| 3 | 64 → 128 | 3 | 1 | 1 | 1 |
+
+The weights use reparameterized convolutions (`reparam_conv`) — at inference, the separate conv+bn branches are fused into a single convolution.
+
+## LSTM
+
+A single-layer unidirectional LSTM with hidden size 128. Receives a single timestep from the encoder and updates its hidden/cell state. The state is carried across chunks for streaming — this is what gives the model temporal context beyond the 32ms window.
+
+The decoder uses only the LSTM hidden state `h` (not the full sequence output), reshaped to `[B, 1, 128]` for the final Conv1d.
+
+## Decoder
+
+Applies ReLU, then a 1×1 convolution (`Conv1d(128→1, k=1)`) followed by sigmoid to produce a probability in [0, 1].
+
+## StreamingVADProcessor
+
+The `StreamingVADProcessor` wraps `SileroVADModel` with a four-state machine for event-driven speech detection:
+
+```
+                onset crossed
+    ┌─────────┐ ─────────────→ ┌──────────────┐
+    │ silence │                │ pendingSpeech │
+    └─────────┘ ←───────────── └──────────────┘
+                 offset crossed       │
+                 (too brief)          │ duration ≥ minSpeechDuration
+                                      │ → emit speechStarted
+                                      ▼
+    ┌────────────────┐         ┌─────────┐
+    │ pendingSilence │ ←────── │ speech  │
+    └────────────────┘ offset  └─────────┘
+           │          crossed         ▲
+           │                          │
+           │ onset crossed            │
+           │ (speech resumed) ────────┘
+           │
+           │ silence ≥ minSilenceDuration
+           │ → emit speechEnded
+           ▼
+    ┌─────────┐
+    │ silence │
+    └─────────┘
+```
+
+**States:**
+- **silence** — Waiting for probability to cross onset threshold
+- **pendingSpeech** — Onset crossed, waiting for `minSpeechDuration` before confirming
+- **speech** — Confirmed speech, `speechStarted` event emitted
+- **pendingSilence** — Offset crossed, waiting for `minSilenceDuration` before ending
+
+## Configuration
+
+```swift
+// Default Silero thresholds (VADConfig.sileroDefault)
+onset:            0.5    // Speech starts when prob ≥ 0.5
+offset:           0.35   // Speech ends when prob < 0.35
+minSpeechDuration: 0.25  // Ignore speech shorter than 250ms
+minSilenceDuration: 0.1  // Ignore silence gaps shorter than 100ms
+```
+
+## Weight Conversion
+
+```bash
+python3 scripts/convert_silero_vad.py --upload
+```
+
+The conversion script:
+1. Downloads the Silero VAD v5 JIT model via `torch.hub`
+2. Extracts the 16kHz model weights (ignoring the 8kHz variant)
+3. Transposes Conv1d weights from PyTorch `[O, I, K]` to MLX `[O, K, I]`
+4. Sums LSTM biases: `bias = bias_ih + bias_hh`
+5. Saves as `model.safetensors` + `config.json`
+
+Weights hosted at [aufklarer/Silero-VAD-v5-MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX).
+
+## Comparison with Pyannote VAD
+
+| | Pyannote (PyanNet) | Silero VAD v5 |
+|---|---|---|
+| **Parameters** | ~1.49M | ~309K |
+| **Download** | ~5.7 MB | ~1.2 MB |
+| **Processing** | 10s sliding windows (batch) | 32ms chunks (streaming) |
+| **Architecture** | SincNet → BiLSTM(4L) → Linear → Softmax | STFT → Conv encoder → LSTM → Sigmoid |
+| **Output** | 7-class powerset → speech probability | Direct speech probability |
+| **Streaming** | No (requires full windows) | Yes (LSTM state across chunks) |
+| **Latency** | ~seconds (window aggregation) | ~40μs per chunk |
+| **Use case** | Offline/batch processing | Real-time microphone input |
+
+Both models conform to `VoiceActivityDetectionModel` and can be used interchangeably for the `detectSpeech(audio:sampleRate:)` batch API.

--- a/docs/speaker-diarization.md
+++ b/docs/speaker-diarization.md
@@ -1,0 +1,171 @@
+# Speaker Diarization & Speaker Embedding
+
+## Overview
+
+Speaker diarization identifies **who spoke when** in an audio recording. This module combines two models:
+
+1. **Pyannote Segmentation** (PyanNet) — already used for VAD, outputs 7-class powerset probabilities for up to 3 local speakers per window
+2. **WeSpeaker ResNet34-LM** — speaker embedding model that produces 256-dim vectors from speech, used to link local speakers across windows
+
+## Architecture
+
+### Three-Stage Pipeline
+
+```
+Audio → [Stage 1: Segmentation] → [Stage 2: Embedding] → [Stage 3: Clustering] → Diarized Segments
+```
+
+**Stage 1 — Segmentation**: Pyannote model processes 10s sliding windows. Instead of collapsing the 7-class powerset to binary VAD, we use `PowersetDecoder` to extract per-speaker probabilities:
+- spk1 = P(class 1) + P(class 4) + P(class 5)
+- spk2 = P(class 2) + P(class 4) + P(class 6)
+- spk3 = P(class 3) + P(class 5) + P(class 6)
+
+Hysteresis binarization produces local speaker segments per window.
+
+**Stage 2 — Embedding**: For each local segment, crop the audio and extract a 256-dim speaker embedding using WeSpeaker ResNet34-LM.
+
+**Stage 3 — Clustering**: Agglomerative clustering with average linkage and cosine distance merges local speaker embeddings into global speaker IDs.
+
+### WeSpeaker ResNet34-LM
+
+~6.6M params, 256-dim output, ~25 MB.
+
+```
+Input: [B, T, 80, 1] log-mel spectrogram (80 fbank, 16kHz)
+  │
+  ├─ Conv2d(1→32, k=3, p=1) + ReLU           (BN fused)
+  ├─ Layer1: 3× BasicBlock(32→32)
+  ├─ Layer2: 4× BasicBlock(32→64, s=2)
+  ├─ Layer3: 6× BasicBlock(64→128, s=2)
+  ├─ Layer4: 3× BasicBlock(128→256, s=2)
+  │
+  ├─ Statistics Pooling: mean + std → [B, 5120]
+  ├─ Linear(5120→256) → L2 normalize
+  │
+  Output: 256-dim L2-normalized speaker embedding
+```
+
+BatchNorm is **fused into Conv2d at conversion time** — no BN layers in the Swift model. This simplifies the model and avoids train/eval mode differences.
+
+### Mel Feature Extraction
+
+80-dim log-mel spectrogram via vDSP (same pipeline as WhisperFeatureExtractor but with different parameters):
+- **Hamming window** (not Hann): `0.54 - 0.46 * cos(2π*i/N)`
+- nFFT=400, hop=160, 16kHz
+- 80 mel bins with Slaney normalization
+- Simple `log(max(mel, 1e-10))` — no Whisper-specific normalization
+
+## Usage
+
+### Speaker Diarization
+
+```swift
+let pipeline = try await DiarizationPipeline.fromPretrained()
+let result = pipeline.diarize(audio: samples, sampleRate: 16000)
+
+for seg in result.segments {
+    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
+}
+print("\(result.numSpeakers) speakers detected")
+```
+
+### Speaker Embedding
+
+```swift
+let model = try await WeSpeakerModel.fromPretrained()
+let embedding = model.embed(audio: samples, sampleRate: 16000)
+// embedding: [Float] of length 256, L2-normalized
+```
+
+### Speaker Extraction
+
+Given a reference audio of a target speaker, extract only their segments:
+
+```swift
+let pipeline = try await DiarizationPipeline.fromPretrained()
+
+// Get target speaker embedding from enrollment audio
+let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
+
+// Extract target speaker's segments from the main audio
+let segments = pipeline.extractSpeaker(
+    audio: meetingAudio, sampleRate: 16000,
+    targetEmbedding: targetEmb
+)
+```
+
+### CLI Commands
+
+```bash
+# Full diarization
+audio diarize meeting.wav
+# Speaker 0: [0.50s - 3.20s] (2.70s)
+# Speaker 1: [3.50s - 7.10s] (3.60s)
+# Speaker 0: [7.30s - 9.80s] (2.50s)
+# --- 2 speaker(s) ---
+
+# With options
+audio diarize meeting.wav --threshold 0.6 --max-speakers 3 --json
+
+# Speaker extraction
+audio diarize meeting.wav --target-speaker enrollment.wav
+
+# Embed a speaker's voice
+audio embed-speaker enrollment.wav
+audio embed-speaker enrollment.wav --json
+```
+
+## Model Weights
+
+- **Segmentation**: `aufklarer/Pyannote-Segmentation-MLX` (~5.7 MB)
+- **Speaker Embedding**: `aufklarer/WeSpeaker-ResNet34-LM-MLX` (~25 MB)
+- Cache: `~/Library/Caches/qwen3-speech/`
+
+### Weight Conversion
+
+```bash
+# Convert WeSpeaker weights (requires HuggingFace token for gated model)
+python scripts/convert_wespeaker.py --token YOUR_HF_TOKEN
+
+# Upload to HuggingFace
+python scripts/convert_wespeaker.py --upload --repo-id aufklarer/WeSpeaker-ResNet34-LM-MLX
+```
+
+The conversion script:
+1. Downloads `pyannote/wespeaker-voxceleb-resnet34-LM`
+2. Fuses BatchNorm into Conv2d: `w_fused = w * γ/√(σ²+ε)`, `b_fused = β - μ·γ/√(σ²+ε)`
+3. Transposes Conv2d weights: `[O,I,H,W]` → `[O,H,W,I]` for MLX channels-last
+4. Renames `seg_1` → `embedding`
+5. Saves as safetensors + config.json
+
+## Protocols
+
+The module provides protocol conformances in `AudioCommon`:
+
+```swift
+// SpeakerEmbeddingModel
+extension WeSpeakerModel: SpeakerEmbeddingModel {}
+
+// SpeakerDiarizationModel
+extension DiarizationPipeline: SpeakerDiarizationModel {
+    func diarize(audio: [Float], sampleRate: Int) -> [DiarizedSegment]
+}
+```
+
+## File Structure
+
+```
+Sources/SpeechVAD/
+├── MelFeatureExtractor.swift      80-dim fbank via vDSP
+├── WeSpeakerModel.swift           ResNet34 network (BN-fused Conv2d)
+├── WeSpeakerWeightLoading.swift   Weight loading from safetensors
+├── WeSpeaker.swift                Public API: embed(), fromPretrained()
+├── PowersetDecoder.swift          7-class powerset → per-speaker probs
+├── DiarizationPipeline.swift      Full pipeline + speaker extraction
+└── SpeechVAD+Protocols.swift      Protocol conformances
+
+Sources/AudioCommon/Protocols.swift    DiarizedSegment, SpeakerEmbeddingModel, SpeakerDiarizationModel
+Sources/AudioCLILib/DiarizeCommand.swift       `audio diarize`
+Sources/AudioCLILib/EmbedSpeakerCommand.swift  `audio embed-speaker`
+scripts/convert_wespeaker.py                    Weight conversion
+```

--- a/scripts/convert_pyannote.py
+++ b/scripts/convert_pyannote.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+Convert pyannote/segmentation-3.0 (PyanNet) weights to safetensors for Swift/MLX.
+
+The model uses SincNet → BiLSTM → Linear → Classifier architecture (~1.5M params).
+Key transformations:
+  - SincNet: pre-compute 80 sinc filters (40 cos + 40 sin) from learned low_hz_/band_hz_
+    using the same formulation as asteroid_filterbanks.ParamSincFB
+  - Conv1d: transpose weights from PyTorch [O,I,K] → MLX [O,K,I]
+  - BiLSTM: split into forward/backward, sum bias_ih + bias_hh
+  - Linear/classifier: keep as-is (already [O,I])
+
+Loads pytorch_model.bin directly with a custom unpickler — does NOT require pyannote.audio.
+
+Requires: pip install torch safetensors numpy huggingface_hub
+Note: pyannote/segmentation-3.0 is a gated model — you need a HuggingFace token
+      with access granted at https://huggingface.co/pyannote/segmentation-3.0
+
+Usage:
+  python scripts/convert_pyannote.py --token YOUR_HF_TOKEN
+  python scripts/convert_pyannote.py --output-dir ./pyannote-mlx
+  python scripts/convert_pyannote.py --upload --repo-id you/Pyannote-Segmentation-MLX
+"""
+
+import argparse
+import io
+import json
+import os
+import pickle
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+from safetensors.numpy import save_file
+
+
+# ── Custom unpickler to load pyannote checkpoints without pyannote installed ──
+
+class _StubModule(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+class _StubObject:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class _PyannoteUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module.startswith("pyannote"):
+            if "Model" in name or "Net" in name or "LSTM" in name or "Linear" in name:
+                return _StubModule
+            return _StubObject
+        return super().find_class(module, name)
+
+
+def _load_checkpoint(path):
+    """Load a PyTorch Lightning checkpoint with pyannote class stubs."""
+    with open(path, "rb") as f:
+        data = f.read()
+
+    if not zipfile.is_zipfile(io.BytesIO(data)):
+        raise ValueError("Checkpoint is not a zip file")
+
+    zf = zipfile.ZipFile(io.BytesIO(data))
+    pkl_names = [n for n in zf.namelist() if n.endswith(".pkl")]
+    if not pkl_names:
+        raise ValueError("No .pkl found in checkpoint zip")
+    pkl_name = pkl_names[0]
+    data_prefix = pkl_name.rsplit("/", 1)[0] + "/data/" if "/" in pkl_name else "data/"
+
+    class _TorchUnpickler(_PyannoteUnpickler):
+        def __init__(self, file, zf, data_prefix):
+            super().__init__(file)
+            self.zf = zf
+            self.data_prefix = data_prefix
+            self._storages = {}
+
+        def persistent_load(self, saved_id):
+            if isinstance(saved_id, tuple) and saved_id[0] == "storage":
+                _, storage_type, key, location, numel = saved_id
+                if key not in self._storages:
+                    raw = self.zf.read(self.data_prefix + str(key))
+                    storage = storage_type.from_buffer(raw, byte_order="little")
+                    self._storages[key] = storage
+                return self._storages[key]
+            raise RuntimeError(f"Unknown persistent_id: {saved_id}")
+
+    pkl_data = zf.read(pkl_name)
+    result = _TorchUnpickler(io.BytesIO(pkl_data), zf, data_prefix).load()
+
+    # PyTorch Lightning checkpoints nest the model weights under "state_dict"
+    if isinstance(result, dict) and "state_dict" in result:
+        return result["state_dict"]
+    if hasattr(result, "state_dict"):
+        return result.state_dict()
+    return result
+
+
+# ── SincNet filter computation (matching asteroid ParamSincFB) ──
+
+def compute_sinc_filters(low_hz_param, band_hz_param, n_buffer, window_buffer,
+                         min_low_hz=50, min_band_hz=50, sample_rate=16000):
+    """Compute 80 sinc bandpass filters (40 cos + 40 sin) from 40 learned parameters.
+
+    This matches asteroid_filterbanks.ParamSincFB.filters() exactly:
+    - Cosine filters (even, symmetric): standard sinc bandpass
+    - Sine filters (odd, antisymmetric): Hilbert transform of the bandpass
+
+    Args:
+        low_hz_param: (40, 1) learned low frequency parameters
+        band_hz_param: (40, 1) learned bandwidth parameters
+        n_buffer: (1, 125) time buffer: 2π * [-125, ..., -1] / sample_rate
+        window_buffer: (125,) left half of Hamming window
+        min_low_hz: minimum low frequency offset (50 Hz for pyannote)
+        min_band_hz: minimum bandwidth offset (50 Hz for pyannote)
+        sample_rate: audio sample rate
+
+    Returns:
+        filters: (80, 1, 251) pre-computed filter kernels [PyTorch format: O, I, K]
+    """
+    # Apply parameter transforms (matching asteroid's forward pass)
+    low = min_low_hz + np.abs(low_hz_param)          # (40, 1)
+    high = np.clip(
+        low + min_band_hz + np.abs(band_hz_param),
+        min_low_hz,
+        sample_rate / 2
+    )  # (40, 1)
+
+    n_filters_half = len(low_hz_param)
+    kernel_size = 2 * len(window_buffer) + 1  # 125 * 2 + 1 = 251
+
+    def make_filters(low, high, filt_type):
+        band = (high - low)[:, 0]            # (40,)
+        ft_low = low @ n_buffer               # (40, 125)
+        ft_high = high @ n_buffer             # (40, 125)
+
+        if filt_type == "cos":
+            bp_left = ((np.sin(ft_high) - np.sin(ft_low)) / (n_buffer / 2)) * window_buffer
+            bp_center = 2 * band.reshape(-1, 1)
+            bp_right = np.flip(bp_left, axis=1)
+        elif filt_type == "sin":
+            bp_left = ((np.cos(ft_low) - np.cos(ft_high)) / (n_buffer / 2)) * window_buffer
+            bp_center = np.zeros_like(band.reshape(-1, 1))
+            bp_right = -np.flip(bp_left, axis=1)
+        else:
+            raise ValueError(f"Invalid filter type {filt_type}")
+
+        bp = np.concatenate([bp_left, bp_center, bp_right], axis=1)  # (40, 251)
+        bp = bp / (2 * band[:, None])
+        return bp.reshape(n_filters_half, 1, kernel_size)
+
+    cos_filters = make_filters(low, high, "cos")  # (40, 1, 251)
+    sin_filters = make_filters(low, high, "sin")  # (40, 1, 251)
+    filters = np.concatenate([cos_filters, sin_filters], axis=0)  # (80, 1, 251)
+    return filters.astype(np.float32)
+
+
+def convert(
+    source_model: str = "pyannote/segmentation-3.0",
+    output_dir: str = "./pyannote-segmentation-mlx",
+    token: str = None,
+):
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if not token:
+        token_path = Path.home() / ".cache" / "huggingface" / "token"
+        if token_path.exists():
+            token = token_path.read_text().strip()
+
+    print(f"Downloading pytorch_model.bin from {source_model}...")
+    path = hf_hub_download(source_model, "pytorch_model.bin", token=token)
+
+    print("Loading state dict with custom unpickler...")
+    state_dict = _load_checkpoint(path)
+
+    # Filter to only tensors
+    for k in list(state_dict.keys()):
+        if not isinstance(state_dict[k], torch.Tensor):
+            del state_dict[k]
+
+    print(f"Loaded {len(state_dict)} tensors")
+    for k, v in sorted(state_dict.items()):
+        print(f"  {k}: {list(v.shape)} {v.dtype}")
+
+    output_tensors = {}
+
+    # ── 1. SincNet filterbank (40 params → 80 cos+sin filters) ──
+    low_hz = state_dict["sincnet.conv1d.0.filterbank.low_hz_"].numpy()     # (40, 1)
+    band_hz = state_dict["sincnet.conv1d.0.filterbank.band_hz_"].numpy()   # (40, 1)
+    n_buffer = state_dict["sincnet.conv1d.0.filterbank.n_"].numpy()        # (1, 125)
+    window_buffer = state_dict["sincnet.conv1d.0.filterbank.window_"].numpy()  # (125,)
+
+    print(f"\nSincNet: {len(low_hz)} parameter pairs → 80 filters (cos + sin)")
+    print(f"  low_hz range: [{low_hz.min():.1f}, {low_hz.max():.1f}]")
+    print(f"  band_hz range: [{band_hz.min():.1f}, {band_hz.max():.1f}]")
+
+    filters = compute_sinc_filters(low_hz, band_hz, n_buffer, window_buffer)
+    # Transpose to MLX Conv1d format: [O, I, K] → [O, K, I]
+    output_tensors["sincnet.conv.0.weight"] = np.transpose(filters, (0, 2, 1))
+    print(f"  Pre-computed filters: {filters.shape} → MLX {output_tensors['sincnet.conv.0.weight'].shape}")
+
+    # ── 2. Conv layers 1, 2 ──
+    for i in [1, 2]:
+        w = state_dict[f"sincnet.conv1d.{i}.weight"].numpy()
+        output_tensors[f"sincnet.conv.{i}.weight"] = np.transpose(w, (0, 2, 1))
+        output_tensors[f"sincnet.conv.{i}.bias"] = state_dict[f"sincnet.conv1d.{i}.bias"].numpy()
+        print(f"  Conv {i}: {w.shape} → {output_tensors[f'sincnet.conv.{i}.weight'].shape}")
+
+    # ── 3. InstanceNorm ──
+    for i in range(3):
+        for p in ["weight", "bias"]:
+            output_tensors[f"sincnet.norm.{i}.{p}"] = state_dict[f"sincnet.norm1d.{i}.{p}"].numpy()
+    for p in ["weight", "bias"]:
+        output_tensors[f"sincnet.wav_norm.{p}"] = state_dict[f"sincnet.wav_norm1d.{p}"].numpy()
+
+    # ── 4. BiLSTM ──
+    num_layers = 0
+    while f"lstm.weight_ih_l{num_layers}" in state_dict:
+        num_layers += 1
+    print(f"\nBiLSTM: {num_layers} layers")
+
+    for i in range(num_layers):
+        for direction, suffix in [("fwd", ""), ("bwd", "_reverse")]:
+            wih = state_dict[f"lstm.weight_ih_l{i}{suffix}"].numpy()
+            whh = state_dict[f"lstm.weight_hh_l{i}{suffix}"].numpy()
+            bih = state_dict[f"lstm.bias_ih_l{i}{suffix}"].numpy()
+            bhh = state_dict[f"lstm.bias_hh_l{i}{suffix}"].numpy()
+            output_tensors[f"lstm_{direction}.layers.{i}.Wx"] = wih
+            output_tensors[f"lstm_{direction}.layers.{i}.Wh"] = whh
+            output_tensors[f"lstm_{direction}.layers.{i}.bias"] = bih + bhh
+            print(f"  {direction} layer {i}: Wx={wih.shape}, Wh={whh.shape}")
+
+    # ── 5. Linear + classifier ──
+    print("\nLinear layers:")
+    for k in sorted(state_dict):
+        if k.startswith("linear.") or k.startswith("classifier."):
+            output_tensors[k] = state_dict[k].numpy()
+            print(f"  {k}: {output_tensors[k].shape}")
+
+    # ── Save ──
+    output_file = output_path / "model.safetensors"
+    print(f"\nSaving to {output_file}...")
+    save_file(output_tensors, str(output_file))
+
+    file_size_mb = output_file.stat().st_size / (1024 * 1024)
+    print(f"  Output size: {file_size_mb:.1f} MB")
+
+    config = {
+        "model_type": "pyannote-segmentation",
+        "sample_rate": 16000,
+        "sincnet": {
+            "n_filters": [80, 60, 60],
+            "kernel_sizes": [251, 5, 5],
+            "strides": [10, 1, 1],
+            "pool_sizes": [3, 3, 3],
+        },
+        "lstm": {
+            "hidden_size": 128,
+            "num_layers": num_layers,
+            "bidirectional": True,
+        },
+        "linear": {
+            "hidden_size": 128,
+            "num_layers": 2,
+        },
+        "num_classes": 7,
+        "max_speakers": 3,
+        "powerset_max_classes": 2,
+        "num_frames_per_chunk": 589,
+        "chunk_duration": 10.0,
+        "chunk_step_ratio": 0.1,
+        "warm_up": [0.0, 0.0],
+    }
+    with open(output_path / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+    print("  Saved config.json")
+
+    print(f"\nConversion complete! Output in: {output_path}")
+    total_params = sum(np.prod(v.shape) for v in output_tensors.values())
+    print(f"Total parameters: {total_params:,}")
+    return output_path
+
+
+def upload(output_dir: str, repo_id: str):
+    """Upload converted model to HuggingFace Hub."""
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    api.create_repo(repo_id, exist_ok=True)
+    api.upload_folder(
+        folder_path=output_dir,
+        repo_id=repo_id,
+        commit_message="Upload pyannote segmentation model for MLX Swift",
+    )
+    print(f"Uploaded to: https://huggingface.co/{repo_id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert pyannote/segmentation-3.0 to safetensors for MLX Swift"
+    )
+    parser.add_argument("--source", default="pyannote/segmentation-3.0",
+                        help="Source model ID on HuggingFace")
+    parser.add_argument("--output-dir", default="./pyannote-segmentation-mlx",
+                        help="Output directory")
+    parser.add_argument("--token", default=None,
+                        help="HuggingFace token (reads ~/.cache/huggingface/token if not set)")
+    parser.add_argument("--upload", action="store_true",
+                        help="Upload to HuggingFace Hub after conversion")
+    parser.add_argument("--repo-id", default="aufklarer/Pyannote-Segmentation-MLX",
+                        help="HuggingFace repo ID for upload")
+    args = parser.parse_args()
+
+    output_path = convert(
+        source_model=args.source,
+        output_dir=args.output_dir,
+        token=args.token,
+    )
+
+    if args.upload:
+        upload(str(output_path), args.repo_id)

--- a/scripts/convert_silero_vad.py
+++ b/scripts/convert_silero_vad.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Convert Silero VAD v5 (JIT) to MLX safetensors format.
+
+Usage:
+    python3 scripts/convert_silero_vad.py [--output silero_vad_mlx] [--upload]
+
+Downloads the Silero VAD v5 model via torch.hub, extracts weights from the
+JIT model, remaps keys for MLX Conv1d (channels-last), sums LSTM biases,
+and saves as safetensors + config.json.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+import torch
+from safetensors.numpy import save_file
+
+
+def extract_jit_state_dict(model):
+    """Extract all parameters and buffers from a JIT ScriptModule."""
+    state_dict = {}
+
+    # state_dict() works on JIT models
+    for name, tensor in model.state_dict().items():
+        state_dict[name] = tensor.detach().cpu().numpy()
+
+    # Also grab named buffers (forward_basis_buffer is a buffer, not a parameter)
+    try:
+        for name, tensor in model.named_buffers():
+            if name not in state_dict:
+                state_dict[name] = tensor.detach().cpu().numpy()
+    except Exception:
+        pass
+
+    return state_dict
+
+
+def convert_weights(state_dict, verbose=True):
+    """Map Silero VAD JIT keys to MLX keys with appropriate transpositions."""
+    mlx_weights = {}
+
+    if verbose:
+        print("Source keys:")
+        for k, v in sorted(state_dict.items()):
+            print(f"  {k}: {v.shape} {v.dtype}")
+        print()
+
+    # --- STFT ---
+    # forward_basis_buffer: [n_fft+2, 1, filter_length] = [258, 1, 256]
+    # MLX Conv1d: [out_channels, kernel_size, in_channels] = [258, 256, 1]
+    stft_key = None
+    for k in state_dict:
+        if "stft" in k and "forward_basis" in k:
+            stft_key = k
+            break
+    if stft_key is None:
+        raise KeyError("Could not find STFT forward_basis_buffer in state dict")
+
+    stft_w = state_dict[stft_key].astype(np.float32)
+    if stft_w.ndim == 4:
+        stft_w = stft_w.squeeze(0)  # Remove batch dim if present
+    assert stft_w.ndim == 3, f"Expected 3D STFT weight, got shape {stft_w.shape}"
+    # [O, I, K] → [O, K, I]
+    mlx_weights["stft.weight"] = stft_w.transpose(0, 2, 1)
+
+    # --- Encoder: 4 Conv1d layers ---
+    for i in range(4):
+        # Try reparam_conv first (fused weights), then plain conv
+        w_key = None
+        b_key = None
+        for prefix in [
+            f"_model.encoder.{i}.reparam_conv",
+            f"_model.encoder.{i}.conv",
+            f"_model.encoder.{i}",
+        ]:
+            if f"{prefix}.weight" in state_dict:
+                w_key = f"{prefix}.weight"
+                b_key = f"{prefix}.bias"
+                break
+
+        if w_key is None:
+            raise KeyError(f"Could not find encoder layer {i} weights")
+
+        w = state_dict[w_key].astype(np.float32)
+        # PyTorch Conv1d [O, I, K] → MLX Conv1d [O, K, I]
+        mlx_weights[f"encoder.{i}.weight"] = w.transpose(0, 2, 1)
+
+        if b_key and b_key in state_dict:
+            mlx_weights[f"encoder.{i}.bias"] = state_dict[b_key].astype(np.float32)
+
+    # --- LSTM ---
+    # Silero uses: _model.decoder.rnn (a single-layer LSTM)
+    lstm_prefix = None
+    for prefix in ["_model.decoder.rnn", "_model.rnn"]:
+        if f"{prefix}.weight_ih" in state_dict:
+            lstm_prefix = prefix
+            break
+    if lstm_prefix is None:
+        # Try weight_ih_l0 (multi-layer LSTM format)
+        for prefix in ["_model.decoder.rnn", "_model.rnn"]:
+            if f"{prefix}.weight_ih_l0" in state_dict:
+                lstm_prefix = prefix
+                break
+
+    if lstm_prefix is None:
+        raise KeyError("Could not find LSTM weights in state dict")
+
+    # Handle both single-layer and multi-layer LSTM key formats
+    if f"{lstm_prefix}.weight_ih" in state_dict:
+        wih = state_dict[f"{lstm_prefix}.weight_ih"].astype(np.float32)
+        whh = state_dict[f"{lstm_prefix}.weight_hh"].astype(np.float32)
+        bih = state_dict[f"{lstm_prefix}.bias_ih"].astype(np.float32)
+        bhh = state_dict[f"{lstm_prefix}.bias_hh"].astype(np.float32)
+    else:
+        wih = state_dict[f"{lstm_prefix}.weight_ih_l0"].astype(np.float32)
+        whh = state_dict[f"{lstm_prefix}.weight_hh_l0"].astype(np.float32)
+        bih = state_dict[f"{lstm_prefix}.bias_ih_l0"].astype(np.float32)
+        bhh = state_dict[f"{lstm_prefix}.bias_hh_l0"].astype(np.float32)
+
+    mlx_weights["lstm.Wx"] = wih  # [4*H, input_size]
+    mlx_weights["lstm.Wh"] = whh  # [4*H, hidden_size]
+    mlx_weights["lstm.bias"] = bih + bhh  # Sum biases [4*H]
+
+    # --- Decoder: Conv1d(128, 1, k=1) ---
+    # decoder.decoder is Sequential: [0]=ReLU, [1]=Dropout, [2]=Conv1d
+    dec_key = None
+    for k in [
+        "_model.decoder.decoder.2.weight",
+        "_model.decoder.decoder.1.weight",
+        "_model.decoder.classifier.weight",
+    ]:
+        if k in state_dict:
+            dec_key = k
+            break
+    if dec_key is None:
+        # Find any decoder conv weight
+        for k in state_dict:
+            if "decoder" in k and "decoder" in k and "weight" in k and "rnn" not in k:
+                dec_key = k
+                break
+    if dec_key is None:
+        raise KeyError("Could not find decoder conv weight")
+
+    dec_bias_key = dec_key.replace(".weight", ".bias")
+
+    w = state_dict[dec_key].astype(np.float32)
+    # [O, I, K] → [O, K, I]
+    mlx_weights["decoder.weight"] = w.transpose(0, 2, 1)
+
+    if dec_bias_key in state_dict:
+        mlx_weights["decoder.bias"] = state_dict[dec_bias_key].astype(np.float32)
+
+    return mlx_weights
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert Silero VAD v5 to MLX format")
+    parser.add_argument(
+        "--output", default="silero_vad_mlx", help="Output directory"
+    )
+    parser.add_argument(
+        "--upload", action="store_true", help="Upload to HuggingFace"
+    )
+    parser.add_argument(
+        "--repo-id",
+        default="aufklarer/Silero-VAD-v5-MLX",
+        help="HuggingFace repo ID for upload",
+    )
+    args = parser.parse_args()
+
+    print("Loading Silero VAD v5 via torch.hub...")
+    model, utils = torch.hub.load(
+        repo_or_dir="snakers4/silero-vad",
+        model="silero_vad",
+        force_reload=False,
+        trust_repo=True,
+    )
+    print(f"Model type: {type(model)}")
+
+    print("\nExtracting state dict...")
+    state_dict = extract_jit_state_dict(model)
+    print(f"Found {len(state_dict)} tensors")
+
+    print("\nConverting weights...")
+    mlx_weights = convert_weights(state_dict)
+
+    # Save
+    os.makedirs(args.output, exist_ok=True)
+
+    weights_path = os.path.join(args.output, "model.safetensors")
+    save_file(mlx_weights, weights_path)
+    print(f"\nSaved weights to {weights_path}")
+
+    # Print output shapes
+    print("\nMLX weight shapes:")
+    total_params = 0
+    for k, v in sorted(mlx_weights.items()):
+        print(f"  {k}: {v.shape}")
+        total_params += v.size
+    print(f"\nTotal parameters: {total_params:,}")
+
+    # Config
+    config = {
+        "model_type": "silero_vad_v5",
+        "sample_rate": 16000,
+        "chunk_size": 512,
+        "context_size": 64,
+        "filter_length": 256,
+        "hop_length": 128,
+        "encoder_channels": [129, 128, 64, 64, 128],
+        "encoder_kernel_sizes": [3, 3, 3, 3],
+        "encoder_strides": [1, 2, 2, 1],
+        "lstm_hidden_size": 128,
+        "lstm_num_layers": 1,
+    }
+    config_path = os.path.join(args.output, "config.json")
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+    print(f"Saved config to {config_path}")
+
+    # Verify shapes
+    print("\nVerifying weight shapes...")
+    assert mlx_weights["stft.weight"].shape == (258, 256, 1), (
+        f"STFT weight shape mismatch: {mlx_weights['stft.weight'].shape}"
+    )
+    assert mlx_weights["lstm.Wx"].shape[0] == 512, (
+        f"LSTM Wx shape mismatch: {mlx_weights['lstm.Wx'].shape}"
+    )
+    assert mlx_weights["lstm.Wh"].shape == (512, 128), (
+        f"LSTM Wh shape mismatch: {mlx_weights['lstm.Wh'].shape}"
+    )
+    assert mlx_weights["lstm.bias"].shape == (512,), (
+        f"LSTM bias shape mismatch: {mlx_weights['lstm.bias'].shape}"
+    )
+    print("All shapes verified!")
+
+    # Upload
+    if args.upload:
+        try:
+            from huggingface_hub import HfApi
+
+            api = HfApi()
+            api.create_repo(args.repo_id, exist_ok=True)
+            api.upload_folder(
+                folder_path=args.output,
+                repo_id=args.repo_id,
+            )
+            print(f"\nUploaded to {args.repo_id}")
+        except Exception as e:
+            print(f"\nUpload failed: {e}")
+            print(
+                f"Upload manually: huggingface-cli upload {args.repo_id} {args.output}/"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_wespeaker.py
+++ b/scripts/convert_wespeaker.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+Convert pyannote/wespeaker-voxceleb-resnet34-LM to safetensors for Swift/MLX.
+
+ResNet34 speaker embedding model (~6.6M params, 256-dim output, ~25 MB).
+Key transformations:
+  - Fuse BatchNorm into Conv2d: w_fused = w * γ/√(σ²+ε), b_fused = β - μ·γ/√(σ²+ε)
+  - Transpose Conv2d: [O, I, H, W] → [O, H, W, I] (PyTorch to MLX channels-last)
+  - Rename: strip "resnet." prefix, "seg_1" → "embedding"
+  - Drop num_batches_tracked keys
+
+Loads pytorch_model.bin with a custom unpickler — does NOT require pyannote.audio or wespeaker.
+
+Requires: pip install torch safetensors numpy huggingface_hub
+
+Usage:
+  python scripts/convert_wespeaker.py --token YOUR_HF_TOKEN
+  python scripts/convert_wespeaker.py --output-dir ./wespeaker-mlx
+  python scripts/convert_wespeaker.py --upload --repo-id aufklarer/WeSpeaker-ResNet34-LM-MLX
+"""
+
+import argparse
+import io
+import json
+import pickle
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+from safetensors.numpy import save_file
+
+
+# ── Custom unpickler to load pyannote checkpoints without pyannote installed ──
+
+class _StubModule(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+class _StubObject:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class _WeSpeakerUnpickler(pickle.Unpickler):
+    """Custom unpickler that stubs out pyannote/wespeaker classes."""
+    def find_class(self, module, name):
+        # Stub out any pyannote or wespeaker classes
+        if module.startswith(("pyannote", "wespeaker")):
+            if any(kw in name for kw in ("Model", "Net", "LSTM", "Linear", "ResNet", "Block")):
+                return _StubModule
+            return _StubObject
+        # Handle TorchVersion
+        if module == "torch.torch_version" and name == "TorchVersion":
+            return str
+        # Handle collections.OrderedDict
+        if module == "collections" and name == "OrderedDict":
+            from collections import OrderedDict
+            return OrderedDict
+        return super().find_class(module, name)
+
+
+def _load_checkpoint(path):
+    """Load a PyTorch checkpoint with class stubs to avoid dependency hell."""
+    with open(path, "rb") as f:
+        data = f.read()
+
+    # Check if it's a zip file (PyTorch save format)
+    if zipfile.is_zipfile(io.BytesIO(data)):
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        pkl_names = [n for n in zf.namelist() if n.endswith(".pkl")]
+        if not pkl_names:
+            raise ValueError("No .pkl found in checkpoint zip")
+        pkl_name = pkl_names[0]
+        data_prefix = pkl_name.rsplit("/", 1)[0] + "/data/" if "/" in pkl_name else "data/"
+
+        class _TorchUnpickler(_WeSpeakerUnpickler):
+            def __init__(self, file, zf, data_prefix):
+                super().__init__(file)
+                self.zf = zf
+                self.data_prefix = data_prefix
+                self._storages = {}
+
+            def persistent_load(self, saved_id):
+                if isinstance(saved_id, tuple) and saved_id[0] == "storage":
+                    _, storage_type, key, location, numel = saved_id
+                    if key not in self._storages:
+                        raw = self.zf.read(self.data_prefix + str(key))
+                        storage = storage_type.from_buffer(raw, byte_order="little")
+                        self._storages[key] = storage
+                    return self._storages[key]
+                raise RuntimeError(f"Unknown persistent_id: {saved_id}")
+
+        pkl_data = zf.read(pkl_name)
+        result = _TorchUnpickler(io.BytesIO(pkl_data), zf, data_prefix).load()
+    else:
+        raise ValueError("Checkpoint is not a zip file")
+
+    # Extract state_dict from various wrapper formats
+    if isinstance(result, dict):
+        if "state_dict" in result:
+            return result["state_dict"]
+        # Might be a plain state dict already
+        has_tensors = any(isinstance(v, torch.Tensor) for v in result.values())
+        if has_tensors:
+            return result
+    if hasattr(result, "state_dict"):
+        sd = result.state_dict()
+        if isinstance(sd, dict):
+            return sd
+
+    return result
+
+
+def fuse_bn_into_conv(conv_weight, bn_weight, bn_bias, bn_mean, bn_var, eps=1e-5):
+    """Fuse BatchNorm parameters into Conv2d weight and bias.
+
+    w_fused = w * (γ / √(σ² + ε))
+    b_fused = β - μ * γ / √(σ² + ε)
+    """
+    scale = bn_weight / np.sqrt(bn_var + eps)  # [O]
+    fused_weight = conv_weight * scale[:, None, None, None]
+    fused_bias = bn_bias - bn_mean * scale
+    return fused_weight.astype(np.float32), fused_bias.astype(np.float32)
+
+
+def convert(
+    source_model: str = "pyannote/wespeaker-voxceleb-resnet34-LM",
+    output_dir: str = "./wespeaker-resnet34-lm-mlx",
+    token: str = None,
+):
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if not token:
+        token_path = Path.home() / ".cache" / "huggingface" / "token"
+        if token_path.exists():
+            token = token_path.read_text().strip()
+
+    print(f"Downloading pytorch_model.bin from {source_model}...")
+    path = hf_hub_download(source_model, "pytorch_model.bin", token=token)
+
+    print("Loading state dict with custom unpickler...")
+    state_dict = _load_checkpoint(path)
+
+    # Filter to only tensors
+    for k in list(state_dict.keys()):
+        if not isinstance(state_dict[k], torch.Tensor):
+            del state_dict[k]
+
+    print(f"Loaded {len(state_dict)} tensors")
+    for k, v in sorted(state_dict.items()):
+        print(f"  {k}: {list(v.shape)} {v.dtype}")
+
+    output_tensors = {}
+
+    # ── 1. Initial conv1 + bn1 ──
+    print("\n--- conv1 + bn1 ---")
+    conv1_w = state_dict["resnet.conv1.weight"].numpy()  # [32, 1, 3, 3]
+    bn1_w = state_dict["resnet.bn1.weight"].numpy()
+    bn1_b = state_dict["resnet.bn1.bias"].numpy()
+    bn1_m = state_dict["resnet.bn1.running_mean"].numpy()
+    bn1_v = state_dict["resnet.bn1.running_var"].numpy()
+
+    fused_w, fused_b = fuse_bn_into_conv(conv1_w, bn1_w, bn1_b, bn1_m, bn1_v)
+    # Transpose [O, I, H, W] → [O, H, W, I] for MLX
+    output_tensors["conv1.weight"] = np.transpose(fused_w, (0, 2, 3, 1))
+    output_tensors["conv1.bias"] = fused_b
+    print(f"  conv1: {conv1_w.shape} → {output_tensors['conv1.weight'].shape}")
+
+    # ── 2. ResNet layers ──
+    layer_configs = [
+        ("layer1", 3),   # 3 blocks, 32→32
+        ("layer2", 4),   # 4 blocks, 32→64, first stride=2
+        ("layer3", 6),   # 6 blocks, 64→128, first stride=2
+        ("layer4", 3),   # 3 blocks, 128→256, first stride=2
+    ]
+
+    for layer_name, num_blocks in layer_configs:
+        print(f"\n--- {layer_name} ({num_blocks} blocks) ---")
+        for block_idx in range(num_blocks):
+            prefix = f"resnet.{layer_name}.{block_idx}"
+            out_prefix = f"{layer_name}.{block_idx}"
+
+            # conv1 + bn1, conv2 + bn2
+            for conv_idx in [1, 2]:
+                conv_key = f"{prefix}.conv{conv_idx}.weight"
+                bn_prefix = f"{prefix}.bn{conv_idx}"
+
+                conv_w = state_dict[conv_key].numpy()
+                bn_w = state_dict[f"{bn_prefix}.weight"].numpy()
+                bn_b = state_dict[f"{bn_prefix}.bias"].numpy()
+                bn_m = state_dict[f"{bn_prefix}.running_mean"].numpy()
+                bn_v = state_dict[f"{bn_prefix}.running_var"].numpy()
+
+                fused_w, fused_b = fuse_bn_into_conv(conv_w, bn_w, bn_b, bn_m, bn_v)
+                out_key = f"{out_prefix}.conv{conv_idx}"
+                output_tensors[f"{out_key}.weight"] = np.transpose(fused_w, (0, 2, 3, 1))
+                output_tensors[f"{out_key}.bias"] = fused_b
+                print(f"  {out_key}: {conv_w.shape} → {output_tensors[f'{out_key}.weight'].shape}")
+
+            # Shortcut (downsample) if present
+            shortcut_conv_key = f"{prefix}.shortcut.0.weight"
+            if shortcut_conv_key in state_dict:
+                conv_w = state_dict[shortcut_conv_key].numpy()  # [O, I, 1, 1]
+                bn_w = state_dict[f"{prefix}.shortcut.1.weight"].numpy()
+                bn_b = state_dict[f"{prefix}.shortcut.1.bias"].numpy()
+                bn_m = state_dict[f"{prefix}.shortcut.1.running_mean"].numpy()
+                bn_v = state_dict[f"{prefix}.shortcut.1.running_var"].numpy()
+
+                fused_w, fused_b = fuse_bn_into_conv(conv_w, bn_w, bn_b, bn_m, bn_v)
+                out_key = f"{out_prefix}.shortcut"
+                output_tensors[f"{out_key}.weight"] = np.transpose(fused_w, (0, 2, 3, 1))
+                output_tensors[f"{out_key}.bias"] = fused_b
+                print(f"  {out_key}: {conv_w.shape} → {output_tensors[f'{out_key}.weight'].shape}")
+
+    # ── 3. Embedding layer (seg_1) ──
+    print("\n--- embedding (seg_1) ---")
+    output_tensors["embedding.weight"] = state_dict["resnet.seg_1.weight"].numpy()
+    output_tensors["embedding.bias"] = state_dict["resnet.seg_1.bias"].numpy()
+    print(f"  embedding: {output_tensors['embedding.weight'].shape}")
+
+    # ── Save ──
+    output_file = output_path / "model.safetensors"
+    print(f"\nSaving to {output_file}...")
+    save_file(output_tensors, str(output_file))
+
+    file_size_mb = output_file.stat().st_size / (1024 * 1024)
+    print(f"  Output size: {file_size_mb:.1f} MB")
+
+    config = {
+        "model_type": "wespeaker-resnet34-lm",
+        "sample_rate": 16000,
+        "n_mels": 80,
+        "embedding_dim": 256,
+        "layers": [3, 4, 6, 3],
+        "channels": [32, 64, 128, 256],
+        "pooling_output_dim": 5120,
+    }
+    with open(output_path / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+    print("  Saved config.json")
+
+    print(f"\nConversion complete! Output in: {output_path}")
+    total_params = sum(np.prod(v.shape) for v in output_tensors.values())
+    print(f"Total parameters: {total_params:,}")
+    return output_path
+
+
+def upload(output_dir: str, repo_id: str):
+    """Upload converted model to HuggingFace Hub."""
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    api.create_repo(repo_id, exist_ok=True)
+    api.upload_folder(
+        folder_path=output_dir,
+        repo_id=repo_id,
+        commit_message="Upload WeSpeaker ResNet34-LM speaker embedding model for MLX Swift",
+    )
+    print(f"Uploaded to: https://huggingface.co/{repo_id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert pyannote/wespeaker-voxceleb-resnet34-LM to safetensors for MLX Swift"
+    )
+    parser.add_argument("--source", default="pyannote/wespeaker-voxceleb-resnet34-LM",
+                        help="Source model ID on HuggingFace")
+    parser.add_argument("--output-dir", default="./wespeaker-resnet34-lm-mlx",
+                        help="Output directory")
+    parser.add_argument("--token", default=None,
+                        help="HuggingFace token (reads ~/.cache/huggingface/token if not set)")
+    parser.add_argument("--upload", action="store_true",
+                        help="Upload to HuggingFace Hub after conversion")
+    parser.add_argument("--repo-id", default="aufklarer/WeSpeaker-ResNet34-LM-MLX",
+                        help="HuggingFace repo ID for upload")
+    args = parser.parse_args()
+
+    output_path = convert(
+        source_model=args.source,
+        output_dir=args.output_dir,
+        token=args.token,
+    )
+
+    if args.upload:
+        upload(str(output_path), args.repo_id)


### PR DESCRIPTION
## Summary

- **SpeechVAD module** with three models: Pyannote Segmentation 3.0 (offline VAD, multi-speaker overlap), Silero VAD v5 (streaming 32ms chunks, 23x real-time), WeSpeaker ResNet34-LM (256-dim speaker embeddings)
- **Speaker diarization pipeline**: segmentation → embedding → agglomerative clustering, with speaker extraction via enrollment embedding
- **StreamingVADProcessor**: 4-state hysteresis machine for event-driven real-time VAD
- **CLI commands**: `audio vad`, `audio vad-stream`, `audio diarize`, `audio embed-speaker`
- **Conversion scripts** for all three models (custom unpicklers, no pyannote.audio dependency)
- Also includes forced aligner, unified CLI (`audio` command), `AudioCommon` rename, shared protocols

## Models

| Model | Params | Download | Use Case |
|-------|--------|----------|----------|
| Pyannote Segmentation 3.0 | ~1.49M | ~5.7 MB | Offline VAD, multi-speaker segmentation |
| Silero VAD v5 | ~309K | ~1.2 MB | Streaming VAD (32ms chunks) |
| WeSpeaker ResNet34-LM | ~6.6M | ~25 MB | Speaker embeddings (256-dim) |

## Test plan

- [x] 62 SpeechVAD tests pass (unit + E2E with real weights)
- [x] E2E: pyannote VAD detects speech at [5.16s-8.44s] matching Python reference
- [x] E2E: Silero streaming VAD detects speech at [5.22s-8.38s] matching Python reference
- [x] E2E: WeSpeaker produces L2-normalized 256-dim embeddings, deterministic
- [x] E2E: Diarization pipeline detects speakers with valid segment boundaries
- [x] E2E: Speaker extraction via enrollment embedding works
- [x] E2E: Pyannote and Silero cross-validate (speech regions within 2s)
- [x] E2E: Protocol conformance (VoiceActivityDetectionModel, SpeakerEmbeddingModel, SpeakerDiarizationModel)
- [x] `swift build` compiles cleanly