### PR TITLE
fix: guard invalid ranges in streaming transcription

### DIFF
--- a/Sources/Qwen3ASR/StreamingASR.swift
+++ b/Sources/Qwen3ASR/StreamingASR.swift
@@ -94,6 +94,13 @@ public class StreamingASR {
                 var segmentIndex = 0
                 var speechStartSample: Int?
 
+                func safeSegmentAudio(startSample: Int, endSample: Int) -> [Float]? {
+                    let safeStart = max(0, min(startSample, samples.count))
+                    let safeEnd = max(safeStart, min(endSample, samples.count))
+                    guard safeStart < safeEnd else { return nil }
+                    return Array(samples[safeStart..<safeEnd])
+                }
+
                 // Phase 2 state
                 var lastPartialTime: Float = 0
 
@@ -112,7 +119,10 @@ public class StreamingASR {
                         case .speechEnded(let segment):
                             if let startSample = speechStartSample {
                                 let endSample = min(Int(segment.endTime * 16000), samples.count)
-                                let segmentAudio = Array(samples[startSample..<endSample])
+                                guard let segmentAudio = safeSegmentAudio(startSample: startSample, endSample: endSample) else {
+                                    speechStartSample = nil
+                                    continue
+                                }
                                 let text = asrModel.transcribe(
                                     audio: segmentAudio, sampleRate: 16000,
                                     language: config.language, maxTokens: config.maxTokens)
@@ -139,7 +149,10 @@ public class StreamingASR {
 
                         if currentTime - lastPartialTime >= config.partialResultInterval {
                             let endSample = min(Int(currentTime * 16000), samples.count)
-                            let segmentAudio = Array(samples[startSample..<endSample])
+                            guard let segmentAudio = safeSegmentAudio(startSample: startSample, endSample: endSample) else {
+                                lastPartialTime = currentTime
+                                continue
+                            }
                             let text = asrModel.transcribe(
                                 audio: segmentAudio, sampleRate: 16000,
                                 language: config.language, maxTokens: config.maxTokens)
@@ -160,7 +173,11 @@ public class StreamingASR {
                         // Force-split if speech exceeds maxSegmentDuration
                         if speechDuration >= config.maxSegmentDuration {
                             let endSample = min(Int(currentTime * 16000), samples.count)
-                            let segmentAudio = Array(samples[startSample..<endSample])
+                            guard let segmentAudio = safeSegmentAudio(startSample: startSample, endSample: endSample) else {
+                                speechStartSample = Int(currentTime * 16000)
+                                lastPartialTime = currentTime
+                                continue
+                            }
                             let text = asrModel.transcribe(
                                 audio: segmentAudio, sampleRate: 16000,
                                 language: config.language, maxTokens: config.maxTokens)
@@ -185,7 +202,10 @@ public class StreamingASR {
 
                         if speechDuration >= config.maxSegmentDuration {
                             let endSample = min(Int(currentTime * 16000), samples.count)
-                            let segmentAudio = Array(samples[startSample..<endSample])
+                            guard let segmentAudio = safeSegmentAudio(startSample: startSample, endSample: endSample) else {
+                                speechStartSample = Int(currentTime * 16000)
+                                continue
+                            }
                             let text = asrModel.transcribe(
                                 audio: segmentAudio, sampleRate: 16000,
                                 language: config.language, maxTokens: config.maxTokens)
@@ -211,7 +231,9 @@ public class StreamingASR {
                 for event in flushEvents {
                     if case .speechEnded(let segment) = event, let startSample = speechStartSample {
                         let endSample = min(Int(segment.endTime * 16000), samples.count)
-                        let segmentAudio = Array(samples[startSample..<endSample])
+                        guard let segmentAudio = safeSegmentAudio(startSample: startSample, endSample: endSample) else {
+                            continue
+                        }
                         let text = asrModel.transcribe(
                             audio: segmentAudio, sampleRate: 16000,
                             language: config.language, maxTokens: config.maxTokens)


### PR DESCRIPTION
## Summary
- add a shared helper to clamp streaming segment sample indices to valid bounds
- skip transcription work when the resulting audio slice is empty instead of slicing with an invalid range
- apply the guard consistently across speech end, partial emission, max-duration splits, and flush handling

## Testing
- swift test --filter StreamingASRTests/testDefaultConfig

## Docs
- No docs update required; this is an internal safety fix with no public API or CLI changes.