### PR TITLE
Add built-in PipelineLLM adapter, move protocol to AudioCommon

### DIFF
--- a/Sources/AudioCommon/PipelineLLM.swift
+++ b/Sources/AudioCommon/PipelineLLM.swift
@@ -1,0 +1,26 @@
+// MARK: - LLM Protocol
+
+/// Protocol for language model integration with voice pipelines.
+///
+/// Conforming types bridge an LLM (local or remote) to the VoicePipeline's
+/// ASR → LLM → TTS flow. The pipeline calls `chat()` on a background thread
+/// and expects blocking behavior (return when generation is complete).
+public protocol PipelineLLM: AnyObject {
+    /// Generate a response given conversation messages.
+    ///
+    /// Called on the pipeline's worker thread (blocking). Emit tokens via
+    /// `onToken(text, isFinal)` — the pipeline forwards them to TTS.
+    func chat(messages: [(role: MessageRole, content: String)],
+              onToken: @escaping (String, Bool) -> Void)
+
+    /// Cancel in-progress generation. Thread-safe.
+    func cancel()
+}
+
+/// Message roles for LLM conversation.
+public enum MessageRole: Int, Sendable {
+    case system = 0
+    case user = 1
+    case assistant = 2
+    case tool = 3
+}

--- a/Sources/Qwen3Chat/Qwen3PipelineLLM.swift
+++ b/Sources/Qwen3Chat/Qwen3PipelineLLM.swift
@@ -1,0 +1,125 @@
+import Foundation
+import AudioCommon
+import os
+
+private let log = Logger(subsystem: "com.qwen3speech", category: "PipelineLLM")
+
+/// Adapter bridging Qwen3ChatModel to the PipelineLLM protocol for VoicePipeline.
+///
+/// Handles async-to-blocking bridge, cancellation, token cleanup, and
+/// pending phrase accumulation for interrupted turns.
+///
+/// ```swift
+/// let chat = try await Qwen3ChatModel.fromPretrained()
+/// let llm = Qwen3PipelineLLM(model: chat, systemPrompt: "Be brief.")
+/// let pipeline = VoicePipeline(stt: asr, tts: tts, vad: vad, llm: llm, ...)
+/// ```
+public final class Qwen3PipelineLLM: PipelineLLM {
+    private let model: Qwen3ChatModel
+    private let systemPrompt: String?
+    private let sampling: ChatSamplingConfig
+    private var cancelled = false
+    private var consumeTask: Task<Void, Never>?
+
+    /// Unanswered user phrases from cancelled turns — prepended to the next LLM call.
+    private var pendingPhrases: [String] = []
+
+    /// Optional callback to forward tokens to the UI (called on background thread).
+    public var onToken: ((String) -> Void)?
+
+    /// Maximum response length in characters. Prevents TTS OOM from long outputs.
+    public var maxResponseChars: Int = 200
+
+    public init(
+        model: Qwen3ChatModel,
+        systemPrompt: String? = nil,
+        sampling: ChatSamplingConfig = ChatSamplingConfig(
+            temperature: 0.6, topK: 40, maxTokens: 30)
+    ) {
+        self.model = model
+        self.systemPrompt = systemPrompt
+        self.sampling = sampling
+    }
+
+    public func chat(
+        messages: [(role: MessageRole, content: String)],
+        onToken: @escaping (String, Bool) -> Void
+    ) {
+        cancelled = false
+
+        // Extract the last user message
+        guard let lastUser = messages.last(where: { $0.role == .user }) else {
+            onToken("", true)
+            return
+        }
+
+        // Combine any unanswered phrases from cancelled turns
+        let combinedInput: String
+        if pendingPhrases.isEmpty {
+            combinedInput = lastUser.content
+        } else {
+            pendingPhrases.append(lastUser.content)
+            combinedInput = pendingPhrases.joined(separator: ". ")
+            log.info("Combined \(self.pendingPhrases.count) phrases: '\(combinedInput)'")
+            pendingPhrases.removeAll()
+        }
+
+        log.info("Input: '\(combinedInput)'")
+
+        let stream = model.chatStream(
+            combinedInput,
+            systemPrompt: systemPrompt,
+            sampling: sampling
+        )
+
+        // Block until stream completes (pipeline calls from background thread)
+        let sem = DispatchSemaphore(value: 0)
+        var fullResponse = ""
+        let task = Task {
+            defer { sem.signal() }
+            do {
+                for try await token in stream {
+                    guard !self.cancelled else {
+                        log.info("Cancelled after \(fullResponse.count) chars")
+                        break
+                    }
+                    // Skip garbage tokens (broken unicode from INT4 quantization)
+                    let clean = token.filter {
+                        $0.isASCII || $0.isLetter || $0.isNumber ||
+                        $0.isPunctuation || $0.isWhitespace
+                    }
+                    guard !clean.isEmpty else { continue }
+
+                    // Cap response length to prevent TTS OOM
+                    guard fullResponse.count < self.maxResponseChars else {
+                        log.info("Response capped at \(self.maxResponseChars) chars")
+                        break
+                    }
+
+                    fullResponse += clean
+                    self.onToken?(clean)
+                    onToken(clean, false)
+                }
+                log.info("Output (\(fullResponse.count) chars): '\(fullResponse)'")
+                onToken("", true)
+            } catch {
+                log.error("Error: \(error)")
+                onToken("", true)
+            }
+        }
+        consumeTask = task
+        sem.wait()
+        consumeTask = nil
+
+        // If cancelled, save phrase for next call
+        if cancelled {
+            pendingPhrases.append(lastUser.content)
+            log.info("Queued unanswered phrase (pending: \(self.pendingPhrases.count))")
+        }
+    }
+
+    public func cancel() {
+        cancelled = true
+        consumeTask?.cancel()
+    }
+}

--- a/Sources/SpeechCore/VoicePipeline.swift
+++ b/Sources/SpeechCore/VoicePipeline.swift
@@ -66,24 +66,9 @@ public struct PipelineConfig {
     public init() {}
 }
 
-// MARK: - LLM Protocol
-
-/// Protocol for language model integration with the voice pipeline.
-public protocol PipelineLLM: AnyObject {
-    /// Chat with streaming token output.
-    func chat(messages: [(role: MessageRole, content: String)],
-              onToken: @escaping (String, Bool) -> Void)
-    /// Cancel in-progress generation.
-    func cancel()
-}
-
-/// Message roles matching speech-core's sc_role_t.
-public enum MessageRole: Int {
-    case system = 0
-    case user = 1
-    case assistant = 2
-    case tool = 3
-}
+// PipelineLLM and MessageRole are defined in AudioCommon.
+// Re-exported here for backward compatibility.
+// import AudioCommon to access them directly.
 
 // MARK: - Bridge Classes
 


### PR DESCRIPTION
## Summary
- Move `PipelineLLM` protocol + `MessageRole` enum from SpeechCore to AudioCommon (alongside other model protocols)
- Add `Qwen3PipelineLLM` adapter in Qwen3Chat — eliminates ~65 lines of boilerplate per app
- Token cleanup, cancellation, pending phrase accumulation, configurable max response length

## Usage
```swift
let chat = try await Qwen3ChatModel.fromPretrained()
let llm = Qwen3PipelineLLM(model: chat, systemPrompt: "Be brief.")
let pipeline = VoicePipeline(stt: asr, tts: tts, vad: vad, llm: llm, ...)
```

## Test plan
- [x] 173 unit tests pass, 0 failures
- [x] Release build succeeds
- [x] SpeechCore still compiles (backward compatible via AudioCommon import)

Closes #120