### PR TITLE
Improve discoverability, CLI output, and generation quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ Then use:
 audio transcribe recording.wav
 audio speak "Hello world"
 audio speak "Hallo Welt" --engine cosyvoice --language german
-audio respond --input question.wav
+audio respond --input question.wav --transcript
 ```
+
+> For interactive voice conversation with microphone input, see **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**.
 
 ### Swift Package Manager
 
@@ -92,11 +94,21 @@ import AudioCommon        // Shared utilities
 - Apple Silicon (M1/M2/M3/M4)
 - Xcode 15+
 
+## Try the Voice Assistant
+
+**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** is a ready-to-run macOS voice assistant — tap to talk, get spoken responses in real-time. Uses microphone input with Silero VAD for automatic speech detection, Qwen3-ASR for transcription, and PersonaPlex 7B for speech-to-speech generation. Multi-turn conversation with 18 voice presets and inner monologue transcript display.
+
+```bash
+cd Examples/PersonaPlexDemo
+swift build -c release
+# See Examples/PersonaPlexDemo/README.md for .app bundle instructions
+```
+
+> RTF ~0.94 on M2 Max (faster than real-time). Models download automatically on first run (~5.5 GB PersonaPlex + ~400 MB ASR).
+
 ## Demo Apps
 
-Ready-to-run SwiftUI macOS apps in the `Examples/` directory:
-
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Conversational voice assistant powered by PersonaPlex 7B. Toggle-based conversation loop with Silero VAD speech detection, Qwen3-ASR transcription, and inner monologue transcript. RTF ~0.94 on M2 Max.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Conversational voice assistant (mic input, VAD, multi-turn). See above.
 - **[SpeechDemo](Examples/SpeechDemo/)** — Dictation (Parakeet TDT / Qwen3-ASR with language auto-detect) and text-to-speech synthesis (Qwen3-TTS) in a tabbed interface.
 
 Build and run as a macOS `.app` bundle — see each demo's README for instructions.
@@ -345,6 +357,8 @@ CLI:
 
 ## PersonaPlex Usage
 
+> For an interactive voice assistant with microphone input, see **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — tap to talk, multi-turn conversation with automatic speech detection.
+
 ### Speech-to-Speech
 
 ```swift
@@ -355,9 +369,20 @@ let model = try await PersonaPlexModel.fromPretrained()
 // Downloads ~5.5 GB on first run (temporal 4-bit + depformer + Mimi codec + voice presets)
 
 let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let response = model.respond(userAudio: audio, voice: .NATM0)
-// Output is 24kHz mono float samples
-try WAVWriter.write(samples: response, sampleRate: 24000, to: outputURL)
+let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
+// response: 24kHz mono float samples
+// textTokens: model's inner monologue (SentencePiece token IDs)
+try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+```
+
+### Inner Monologue (Text Output)
+
+PersonaPlex generates text tokens alongside audio — the model's internal reasoning. Decode them with the built-in SentencePiece decoder:
+
+```swift
+let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
+let transcript = decoder.decode(textTokens)
+print(transcript)  // e.g. "Sure, I can help you with that..."
 ```
 
 ### Streaming Speech-to-Speech
@@ -402,8 +427,17 @@ swift build -c release
 # Basic speech-to-speech
 .build/release/audio respond --input question.wav --output response.wav
 
+# With transcript (decodes inner monologue text)
+.build/release/audio respond --input question.wav --transcript
+
+# JSON output (audio path, transcript, latency metrics)
+.build/release/audio respond --input question.wav --json
+
 # Choose a voice and system prompt preset
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused --output response.wav
+.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
+
+# Tune sampling parameters
+.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
 
 # List available voices and prompts
 .build/release/audio respond --list-voices
@@ -608,6 +642,65 @@ swift build -c release
 ```
 
 See [Speech Enhancement](docs/speech-enhancement.md) for architecture details.
