### PR TITLE
Fix PersonaPlexDemo .app bundle build script

### DIFF
--- a/Examples/PersonaPlexDemo/README.md
+++ b/Examples/PersonaPlexDemo/README.md
@@ -116,9 +116,7 @@ swift build -c release --disable-sandbox
 APP="/tmp/PersonaPlexDemo.app"
 mkdir -p "$APP/Contents/MacOS"
 
-# Find the built binary
-BINARY=$(find .build -name 'PersonaPlexDemo' -type f | head -1)
-cp "$BINARY" "$APP/Contents/MacOS/"
+cp .build/release/PersonaPlexDemo "$APP/Contents/MacOS/"
 
 # Copy MLX metallib (required for GPU inference)
 cp .build/release/mlx.metallib "$APP/Contents/MacOS/"


### PR DESCRIPTION
## Summary
- Fix `find` command in README build script that picks up dSYM debug symbols instead of the actual executable, causing "Launchd job spawn failed" (error 111) when launching the .app bundle
- Replace with direct path `.build/release/PersonaPlexDemo`

Closes #71

## Test plan
- [x] Build PersonaPlexDemo and wrap as .app using the updated script
- [x] Verify the app launches without "Launchd job spawn failed" error