### PR TITLE
fix: remove 30s audio truncation in Qwen3-ASR preprocessing

### DIFF
--- a/Sources/Qwen3ASR/AudioPreprocessing.swift
+++ b/Sources/Qwen3ASR/AudioPreprocessing.swift
@@ -282,12 +282,21 @@ public class WhisperFeatureExtractor {
         let trimmedFrames = nFrames - 1
         let trimmedMelSpec = Array(melSpec.prefix(trimmedFrames * nMels))
 
-        // No truncation — Qwen3-ASR encoder handles arbitrary-length audio via windowed
-        // attention. The chunkLength=30 from preprocessor_config.json is inherited from the
-        // HuggingFace WhisperFeatureExtractor class but is not enforced by the official
-        // Qwen3-ASR pipeline (which processes up to 1200 seconds).
-        let finalMelSpec = trimmedMelSpec
-        let finalFrames = trimmedFrames
+        // Qwen3-ASR encoder handles arbitrary-length audio via windowed attention.
+        // The chunkLength=30 from preprocessor_config.json is inherited from the HuggingFace
+        // WhisperFeatureExtractor class but is not enforced by the official Qwen3-ASR pipeline.
+        // Cap at 1200 seconds (120000 frames) to match the official pipeline's upper bound
+        // and prevent OOM on extremely long inputs.
+        let maxFrames = 1200 * sampleRate / hopLength  // 120000 frames at 16kHz/160hop
+        let finalFrames: Int
+        let finalMelSpec: [Float]
+        if trimmedFrames > maxFrames {
+            finalFrames = maxFrames
+            finalMelSpec = Array(trimmedMelSpec.prefix(maxFrames * nMels))
+        } else {
+            finalFrames = trimmedFrames
+            finalMelSpec = trimmedMelSpec
+        }
 
         let array = MLXArray(finalMelSpec, [finalFrames, nMels])
         return array.transposed(1, 0)  // [mel_bins, time_frames]


### PR DESCRIPTION
## Summary

`WhisperFeatureExtractor.extractFeatures()` truncates mel spectrograms to 3000 frames (30 seconds) based on `chunk_length: 30` from `preprocessor_config.json`. This field is inherited from the HuggingFace `WhisperFeatureExtractor` class that Qwen3-ASR reuses for mel spectrogram extraction, but the official Qwen3-ASR inference pipeline does not enforce it — it processes up to 1200 seconds.

The Qwen3-ASR encoder handles arbitrary-length audio natively via windowed attention. The truncation causes silent transcription loss for audio longer than 30 seconds.

This change removes the truncation so the full mel spectrogram reaches the encoder.

## Evidence

Tested on 22 WAV samples (5s–119s), both `Qwen3-ASR-0.6B-MLX-4bit` and `Qwen3-ASR-1.7B-MLX-8bit`, Apple M1 Pro:

| Metric | Before | After |
|--------|--------|-------|
| 0.6B pass rate (norm edit dist ≤ 0.20) | 15/22 (68%) | **20/22 (91%)** |
| 1.7B pass rate (norm edit dist ≤ 0.20) | 16/22 (73%) | **21/22 (95%)** |
| 0.6B avg normalized edit distance | 0.201 | **0.071** |
| 1.7B avg normalized edit distance | 0.165 | **0.031** |

Long clips that were silently truncated now transcribe fully:

| Clip duration | Before (1.7B) | After (1.7B) |
|---------------|--------------|--------------|
| 119s | 0.743 | **0.005** |
| 89s | 0.696 | **0.007** |
| 60s | 0.479 | **0.008** |
| 45s | 0.653 | **0.000** |

All realtime factors remain under 0.15x on M1 Pro.