+
+## Pipelines
+
+All models conform to shared protocols (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel`, etc.) and can be composed into pipelines:
+
+### Noisy Speech Recognition (DeepFilterNet + ASR)
+
+```swift
+import SpeechEnhancement
+import Qwen3ASR
+
+let enhancer = try await SpeechEnhancer.fromPretrained()
+let asr = try await Qwen3ASRModel.fromPretrained()
+
+// Enhance at 48kHz, then transcribe at 16kHz
+let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
+let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
+let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
+```
+
+### Voice-to-Voice Relay (VAD + ASR + TTS)
+
+```swift
+import SpeechVAD
+import Qwen3ASR
+import Qwen3TTS
+
+let vad = try await SileroVADModel.fromPretrained()
+let asr = try await Qwen3ASRModel.fromPretrained()
+let tts = try await Qwen3TTSModel.fromPretrained()
+
+// Detect speech segments, transcribe, re-synthesize
+let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
+for seg in segments {
+    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
+    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
+    let speech = tts.synthesize(text: text, language: "english")
+    // speech: 24kHz mono float samples
+}
+```
+
+### Meeting Transcription (Diarization + ASR)
+
+```swift
+import SpeechVAD
+import Qwen3ASR
+
+let pipeline = try await DiarizationPipeline.fromPretrained()
+let asr = try await Qwen3ASRModel.fromPretrained()
+
+let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
+for seg in result.segments {
+    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
+    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
+    print("Speaker \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
+}
+```
+
+See [Shared Protocols](docs/shared-protocols.md) for the full protocol reference.
 
 ## Latency (M2 Max, 64 GB)
 

--- a/Sources/AudioCLILib/RespondCommand.swift
+++ b/Sources/AudioCLILib/RespondCommand.swift
@@ -46,6 +46,34 @@ public struct RespondCommand: ParsableCommand {
     @Flag(name: .long, help: "Show detailed timing info")
     public var verbose: Bool = false
 
+    @Flag(name: .long, help: "Decode and print the model's inner monologue text")
+    public var transcript: Bool = false
+
+    @Flag(name: .long, help: "Output results as JSON (includes transcript, latency, audio path)")
+    public var json: Bool = false
+
+    // Sampling config overrides
+    @Option(name: .long, help: "Audio sampling temperature (default: 0.8)")
+    public var audioTemp: Float?
+
+    @Option(name: .long, help: "Text sampling temperature (default: 0.7)")
+    public var textTemp: Float?
+
+    @Option(name: .long, help: "Audio top-k candidates (default: 250)")
+    public var audioTopK: Int?
+
+    @Option(name: .long, help: "Audio repetition penalty (default: 1.2, 1.0 = disabled)")
+    public var repetitionPenalty: Float?
+
+    @Option(name: .long, help: "Text repetition penalty (default: 1.2, 1.0 = disabled)")
+    public var textRepetitionPenalty: Float?
+
+    @Option(name: .long, help: "Repetition penalty window in frames (default: 30)")
+    public var repetitionWindow: Int?
+
+    @Option(name: .long, help: "Silence frames before early stop (default: 15, 0 = disabled)")
+    public var silenceEarlyStop: Int?
+
     public init() {}
 
     public func run() throws {
@@ -90,6 +118,15 @@ public struct RespondCommand: ParsableCommand {
             let model = try await PersonaPlexModel.fromPretrained(
                 modelId: modelId, progressHandler: reportProgress)
 
+            // Apply sampling config overrides
+            if let v = audioTemp { model.cfg.sampling.audioTemp = v }
+            if let v = textTemp { model.cfg.sampling.textTemp = v }
+            if let v = audioTopK { model.cfg.sampling.audioTopK = v }
+            if let v = repetitionPenalty { model.cfg.sampling.audioRepetitionPenalty = v }
+            if let v = textRepetitionPenalty { model.cfg.sampling.textRepetitionPenalty = v }
+            if let v = repetitionWindow { model.cfg.sampling.repetitionWindow = v }
+            if let v = silenceEarlyStop { model.cfg.sampling.silenceEarlyStopFrames = v }
+
             if compile {
                 print("Warming up compiled temporal transformer...")
                 let warmStart = CFAbsoluteTimeGetCurrent()
@@ -98,15 +135,33 @@ public struct RespondCommand: ParsableCommand {
                 print("  Warmup: \(String(format: "%.2f", warmTime))s")
             }
 
-            print("Loading input audio: \(input)")
+            // Load SentencePiece decoder for transcript
+            var spmDecoder: SentencePieceDecoder?
+            if transcript || json {
+                do {
+                    let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+                    let spmPath = cacheDir.appendingPathComponent("tokenizer_spm_32k_3.model").path
+                    if FileManager.default.fileExists(atPath: spmPath) {
+                        spmDecoder = try SentencePieceDecoder(modelPath: spmPath)
+                    }
+                } catch {
+                    if !json { print("Warning: Could not load SentencePiece decoder: \(error)") }
+                }
+            }
+
+            if !json { print("Loading input audio: \(input)") }
             let inputURL = URL(fileURLWithPath: input)
             let audio = try AudioFileLoader.load(
                 url: inputURL, targetSampleRate: 24000)
             let duration = Double(audio.count) / 24000.0
-            print("  Duration: \(String(format: "%.2f", duration))s (\(audio.count) samples)")
-
-            print("Generating response with voice \(selectedVoice.rawValue), prompt: \(selectedPrompt.rawValue)")
+            if !json {
+                print("  Duration: \(String(format: "%.2f", duration))s (\(audio.count) samples)")
+                print("Generating response with voice \(selectedVoice.rawValue), prompt: \(selectedPrompt.rawValue)")
+            }
             let startTime = CFAbsoluteTimeGetCurrent()
+
+            var responseSamples: [Float] = []
+            var textTokens: [Int32] = []
 
             if stream {
                 let streamingConfig = PersonaPlexModel.PersonaPlexStreamingConfig(
@@ -119,48 +174,64 @@ public struct RespondCommand: ParsableCommand {
                     streaming: streamingConfig,
                     verbose: verbose)
 
-                var allSamples: [Float] = []
                 var chunkCount = 0
                 for try await chunk in audioStream {
-                    allSamples.append(contentsOf: chunk.samples)
+                    responseSamples.append(contentsOf: chunk.samples)
                     chunkCount += 1
+                    if chunk.isFinal { textTokens = chunk.textTokens }
                     if verbose {
                         let chunkDuration = Double(chunk.samples.count) / 24000.0
                         print("  Chunk \(chunkCount): \(chunk.samples.count) samples (\(String(format: "%.2f", chunkDuration))s) at \(String(format: "%.2f", chunk.elapsedTime ?? 0))s")
                     }
                 }
-
-                let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-                let responseDuration = Double(allSamples.count) / 24000.0
-
-                print("Response: \(String(format: "%.2f", responseDuration))s (\(chunkCount) chunks)")
-                print("Time: \(String(format: "%.2f", elapsed))s")
-                if responseDuration > 0 {
-                    print("RTF: \(String(format: "%.2f", elapsed / responseDuration))")
-                }
-
-                let outputURL = URL(fileURLWithPath: output)
-                try WAVWriter.write(samples: allSamples, sampleRate: 24000, to: outputURL)
-                print("Saved to \(output)")
             } else {
-                let (response, textTokens) = model.respond(
+                let result = model.respond(
                     userAudio: audio,
                     voice: selectedVoice,
                     systemPromptTokens: selectedPrompt.tokens,
                     maxSteps: maxSteps,
                     verbose: verbose)
+                responseSamples = result.audio
+                textTokens = result.textTokens
+            }
 
-                let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-                let responseDuration = Double(response.count) / 24000.0
+            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+            let responseDuration = Double(responseSamples.count) / 24000.0
+            let rtf = responseDuration > 0 ? elapsed / responseDuration : 0
 
+            let outputURL = URL(fileURLWithPath: output)
+            try WAVWriter.write(samples: responseSamples, sampleRate: 24000, to: outputURL)
+
+            // Decode transcript
+            var decodedTranscript: String?
+            if let dec = spmDecoder, !textTokens.isEmpty {
+                decodedTranscript = dec.decode(textTokens)
+            }
+
+            if json {
+                var result: [String: Any] = [
+                    "audio": output,
+                    "voice": selectedVoice.rawValue,
+                    "system_prompt": selectedPrompt.rawValue,
+                    "input_duration": round(duration * 100) / 100,
+                    "output_duration": round(responseDuration * 100) / 100,
+                    "elapsed": round(elapsed * 100) / 100,
+                    "rtf": round(rtf * 100) / 100,
+                    "text_tokens": textTokens.count
+                ]
+                if let t = decodedTranscript { result["transcript"] = t }
+                let jsonData = try JSONSerialization.data(
+                    withJSONObject: result, options: [.prettyPrinted, .sortedKeys])
+                print(String(data: jsonData, encoding: .utf8) ?? "{}")
+            } else {
                 print("Response: \(String(format: "%.2f", responseDuration))s (\(textTokens.count) text tokens)")
                 print("Time: \(String(format: "%.2f", elapsed))s")
                 if responseDuration > 0 {
-                    print("RTF: \(String(format: "%.2f", elapsed / responseDuration))")
+                    print("RTF: \(String(format: "%.2f", rtf))")
                 }
-
-                let outputURL = URL(fileURLWithPath: output)
-                try WAVWriter.write(samples: response, sampleRate: 24000, to: outputURL)
+                if let t = decodedTranscript, transcript {
+                    print("Transcript: \(t)")
+                }
                 print("Saved to \(output)")
             }
         }

--- a/Sources/PersonaPlex/Configuration.swift
+++ b/Sources/PersonaPlex/Configuration.swift
@@ -269,7 +269,10 @@ public struct PersonaPlexSamplingConfig: Sendable {
     public var textTemp: Float
     public var textTopK: Int
     public var audioRepetitionPenalty: Float
+    public var textRepetitionPenalty: Float
     public var repetitionWindow: Int
+    /// Number of consecutive silence frames before early stopping (0 = disabled)
+    public var silenceEarlyStopFrames: Int
 
     public init(
         audioTemp: Float = 0.8,
@@ -277,14 +280,18 @@ public struct PersonaPlexSamplingConfig: Sendable {
         textTemp: Float = 0.7,
         textTopK: Int = 25,
         audioRepetitionPenalty: Float = 1.2,
-        repetitionWindow: Int = 30
+        textRepetitionPenalty: Float = 1.2,
+        repetitionWindow: Int = 30,
+        silenceEarlyStopFrames: Int = 15
     ) {
         self.audioTemp = audioTemp
         self.audioTopK = audioTopK
         self.textTemp = textTemp
         self.textTopK = textTopK
         self.audioRepetitionPenalty = audioRepetitionPenalty
+        self.textRepetitionPenalty = textRepetitionPenalty
         self.repetitionWindow = repetitionWindow
+        self.silenceEarlyStopFrames = silenceEarlyStopFrames
     }
 
     public static var `default`: PersonaPlexSamplingConfig { PersonaPlexSamplingConfig() }

--- a/Sources/PersonaPlex/PersonaPlex.swift
+++ b/Sources/PersonaPlex/PersonaPlex.swift
@@ -9,7 +9,7 @@ import AudioCommon
 ///
 /// - Warning: This class is not thread-safe. Create separate instances for concurrent use.
 public final class PersonaPlexModel: Module {
-    public let cfg: PersonaPlexConfig
+    public var cfg: PersonaPlexConfig
 
     @ModuleInfo public var temporal: TemporalTransformer
     @ModuleInfo public var depformer: Depformer
@@ -285,6 +285,8 @@ public final class PersonaPlexModel: Module {
         let useCompiledStep = temporal.compiledStep != nil
         let b = 1  // batch size
         var allTextTokens: [Int32] = []
+        var consecutiveSilenceFrames = 0
+        let silenceEarlyStop = cfg.sampling.silenceEarlyStopFrames
 
         for step in promptLen..<(prefillLen + maxSteps) {
             // Build input tokens for this step.
@@ -325,12 +327,15 @@ public final class PersonaPlexModel: Module {
                 )
             }
 
-            // Sample text token — eval here forces textLogits (and hidden) computation.
+            // Sample text token with repetition penalty.
             // Depformer needs textToken value for embedding lookup.
-            let textToken = sampleTopK(
+            let textHistory = Array(allTextTokens.suffix(cfg.sampling.repetitionWindow))
+            let textToken = sampleTextWithPenalty(
                 logits: textLogits.squeezed(axis: 1),
                 temperature: cfg.sampling.textTemp,
-                topK: cfg.sampling.textTopK
+                topK: cfg.sampling.textTopK,
+                pastTokens: textHistory,
+                penalty: cfg.sampling.textRepetitionPenalty
             )
             eval(textToken)
 
@@ -408,6 +413,21 @@ public final class PersonaPlexModel: Module {
                     tokenCache[1 + cb][step] = tok
                 }
                 agentTokens[cb].append(tok)
+            }
+
+            // Silence early stopping: if agent audio produces silence tokens
+            // for consecutive frames, stop generation to avoid filling dead air.
+            if step >= prefillLen, silenceEarlyStop > 0 {
+                let isSilence = (0..<nQ).allSatisfy { cb in
+                    agentTokens[cb].last == TemporalTransformerConfig.silenceTokens[cb]
+                }
+                consecutiveSilenceFrames = isSilence ? consecutiveSilenceFrames + 1 : 0
+                if consecutiveSilenceFrames >= silenceEarlyStop {
+                    if verbose {
+                        print("  Early stop: \(silenceEarlyStop) consecutive silence frames at step \(step - prefillLen)/\(maxSteps)")
+                    }
+                    break
+                }
             }
         }
 
@@ -671,6 +691,8 @@ public final class PersonaPlexModel: Module {
                     let useCompiledStep = temporal.compiledStep != nil
                     let b = 1
                     let genStart = CFAbsoluteTimeGetCurrent()
+                    var consecutiveSilenceFrames = 0
+                    let silenceEarlyStop = cfg.sampling.silenceEarlyStopFrames
 
                     for step in promptLen..<(prefillLen + maxSteps) {
                         let readIdx = step - 1
@@ -702,10 +724,13 @@ public final class PersonaPlexModel: Module {
                                 textTokens: textTokenArr, audioTokens: audioTokens, offset: step)
                         }
 
-                        let textToken = sampleTopK(
+                        let textHistory = Array(allTextTokens.suffix(cfg.sampling.repetitionWindow))
+                        let textToken = sampleTextWithPenalty(
                             logits: textLogits.squeezed(axis: 1),
                             temperature: cfg.sampling.textTemp,
-                            topK: cfg.sampling.textTopK)
+                            topK: cfg.sampling.textTopK,
+                            pastTokens: textHistory,
+                            penalty: cfg.sampling.textRepetitionPenalty)
                         eval(textToken)
 
                         var providedTokens: [Int32]? = nil
@@ -750,6 +775,20 @@ public final class PersonaPlexModel: Module {
                                 tokenCache[1 + cb][step] = tok
                             }
                             agentTokens[cb].append(tok)
+                        }
+
+                        // Silence early stopping
+                        if step >= prefillLen, silenceEarlyStop > 0 {
+                            let isSilence = (0..<nQ).allSatisfy { cb in
+                                agentTokens[cb].last == TemporalTransformerConfig.silenceTokens[cb]
+                            }
+                            consecutiveSilenceFrames = isSilence ? consecutiveSilenceFrames + 1 : 0
+                            if consecutiveSilenceFrames >= silenceEarlyStop {
+                                if verbose {
+                                    print("  Early stop: \(silenceEarlyStop) consecutive silence frames")
+                                }
+                                break
+                            }
                         }
 
                         // Emit chunk when enough frames accumulated

--- a/Sources/PersonaPlex/Sampling.swift
+++ b/Sources/PersonaPlex/Sampling.swift
@@ -84,3 +84,36 @@ public func sampleTopKWithPenalty(
 
     return sampleTopK(logits: penalized, temperature: temperature, topK: topK)
 }
+
+// MARK: - Text Repetition Penalty Sampling
+
+/// Sample text logits with repetition penalty applied to recent text tokens.
+/// Prevents text token collapse that can drive audio death spirals.
+public func sampleTextWithPenalty(
+    logits: MLXArray,
+    temperature: Float,
+    topK: Int,
+    pastTokens: [Int32],
+    penalty: Float
+) -> MLXArray {
+    guard penalty > 1.0, !pastTokens.isEmpty else {
+        return sampleTopK(logits: logits, temperature: temperature, topK: topK)
+    }
+
+    let uniquePast = Set(pastTokens)
+    let vocabSize = logits.shape[logits.ndim - 1]
+
+    var penaltyMask = [Float](repeating: 1.0, count: vocabSize)
+    for tok in uniquePast {
+        let idx = Int(tok)
+        if idx >= 0, idx < vocabSize {
+            penaltyMask[idx] = penalty
+        }
+    }
+    let penaltyArr = MLXArray(penaltyMask).reshaped([1, vocabSize])
+
+    let positive = logits .> MLXArray(Float(0))
+    let penalized = MLX.where(positive, logits / penaltyArr, logits * penaltyArr)
+
+    return sampleTopK(logits: penalized, temperature: temperature, topK: topK)
+}

--- a/Sources/PersonaPlex/SentencePieceDecoder.swift
+++ b/Sources/PersonaPlex/SentencePieceDecoder.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Minimal SentencePiece .model file reader that extracts the vocabulary
+/// for decoding token IDs back to text. Parses the protobuf wire format
+/// directly without requiring protobuf dependencies.
+///
+/// SentencePiece model format (sentencepiece_model.proto):
+///   ModelProto {
+///     repeated SentencePiece pieces = 1;  // vocabulary
+///     ...
+///   }
+///   SentencePiece {
+///     string piece = 1;
+///     float score = 2;
+///     Type type = 3;  // NORMAL=1, UNKNOWN=2, CONTROL=3, ...
+///   }
+public struct SentencePieceDecoder: Sendable {
+    private let vocab: [Int: String]
+
+    public init(modelPath: String) throws {
+        let data = try Data(contentsOf: URL(fileURLWithPath: modelPath))
+        var pieces: [String] = []
+        var offset = 0
+
+        while offset < data.count {
+            let (fieldNumber, wireType, newOffset) = Self.readTag(data: data, offset: offset)
+            offset = newOffset
+
+            if fieldNumber == 1 && wireType == 2 {
+                // Length-delimited: SentencePiece submessage
+                let (length, dataOffset) = Self.readVarint(data: data, offset: offset)
+                offset = dataOffset
+                let end = offset + length
+
+                // Parse submessage to extract piece string (field 1)
+                var piece: String?
+                var subOffset = offset
+                while subOffset < end {
+                    let (subField, subWire, subNewOffset) = Self.readTag(data: data, offset: subOffset)
+                    subOffset = subNewOffset
+
+                    if subField == 1 && subWire == 2 {
+                        // String field
+                        let (strLen, strOffset) = Self.readVarint(data: data, offset: subOffset)
+                        subOffset = strOffset
+                        if let s = String(data: data[subOffset..<(subOffset + strLen)], encoding: .utf8) {
+                            piece = s
+                        }
+                        subOffset += strLen
+                    } else {
+                        // Skip other fields
+                        subOffset = Self.skipField(data: data, offset: subOffset, wireType: subWire)
+                    }
+                }
+
+                pieces.append(piece ?? "")
+                offset = end
+            } else {
+                // Skip non-piece fields
+                offset = Self.skipField(data: data, offset: offset, wireType: wireType)
+            }
+        }
+
+        var v: [Int: String] = [:]
+        for (i, p) in pieces.enumerated() {
+            v[i] = p
+        }
+        self.vocab = v
+    }
+
+    /// Text padding token ID used by PersonaPlex (generated when model is producing audio but not text)
+    private static let textPaddingId: Int32 = 3
+
+    public func decode(_ tokens: [Int32]) -> String {
+        var result = ""
+        for token in tokens {
+            // Skip padding tokens (most steps are padding when model generates audio)
+            if token == Self.textPaddingId { continue }
+            guard let piece = vocab[Int(token)] else { continue }
+            // Skip control tokens (e.g. <s>, </s>, <unk>)
+            if piece.hasPrefix("<") && piece.hasSuffix(">") { continue }
+            result += piece
+        }
+        // SentencePiece uses U+2581 (▁) as word boundary / space
+        return result.replacingOccurrences(of: "\u{2581}", with: " ").trimmingCharacters(in: .whitespaces)
+    }
+
+    // MARK: - Protobuf Wire Format Helpers
+
+    private static func readVarint(data: Data, offset: Int) -> (value: Int, newOffset: Int) {
+        var result = 0
+        var shift = 0
+        var off = offset
+        while off < data.count {
+            let byte = Int(data[off])
+            off += 1
+            result |= (byte & 0x7F) << shift
+            if byte & 0x80 == 0 { break }
+            shift += 7
+        }
+        return (result, off)
+    }
+
+    private static func readTag(data: Data, offset: Int) -> (fieldNumber: Int, wireType: Int, newOffset: Int) {
+        let (tag, newOffset) = readVarint(data: data, offset: offset)
+        return (tag >> 3, tag & 0x07, newOffset)
+    }
+
+    private static func skipField(data: Data, offset: Int, wireType: Int) -> Int {
+        switch wireType {
+        case 0: // Varint
+            let (_, newOffset) = readVarint(data: data, offset: offset)
+            return newOffset
+        case 1: // 64-bit
+            return offset + 8
+        case 2: // Length-delimited
+            let (length, newOffset) = readVarint(data: data, offset: offset)
+            return newOffset + length
+        case 5: // 32-bit
+            return offset + 4
+        default:
+            return data.count // Unknown wire type, skip to end
+        }
+    }
+}


### PR DESCRIPTION
Closes #60

## Summary
- **README discoverability**: Add "Try the Voice Assistant" section near the top promoting PersonaPlexDemo, link from brew install and PersonaPlex Usage sections
- **CLI transcript/JSON**: Add `--transcript` and `--json` flags to `audio respond` — decodes inner monologue text via SentencePieceDecoder (moved from demo app into library)
- **Death spiral prevention**: Text repetition penalty + silence early stopping (15 frames ~1.2s default)
- **Pipeline composition docs**: New "Pipelines" section with DeepFilterNet+ASR, VAD+ASR+TTS, Diarization+ASR examples
- **Sampling config CLI**: Expose `--audio-temp`, `--text-temp`, `--audio-top-k`, `--repetition-penalty`, `--text-repetition-penalty`, `--repetition-window`, `--silence-early-stop`

## Changes

| File | Change |
|------|--------|
| `Sources/PersonaPlex/SentencePieceDecoder.swift` | New — moved from `Examples/PersonaPlexDemo/` into library with `public` access |
| `Sources/PersonaPlex/Sampling.swift` | Add `sampleTextWithPenalty()` for text token repetition penalty |
| `Sources/PersonaPlex/Configuration.swift` | Add `textRepetitionPenalty` and `silenceEarlyStopFrames` to sampling config |
| `Sources/PersonaPlex/PersonaPlex.swift` | Text repetition penalty in both `respond()` and `respondStream()`, silence early stopping, `cfg` now `var` |
| `Sources/AudioCLILib/RespondCommand.swift` | `--transcript`, `--json`, sampling config flags, SentencePiece decoder loading |
| `README.md` | "Try the Voice Assistant" section, PersonaPlex demo callouts, Pipelines section |

## Test plan
- [x] `swift build` compiles clean (only pre-existing deprecation warning)
- [x] PersonaPlexTests pass (14/14)
- [x] Config and sampling tests pass (15/15)
- [ ] Manual: `audio respond --input test.wav --transcript --json`
- [ ] Manual: verify silence early stopping triggers on quiet responses