### PR TITLE
Simplify tokenizer decode + UTF-8 regression tests

### DIFF
--- a/Sources/AudioCommon/Tokenizer.swift
+++ b/Sources/AudioCommon/Tokenizer.swift
@@ -27,6 +27,12 @@ public class Qwen3Tokenizer {
 
     public init() {}
 
+    /// Test-only initializer with pre-built token mappings
+    internal init(idToToken: [Int: String]) {
+        self.idToToken = idToToken
+        for (id, token) in idToToken { tokenToId[token] = id }
+    }
+
     /// Load tokenizer from vocab.json file (direct token->id mapping)
     public func load(from url: URL) throws {
         let data = try Data(contentsOf: url)
@@ -99,57 +105,40 @@ public class Qwen3Tokenizer {
         }
     }
 
-    /// Decode token IDs to text
-    ///
-    /// Collects all byte-level BPE tokens into a single byte buffer before
-    /// decoding as UTF-8. This is necessary because a single UTF-8 character
-    /// (e.g. Chinese 「來」= 3 bytes) may be split across multiple BPE tokens.
-    /// Decoding each token independently would produce incomplete byte sequences
-    /// that fail UTF-8 validation and cause garbled output.
+    /// Decode token IDs to text using a unified byte buffer.
+    /// Collects all bytes before converting to UTF-8, so multi-byte characters
+    /// split across BPE tokens (e.g. CJK) decode correctly.
     public func decode(tokens: [Int]) -> String {
-        var bytes: [UInt8] = []
+        var buffer: [UInt8] = []
 
         for tokenId in tokens {
             guard let token = idToToken[tokenId] else { continue }
 
-            // Skip special tokens like <|endoftext|>, <|im_start|>, etc.
+            // Skip <|...|> special tokens
             if token.hasPrefix("<|") && token.hasSuffix("|>") {
                 continue
             }
 
-            // Keep <asr_text> and similar markers for output parsing.
-            // Flush accumulated bytes first so they decode correctly.
+            // Keep <asr_text> and similar markers — append their UTF-8 bytes
             if token.hasPrefix("<") && token.hasSuffix(">") && !token.contains("|") {
-                if let decoded = String(bytes: bytes, encoding: .utf8) {
-                    bytes.removeAll()
-                    // Re-add as raw UTF-8 bytes so final decode works
-                    bytes.append(contentsOf: decoded.utf8)
-                }
-                bytes.append(contentsOf: token.utf8)
+                buffer.append(contentsOf: Array(token.utf8))
                 continue
             }
 
-            // Handle byte-level tokens (Ġ prefix means space in GPT-2 BPE)
-            var rawToken = token
-            if rawToken.hasPrefix("Ġ") {
-                bytes.append(UInt8(ascii: " "))
-                rawToken = String(rawToken.dropFirst())
-            }
-
-            // Map each character through the unicode-to-byte table
-            for char in rawToken {
+            // Convert each char via unicodeToByte (Ġ→0x20 space is handled
+            // automatically since unicodeToByte maps Ġ (U+0120) → byte 32)
+            for char in token {
                 if let byte = Self.unicodeToByte[char] {
-                    bytes.append(byte)
+                    buffer.append(byte)
                 } else {
-                    // Character not in BPE mapping — keep as raw UTF-8
-                    bytes.append(contentsOf: String(char).utf8)
+                    buffer.append(contentsOf: String(char).utf8)
                 }
             }
         }
 
-        let result = String(bytes: bytes, encoding: .utf8)
-            ?? String(decoding: bytes, as: UTF8.self)
-        return result.trimmingCharacters(in: .whitespaces)
+        let text = String(bytes: buffer, encoding: .utf8)
+            ?? String(decoding: buffer, as: UTF8.self)
+        return text.trimmingCharacters(in: .whitespaces)
     }
 
     /// Byte-to-unicode mapping table (GPT-2 style)
@@ -190,28 +179,6 @@ public class Qwen3Tokenizer {
         }
         return reverse
     }()
-
-    /// Decode byte-level BPE token to proper UTF-8 string
-    private func decodeByteLevelToken(_ token: String) -> String {
-        var bytes: [UInt8] = []
-
-        for char in token {
-            if let byte = Self.unicodeToByte[char] {
-                bytes.append(byte)
-            } else {
-                // Character not in mapping - keep as UTF-8
-                bytes.append(contentsOf: String(char).utf8)
-            }
-        }
-
-        // Decode bytes as UTF-8
-        if let decoded = String(bytes: bytes, encoding: .utf8) {
-            return decoded
-        } else {
-            // Fallback to original if decoding fails
-            return token
-        }
-    }
 
     /// Encode a byte-level BPE token string from raw text bytes
     private func encodeByteLevelToken(_ text: String) -> String {

--- a/Tests/Qwen3ASRTests/Qwen3ASRTests.swift
+++ b/Tests/Qwen3ASRTests/Qwen3ASRTests.swift
@@ -233,6 +233,190 @@ final class Qwen3ASRTests: XCTestCase {
         XCTAssertTrue(decoded.contains("English"), "Decoded text should contain 'English'")
     }
 
+    // MARK: - UTF-8 Decode Regression Tests (no model download)
+
+    /// Synthetic token map for multi-byte UTF-8 decode tests.
+    /// BPE token strings use the GPT-2 byte-to-unicode mapping:
+    ///   bytes 33-126, 161-172, 174-255 → same Unicode scalar
+    ///   remaining bytes → U+0100 onwards (e.g. space=Ġ U+0120, 0x86=Ĩ U+0128)
+    private func makeUTF8TokenMap() -> [Int: String] {
+        [
+            // ASCII
+            100: "Hello",
+            101: "\u{0120}world",          // Ġworld → " world"
+            // 來 (U+4F86) = E4 BE 86, split into 3 byte-tokens
+            102: "\u{00E4}",               // byte 0xE4
+            103: "\u{00BE}",               // byte 0xBE
+            104: "\u{0128}",               // byte 0x86 → U+0128
+            // 好 (U+597D) = E5 A5 BD, split into 3 byte-tokens
+            105: "\u{00E5}",               // byte 0xE5
+            106: "\u{00A5}",               // byte 0xA5
+            107: "\u{00BD}",               // byte 0xBD
+            // Ġ + 來 as a single merged token
+            108: "\u{0120}\u{00E4}\u{00BE}\u{0128}",
+            // Markers
+            200: "<asr_text>",
+            201: "<|im_start|>",
+        ]
+    }
+
+    func testDecodeCJKSplitAcrossThreeTokens() {
+        let tok = Qwen3Tokenizer(idToToken: makeUTF8TokenMap())
+        // 來 = E4 BE 86, each byte is a separate BPE token
+        let result = tok.decode(tokens: [102, 103, 104])
+        XCTAssertEqual(result, "來")
+    }
+
+    func testDecodeMixedASCIIAndCJK() {
+        let tok = Qwen3Tokenizer(idToToken: makeUTF8TokenMap())
+        let result = tok.decode(tokens: [100, 102, 103, 104])
+        XCTAssertEqual(result, "Hello來")
+    }
+
+    func testDecodeConsecutiveMultiByteCharacters() {
+        let tok = Qwen3Tokenizer(idToToken: makeUTF8TokenMap())
+        // 來好 — six byte-tokens back to back
+        let result = tok.decode(tokens: [102, 103, 104, 105, 106, 107])
+        XCTAssertEqual(result, "來好")
+    }
+
+    func testDecodeGPrefixBeforeMultiByteCharacter() {
+        let tok = Qwen3Tokenizer(idToToken: makeUTF8TokenMap())
+        // "Hello 來" — token 108 is Ġ + 來 bytes (space + CJK in one token)
+        let result = tok.decode(tokens: [100, 108])
+        XCTAssertEqual(result, "Hello 來")
+    }
+
+    func testDecodeASRTextMarkerBetweenMultiByteSequences() {
+        let tok = Qwen3Tokenizer(idToToken: makeUTF8TokenMap())
+        // 來<asr_text>好
+        let result = tok.decode(tokens: [102, 103, 104, 200, 105, 106, 107])
+        XCTAssertEqual(result, "來<asr_text>好")
+    }
+
+    // MARK: - Extended CJK / hieroglyph robustness tests
+
+    /// GPT-2 byte-to-unicode: maps a raw byte to the BPE character used in vocab.
+    private static func bpeChar(_ byte: UInt8) -> Character {
+        if (33...126).contains(byte) || (161...172).contains(byte) || (174...255).contains(byte) {
+            return Character(UnicodeScalar(byte))
+        }
+        var n = 0
+        for b: UInt8 in 0...255 {
+            if (33...126).contains(b) || (161...172).contains(b) || (174...255).contains(b) { continue }
+            if b == byte { return Character(UnicodeScalar(0x100 + n)!) }
+            n += 1
+        }
+        fatalError("unreachable")
+    }
+
+    /// Build a BPE token string from raw UTF-8 bytes.
+    private static func bpeToken(_ bytes: [UInt8]) -> String {
+        String(bytes.map { bpeChar($0) })
+    }
+
+    /// Build a token map from (id, UTF-8 bytes) pairs, plus optional literal entries.
+    private func makeTokenMap(
+        bytes: [(Int, [UInt8])],
+        literals: [(Int, String)] = []
+    ) -> [Int: String] {
+        var map: [Int: String] = [:]
+        for (id, b) in bytes { map[id] = Self.bpeToken(b) }
+        for (id, s) in literals { map[id] = s }
+        return map
+    }
+
+    func testDecodeTruncatedUTF8FallsBackToReplacementChar() {
+        // Only 2 of 3 bytes for 來 (simulates max-token truncation mid-character)
+        let tok = Qwen3Tokenizer(idToToken: makeTokenMap(
+            bytes: [(1, [0xE4]), (2, [0xBE])]
+        ))
+        let result = tok.decode(tokens: [1, 2])
+        // String(bytes:encoding:.utf8) returns nil → fallback uses U+FFFD replacement
+        XCTAssertTrue(result.contains("\u{FFFD}"), "Truncated UTF-8 should produce replacement character")
+    }
+
+    func testDecodeSpecialTokenSkippedBetweenCJKBytes() {
+        // <|im_end|> between bytes of 來 should be skipped, bytes land contiguously
+        let tok = Qwen3Tokenizer(idToToken: makeTokenMap(
+            bytes: [(1, [0xE4]), (2, [0xBE]), (3, [0x86])],
+            literals: [(900, "<|im_end|>")]
+        ))
+        let result = tok.decode(tokens: [1, 2, 900, 3])
+        XCTAssertEqual(result, "來")
+    }
+
+    func testDecode4ByteUTF8CJKExtensionB() {
+        // 𠀀 (U+20000) = F0 A0 80 80 — rare CJK char needing 4 byte-tokens
+        let tok = Qwen3Tokenizer(idToToken: makeTokenMap(
+            bytes: [(1, [0xF0]), (2, [0xA0]), (3, [0x80]), (4, [0x80])]
+        ))
+        let result = tok.decode(tokens: [1, 2, 3, 4])
+        XCTAssertEqual(result, "𠀀")
+    }
+
+    func testDecodeBPETokenSpanningUTF8Boundary() {
+        // One merged BPE token contains last byte of 來 (0x86) + first byte of 好 (0xE5)
+        // Buffer: [E4, BE, 86, E5, A5, BD] → "來好"
+        let tok = Qwen3Tokenizer(idToToken: makeTokenMap(
+            bytes: [
+                (1, [0xE4]), (2, [0xBE]),
+                (3, [0x86, 0xE5]),  // merged token spanning boundary
+                (4, [0xA5]), (5, [0xBD]),
+            ]
+        ))
+        let result = tok.decode(tokens: [1, 2, 3, 4, 5])
+        XCTAssertEqual(result, "來好")
+    }
+
+    func testDecodeKoreanHangul() {
+        // 한국 = ED 95 9C  EA B5 AD
+        let tok = Qwen3Tokenizer(idToToken: makeTokenMap(
+            bytes: [
+                (1, [0xED]), (2, [0x95]), (3, [0x9C]),
+                (4, [0xEA]), (5, [0xB5]), (6, [0xAD]),
+            ]
+        ))
+        let result = tok.decode(tokens: [1, 2, 3, 4, 5, 6])
+        XCTAssertEqual(result, "한국")
+    }
+
+    func testDecodeJapaneseMixedHiraganaKanji() {
+        // こんにちは日本語 — 8 chars × 3 bytes each
+        let tok = Qwen3Tokenizer(idToToken: makeTokenMap(
+            bytes: [
+                // こ E3 81 93
+                (1, [0xE3]), (2, [0x81]), (3, [0x93]),
+                // ん E3 82 93
+                (4, [0x82]),
+                // に E3 81 AB
+                (5, [0xAB]),
+                // ち E3 81 A1
+                (6, [0xA1]),
+                // は E3 81 AF
+                (7, [0xAF]),
+                // 日 E6 97 A5
+                (8, [0xE6]), (9, [0x97]), (10, [0xA5]),
+                // 本 E6 9C AC
+                (11, [0x9C]), (12, [0xAC]),
+                // 語 E8 AA 9E
+                (13, [0xE8]), (14, [0xAA]), (15, [0x9E]),
+            ]
+        ))
+        // こ      ん            に         ち         は         日         本            語
+        let result = tok.decode(tokens: [1,2,3, 1,4,3, 1,2,5, 1,2,6, 1,2,7, 8,9,10, 8,11,12, 13,14,15])
+        XCTAssertEqual(result, "こんにちは日本語")
+    }
+
+    func testDecodeUnknownTokenIdBetweenCJKBytes() {
+        // Unknown token ID (999) between bytes of 來 — skipped, bytes still contiguous
+        let tok = Qwen3Tokenizer(idToToken: makeTokenMap(
+            bytes: [(1, [0xE4]), (2, [0xBE]), (3, [0x86])]
+        ))
+        let result = tok.decode(tokens: [1, 2, 999, 3])
+        XCTAssertEqual(result, "來", "Unknown token IDs should be skipped without breaking byte sequence")
+    }
+
     func testTokenizerSkipsSpecialTokensWithPipes() throws {
         let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
             .appendingPathComponent("qwen3-asr")


### PR DESCRIPTION
## Summary
- Simplify the byte-buffer decode from #41: remove redundant Ġ special-case (`unicodeToByte` already maps Ġ→0x20), remove unnecessary flush-before-marker logic, delete dead `decodeByteLevelToken()`
- Add `internal init(idToToken:)` for testing with synthetic token mappings (no model download needed)
- 12 new regression tests for multi-byte UTF-8 decode

## Test plan
- [x] CJK character split across 3 BPE tokens (來)
- [x] Mixed ASCII + CJK, consecutive multi-byte chars
- [x] Ġ prefix before multi-byte character
- [x] `<asr_text>` marker between multi-byte sequences
- [x] Korean Hangul (한국)
- [x] Japanese mixed hiragana + kanji (こんにちは日本語)
- [x] 4-byte UTF-8 CJK Extension B (𠀀)
- [x] BPE token spanning UTF-8 boundary
- [x] Truncated UTF-8 → U+FFFD fallback
- [x] Special token skipped between CJK bytes
- [x] Unknown token ID between CJK bytes
- [x] All 88 existing tests pass (including E2E integration + streaming ASR)

Closes #44