### PR TITLE
fix: place CustomVoice speaker token before pad+bos in codec prefix

### DIFF
--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -1219,19 +1219,19 @@ public class Qwen3TTSModel {
     // MARK: - Codec Prefix
 
     /// Build codec prefix: [think, think_bos, lang_id, think_eos, pad, bos] (6 tokens)
-    /// With speaker: [think, think_bos, lang_id, think_eos, pad, bos, spk_token] (7 tokens)
+    /// With speaker: [think, think_bos, lang_id, think_eos, spk_token, pad, bos] (7 tokens)
     func buildCodecPrefix(languageId: Int, speakerTokenId: Int? = nil) -> [Int32] {
         var prefix: [Int32] = [
             Int32(CodecTokens.codecThink),
             Int32(CodecTokens.codecThinkBos),
             Int32(languageId),
             Int32(CodecTokens.codecThinkEos),
-            Int32(CodecTokens.codecPad),
-            Int32(CodecTokens.codecBos),
         ]
         if let spkId = speakerTokenId {
             prefix.append(Int32(spkId))
         }
+        prefix.append(Int32(CodecTokens.codecPad))
+        prefix.append(Int32(CodecTokens.codecBos))
         return prefix
     }
 


### PR DESCRIPTION
## Summary

- The speaker token in `buildCodecPrefix` was appended **after** `bos`: `[think, think_bos, lang, think_eos, pad, bos, SPEAKER]`
- The official Python implementation (`modeling_qwen3_tts.py` lines 2149-2172) places it **before** `pad`+`bos`: `[think, think_bos, lang, think_eos, SPEAKER, pad, bos]`
- This caused the speaker embedding to be summed with the first text token instead of `bos` during prefill construction, breaking voice identity for all CustomVoice speakers (e.g. Ryan sounded female)

The voice cloning path (`speakerEmbedding`) was already correct — only the token ID path was wrong.

## Verification

Verified position-by-position against [QwenLM/Qwen3-TTS `modeling_qwen3_tts.py`](https://github.com/QwenLM/Qwen3-TTS/blob/main/qwen_tts/core/models/modeling_qwen3_tts.py):

```python
# Python reference (lines 2149-2172):
codec_input_emebdding_0 = embed([[think, think_bos, lang, think_eos]])
codec_input_emebdding_1 = embed([[pad, bos]])
codec_input_emebdding = cat([emb_0, speaker_embed, emb_1])  # speaker BETWEEN
```

## Test plan

- [x] Verified against official Python source
- [ ] Test CustomVoice synthesis with named speakers (Ryan, Vivian, etc.) produces correct voice identity
- [ ] Test Base model (no speaker) still works unchanged