### PR TITLE
Add context parameter to transcribe() for system prompt injection

### DIFF
--- a/Sources/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/Qwen3ASR/Qwen3ASR.swift
@@ -60,7 +60,8 @@ public class Qwen3ASRModel {
         audio: [Float],
         sampleRate: Int = 16000,
         language: String? = nil,
-        maxTokens: Int = 448
+        maxTokens: Int = 448,
+        context: String? = nil
     ) -> String {
         // Extract mel features
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
@@ -85,7 +86,8 @@ public class Qwen3ASRModel {
             audioEmbeds: audioEmbeds,
             textDecoder: textDecoder,
             language: language,
-            maxTokens: maxTokens
+            maxTokens: maxTokens,
+            context: context
         )
     }
 
@@ -94,7 +96,8 @@ public class Qwen3ASRModel {
         audioEmbeds: MLXArray,
         textDecoder: QuantizedTextModel,
         language: String?,
-        maxTokens: Int
+        maxTokens: Int,
+        context: String? = nil
     ) -> String {
         // Special token IDs
         let imStartId = 151644
@@ -116,8 +119,13 @@ public class Qwen3ASRModel {
         // Build input_ids array with audio_pad placeholder tokens
         var inputIds: [Int32] = []
 
-        // <|im_start|>system\n<|im_end|>\n
-        inputIds.append(contentsOf: [imStartId, systemId, newlineId, imEndId, newlineId].map { Int32($0) })
+        // <|im_start|>system\n{context}<|im_end|>\n
+        inputIds.append(contentsOf: [imStartId, systemId, newlineId].map { Int32($0) })
+        if let context = context, !context.isEmpty, let tokenizer = tokenizer {
+            let contextTokens = tokenizer.encode(context)
+            inputIds.append(contentsOf: contextTokens.map { Int32($0) })
+        }
+        inputIds.append(contentsOf: [imEndId, newlineId].map { Int32($0) })
 
         // <|im_start|>user\n<|audio_start|>
         inputIds.append(contentsOf: [imStartId, userId, newlineId, audioStartId].map { Int32($0) })

--- a/Sources/Qwen3ASR/StreamingASR.swift
+++ b/Sources/Qwen3ASR/StreamingASR.swift
@@ -29,6 +29,7 @@ public struct StreamingASRConfig: Sendable {
     public var maxTokens: Int
     public var emitPartialResults: Bool
     public var partialResultInterval: Float
+    public var context: String?
 
     public init(
         maxSegmentDuration: Float = 10.0,
@@ -36,7 +37,8 @@ public struct StreamingASRConfig: Sendable {
         language: String? = nil,
         maxTokens: Int = 448,
         emitPartialResults: Bool = false,
-        partialResultInterval: Float = 1.0
+        partialResultInterval: Float = 1.0,
+        context: String? = nil
     ) {
         self.maxSegmentDuration = maxSegmentDuration
         self.vadConfig = vadConfig
@@ -44,6 +46,7 @@ public struct StreamingASRConfig: Sendable {
         self.maxTokens = maxTokens
         self.emitPartialResults = emitPartialResults
         self.partialResultInterval = partialResultInterval
+        self.context = context
     }
 
     public static let `default` = StreamingASRConfig()
@@ -120,7 +123,8 @@ public class StreamingASR {
                                 let segmentAudio = Array(samples[startSample..<endSample])
                                 let text = asrModel.transcribe(
                                     audio: segmentAudio, sampleRate: 16000,
-                                    language: config.language, maxTokens: config.maxTokens)
+                                    language: config.language, maxTokens: config.maxTokens,
+                                    context: config.context)
                                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                                 if !trimmed.isEmpty {
                                     continuation.yield(TranscriptionSegment(
@@ -151,7 +155,8 @@ public class StreamingASR {
                             let segmentAudio = Array(samples[startSample..<endSample])
                             let text = asrModel.transcribe(
                                 audio: segmentAudio, sampleRate: 16000,
-                                language: config.language, maxTokens: config.maxTokens)
+                                language: config.language, maxTokens: config.maxTokens,
+                                context: config.context)
                             let currentWords = text.trimmingCharacters(in: .whitespacesAndNewlines)
                                 .split(separator: " ").map(String.init)
 
@@ -177,7 +182,8 @@ public class StreamingASR {
                             let segmentAudio = Array(samples[startSample..<endSample])
                             let text = asrModel.transcribe(
                                 audio: segmentAudio, sampleRate: 16000,
-                                language: config.language, maxTokens: config.maxTokens)
+                                language: config.language, maxTokens: config.maxTokens,
+                                context: config.context)
                             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                             if !trimmed.isEmpty {
                                 continuation.yield(TranscriptionSegment(
@@ -206,7 +212,8 @@ public class StreamingASR {
                             let segmentAudio = Array(samples[startSample..<endSample])
                             let text = asrModel.transcribe(
                                 audio: segmentAudio, sampleRate: 16000,
-                                language: config.language, maxTokens: config.maxTokens)
+                                language: config.language, maxTokens: config.maxTokens,
+                                context: config.context)
                             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                             if !trimmed.isEmpty {
                                 continuation.yield(TranscriptionSegment(
@@ -233,7 +240,8 @@ public class StreamingASR {
                         let segmentAudio = Array(samples[startSample..<endSample])
                         let text = asrModel.transcribe(
                             audio: segmentAudio, sampleRate: 16000,
-                            language: config.language, maxTokens: config.maxTokens)
+                            language: config.language, maxTokens: config.maxTokens,
+                            context: config.context)
                         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                         if !trimmed.isEmpty {
                             continuation.yield(TranscriptionSegment(


### PR DESCRIPTION
## Summary

- Add optional `context: String?` parameter to `Qwen3ASRModel.transcribe()` and `generateText()`
- When provided, the context text is tokenized and injected into the ChatML system message
- Add `context` to `StreamingASRConfig` and pass it through all `transcribe()` calls in `StreamingASR`
- Fully backward-compatible: defaults to `nil`, preserving existing empty system message behavior

## Motivation

Qwen3-ASR uses a ChatML-style decoder input template:

```
<|im_start|>system\n{CONTEXT}<|im_end|>\n
<|im_start|>user\n<|audio_start|>...<|audio_end|><|im_end|>\n
<|im_start|>assistant\n{language hint}<asr_text>
```

The [official Python implementation](https://github.com/QwenLM/Qwen3-ASR) (`_build_messages()`) and [antirez's C implementation](https://github.com/antirez/qwen-asr) both support injecting text into the system message position. This is useful for:

- **Dictionary/terminology hints**: biasing the decoder toward domain-specific vocabulary (e.g., proper nouns, technical terms)
- **Style guidance**: steering transcription formatting
- **Multi-segment coherence**: providing prior transcript context

The current speech-swift implementation always sends an empty system message, leaving this capability unused.

## Changes

- `transcribe(audio:sampleRate:language:maxTokens:context:)` — new optional `context` parameter
- `generateText(audioEmbeds:textDecoder:language:maxTokens:context:)` — passes context through
- Token assembly: inserts `tokenizer.encode(context)` between `system\n` and `<|im_end|>` when context is provided
- `StreamingASRConfig.context` — new optional field, passed to all 6 `transcribe()` call sites in `StreamingASR`

## Test plan

- [ ] Verify transcription without context produces identical results (backward compat)
- [ ] Verify transcription with context injects tokens into correct position
- [ ] Test with CJK and multi-byte context strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)