### PR TITLE
Fix speech enhancement: float16 output, 960-point FFT, double lookahead

### DIFF
--- a/Sources/SpeechEnhancement/AudioProcessing.swift
+++ b/Sources/SpeechEnhancement/AudioProcessing.swift
@@ -107,70 +107,51 @@ func computeERBFilterbank(
 
 // MARK: - STFT / iSTFT
 
-/// Forward STFT using vDSP Accelerate.
+/// Forward/inverse STFT using vDSP_DFT (supports non-power-of-2 sizes like 960).
 ///
-/// Computes the Short-Time Fourier Transform of the input audio.
-///
-/// - Parameters:
-///   - audio: Input audio samples
-///   - window: Analysis window (Vorbis)
-///   - fftSize: FFT window size (960)
-///   - hopSize: Hop size (480)
-/// - Returns: Complex spectrum as interleaved [real, imag] per bin,
-///   shape `[numFrames, freqBins, 2]` flattened
+/// Uses `vDSP_DFT_zop` for complex-to-complex DFT, handling real signals by
+/// setting imaginary input to zero and exploiting conjugate symmetry.
+/// This avoids zero-padding to the next power of 2 (1024), which would produce
+/// different frequency bin values than the native 960-point DFT that
+/// DeepFilterNet3 expects.
 final class STFTProcessor {
     let fftSize: Int
     let hopSize: Int
-    let paddedFFT: Int
-    let log2N: vDSP_Length
     let freqBins: Int
     let window: [Float]
-    let fftSetup: FFTSetup
-    /// Forward FFT scale: 1/2 (vDSP correction for real-to-complex)
-    let forwardScale: Float
-    /// Inverse FFT scale: 1/paddedFFT (vDSP correction for complex-to-real)
+    let forwardSetup: OpaquePointer
+    let inverseSetup: OpaquePointer
+    /// Inverse DFT scale: 1/fftSize
     let inverseScale: Float
 
     init(fftSize: Int, hopSize: Int, window: [Float]) {
         self.fftSize = fftSize
         self.hopSize = hopSize
         self.window = window
+        self.freqBins = fftSize / 2 + 1  // 481 for 960-point DFT
+        self.inverseScale = 1.0 / Float(fftSize)
 
-        // Next power of 2 for FFT
-        var padded = 1
-        var log2 = 0
-        while padded < fftSize {
-            padded *= 2
-            log2 += 1
+        guard let fwd = vDSP_DFT_zop_CreateSetup(nil, vDSP_Length(fftSize), .FORWARD) else {
+            fatalError("Failed to create forward DFT setup for N=\(fftSize)")
         }
-        self.paddedFFT = padded
-        self.log2N = vDSP_Length(log2)
-        // Use all bins from padded FFT for perfect reconstruction
-        self.freqBins = padded / 2 + 1
+        self.forwardSetup = fwd
 
-        // vDSP real-FFT scales: forward result is 2x, inverse result needs /N
-        self.forwardScale = 0.5
-        self.inverseScale = 1.0 / Float(padded)
-
-        guard let setup = vDSP_create_fftsetup(self.log2N, FFTRadix(kFFTRadix2)) else {
-            fatalError("Failed to create vDSP FFT setup for paddedFFT=\(padded)")
+        guard let inv = vDSP_DFT_zop_CreateSetup(nil, vDSP_Length(fftSize), .INVERSE) else {
+            fatalError("Failed to create inverse DFT setup for N=\(fftSize)")
         }
-        self.fftSetup = setup
+        self.inverseSetup = inv
     }
 
     deinit {
-        vDSP_destroy_fftsetup(fftSetup)
+        vDSP_DFT_DestroySetup(forwardSetup)
+        vDSP_DFT_DestroySetup(inverseSetup)
     }
 
-    /// Analysis STFT: audio → complex spectrum [numFrames][freqBins][2]
+    /// Analysis STFT: audio → complex spectrum.
     ///
-    /// Maintains analysis memory for streaming (overlap region from previous call).
     /// Returns (real, imaginary) arrays each of shape [numFrames * freqBins].
     func forward(audio: [Float], analysisMem: inout [Float]) -> (real: [Float], imag: [Float]) {
-        let halfPadded = paddedFFT / 2
         let overlapSize = fftSize - hopSize
-
-        // Build full buffer: [analysisMem | audio]
         let buffer = analysisMem + audio
 
         let numFrames = max(0, (buffer.count - fftSize) / hopSize + 1)
@@ -182,59 +163,38 @@ final class STFTProcessor {
         var real = [Float](repeating: 0, count: numFrames * freqBins)
         var imag = [Float](repeating: 0, count: numFrames * freqBins)
 
-        var paddedFrame = [Float](repeating: 0, count: paddedFFT)
-        var splitReal = [Float](repeating: 0, count: halfPadded)
-        var splitImag = [Float](repeating: 0, count: halfPadded)
+        var windowedFrame = [Float](repeating: 0, count: fftSize)
+        var zeroImag = [Float](repeating: 0, count: fftSize)
+        var outReal = [Float](repeating: 0, count: fftSize)
+        var outImag = [Float](repeating: 0, count: fftSize)
 
         for frame in 0..<numFrames {
             let start = frame * hopSize
 
             // Apply window
             buffer.withUnsafeBufferPointer { buf in
-                vDSP_vmul(buf.baseAddress! + start, 1, window, 1, &paddedFrame, 1, vDSP_Length(fftSize))
-            }
-            // Zero-pad
-            for i in fftSize..<paddedFFT {
-                paddedFrame[i] = 0
+                vDSP_vmul(buf.baseAddress! + start, 1, window, 1, &windowedFrame, 1, vDSP_Length(fftSize))
             }
 
-            // Pack into split-complex
-            for i in 0..<halfPadded {
-                splitReal[i] = paddedFrame[2 * i]
-                splitImag[i] = paddedFrame[2 * i + 1]
-            }
+            // Zero imaginary input (real signal)
+            vDSP_vclr(&zeroImag, 1, vDSP_Length(fftSize))
 
-            // FFT
-            splitReal.withUnsafeMutableBufferPointer { realBuf in
-                splitImag.withUnsafeMutableBufferPointer { imagBuf in
-                    var splitComplex = DSPSplitComplex(
-                        realp: realBuf.baseAddress!,
-                        imagp: imagBuf.baseAddress!)
-                    vDSP_fft_zrip(fftSetup, &splitComplex, 1, log2N, FFTDirection(kFFTDirection_Forward))
-                }
-            }
+            // Complex DFT
+            vDSP_DFT_Execute(forwardSetup,
+                windowedFrame, zeroImag,
+                &outReal, &outImag)
 
+            // Copy first freqBins (481) unique bins (conjugate symmetry)
             let baseIdx = frame * freqBins
-
-            // DC component (purely real, stored in realp[0])
-            real[baseIdx] = splitReal[0] * forwardScale
-            imag[baseIdx] = 0
-
-            // Bins 1 to halfPadded-1
-            for k in 1..<halfPadded {
-                real[baseIdx + k] = splitReal[k] * forwardScale
-                imag[baseIdx + k] = splitImag[k] * forwardScale
+            for k in 0..<freqBins {
+                real[baseIdx + k] = outReal[k]
+                imag[baseIdx + k] = outImag[k]
             }
-
-            // Nyquist bin (purely real, packed in imagp[0])
-            real[baseIdx + halfPadded] = splitImag[0] * forwardScale
-            imag[baseIdx + halfPadded] = 0
         }
 
         // Update analysis memory
         let consumed = numFrames * hopSize
         analysisMem = Array(buffer.suffix(buffer.count - consumed))
-        // Ensure it's exactly overlapSize
         if analysisMem.count > overlapSize {
             analysisMem = Array(analysisMem.suffix(overlapSize))
         } else if analysisMem.count < overlapSize {
@@ -244,81 +204,63 @@ final class STFTProcessor {
         return (real, imag)
     }
 
-    /// Inverse STFT: complex spectrum → audio
-    ///
-    /// - Parameters:
-    ///   - real: Real parts [numFrames * freqBins]
-    ///   - imag: Imaginary parts [numFrames * freqBins]
-    ///   - synthesisMem: Overlap-add buffer (mutated)
-    /// - Returns: Reconstructed audio samples
+    /// Inverse STFT: complex spectrum → audio via overlap-add.
     func inverse(real: [Float], imag: [Float], synthesisMem: inout [Float]) -> [Float] {
-        let halfPadded = paddedFFT / 2
         let numFrames = real.count / freqBins
         guard numFrames > 0 else { return [] }
 
         let outputLen = numFrames * hopSize
         var output = [Float](repeating: 0, count: outputLen)
 
-        var splitReal = [Float](repeating: 0, count: halfPadded)
-        var splitImag = [Float](repeating: 0, count: halfPadded)
-        var timeFrame = [Float](repeating: 0, count: paddedFFT)
+        var fullReal = [Float](repeating: 0, count: fftSize)
+        var fullImag = [Float](repeating: 0, count: fftSize)
+        var outReal = [Float](repeating: 0, count: fftSize)
+        var outImag = [Float](repeating: 0, count: fftSize)
 
         for frame in 0..<numFrames {
             let baseIdx = frame * freqBins
 
-            // Pack into split-complex format
-            splitReal[0] = real[baseIdx]  // DC
-            splitImag[0] = real[baseIdx + halfPadded]  // Nyquist
-
-            // Bins 1 to halfPadded-1
-            for k in 1..<halfPadded {
-                splitReal[k] = real[baseIdx + k]
-                splitImag[k] = imag[baseIdx + k]
+            // Fill first freqBins (481) bins
+            for k in 0..<freqBins {
+                fullReal[k] = real[baseIdx + k]
+                fullImag[k] = imag[baseIdx + k]
             }
 
-            // Inverse FFT
-            splitReal.withUnsafeMutableBufferPointer { realBuf in
-                splitImag.withUnsafeMutableBufferPointer { imagBuf in
-                    var splitComplex = DSPSplitComplex(
-                        realp: realBuf.baseAddress!,
-                        imagp: imagBuf.baseAddress!)
-                    vDSP_fft_zrip(fftSetup, &splitComplex, 1, log2N, FFTDirection(kFFTDirection_Inverse))
-                }
+            // Reconstruct conjugate symmetric part: X[N-k] = conj(X[k])
+            for k in 1..<(fftSize / 2) {
+                fullReal[fftSize - k] = fullReal[k]
+                fullImag[fftSize - k] = -fullImag[k]
             }
 
-            // Unpack from split-complex to interleaved
-            for i in 0..<halfPadded {
-                timeFrame[2 * i] = splitReal[i]
-                timeFrame[2 * i + 1] = splitImag[i]
-            }
+            // Inverse DFT
+            vDSP_DFT_Execute(inverseSetup,
+                fullReal, fullImag,
+                &outReal, &outImag)
 
-            // vDSP real-FFT inverse scale: 1/paddedFFT
+            // Scale by 1/N (vDSP_DFT doesn't include normalization)
             var scale = inverseScale
-            vDSP_vsmul(timeFrame, 1, &scale, &timeFrame, 1, vDSP_Length(paddedFFT))
+            vDSP_vsmul(outReal, 1, &scale, &outReal, 1, vDSP_Length(fftSize))
 
-            // Apply window
+            // Apply synthesis window
             var windowed = [Float](repeating: 0, count: fftSize)
-            vDSP_vmul(timeFrame, 1, window, 1, &windowed, 1, vDSP_Length(fftSize))
+            vDSP_vmul(outReal, 1, window, 1, &windowed, 1, vDSP_Length(fftSize))
 
             // Overlap-add with synthesis memory
-            let outStart = frame * hopSize
-            for i in 0..<fftSize {
-                if i < synthesisMem.count {
-                    windowed[i] += synthesisMem[i]
-                }
+            for i in 0..<min(fftSize, synthesisMem.count) {
+                windowed[i] += synthesisMem[i]
             }
 
             // Copy hop-size samples to output
+            let outStart = frame * hopSize
             for i in 0..<hopSize {
                 if outStart + i < outputLen {
                     output[outStart + i] = windowed[i]
                 }
             }
 
-            // Update synthesis memory (remaining overlap)
+            // Update synthesis memory
             let overlapSize = fftSize - hopSize
             synthesisMem = Array(windowed[hopSize..<fftSize])
-            // Pad to full overlap size if needed
             if synthesisMem.count < overlapSize {
                 synthesisMem.append(contentsOf: [Float](repeating: 0, count: overlapSize - synthesisMem.count))
             }

--- a/Sources/SpeechEnhancement/SpeechEnhancement.swift
+++ b/Sources/SpeechEnhancement/SpeechEnhancement.swift
@@ -81,27 +81,15 @@ public final class SpeechEnhancer {
         resetState()
 
         let hop = config.hopSize
+        let freqBins = config.freqBins  // 481 (960/2 + 1)
 
         // Pad audio so inverse STFT captures the full signal
         let paddedSamples = samples + [Float](repeating: 0, count: hop)
 
-        // STFT (produces paddedFFT/2+1 bins for perfect reconstruction)
-        let (stftReal, stftImag) = stft.forward(audio: paddedSamples, analysisMem: &analysisMem)
-        let stftBins = stft.freqBins  // 513 (padded FFT)
-        let modelBins = config.freqBins  // 481 (model expects fftSize/2+1)
-        let numFrames = stftReal.count / stftBins
+        // STFT — 960-point DFT producing 481 frequency bins
+        let (specReal, specImag) = stft.forward(audio: paddedSamples, analysisMem: &analysisMem)
+        let numFrames = specReal.count / freqBins
         guard numFrames > 0 else { return [] }
-
-        // Truncate to model's expected 481 bins for feature computation
-        var specReal = [Float](repeating: 0, count: numFrames * modelBins)
-        var specImag = [Float](repeating: 0, count: numFrames * modelBins)
-        for t in 0..<numFrames {
-            for f in 0..<modelBins {
-                specReal[t * modelBins + f] = stftReal[t * stftBins + f]
-                specImag[t * modelBins + f] = stftImag[t * stftBins + f]
-            }
-        }
-        let freqBins = modelBins
 
         // Compute ERB features
         var erbFeats = computeERBFeatures(
@@ -132,23 +120,13 @@ public final class SpeechEnhancer {
             alpha: config.normAlpha,
             dfBins: config.dfBins, numFrames: numFrames)
 
-        // Apply lookahead padding
-        let lookahead = config.convLookahead
-        let paddedErbFeats = applyLookaheadPad(
-            erbFeats, featuresPerFrame: config.erbBands,
-            numFrames: numFrames, lookahead: lookahead)
-        let paddedSpecReal = applyLookaheadPad(
-            specFeatReal, featuresPerFrame: config.dfBins,
-            numFrames: numFrames, lookahead: lookahead)
-        let paddedSpecImag = applyLookaheadPad(
-            specFeatImag, featuresPerFrame: config.dfBins,
-            numFrames: numFrames, lookahead: lookahead)
+        // No lookahead padding here — the Core ML model applies it internally
 
-        // Create Core ML input arrays using direct pointer access
+        // Create Core ML input arrays
         // ERB: [1, 1, T, 32] (NCHW)
         let erbInput = try MLMultiArray(shape: [1, 1, numFrames as NSNumber, config.erbBands as NSNumber], dataType: .float32)
         let erbPtr = erbInput.dataPointer.assumingMemoryBound(to: Float.self)
-        paddedErbFeats.withUnsafeBufferPointer { src in
+        erbFeats.withUnsafeBufferPointer { src in
             erbPtr.update(from: src.baseAddress!, count: numFrames * config.erbBands)
         }
 
@@ -156,39 +134,36 @@ public final class SpeechEnhancer {
         let specInput = try MLMultiArray(shape: [1, 2, numFrames as NSNumber, config.dfBins as NSNumber], dataType: .float32)
         let specPtr = specInput.dataPointer.assumingMemoryBound(to: Float.self)
         let specChannelStride = numFrames * config.dfBins
-        paddedSpecReal.withUnsafeBufferPointer { src in
+        specFeatReal.withUnsafeBufferPointer { src in
             specPtr.update(from: src.baseAddress!, count: specChannelStride)
         }
-        paddedSpecImag.withUnsafeBufferPointer { src in
+        specFeatImag.withUnsafeBufferPointer { src in
             (specPtr + specChannelStride).update(from: src.baseAddress!, count: specChannelStride)
         }
 
         // Run neural network (single pass — GRU state is sequential, can't be chunked)
         let (erbMaskArray, coefsArray) = try network.predict(featErb: erbInput, featSpec: specInput)
 
-        // Extract ERB mask [1, 1, T, 32] → flat [T * 32] via pointer
-        let erbMaskPtr = erbMaskArray.dataPointer.assumingMemoryBound(to: Float.self)
+        // Extract ERB mask [1, 1, T, 32] — handle float16 output from Core ML
         let erbMaskCount = numFrames * config.erbBands
         var erbMaskFlat = [Float](repeating: 0, count: erbMaskCount)
-        erbMaskFlat.withUnsafeMutableBufferPointer { dst in
-            dst.baseAddress!.update(from: erbMaskPtr, count: erbMaskCount)
-        }
+        extractMLMultiArrayFlat(erbMaskArray, into: &erbMaskFlat, count: erbMaskCount)
 
-        // Extract DF coefficients [1, 5, T, 96, 2] → flat [T * 96 * 5 * 2]
-        // Core ML layout: [1, O=5, T, F=96, C=2] contiguous
-        // Target layout: [T, F, O, C=2]
+        // Extract DF coefficients [1, 5, T, 96, 2] → [T, F, O, C=2]
         let dfOrder = config.dfOrder
-        let coefsPtr = coefsArray.dataPointer.assumingMemoryBound(to: Float.self)
-        var coefsFlat = [Float](repeating: 0, count: numFrames * config.dfBins * dfOrder * 2)
-        coefsFlat.withUnsafeMutableBufferPointer { dst in
-            for t in 0..<numFrames {
-                for f in 0..<config.dfBins {
-                    for o in 0..<dfOrder {
-                        let srcIdx = ((o * numFrames + t) * config.dfBins + f) * 2
-                        let dstIdx = ((t * config.dfBins + f) * dfOrder + o) * 2
-                        dst[dstIdx] = coefsPtr[srcIdx]
-                        dst[dstIdx + 1] = coefsPtr[srcIdx + 1]
-                    }
+        let coefsCount = dfOrder * numFrames * config.dfBins * 2
+        var coefsRaw = [Float](repeating: 0, count: coefsCount)
+        extractMLMultiArrayFlat(coefsArray, into: &coefsRaw, count: coefsCount)
+
+        // Reshape from Core ML layout [O, T, F, 2] to [T, F, O, 2]
+        var coefsFlat = [Float](repeating: 0, count: coefsCount)
+        for t in 0..<numFrames {
+            for f in 0..<config.dfBins {
+                for o in 0..<dfOrder {
+                    let srcIdx = ((o * numFrames + t) * config.dfBins + f) * 2
+                    let dstIdx = ((t * config.dfBins + f) * dfOrder + o) * 2
+                    coefsFlat[dstIdx] = coefsRaw[srcIdx]
+                    coefsFlat[dstIdx + 1] = coefsRaw[srcIdx + 1]
                 }
             }
         }
@@ -218,18 +193,8 @@ public final class SpeechEnhancer {
             }
         }
 
-        // Expand back to full STFT bins for reconstruction
-        var fullReal = stftReal
-        var fullImag = stftImag
-        for t in 0..<numFrames {
-            for f in 0..<modelBins {
-                fullReal[t * stftBins + f] = enhancedReal[t * freqBins + f]
-                fullImag[t * stftBins + f] = enhancedImag[t * freqBins + f]
-            }
-        }
-
         // Inverse STFT
-        let rawOutput = stft.inverse(real: fullReal, imag: fullImag, synthesisMem: &synthesisMem)
+        let rawOutput = stft.inverse(real: enhancedReal, imag: enhancedImag, synthesisMem: &synthesisMem)
 
         // Trim the hop-size latency from prepended analysis memory
         let trimStart = hop
@@ -283,6 +248,21 @@ public final class SpeechEnhancer {
         progressHandler?(1.0, "Ready")
 
         return SpeechEnhancer(network: network, config: config, auxData: auxData)
+    }
+
+    /// Extract float32 data from an MLMultiArray, handling float16 output from Core ML.
+    private func extractMLMultiArrayFlat(_ array: MLMultiArray, into output: inout [Float], count: Int) {
+        if array.dataType == .float16 {
+            let ptr = array.dataPointer.assumingMemoryBound(to: Float16.self)
+            for i in 0..<count {
+                output[i] = Float(ptr[i])
+            }
+        } else {
+            let ptr = array.dataPointer.assumingMemoryBound(to: Float.self)
+            output.withUnsafeMutableBufferPointer { dst in
+                dst.baseAddress!.update(from: ptr, count: count)
+            }
+        }
     }
 
     /// Simple linear resampling.

--- a/Tests/SpeechEnhancementTests/SpeechEnhancementTests.swift
+++ b/Tests/SpeechEnhancementTests/SpeechEnhancementTests.swift
@@ -112,8 +112,7 @@ final class SpeechEnhancementTests: XCTestCase {
     func testSTFTFreqBins() {
         let window = computeVorbisWindow(size: 960)
         let stft = STFTProcessor(fftSize: 960, hopSize: 480, window: window)
-        XCTAssertEqual(stft.paddedFFT, 1024)
-        XCTAssertEqual(stft.freqBins, 513)
+        XCTAssertEqual(stft.freqBins, 481)  // 960/2 + 1
     }
 
     func testSTFTFrameCount() {
@@ -333,10 +332,141 @@ final class SpeechEnhancementTests: XCTestCase {
         // Verify the NPZ reader can parse numpy files
         // Create a temporary npz for testing
         let tmpDir = FileManager.default.temporaryDirectory
-        let npzURL = tmpDir.appendingPathComponent("test_aux.npz")
+        let _ = tmpDir.appendingPathComponent("test_aux.npz")
 
         // We can't easily create an npz in Swift, but we can test the structure
         // Just verify the reader type exists
         XCTAssertNotNil(NpzReader.self)
+    }
+
+    // MARK: - E2E Tests
+
+    func testE2EEnhancePreservesCleanSpeech() async throws {
+        // Load test audio
+        let testAudioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+
+        guard FileManager.default.fileExists(atPath: testAudioURL.path) else {
+            throw XCTSkip("Test audio not found")
+        }
+
+        let (samples, sr) = try loadWAV(url: testAudioURL)
+        XCTAssertGreaterThan(samples.count, 0)
+
+        // Load model
+        let enhancer = try await SpeechEnhancer.fromPretrained()
+
+        // Enhance
+        let enhanced = try enhancer.enhance(audio: samples, sampleRate: sr)
+        XCTAssertGreaterThan(enhanced.count, 0)
+
+        // For clean speech, enhanced output should preserve amplitude (within -3 dB)
+        let origRMS: Float = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(samples.count))
+        let enhRMS: Float = sqrt(enhanced.reduce(0) { $0 + $1 * $1 } / Float(enhanced.count))
+
+        let dbDiff = 20 * log10(enhRMS / origRMS)
+        print("E2E: origRMS=\(origRMS), enhRMS=\(enhRMS), diff=\(dbDiff) dB")
+
+        // Clean speech should not be significantly attenuated
+        XCTAssertGreaterThan(dbDiff, -3.0, "Enhanced audio attenuated by more than 3 dB — model may be suppressing speech")
+        XCTAssertLessThan(dbDiff, 3.0, "Enhanced audio amplified by more than 3 dB")
+    }
+
+    func testE2EEnhanceReducesNoise() async throws {
+        let testAudioURL = URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+
+        guard FileManager.default.fileExists(atPath: testAudioURL.path) else {
+            throw XCTSkip("Test audio not found")
+        }
+
+        let (cleanSamples, sr) = try loadWAV(url: testAudioURL)
+
+        // Resample to 48kHz for noise addition
+        let ratio = Double(48000) / Double(sr)
+        let outLen = Int(Double(cleanSamples.count) * ratio)
+        var samples48k = [Float](repeating: 0, count: outLen)
+        for i in 0..<outLen {
+            let srcPos = Double(i) / ratio
+            let srcIdx = Int(srcPos)
+            let frac = Float(srcPos - Double(srcIdx))
+            if srcIdx + 1 < cleanSamples.count {
+                samples48k[i] = cleanSamples[srcIdx] * (1 - frac) + cleanSamples[srcIdx + 1] * frac
+            } else if srcIdx < cleanSamples.count {
+                samples48k[i] = cleanSamples[srcIdx]
+            }
+        }
+
+        // Add white noise at ~10 dB SNR
+        let cleanRMS: Float = sqrt(samples48k.reduce(0) { $0 + $1 * $1 } / Float(samples48k.count))
+        let noiseLevel = cleanRMS * 0.3
+        var noisy = samples48k
+        srand48(42)
+        for i in 0..<noisy.count {
+            noisy[i] += Float(drand48() * 2 - 1) * noiseLevel * sqrt(3)
+        }
+
+        let noisyRMS: Float = sqrt(noisy.reduce(0) { $0 + $1 * $1 } / Float(noisy.count))
+
+        // Enhance
+        let enhancer = try await SpeechEnhancer.fromPretrained()
+        let enhanced = try enhancer.enhance(audio: noisy, sampleRate: 48000)
+        XCTAssertGreaterThan(enhanced.count, 0)
+
+        let enhRMS: Float = sqrt(enhanced.reduce(0) { $0 + $1 * $1 } / Float(enhanced.count))
+
+        // Check silence region (first 2s has no speech) — noise should be reduced
+        let silenceEnd = min(2 * 48000, min(noisy.count, enhanced.count))
+        let noisySilenceSlice = Array(noisy[0..<silenceEnd])
+        let enhSilenceSlice = Array(enhanced[0..<silenceEnd])
+        let noisySilenceRMS: Float = sqrt(noisySilenceSlice.reduce(0) { $0 + $1 * $1 } / Float(silenceEnd))
+        let enhSilenceRMS: Float = sqrt(enhSilenceSlice.reduce(0) { $0 + $1 * $1 } / Float(silenceEnd))
+
+        let silenceReduction = 20 * log10(enhSilenceRMS / (noisySilenceRMS + 1e-10))
+        print("E2E noise: noisyRMS=\(noisyRMS), enhRMS=\(enhRMS)")
+        print("E2E silence: noisySilence=\(noisySilenceRMS), enhSilence=\(enhSilenceRMS), reduction=\(silenceReduction) dB")
+
+        // Noise in silence region should be reduced by at least 3 dB
+        XCTAssertLessThan(silenceReduction, -3.0, "Noise in silence region not sufficiently reduced")
+    }
+
+    /// Load a WAV file as Float32 samples.
+    private func loadWAV(url: URL) throws -> (samples: [Float], sampleRate: Int) {
+        let data = try Data(contentsOf: url)
+        guard data.count > 44 else { throw NSError(domain: "WAV", code: 1) }
+
+        let sampleRate = data.withUnsafeBytes { raw in
+            raw.loadUnaligned(fromByteOffset: 24, as: UInt32.self)
+        }
+        let bitsPerSample = data.withUnsafeBytes { raw in
+            raw.loadUnaligned(fromByteOffset: 34, as: UInt16.self)
+        }
+
+        // Find "data" chunk
+        var offset = 12
+        while offset + 8 < data.count {
+            let chunkID = String(data: data[offset..<offset+4], encoding: .ascii) ?? ""
+            let chunkSize = data.withUnsafeBytes { raw in
+                raw.loadUnaligned(fromByteOffset: offset + 4, as: UInt32.self)
+            }
+            if chunkID == "data" {
+                offset += 8
+                break
+            }
+            offset += 8 + Int(chunkSize)
+        }
+
+        let bytesPerSample = Int(bitsPerSample) / 8
+        let numSamples = (data.count - offset) / bytesPerSample
+        var samples = [Float](repeating: 0, count: numSamples)
+
+        if bitsPerSample == 16 {
+            data.withUnsafeBytes { raw in
+                for i in 0..<numSamples {
+                    let val = raw.loadUnaligned(fromByteOffset: offset + i * 2, as: Int16.self)
+                    samples[i] = Float(val) / 32768.0
+                }
+            }
+        }
+
+        return (samples, Int(sampleRate))
     }
 }


### PR DESCRIPTION
## Summary
- **Float16 output handling**: Core ML MLProgram outputs float16 (dataType 65552). Previously read as float32 via `dataPointer.assumingMemoryBound(to: Float.self)`, garbling all mask/coefficient values and suppressing speech by -54 dB. Now correctly detects float16 and converts via `Float16` pointer.
- **Native 960-point FFT**: Replaced `vDSP_fft_zrip` (power-of-2 only, forced 1024-point zero-padding) with `vDSP_DFT_zop` (supports 960 = 2^6 × 3 × 5). Eliminates 4.46 dB mean ERB feature error from wrong bin spacing.
- **Remove double lookahead**: The Core ML model already applies lookahead padding internally (traced from Python wrapper). Swift was applying it again before inference.
- **E2E tests**: Added tests verifying clean speech preservation (< 3 dB attenuation) and noise reduction (> 3 dB in silence regions).

## Test plan
- [x] All 24 SpeechEnhancement tests pass (22 unit + 2 E2E)
- [x] E2E: clean speech attenuation = -0.46 dB (was -54 dB)
- [x] E2E: silence noise reduction = -8.6 dB after enhancement
- [x] ASR round-trip produces identical transcription on enhanced audio