### PR TITLE
Add streaming ASR with VAD-guided segmentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ let package = Package(
             name: "Qwen3ASR",
             dependencies: [
                 "AudioCommon",
+                "SpeechVAD",
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXFast", package: "mlx-swift")
@@ -119,7 +120,7 @@ let package = Package(
         ),
         .testTarget(
             name: "Qwen3ASRTests",
-            dependencies: ["Qwen3ASR", "AudioCommon"],
+            dependencies: ["Qwen3ASR", "SpeechVAD", "AudioCommon"],
             resources: [
                 .copy("Resources/test_audio.wav")
             ]

--- a/Sources/AudioCommon/AudioFileLoader.swift
+++ b/Sources/AudioCommon/AudioFileLoader.swift
@@ -122,7 +122,7 @@ public enum AudioFileLoader {
     }
 
     /// Simple linear resampling
-    private static func resample(_ samples: [Float], from inputRate: Int, to outputRate: Int) -> [Float] {
+    public static func resample(_ samples: [Float], from inputRate: Int, to outputRate: Int) -> [Float] {
         let ratio = Double(outputRate) / Double(inputRate)
         let outputLength = Int(Double(samples.count) * ratio)
 

--- a/Sources/Qwen3ASR/StreamingASR.swift
+++ b/Sources/Qwen3ASR/StreamingASR.swift
@@ -1,0 +1,245 @@
+import Foundation
+import AudioCommon
+@preconcurrency import SpeechVAD
+
+// MARK: - TranscriptionSegment
+
+public struct TranscriptionSegment: Sendable {
+    public let text: String
+    public let startTime: Float
+    public let endTime: Float
+    public let isFinal: Bool
+    public let segmentIndex: Int
+
+    public init(text: String, startTime: Float, endTime: Float, isFinal: Bool, segmentIndex: Int) {
+        self.text = text
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isFinal = isFinal
+        self.segmentIndex = segmentIndex
+    }
+}
+
+// MARK: - StreamingASRConfig
+
+public struct StreamingASRConfig: Sendable {
+    public var maxSegmentDuration: Float
+    public var vadConfig: VADConfig
+    public var language: String?
+    public var maxTokens: Int
+    public var emitPartialResults: Bool
+    public var partialResultInterval: Float
+
+    public init(
+        maxSegmentDuration: Float = 10.0,
+        vadConfig: VADConfig = .sileroDefault,
+        language: String? = nil,
+        maxTokens: Int = 448,
+        emitPartialResults: Bool = false,
+        partialResultInterval: Float = 1.0
+    ) {
+        self.maxSegmentDuration = maxSegmentDuration
+        self.vadConfig = vadConfig
+        self.language = language
+        self.maxTokens = maxTokens
+        self.emitPartialResults = emitPartialResults
+        self.partialResultInterval = partialResultInterval
+    }
+
+    public static let `default` = StreamingASRConfig()
+}
+
+// MARK: - StreamingASR
+
+public class StreamingASR {
+    private let asrModel: Qwen3ASRModel
+    private let vadModel: SileroVADModel
+
+    public init(asrModel: Qwen3ASRModel, vadModel: SileroVADModel) {
+        self.asrModel = asrModel
+        self.vadModel = vadModel
+    }
+
+    public static func fromPretrained(
+        asrModelId: String = "mlx-community/Qwen3-ASR-0.6B-4bit",
+        vadModelId: String = SileroVADModel.defaultModelId,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> StreamingASR {
+        let asr = try await Qwen3ASRModel.fromPretrained(
+            modelId: asrModelId, progressHandler: progressHandler)
+        let vad = try await SileroVADModel.fromPretrained(
+            modelId: vadModelId, progressHandler: progressHandler)
+        return StreamingASR(asrModel: asr, vadModel: vad)
+    }
+
+    /// Streaming transcription — emits TranscriptionSegments as speech is detected.
+    public func transcribeStream(
+        audio: [Float],
+        sampleRate: Int = 16000,
+        config: StreamingASRConfig = .default
+    ) -> AsyncThrowingStream<TranscriptionSegment, Error> {
+        AsyncThrowingStream { continuation in
+                let samples: [Float]
+                if sampleRate != 16000 {
+                    samples = AudioFileLoader.resample(audio, from: sampleRate, to: 16000)
+                } else {
+                    samples = audio
+                }
+
+                let processor = StreamingVADProcessor(model: vadModel, config: config.vadConfig)
+                let chunkSize = SileroVADModel.chunkSize
+                var segmentIndex = 0
+                var speechStartSample: Int?
+
+                // Phase 2 state
+                var lastPartialTime: Float = 0
+
+                var offset = 0
+                while offset < samples.count {
+                    let end = min(offset + chunkSize, samples.count)
+                    let chunk = Array(samples[offset..<end])
+                    let events = processor.process(samples: chunk)
+
+                    for event in events {
+                        switch event {
+                        case .speechStarted(let time):
+                            speechStartSample = Int(time * 16000)
+                            lastPartialTime = time
+
+                        case .speechEnded(let segment):
+                            if let startSample = speechStartSample {
+                                let endSample = min(Int(segment.endTime * 16000), samples.count)
+                                let segmentAudio = Array(samples[startSample..<endSample])
+                                let text = asrModel.transcribe(
+                                    audio: segmentAudio, sampleRate: 16000,
+                                    language: config.language, maxTokens: config.maxTokens)
+                                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    continuation.yield(TranscriptionSegment(
+                                        text: trimmed,
+                                        startTime: segment.startTime,
+                                        endTime: segment.endTime,
+                                        isFinal: true,
+                                        segmentIndex: segmentIndex))
+                                    segmentIndex += 1
+                                }
+                                speechStartSample = nil
+                            }
+                        }
+                    }
+
+                    // Phase 2: emit partial results during speech
+                    if config.emitPartialResults, let startSample = speechStartSample {
+                        let currentTime = processor.currentTime
+                        let speechStart = Float(startSample) / 16000
+                        let speechDuration = currentTime - speechStart
+
+                        if currentTime - lastPartialTime >= config.partialResultInterval {
+                            let endSample = min(Int(currentTime * 16000), samples.count)
+                            let segmentAudio = Array(samples[startSample..<endSample])
+                            let text = asrModel.transcribe(
+                                audio: segmentAudio, sampleRate: 16000,
+                                language: config.language, maxTokens: config.maxTokens)
+                            let currentWords = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                .split(separator: " ").map(String.init)
+
+                            if !currentWords.isEmpty {
+                                continuation.yield(TranscriptionSegment(
+                                    text: currentWords.joined(separator: " "),
+                                    startTime: speechStart,
+                                    endTime: currentTime,
+                                    isFinal: false,
+                                    segmentIndex: segmentIndex))
+                            }
+                            lastPartialTime = currentTime
+                        }
+
+                        // Force-split if speech exceeds maxSegmentDuration
+                        if speechDuration >= config.maxSegmentDuration {
+                            let endSample = min(Int(currentTime * 16000), samples.count)
+                            let segmentAudio = Array(samples[startSample..<endSample])
+                            let text = asrModel.transcribe(
+                                audio: segmentAudio, sampleRate: 16000,
+                                language: config.language, maxTokens: config.maxTokens)
+                            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if !trimmed.isEmpty {
+                                continuation.yield(TranscriptionSegment(
+                                    text: trimmed,
+                                    startTime: speechStart,
+                                    endTime: currentTime,
+                                    isFinal: true,
+                                    segmentIndex: segmentIndex))
+                                segmentIndex += 1
+                            }
+                            speechStartSample = Int(currentTime * 16000)
+                            lastPartialTime = currentTime
+                        }
+                    } else if !config.emitPartialResults, let startSample = speechStartSample {
+                        // Force-split without partial results
+                        let currentTime = processor.currentTime
+                        let speechStart = Float(startSample) / 16000
+                        let speechDuration = currentTime - speechStart
+
+                        if speechDuration >= config.maxSegmentDuration {
+                            let endSample = min(Int(currentTime * 16000), samples.count)
+                            let segmentAudio = Array(samples[startSample..<endSample])
+                            let text = asrModel.transcribe(
+                                audio: segmentAudio, sampleRate: 16000,
+                                language: config.language, maxTokens: config.maxTokens)
+                            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if !trimmed.isEmpty {
+                                continuation.yield(TranscriptionSegment(
+                                    text: trimmed,
+                                    startTime: speechStart,
+                                    endTime: currentTime,
+                                    isFinal: true,
+                                    segmentIndex: segmentIndex))
+                                segmentIndex += 1
+                            }
+                            speechStartSample = Int(currentTime * 16000)
+                        }
+                    }
+
+                    offset = end
+                }
+
+                // Flush any remaining speech
+                let flushEvents = processor.flush()
+                for event in flushEvents {
+                    if case .speechEnded(let segment) = event, let startSample = speechStartSample {
+                        let endSample = min(Int(segment.endTime * 16000), samples.count)
+                        let segmentAudio = Array(samples[startSample..<endSample])
+                        let text = asrModel.transcribe(
+                            audio: segmentAudio, sampleRate: 16000,
+                            language: config.language, maxTokens: config.maxTokens)
+                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            continuation.yield(TranscriptionSegment(
+                                text: trimmed,
+                                startTime: segment.startTime,
+                                endTime: segment.endTime,
+                                isFinal: true,
+                                segmentIndex: segmentIndex))
+                        }
+                    }
+                }
+
+                continuation.finish()
+        }
+    }
+}
+
+// MARK: - LocalAgreement Helper
+
+/// Returns the longest common prefix of two word arrays (case-insensitive).
+public func longestCommonPrefix(_ a: [String], _ b: [String]) -> [String] {
+    var result: [String] = []
+    for i in 0..<min(a.count, b.count) {
+        if a[i].lowercased() == b[i].lowercased() {
+            result.append(b[i])
+        } else {
+            break
+        }
+    }
+    return result
+}

--- a/Tests/Qwen3ASRTests/StreamingASRTests.swift
+++ b/Tests/Qwen3ASRTests/StreamingASRTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import Qwen3ASR
+@testable import SpeechVAD
+@testable import AudioCommon
+
+final class StreamingASRTests: XCTestCase {
+
+    // MARK: - LongestCommonPrefix Tests
+
+    func testLCPEmptyArrays() {
+        XCTAssertEqual(longestCommonPrefix([], []), [])
+        XCTAssertEqual(longestCommonPrefix(["hello"], []), [])
+        XCTAssertEqual(longestCommonPrefix([], ["hello"]), [])
+    }
+
+    func testLCPFullMatch() {
+        let a = ["can", "you", "guarantee"]
+        let b = ["can", "you", "guarantee"]
+        XCTAssertEqual(longestCommonPrefix(a, b), ["can", "you", "guarantee"])
+    }
+
+    func testLCPPartialMatch() {
+        let a = ["can", "you", "guarantee"]
+        let b = ["can", "you", "help"]
+        XCTAssertEqual(longestCommonPrefix(a, b), ["can", "you"])
+    }
+
+    func testLCPNoMatch() {
+        let a = ["hello"]
+        let b = ["goodbye"]
+        XCTAssertEqual(longestCommonPrefix(a, b), [])
+    }
+
+    func testLCPCaseInsensitive() {
+        let a = ["Can", "You"]
+        let b = ["can", "you", "help"]
+        let result = longestCommonPrefix(a, b)
+        XCTAssertEqual(result.count, 2)
+        // Returns elements from b
+        XCTAssertEqual(result, ["can", "you"])
+    }
+
+    func testLCPDifferentLengths() {
+        let a = ["the", "quick", "brown", "fox"]
+        let b = ["the", "quick"]
+        XCTAssertEqual(longestCommonPrefix(a, b), ["the", "quick"])
+    }
+
+    // MARK: - StreamingASRConfig Tests
+
+    func testDefaultConfig() {
+        let config = StreamingASRConfig.default
+        XCTAssertEqual(config.maxSegmentDuration, 10.0)
+        XCTAssertEqual(config.maxTokens, 448)
+        XCTAssertFalse(config.emitPartialResults)
+        XCTAssertEqual(config.partialResultInterval, 1.0)
+        XCTAssertNil(config.language)
+    }
+
+    func testCustomConfig() {
+        let config = StreamingASRConfig(
+            maxSegmentDuration: 15.0,
+            language: "en",
+            maxTokens: 256,
+            emitPartialResults: true,
+            partialResultInterval: 0.5
+        )
+        XCTAssertEqual(config.maxSegmentDuration, 15.0)
+        XCTAssertEqual(config.language, "en")
+        XCTAssertEqual(config.maxTokens, 256)
+        XCTAssertTrue(config.emitPartialResults)
+        XCTAssertEqual(config.partialResultInterval, 0.5)
+    }
+
+    // MARK: - TranscriptionSegment Tests
+
+    func testTranscriptionSegment() {
+        let segment = TranscriptionSegment(
+            text: "hello world",
+            startTime: 1.0,
+            endTime: 2.5,
+            isFinal: true,
+            segmentIndex: 0
+        )
+        XCTAssertEqual(segment.text, "hello world")
+        XCTAssertEqual(segment.startTime, 1.0)
+        XCTAssertEqual(segment.endTime, 2.5)
+        XCTAssertTrue(segment.isFinal)
+        XCTAssertEqual(segment.segmentIndex, 0)
+    }
+
+    func testPartialSegment() {
+        let segment = TranscriptionSegment(
+            text: "hello",
+            startTime: 1.0,
+            endTime: 1.5,
+            isFinal: false,
+            segmentIndex: 0
+        )
+        XCTAssertFalse(segment.isFinal)
+    }
+
+    // MARK: - Integration Tests (require model downloads)
+
+    func testStreamingTranscription() async throws {
+        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
+            throw XCTSkip("Test WAV file not found in bundle resources")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
+        let audio = AudioFileLoader.resample(samples, from: sampleRate, to: 16000)
+        print("Loaded audio: \(audio.count) samples (\(String(format: "%.2f", Float(audio.count) / 16000))s)")
+
+        let streaming = try await StreamingASR.fromPretrained { progress, status in
+            print("[\(Int(progress * 100))%] \(status)")
+        }
+
+        var segments: [TranscriptionSegment] = []
+        let stream = streaming.transcribeStream(audio: audio, sampleRate: 16000)
+        for try await segment in stream {
+            let tag = segment.isFinal ? "FINAL" : "partial"
+            print("[\(String(format: "%.2f", segment.startTime))s-\(String(format: "%.2f", segment.endTime))s] [\(tag)] \(segment.text)")
+            segments.append(segment)
+        }
+
+        // Should produce at least one final segment
+        let finalSegments = segments.filter { $0.isFinal }
+        XCTAssertGreaterThan(finalSegments.count, 0, "Should have at least one final segment")
+
+        // Verify transcription content
+        let fullText = finalSegments.map { $0.text }.joined(separator: " ")
+        print("Full transcription: \(fullText)")
+        XCTAssertTrue(fullText.contains("guarantee"), "Should transcribe 'guarantee'")
+        XCTAssertTrue(fullText.contains("replacement"), "Should transcribe 'replacement'")
+        XCTAssertTrue(fullText.contains("shipped"), "Should transcribe 'shipped'")
+        XCTAssertTrue(fullText.contains("tomorrow"), "Should transcribe 'tomorrow'")
+
+        // Verify timestamps are reasonable
+        for segment in finalSegments {
+            XCTAssertGreaterThanOrEqual(segment.startTime, 0)
+            XCTAssertGreaterThan(segment.endTime, segment.startTime)
+        }
+    }
+
+    func testStreamingWithPartialResults() async throws {
+        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
+            throw XCTSkip("Test WAV file not found in bundle resources")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
+        let audio = AudioFileLoader.resample(samples, from: sampleRate, to: 16000)
+
+        let streaming = try await StreamingASR.fromPretrained { progress, status in
+            print("[\(Int(progress * 100))%] \(status)")
+        }
+
+        let config = StreamingASRConfig(
+            emitPartialResults: true,
+            partialResultInterval: 0.5
+        )
+
+        var segments: [TranscriptionSegment] = []
+        let stream = streaming.transcribeStream(audio: audio, sampleRate: 16000, config: config)
+        for try await segment in stream {
+            let tag = segment.isFinal ? "FINAL" : "partial"
+            print("[\(String(format: "%.2f", segment.startTime))s-\(String(format: "%.2f", segment.endTime))s] [\(tag)] \(segment.text)")
+            segments.append(segment)
+        }
+
+        let partials = segments.filter { !$0.isFinal }
+        let finals = segments.filter { $0.isFinal }
+
+        // With partial results, we should see some tentative segments before the final
+        print("Partial segments: \(partials.count), Final segments: \(finals.count)")
+        XCTAssertGreaterThan(finals.count, 0, "Should have at least one final segment")
+
+        // Final segment should contain the full transcription
+        let fullText = finals.map { $0.text }.joined(separator: " ")
+        XCTAssertTrue(fullText.contains("guarantee"), "Final should contain 'guarantee'")
+    }
+}


### PR DESCRIPTION
Closes #36

## Summary
- Compose Silero VAD (streaming, 32ms chunks) with Qwen3-ASR to emit timestamped transcription segments
- **Phase 1**: VAD detects speech boundaries → slices audio → ASR transcribes → yields final `TranscriptionSegment`
- **Phase 2**: Periodic ASR during speech emits incremental partial results (`--partial` flag)
- Force-splits segments exceeding `--max-segment` duration (default 10s)

## Files changed
| File | Change |
|------|--------|
| `Package.swift` | Add `SpeechVAD` dep to `Qwen3ASR` + test target |
| `Sources/Qwen3ASR/StreamingASR.swift` | **New** — `TranscriptionSegment`, `StreamingASRConfig`, `StreamingASR` class |
| `Sources/AudioCLILib/TranscribeCommand.swift` | Add `--stream`, `--max-segment`, `--partial` flags |
| `Sources/AudioCommon/AudioFileLoader.swift` | Make `resample()` public |
| `Tests/Qwen3ASRTests/StreamingASRTests.swift` | **New** — 10 unit tests + 2 integration tests |

## Usage
```
audio transcribe --stream test_audio.wav
# [5.22s-8.38s] [FINAL] Can you guarantee that the replacement part will be shipped tomorrow?

audio transcribe --stream --partial test_audio.wav
# [5.22s-5.73s] [partial] Can you guarantee?
# [5.22s-6.24s] [partial] Can you guarantee the?
# ...
# [5.22s-8.38s] [FINAL] Can you guarantee that the replacement part will be shipped tomorrow?
```

## Test plan
- [x] `swift build` — compiles clean, no warnings
- [x] `swift test --filter StreamingASRTests` — 10 unit tests pass (LCP, config, segment types)
- [x] Integration: streaming transcription produces correct timestamped output
- [x] Integration: partial results emit incremental hypotheses before final