### PR TITLE
Add Makefile to automate metallib build, update build instructions

### DIFF
--- a/Examples/PersonaPlexDemo/README.md
+++ b/Examples/PersonaPlexDemo/README.md
@@ -101,13 +101,17 @@ Contributions welcome.
 
 ```bash
 cd Examples/PersonaPlexDemo
-swift build -c release
+swift build -c release --disable-sandbox
+../../scripts/build_mlx_metallib.sh release
 ```
+
+Or from the repo root: `make build` (builds everything including the metallib).
 
 ### As a macOS app (recommended)
 
 ```bash
-swift build -c release
+swift build -c release --disable-sandbox
+../../scripts/build_mlx_metallib.sh release
 
 APP="/tmp/PersonaPlexDemo.app"
 mkdir -p "$APP/Contents/MacOS"
@@ -116,9 +120,8 @@ mkdir -p "$APP/Contents/MacOS"
 BINARY=$(find .build -name 'PersonaPlexDemo' -type f | head -1)
 cp "$BINARY" "$APP/Contents/MacOS/"
 
-# Copy MLX metallib (required for compiled inference)
-METALLIB=$(find .build -name 'mlx.metallib' 2>/dev/null | head -1)
-cp "$METALLIB" "$APP/Contents/MacOS/"
+# Copy MLX metallib (required for GPU inference)
+cp .build/release/mlx.metallib "$APP/Contents/MacOS/"
 
 cat > "$APP/Contents/Info.plist" << 'EOF'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build debug test clean
+
+CONFIG ?= release
+
+build:
+	swift build -c release --disable-sandbox
+	./scripts/build_mlx_metallib.sh release
+
+debug:
+	swift build -c debug --disable-sandbox
+	./scripts/build_mlx_metallib.sh debug
+
+test: debug
+	swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent"
+
+clean:
+	swift package clean

--- a/README.md
+++ b/README.md
@@ -92,15 +92,27 @@ import AudioCommon        // Shared utilities
 - Swift 5.9+
 - macOS 14+ or iOS 17+
 - Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+
+- Xcode 15+ (with Metal Toolchain — run `xcodebuild -downloadComponent MetalToolchain` if missing)
+
+### Build from Source
+
+```bash
+git clone https://github.com/ivan-digital/qwen3-asr-swift
+cd qwen3-asr-swift
+make build
+```
+
+This compiles the Swift package **and** the MLX Metal shader library in one step. The Metal library (`mlx.metallib`) is required for GPU inference — without it you'll get `Failed to load the default metallib` at runtime.
+
+For debug builds: `make debug`. To run unit tests: `make test`.
 
 ## Try the Voice Assistant
 
 **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** is a ready-to-run macOS voice assistant — tap to talk, get spoken responses in real-time. Uses microphone input with Silero VAD for automatic speech detection, Qwen3-ASR for transcription, and PersonaPlex 7B for speech-to-speech generation. Multi-turn conversation with 18 voice presets and inner monologue transcript display.
 
 ```bash
+make build  # from repo root — builds everything including MLX metallib
 cd Examples/PersonaPlexDemo
-swift build -c release
 # See Examples/PersonaPlexDemo/README.md for .app bundle instructions
 ```
 
@@ -147,7 +159,7 @@ Runs on Neural Engine via CoreML — frees the GPU for concurrent workloads. 25 
 ### ASR CLI
 
 ```bash
-swift build -c release
+make build  # or: swift build -c release && ./scripts/build_mlx_metallib.sh release
 
 # Default (Qwen3-ASR 0.6B, MLX)
 .build/release/audio transcribe audio.wav
@@ -220,7 +232,7 @@ try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ### TTS CLI
 
 ```bash
-swift build -c release
+make build
 .build/release/audio speak "Hello world" --output output.wav --language english
 ```
 
@@ -423,7 +435,7 @@ Available presets: `focused` (default), `assistant`, `customerService`, `teacher
 ### PersonaPlex CLI
 
 ```bash
-swift build -c release
+make build
 
 # Basic speech-to-speech
 .build/release/audio respond --input question.wav --output response.wav
@@ -477,7 +489,7 @@ for try await chunk in model.synthesizeStream(text: "Hello, how are you today?",
 ### CosyVoice TTS CLI
 
 ```bash
-swift build -c release
+make build
 
 # Basic synthesis
 .build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
@@ -533,7 +545,7 @@ let final = processor.flush()
 ### VAD CLI
 
 ```bash
-swift build -c release
+make build
 
 # Streaming Silero VAD (32ms chunks)
 .build/release/audio vad-stream audio.wav
@@ -636,7 +648,7 @@ try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
 ### Denoise CLI
 
 ```bash
-swift build -c release
+make build
 
 # Basic noise removal
 .build/release/audio denoise noisy.wav
@@ -820,12 +832,10 @@ export QWEN3_CACHE_DIR=/path/to/cache
 
 ## MLX Metal Library
 
-If you see `Failed to load the default metallib`, build it manually:
+If you see `Failed to load the default metallib` at runtime, the Metal shader library is missing. Run `make build` (or `./scripts/build_mlx_metallib.sh release` after a manual `swift build`) to compile it. If the Metal Toolchain is missing, install it first:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
-swift build -c release --disable-sandbox
-./scripts/build_mlx_metallib.sh release
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary

- Add `Makefile` with `build`/`debug`/`test`/`clean` targets — `make build` compiles the Swift package **and** the MLX Metal shader library in one step
- Update all CLI sections in README and PersonaPlexDemo README to use `make build`
- Add "Build from Source" section with clear one-step instructions
- Fix PersonaPlexDemo metallib copy (direct path instead of fragile `find`)

## Context

Users building from source with `swift build -c release` hit `Failed to load the default metallib` at runtime (#65, #66) because the Metal shader library requires a separate compilation step that wasn't part of the documented build flow. The Homebrew formula and CI release workflow already handled this, but manual SPM builds did not.

## Test plan

- [x] `make build` completes successfully (swift build + metallib)
- [x] `make test` runs 76 unit tests, 0 failures
- [x] `.build/release/audio --help` works after `make build`
- [x] `mlx.metallib` exists at `.build/release/mlx.metallib` (100 MB)

Fixes #65, fixes #66