### PR TITLE
Document ARM Homebrew requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ See [Roadmap discussion](https://github.com/ivan-digital/qwen3-asr-swift/discuss
 
 ### Homebrew
 
+Requires native ARM Homebrew (`/opt/homebrew`). Rosetta/x86_64 Homebrew is not supported.
+
 ```bash
 brew tap ivan-digital/speech https://github.com/ivan-digital/qwen3-asr-swift
 brew install speech


### PR DESCRIPTION
## Summary
- Add note to Homebrew install section clarifying native ARM Homebrew (`/opt/homebrew`) is required
- Rosetta/x86_64 Homebrew at `/usr/local` fails with "arm64 architecture required"

Closes #67

## Test plan
- [x] README renders correctly with the added note