### PR TITLE
Replace speaker chaining with embedding clustering (DER 71% → 8%)

### DIFF
--- a/Sources/AudioCLILib/DiarizeCommand.swift
+++ b/Sources/AudioCLILib/DiarizeCommand.swift
@@ -36,8 +36,8 @@ public struct DiarizeCommand: ParsableCommand {
     @Option(name: .long, help: "Minimum silence between segments in seconds (default 0.15)")
     public var minSilence: Float = 0.15
 
-    @Option(name: .long, help: "Cosine similarity threshold for merging speaker clusters (default 1.0 = disabled)")
-    public var clusterThreshold: Float = 1.0
+    @Option(name: .long, help: "Cosine distance threshold for speaker clustering (default 0.715, lower = fewer speakers)")
+    public var clusterThreshold: Float = 0.715
 
     public init() {}
 

--- a/Sources/SpeechVAD/DiarizationHelpers.swift
+++ b/Sources/SpeechVAD/DiarizationHelpers.swift
@@ -1,3 +1,4 @@
+import Foundation
 import AudioCommon
 
 /// Shared helpers for diarization post-processing, used by both
@@ -59,5 +60,124 @@ enum DiarizationHelpers {
     /// Resample audio via AVAudioConverter (delegates to AudioFileLoader).
     static func resample(_ audio: [Float], from sourceSR: Int, to targetSR: Int) -> [Float] {
         AudioFileLoader.resample(audio, from: sourceSR, to: targetSR)
+    }
+
+    // MARK: - Constrained Agglomerative Clustering
+
+    /// Item for constrained agglomerative clustering.
+    struct ClusterItem {
+        let windowIndex: Int
+        let localSpeakerId: Int
+        let embedding: [Float]
+    }
+
+    /// Constrained agglomerative clustering with centroid linkage and cosine distance.
+    ///
+    /// Items from the same window can never be merged (same-window constraint).
+    /// Merges closest unconstrained pair until distance exceeds threshold.
+    ///
+    /// - Parameters:
+    ///   - items: per-window per-speaker embeddings
+    ///   - threshold: cosine distance threshold (0–2). Pairs with distance >= threshold are not merged.
+    /// - Returns: cluster assignment for each item, and cluster centroids
+    static func constrainedAgglomerativeClustering(
+        items: [ClusterItem],
+        threshold: Float
+    ) -> (clusterAssignment: [Int], centroids: [[Float]]) {
+        guard !items.isEmpty else { return ([], []) }
+        if items.count == 1 {
+            return ([0], [items[0].embedding])
+        }
+
+        let n = items.count
+        let dim = items[0].embedding.count
+
+        // Each item starts as its own cluster
+        var clusterOf = Array(0..<n)  // item → cluster ID
+        var centroids = items.map { $0.embedding }  // cluster ID → centroid
+        var clusterMembers = (0..<n).map { [$0] }  // cluster ID → member items
+        // Window indices per cluster (for constraint checking)
+        var clusterWindows = items.map { Set([$0.windowIndex]) }
+        var active = Set(0..<n)
+
+        while active.count > 1 {
+            // Find closest unconstrained pair
+            var bestDist: Float = Float.greatestFiniteMagnitude
+            var bestI = -1, bestJ = -1
+
+            let activeList = active.sorted()
+            for ai in 0..<activeList.count {
+                for aj in (ai + 1)..<activeList.count {
+                    let ci = activeList[ai], cj = activeList[aj]
+
+                    // Same-window constraint: if clusters share any window, skip
+                    if !clusterWindows[ci].isDisjoint(with: clusterWindows[cj]) {
+                        continue
+                    }
+
+                    let dist = cosineDistance(centroids[ci], centroids[cj])
+                    if dist < bestDist {
+                        bestDist = dist
+                        bestI = ci
+                        bestJ = cj
+                    }
+                }
+            }
+
+            guard bestDist < threshold && bestI >= 0 else { break }
+
+            // Merge bestJ into bestI
+            let sizeI = clusterMembers[bestI].count
+            let sizeJ = clusterMembers[bestJ].count
+            let totalSize = Float(sizeI + sizeJ)
+
+            // Weighted average centroid
+            var newCentroid = [Float](repeating: 0, count: dim)
+            for d in 0..<dim {
+                newCentroid[d] = (centroids[bestI][d] * Float(sizeI) + centroids[bestJ][d] * Float(sizeJ)) / totalSize
+            }
+            centroids[bestI] = newCentroid
+
+            // Transfer members
+            for member in clusterMembers[bestJ] {
+                clusterOf[member] = bestI
+            }
+            clusterMembers[bestI].append(contentsOf: clusterMembers[bestJ])
+
+            // Propagate window constraints
+            clusterWindows[bestI].formUnion(clusterWindows[bestJ])
+
+            active.remove(bestJ)
+        }
+
+        // Build final compact assignment
+        let activeSorted = active.sorted()
+        var clusterMap = [Int: Int]()  // old cluster ID → new compact ID
+        for (newId, oldId) in activeSorted.enumerated() {
+            clusterMap[oldId] = newId
+        }
+
+        let assignment = (0..<n).map { clusterMap[clusterOf[$0]]! }
+        let finalCentroids = activeSorted.map { centroids[$0] }
+
+        return (assignment, finalCentroids)
+    }
+
+    /// Cosine distance between two vectors: 1 - cosine_similarity.
+    /// Returns value in [0, 2].
+    static func cosineDistance(_ a: [Float], _ b: [Float]) -> Float {
+        let n = min(a.count, b.count)
+        guard n > 0 else { return 2.0 }
+
+        var dot: Float = 0, normA: Float = 0, normB: Float = 0
+        for i in 0..<n {
+            dot += a[i] * b[i]
+            normA += a[i] * a[i]
+            normB += b[i] * b[i]
+        }
+
+        let denom = sqrt(normA) * sqrt(normB)
+        guard denom > 1e-10 else { return 2.0 }
+        return 1.0 - dot / denom
     }
 }

--- a/Sources/SpeechVAD/DiarizationPipeline.swift
+++ b/Sources/SpeechVAD/DiarizationPipeline.swift
@@ -17,8 +17,8 @@ public struct DiarizationConfig: Sendable {
     public var minSpeechDuration: Float
     /// Minimum silence duration between segments in seconds
     public var minSilenceDuration: Float
-    /// Cosine similarity threshold for merging speaker clusters (0.0-1.0)
-    /// Higher = fewer merges (more speakers). Default 0.5.
+    /// Cosine distance threshold for merging speaker clusters (0.0-2.0).
+    /// Lower = more merges (fewer speakers). Default 0.715.
     public var clusteringThreshold: Float
 
     public init(
@@ -26,7 +26,7 @@ public struct DiarizationConfig: Sendable {
         offset: Float = 0.3,
         minSpeechDuration: Float = 0.3,
         minSilenceDuration: Float = 0.15,
-        clusteringThreshold: Float = 1.0  // disabled by default (WeSpeaker similarities too high for conversational audio)
+        clusteringThreshold: Float = 0.715
     ) {
         self.onset = onset
         self.offset = offset
@@ -58,16 +58,15 @@ public struct DiarizationResult: Sendable {
 
 // MARK: - Pipeline
 
-/// Pyannote-based speaker diarization: segmentation + activity-based speaker chaining.
+/// Pyannote-based speaker diarization: segmentation + per-window embedding + constrained clustering.
 ///
 /// - Warning: This class is not thread-safe. Create separate instances for concurrent use.
 ///
 /// Pipeline (with optional VAD pre-filter):
 /// 0. **VAD Pre-filter** (optional): Silero VAD masks non-speech regions → reduces false alarms
-/// 1. **Segmentation + Speaker Chaining**: Pyannote on 10s sliding windows (50% overlap) →
-///    per-speaker probability tracks → Pearson correlation in overlap zones → greedy exclusive
-///    matching → global speaker IDs
-/// 2. **Post-hoc Embedding**: WeSpeaker 256-dim centroid per speaker (for target speaker extraction)
+/// 1. **Segmentation**: Pyannote on 10s sliding windows (50% overlap) → per-speaker probability tracks
+/// 2. **Per-window Embedding**: WeSpeaker 256-dim embedding per local speaker from non-overlapping speech
+/// 3. **Constrained Clustering**: Agglomerative clustering with same-window constraint → global speaker IDs
 ///
 /// ```swift
 /// let pipeline = try await PyannoteDiarizationPipeline.fromPretrained(useVADFilter: true)
@@ -195,49 +194,9 @@ public final class PyannoteDiarizationPipeline {
             return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
         }
 
-        // Stage 1: Per-window segmentation with probability-based speaker chaining
-        let (segments, numSpeakers) = runActivityChainedDiarization(
+        // Run embedding-clustered diarization pipeline
+        return runEmbeddingClusteredDiarization(
             samples: samples, config: config, speechMask: speechMask)
-
-        guard !segments.isEmpty else {
-            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
-        }
-
-        let merged = DiarizationHelpers.mergeSegments(
-            segments, minSilence: config.minSilenceDuration)
-
-        // Stage 2: Compute per-speaker embeddings
-        var speakerEmbeddings = [[Float]]()
-        for spk in 0..<numSpeakers {
-            var spkAudio = [Float]()
-            for seg in merged where seg.speakerId == spk {
-                let s = max(0, Int(seg.startTime * Float(segConfig.sampleRate)))
-                let e = min(samples.count, Int(seg.endTime * Float(segConfig.sampleRate)))
-                if e > s { spkAudio.append(contentsOf: samples[s..<e]) }
-            }
-            if spkAudio.count >= segConfig.sampleRate / 4 {
-                speakerEmbeddings.append(embeddingModel.embed(
-                    audio: spkAudio, sampleRate: segConfig.sampleRate))
-            } else {
-                speakerEmbeddings.append([Float](repeating: 0, count: 256))
-            }
-        }
-
-        // Stage 3: Embedding-based agglomerative clustering
-        // Merge speaker clusters with high cosine similarity to fix
-        // speaker confusion from activity-based chaining.
-        let (refinedSegments, refinedEmbeddings, refinedNumSpeakers) =
-            refineWithEmbeddings(
-                segments: merged,
-                embeddings: speakerEmbeddings,
-                numSpeakers: numSpeakers,
-                threshold: config.clusteringThreshold)
-
-        return DiarizationResult(
-            segments: refinedSegments,
-            numSpeakers: refinedNumSpeakers,
-            speakerEmbeddings: refinedEmbeddings
-        )
     }
 
     /// Extract segments of a target speaker from audio.
@@ -278,7 +237,7 @@ public final class PyannoteDiarizationPipeline {
             .map { SpeechSegment(startTime: $0.startTime, endTime: $0.endTime) }
     }
 
-    // MARK: - Activity-Based Speaker Chaining
+    // MARK: - Embedding-Clustered Diarization
 
     /// Per-window raw probability tracks (3 speakers × nFrames).
     private struct WindowProbs {
@@ -288,118 +247,35 @@ public final class PyannoteDiarizationPipeline {
         let tracks: [[Float]]
     }
 
-    /// Run diarization by chaining speakers across windows using activity correlation
-    /// in the overlap region (no embedding-based matching).
-    ///
-    /// Refine speaker assignments using embedding-based agglomerative clustering.
-    ///
-    /// Activity-based chaining can produce fragmented speaker IDs (same person
-    /// gets different IDs in different windows). This step computes cosine
-    /// similarity between speaker embeddings and merges clusters above threshold.
-    private func refineWithEmbeddings(
-        segments: [DiarizedSegment],
-        embeddings: [[Float]],
-        numSpeakers: Int,
-        threshold: Float
-    ) -> ([DiarizedSegment], [[Float]], Int) {
-        guard numSpeakers > 1 else {
-            return (segments, embeddings, numSpeakers)
-        }
-
-        // Build speaker ID mapping: start with identity
-        var idMap = [Int](0..<numSpeakers)
-
-        // Agglomerative clustering: merge most similar pair until below threshold
-        var active = Set(0..<numSpeakers)
-        // Track merged embeddings (mean of merged clusters)
-        var clusterEmbeddings = embeddings
-
-        while active.count > 1 {
-            // Find most similar pair
-            var bestSim: Float = -1
-            var bestI = -1, bestJ = -1
-
-            let activeList = active.sorted()
-            for ai in 0..<activeList.count {
-                for aj in (ai + 1)..<activeList.count {
-                    let i = activeList[ai], j = activeList[aj]
-                    // Skip zero embeddings (insufficient audio)
-                    let normI = clusterEmbeddings[i].reduce(Float(0)) { $0 + $1 * $1 }
-                    let normJ = clusterEmbeddings[j].reduce(Float(0)) { $0 + $1 * $1 }
-                    guard normI > 0.01 && normJ > 0.01 else { continue }
-
-                    let sim = WeSpeakerModel.cosineSimilarity(
-                        clusterEmbeddings[i], clusterEmbeddings[j])
-                    if sim > bestSim {
-                        bestSim = sim
-                        bestI = i
-                        bestJ = j
-                    }
-                }
-            }
-
-            // Stop if best similarity is below threshold
-            guard bestSim >= threshold && bestI >= 0 else { break }
-
-            // Merge bestJ into bestI
-            // Update embedding: average of the two
-            for d in 0..<clusterEmbeddings[bestI].count {
-                clusterEmbeddings[bestI][d] = (clusterEmbeddings[bestI][d] + clusterEmbeddings[bestJ][d]) / 2.0
-            }
-
-            // Remap all segments with bestJ to bestI
-            for k in 0..<numSpeakers {
-                if idMap[k] == bestJ { idMap[k] = bestI }
-            }
-
-            active.remove(bestJ)
-        }
-
-        // Apply remapping and compact IDs
-        let remapped = segments.map { seg in
-            DiarizedSegment(
-                startTime: seg.startTime,
-                endTime: seg.endTime,
-                speakerId: idMap[seg.speakerId])
-        }
-
-        let compacted = DiarizationHelpers.compactSpeakerIds(remapped)
-        let finalNumSpeakers = Set(compacted.map(\.speakerId)).count
-
-        // Collect final embeddings
-        let finalEmbeddings: [[Float]]
-        if finalNumSpeakers > 0 {
-            var embMap = [[Float]](repeating: [], count: finalNumSpeakers)
-            let uniqueIds = active.sorted()
-            for (newId, oldId) in uniqueIds.enumerated() where newId < finalNumSpeakers {
-                embMap[newId] = clusterEmbeddings[oldId]
-            }
-            finalEmbeddings = embMap
-        } else {
-            finalEmbeddings = []
-        }
-
-        return (compacted, finalEmbeddings, finalNumSpeakers)
+    /// Per-window per-speaker embedding for clustering.
+    private struct WindowSpeakerEmbedding {
+        let windowIndex: Int
+        let localSpeakerId: Int
+        let embedding: [Float]
     }
 
-    /// With 50% overlapping windows, adjacent windows share a half-window overlap region.
-    /// The activity patterns of the 3 local speakers in this overlap are compared via
-    /// Pearson correlation to find the best permutation mapping between windows.
-    private func runActivityChainedDiarization(
+    /// Run diarization using per-window speaker embeddings + constrained agglomerative clustering.
+    ///
+    /// 1. Segment all windows → per-speaker probability tracks
+    /// 2. Extract per-window per-speaker embeddings from non-overlapping speech
+    /// 3. Constrained clustering (same-window items never merge) → global speaker IDs
+    /// 4. Map cluster IDs back to binarized segments
+    private func runEmbeddingClusteredDiarization(
         samples: [Float],
         config: DiarizationConfig,
         speechMask: [SpeechSegment]?
-    ) -> (segments: [DiarizedSegment], numSpeakers: Int) {
+    ) -> DiarizationResult {
         let windowDuration: Float = 10.0
         let sampleRate = segConfig.sampleRate
         let windowSamples = Int(windowDuration * Float(sampleRate))
         let framesPerChunk = 589
         let frameDuration = windowDuration / Float(framesPerChunk)
         let stepSamples = windowSamples / 2  // 50% overlap
-        let halfFrames = framesPerChunk / 2  // ~294 frames in overlap
 
         let numSamples = samples.count
-        guard numSamples > 0 else { return ([], 0) }
+        guard numSamples > 0 else {
+            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        }
 
         // Generate window positions with 50% overlap
         var positions = [(start: Int, end: Int)]()
@@ -419,7 +295,7 @@ public final class PyannoteDiarizationPipeline {
         // Step 1: Run segmentation on all windows, collect probability tracks
         var windowProbs = [WindowProbs]()
 
-        for (_, (start, end)) in positions.enumerated() {
+        for (start, end) in positions {
             var window = Array(samples[start..<end])
             if window.count < windowSamples {
                 window.append(contentsOf: [Float](repeating: 0, count: windowSamples - window.count))
@@ -437,107 +313,96 @@ public final class PyannoteDiarizationPipeline {
             windowProbs.append(WindowProbs(startSample: start, endSample: end, tracks: tracks))
         }
 
-        guard !windowProbs.isEmpty else { return ([], 0) }
+        guard !windowProbs.isEmpty else {
+            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        }
 
-        // Step 2: Chain speakers across adjacent windows using overlap correlation
-        // globalPermutation[w][localSpk] = global speaker ID for window w, local speaker localSpk
-        var globalPermutation = [[Int]](repeating: [0, 1, 2], count: windowProbs.count)
-        var maxGlobalSpk = 2  // max global speaker ID used so far
+        // Step 2: Extract per-window per-speaker embeddings from non-overlapping speech
+        let minEmbeddingSamples = sampleRate / 2  // 0.5s minimum for embedding
+        var windowEmbeddings = [WindowSpeakerEmbedding]()
 
-        for w in 1..<windowProbs.count {
-            let prev = windowProbs[w - 1]
-            let curr = windowProbs[w]
+        for (wIdx, wp) in windowProbs.enumerated() {
+            let windowStartSample = wp.startSample
 
-            // The overlap region: second half of prev == first half of curr
-            // prev frames [halfFrames...589) overlap with curr frames [0...halfFrames)
-            let overlapFrames = min(halfFrames, prev.tracks[0].count - halfFrames,
-                                     curr.tracks[0].count)
-            guard overlapFrames > 10 else {
-                // No meaningful overlap — assign new IDs
-                globalPermutation[w] = [maxGlobalSpk + 1, maxGlobalSpk + 2, maxGlobalSpk + 3]
-                maxGlobalSpk += 3
-                continue
-            }
+            for localSpk in 0..<3 {
+                let probs = wp.tracks[localSpk]
 
-            // Determine which tracks are "active" (have meaningful speech) in the overlap
-            let activityThreshold: Float = 0.05  // mean prob > 5% → active
-            var prevActive = [Int]()
-            var currActive = [Int]()
-            var prevSlices = [[Float]](repeating: [], count: 3)
-            var currSlices = [[Float]](repeating: [], count: 3)
+                // Binarize this speaker's track
+                let binarySegments = PowersetDecoder.binarize(
+                    probs: probs, onset: config.onset,
+                    offset: config.offset, frameDuration: frameDuration)
 
-            for p in 0..<3 {
-                let slice = Array(prev.tracks[p][halfFrames..<(halfFrames + overlapFrames)])
-                prevSlices[p] = slice
-                let mean = slice.reduce(0, +) / Float(overlapFrames)
-                if mean > activityThreshold { prevActive.append(p) }
-            }
-            for c in 0..<3 {
-                let slice = Array(curr.tracks[c][0..<overlapFrames])
-                currSlices[c] = slice
-                let mean = slice.reduce(0, +) / Float(overlapFrames)
-                if mean > activityThreshold { currActive.append(c) }
-            }
+                guard !binarySegments.isEmpty else { continue }
 
-            let prevMapping = globalPermutation[w - 1]
-            var currMapping = [Int](repeating: -1, count: 3)
+                // Collect audio from frames where ONLY this speaker is active (non-overlapping)
+                var spkAudio = [Float]()
 
-            if prevActive.isEmpty || currActive.isEmpty {
-                // No active speakers in overlap — preserve order from previous window
-                currMapping = prevMapping
-            } else {
-                // Compute correlation matrix only for active tracks
-                // Then use greedy exclusive matching
-                var pairs = [(corr: Float, prevLocal: Int, currLocal: Int)]()
-                for p in prevActive {
-                    for c in currActive {
-                        let corr = activityCorrelation(prevSlices[p], currSlices[c])
-                        pairs.append((corr, p, c))
-                    }
-                }
-                pairs.sort { $0.corr > $1.corr }
+                for seg in binarySegments {
+                    let segStartFrame = Int(seg.startTime / frameDuration)
+                    let segEndFrame = min(Int(seg.endTime / frameDuration), probs.count)
 
-                var usedPrev = Set<Int>()
-                var usedCurr = Set<Int>()
-                for (_, p, c) in pairs {
-                    if usedPrev.contains(p) || usedCurr.contains(c) { continue }
-                    currMapping[c] = prevMapping[p]
-                    usedPrev.insert(p)
-                    usedCurr.insert(c)
-                }
+                    for frame in segStartFrame..<segEndFrame {
+                        // Check if other speakers are below offset at this frame
+                        var otherActive = false
+                        for otherSpk in 0..<3 where otherSpk != localSpk {
+                            if wp.tracks[otherSpk][frame] >= config.offset {
+                                otherActive = true
+                                break
+                            }
+                        }
+                        if otherActive { continue }
 
-                // Inactive curr tracks: assign to unmatched prev globals (by order)
-                var unmatchedPrevGlobals = [Int]()
-                for p in 0..<3 {
-                    if !usedPrev.contains(p) {
-                        unmatchedPrevGlobals.append(prevMapping[p])
-                    }
-                }
-                var unmatchedIdx = 0
-                for c in 0..<3 {
-                    if currMapping[c] < 0 {
-                        if unmatchedIdx < unmatchedPrevGlobals.count {
-                            currMapping[c] = unmatchedPrevGlobals[unmatchedIdx]
-                            unmatchedIdx += 1
-                        } else {
-                            maxGlobalSpk += 1
-                            currMapping[c] = maxGlobalSpk
+                        // Extract audio samples for this frame
+                        let frameStartSample = windowStartSample + Int(Float(frame) * frameDuration * Float(sampleRate))
+                        let frameEndSample = min(
+                            windowStartSample + Int(Float(frame + 1) * frameDuration * Float(sampleRate)),
+                            samples.count
+                        )
+                        if frameEndSample > frameStartSample {
+                            spkAudio.append(contentsOf: samples[frameStartSample..<frameEndSample])
                         }
                     }
                 }
-            }
 
-            globalPermutation[w] = currMapping
+                // Need minimum 0.5s of audio for a reliable embedding
+                guard spkAudio.count >= minEmbeddingSamples else { continue }
+
+                let embedding = embeddingModel.embed(audio: spkAudio, sampleRate: sampleRate)
+                windowEmbeddings.append(WindowSpeakerEmbedding(
+                    windowIndex: wIdx, localSpeakerId: localSpk, embedding: embedding))
+            }
         }
 
-        // Step 3: Binarize and build segments with global speaker IDs
+        // Handle edge case: no embeddings could be extracted
+        guard !windowEmbeddings.isEmpty else {
+            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        }
+
+        // Step 3: Constrained agglomerative clustering
+        let clusterItems = windowEmbeddings.map {
+            DiarizationHelpers.ClusterItem(
+                windowIndex: $0.windowIndex,
+                localSpeakerId: $0.localSpeakerId,
+                embedding: $0.embedding)
+        }
+
+        let (clusterAssignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: clusterItems, threshold: config.clusteringThreshold)
+
+        // Build mapping: (windowIndex, localSpeakerId) → global cluster ID
+        var localToGlobal = [Int: [Int: Int]]()  // windowIndex → (localSpeakerId → globalId)
+        for (i, we) in windowEmbeddings.enumerated() {
+            localToGlobal[we.windowIndex, default: [:]][we.localSpeakerId] = clusterAssignment[i]
+        }
+
+        // Step 4: Build segments with global speaker IDs
         var diarizedSegments = [DiarizedSegment]()
 
         for (w, wp) in windowProbs.enumerated() {
             let windowStartTime = Float(wp.startSample) / Float(sampleRate)
             let windowEndTime = Float(wp.endSample) / Float(sampleRate)
 
-            // Center zone ownership
+            // Center zone ownership (same as before)
             let prevEnd = w > 0 ?
                 Float(positions[w - 1].end) / Float(sampleRate) : 0
             let nextStart = w + 1 < positions.count ?
@@ -547,7 +412,10 @@ public final class PyannoteDiarizationPipeline {
                 (windowEndTime + nextStart) / 2 : Float(numSamples) / Float(sampleRate)
 
             for localSpk in 0..<3 {
-                let globalSpk = globalPermutation[w][localSpk]
+                guard let globalSpk = localToGlobal[w]?[localSpk] else {
+                    continue  // No embedding for this speaker — skip (insufficient audio)
+                }
+
                 let probs = wp.tracks[localSpk]
                 let segments = PowersetDecoder.binarize(
                     probs: probs, onset: config.onset,
@@ -588,37 +456,31 @@ public final class PyannoteDiarizationPipeline {
 
         diarizedSegments.sort { $0.startTime < $1.startTime }
 
-        // Compact speaker IDs (remove gaps)
+        // Compact speaker IDs and merge
         diarizedSegments = DiarizationHelpers.compactSpeakerIds(diarizedSegments)
-        let numCompacted = Set(diarizedSegments.map(\.speakerId)).count
+        let merged = DiarizationHelpers.mergeSegments(
+            diarizedSegments, minSilence: config.minSilenceDuration)
+        let numSpeakers = Set(merged.map(\.speakerId)).count
 
-        return (diarizedSegments, numCompacted)
-    }
-
-    /// Correlation between two activity probability vectors.
-    /// Returns value in [-1, 1]; high correlation means similar activity patterns.
-    private func activityCorrelation(_ a: [Float], _ b: [Float]) -> Float {
-        let n = min(a.count, b.count)
-        guard n > 1 else { return 0 }
-
-        var sumA: Float = 0, sumB: Float = 0
-        for i in 0..<n { sumA += a[i]; sumB += b[i] }
-        let meanA = sumA / Float(n)
-        let meanB = sumB / Float(n)
-
-        var cov: Float = 0, varA: Float = 0, varB: Float = 0
-        for i in 0..<n {
-            let da = a[i] - meanA
-            let db = b[i] - meanB
-            cov += da * db
-            varA += da * da
-            varB += db * db
+        // Re-compact centroids to match compacted speaker IDs
+        let finalCentroids: [[Float]]
+        if numSpeakers <= centroids.count {
+            finalCentroids = Array(centroids.prefix(numSpeakers))
+        } else {
+            // Pad with zero embeddings for speakers that had no embedding
+            var padded = centroids
+            while padded.count < numSpeakers {
+                padded.append([Float](repeating: 0, count: 256))
+            }
+            finalCentroids = padded
         }
 
-        let denom = sqrt(varA * varB)
-        return denom > 1e-10 ? cov / denom : 0
+        return DiarizationResult(
+            segments: merged,
+            numSpeakers: numSpeakers,
+            speakerEmbeddings: finalCentroids
+        )
     }
-
 
     /// Trim a segment to intersect with speech regions.
     private func trimToSpeechMask(

--- a/Tests/SpeechVADTests/DiarizationHelpersTests.swift
+++ b/Tests/SpeechVADTests/DiarizationHelpersTests.swift
@@ -147,17 +147,185 @@ final class DiarizationHelpersTests: XCTestCase {
         XCTAssertEqual(config.offset, 0.3, accuracy: 0.001)
         XCTAssertEqual(config.minSpeechDuration, 0.3, accuracy: 0.001)
         XCTAssertEqual(config.minSilenceDuration, 0.15, accuracy: 0.001)
+        XCTAssertEqual(config.clusteringThreshold, 0.715, accuracy: 0.001)
     }
 
     func testDiarizationConfigCustomValues() {
         let config = DiarizationConfig(
             onset: 0.7, offset: 0.4,
-            minSpeechDuration: 0.5, minSilenceDuration: 0.2
+            minSpeechDuration: 0.5, minSilenceDuration: 0.2,
+            clusteringThreshold: 0.5
         )
         XCTAssertEqual(config.onset, 0.7, accuracy: 0.001)
         XCTAssertEqual(config.offset, 0.4, accuracy: 0.001)
         XCTAssertEqual(config.minSpeechDuration, 0.5, accuracy: 0.001)
         XCTAssertEqual(config.minSilenceDuration, 0.2, accuracy: 0.001)
+        XCTAssertEqual(config.clusteringThreshold, 0.5, accuracy: 0.001)
+    }
+
+    // MARK: - cosineDistance
+
+    func testCosineDistanceSameVector() {
+        let a: [Float] = [1, 0, 0]
+        let dist = DiarizationHelpers.cosineDistance(a, a)
+        XCTAssertEqual(dist, 0.0, accuracy: 0.001)
+    }
+
+    func testCosineDistanceOpposite() {
+        let a: [Float] = [1, 0, 0]
+        let b: [Float] = [-1, 0, 0]
+        let dist = DiarizationHelpers.cosineDistance(a, b)
+        XCTAssertEqual(dist, 2.0, accuracy: 0.001)
+    }
+
+    func testCosineDistanceOrthogonal() {
+        let a: [Float] = [1, 0, 0]
+        let b: [Float] = [0, 1, 0]
+        let dist = DiarizationHelpers.cosineDistance(a, b)
+        XCTAssertEqual(dist, 1.0, accuracy: 0.001)
+    }
+
+    func testCosineDistanceZeroVector() {
+        let a: [Float] = [0, 0, 0]
+        let b: [Float] = [1, 0, 0]
+        let dist = DiarizationHelpers.cosineDistance(a, b)
+        XCTAssertEqual(dist, 2.0, accuracy: 0.001)  // degenerate
+    }
+
+    // MARK: - constrainedAgglomerativeClustering
+
+    func testClusteringEmpty() {
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: [], threshold: 0.5)
+        XCTAssertTrue(assignment.isEmpty)
+        XCTAssertTrue(centroids.isEmpty)
+    }
+
+    func testClusteringSingleItem() {
+        let items = [DiarizationHelpers.ClusterItem(
+            windowIndex: 0, localSpeakerId: 0, embedding: [1, 0, 0])]
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 0.5)
+        XCTAssertEqual(assignment, [0])
+        XCTAssertEqual(centroids.count, 1)
+    }
+
+    func testClusteringSimilarEmbeddingsDifferentWindows() {
+        // Two similar embeddings from different windows → should merge
+        let items = [
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 0,
+                                           embedding: [1, 0, 0, 0]),
+            DiarizationHelpers.ClusterItem(windowIndex: 1, localSpeakerId: 0,
+                                           embedding: [0.99, 0.1, 0, 0]),
+        ]
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 0.5)
+
+        // Should be merged into same cluster
+        XCTAssertEqual(assignment[0], assignment[1])
+        XCTAssertEqual(centroids.count, 1)
+    }
+
+    func testClusteringSameWindowNeverMerge() {
+        // Two similar embeddings from SAME window → constraint prevents merge
+        let items = [
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 0,
+                                           embedding: [1, 0, 0, 0]),
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 1,
+                                           embedding: [0.99, 0.1, 0, 0]),
+        ]
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 2.0)  // Very permissive threshold
+
+        // Must NOT merge despite being similar
+        XCTAssertNotEqual(assignment[0], assignment[1])
+        XCTAssertEqual(centroids.count, 2)
+    }
+
+    func testClusteringThresholdRespected() {
+        // Two embeddings with cosine distance > threshold → should NOT merge
+        let items = [
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 0,
+                                           embedding: [1, 0, 0, 0]),
+            DiarizationHelpers.ClusterItem(windowIndex: 1, localSpeakerId: 0,
+                                           embedding: [0, 1, 0, 0]),
+        ]
+        // Cosine distance = 1.0, threshold = 0.5 → should NOT merge
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 0.5)
+
+        XCTAssertNotEqual(assignment[0], assignment[1])
+        XCTAssertEqual(centroids.count, 2)
+    }
+
+    func testClusteringCentroidLinkage() {
+        // After merging, centroid should be the weighted average
+        let items = [
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 0,
+                                           embedding: [1, 0]),
+            DiarizationHelpers.ClusterItem(windowIndex: 1, localSpeakerId: 0,
+                                           embedding: [0.9, 0.1]),
+        ]
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 1.0)
+
+        XCTAssertEqual(assignment[0], assignment[1])
+        XCTAssertEqual(centroids.count, 1)
+        // Centroid should be average: [(1+0.9)/2, (0+0.1)/2] = [0.95, 0.05]
+        XCTAssertEqual(centroids[0][0], 0.95, accuracy: 0.001)
+        XCTAssertEqual(centroids[0][1], 0.05, accuracy: 0.001)
+    }
+
+    func testClusteringTransitiveConstraints() {
+        // Three items: A(win0), B(win1), C(win0)
+        // A and B are similar (closest pair) → merge. Merged {A,B} inherits win0 from A,
+        // so {A,B} cannot merge with C (both have win0).
+        let items = [
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 0,
+                                           embedding: [1, 0, 0, 0]),  // A
+            DiarizationHelpers.ClusterItem(windowIndex: 1, localSpeakerId: 0,
+                                           embedding: [0.99, 0.01, 0, 0]),  // B (close to A)
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 1,
+                                           embedding: [0, 0, 1, 0]),  // C (far from A and B)
+        ]
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 2.0)
+
+        // A and B should merge (closest, different windows)
+        XCTAssertEqual(assignment[0], assignment[1], "A and B should be in same cluster")
+        // C cannot merge with {A,B} — both have window 0
+        XCTAssertNotEqual(assignment[0], assignment[2], "C should not merge with {A,B}")
+        XCTAssertEqual(centroids.count, 2)
+    }
+
+    func testClusteringMultipleSpeakers() {
+        // 2 speakers across 3 windows — speaker embeddings are clearly separated
+        let spk0: [Float] = [1, 0, 0, 0]
+        let spk1: [Float] = [0, 0, 1, 0]
+        let items = [
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 0, embedding: spk0),
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 1, embedding: spk1),
+            DiarizationHelpers.ClusterItem(windowIndex: 1, localSpeakerId: 0, embedding: spk0),
+            DiarizationHelpers.ClusterItem(windowIndex: 1, localSpeakerId: 1, embedding: spk1),
+            DiarizationHelpers.ClusterItem(windowIndex: 2, localSpeakerId: 0, embedding: spk0),
+            DiarizationHelpers.ClusterItem(windowIndex: 2, localSpeakerId: 1, embedding: spk1),
+        ]
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 0.5)
+
+        // Should produce exactly 2 clusters
+        XCTAssertEqual(centroids.count, 2)
+
+        // All spk0 items should be in same cluster
+        XCTAssertEqual(assignment[0], assignment[2])
+        XCTAssertEqual(assignment[0], assignment[4])
+
+        // All spk1 items should be in same cluster
+        XCTAssertEqual(assignment[1], assignment[3])
+        XCTAssertEqual(assignment[1], assignment[5])
+
+        // spk0 and spk1 should be in different clusters
+        XCTAssertNotEqual(assignment[0], assignment[1])
     }
 
     // MARK: - DiarizationResult

--- a/Tests/SpeechVADTests/WeSpeakerTests.swift
+++ b/Tests/SpeechVADTests/WeSpeakerTests.swift
@@ -13,6 +13,7 @@ final class WeSpeakerTests: XCTestCase {
         XCTAssertEqual(config.offset, 0.3, accuracy: 0.001)
         XCTAssertEqual(config.minSpeechDuration, 0.3, accuracy: 0.001)
         XCTAssertEqual(config.minSilenceDuration, 0.15, accuracy: 0.001)
+        XCTAssertEqual(config.clusteringThreshold, 0.715, accuracy: 0.001)
     }
 
     func testDiarizedSegmentDuration() {
@@ -275,22 +276,36 @@ final class E2EWeSpeakerTests: XCTestCase {
         let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
         let result = pipeline.diarize(audio: samples, sampleRate: sampleRate, config: .default)
 
-        // Should detect at least one speaker segment
+        // Single-speaker test audio → exactly 1 speaker
+        XCTAssertEqual(result.numSpeakers, 1,
+                       "Test audio has 1 speaker (got \(result.numSpeakers))")
         XCTAssertGreaterThan(result.segments.count, 0)
-        XCTAssertGreaterThanOrEqual(result.numSpeakers, 1)
 
-        // All segments should have valid times
+        // All segments should have valid times within audio bounds
+        let audioDuration = Float(samples.count) / Float(sampleRate)
         for seg in result.segments {
             XCTAssertGreaterThanOrEqual(seg.startTime, 0)
             XCTAssertGreaterThan(seg.endTime, seg.startTime)
+            XCTAssertLessThanOrEqual(seg.endTime, audioDuration + 0.1)
             XCTAssertGreaterThanOrEqual(seg.speakerId, 0)
             XCTAssertLessThan(seg.speakerId, result.numSpeakers)
         }
+
+        // Speech region should be roughly 5-8.5s
+        let totalSpeech = result.segments.reduce(Float(0)) { $0 + $1.duration }
+        XCTAssertGreaterThan(totalSpeech, 2.0,
+                             "Should detect at least 2s of speech (got \(totalSpeech)s)")
+        XCTAssertLessThan(totalSpeech, 6.0,
+                          "Should not detect more than 6s of speech (got \(totalSpeech)s)")
 
         // Should have centroid for each speaker
         XCTAssertEqual(result.speakerEmbeddings.count, result.numSpeakers)
         for emb in result.speakerEmbeddings {
             XCTAssertEqual(emb.count, 256)
+            // Centroid should be L2-normalized (not a zero vector)
+            let norm = sqrt(emb.reduce(Float(0)) { $0 + $1 * $1 })
+            XCTAssertEqual(norm, 1.0, accuracy: 0.05,
+                           "Centroid should be L2-normalized (got norm \(norm))")
         }
     }
 
@@ -306,16 +321,24 @@ final class E2EWeSpeakerTests: XCTestCase {
 
         let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
 
-        // Test audio has a single speaker — pipeline should detect 1
+        // Test audio has a single speaker — pipeline should detect exactly 1
         let result = pipeline.diarize(audio: samples, sampleRate: sampleRate, config: .default)
+
+        XCTAssertEqual(result.numSpeakers, 1, "Single-speaker audio should produce 1 speaker (got \(result.numSpeakers))")
 
         // All segments should be speaker 0
         for seg in result.segments {
             XCTAssertEqual(seg.speakerId, 0)
         }
 
-        // Segments should cover the speech region
+        // Speech region is ~5.1-8.5s — segments should cover it
         XCTAssertGreaterThan(result.segments.count, 0)
+        let firstStart = result.segments.first!.startTime
+        let lastEnd = result.segments.last!.endTime
+        XCTAssertEqual(firstStart, 5.0, accuracy: 0.5,
+                       "Speech should start around 5s (got \(firstStart)s)")
+        XCTAssertEqual(lastEnd, 8.5, accuracy: 0.5,
+                       "Speech should end around 8.5s (got \(lastEnd)s)")
     }
 
     // MARK: - E2E: Speaker Extraction
@@ -343,12 +366,17 @@ final class E2EWeSpeakerTests: XCTestCase {
         XCTAssertGreaterThan(extracted.count, 0,
                              "Should extract segments matching the target speaker")
 
-        // Extracted segments should be in the speech region (~5-8.5s)
-        for seg in extracted {
-            XCTAssertGreaterThanOrEqual(seg.startTime, 0)
-            XCTAssertGreaterThan(seg.endTime, seg.startTime)
-            XCTAssertGreaterThan(seg.duration, 0.1)
-        }
+        // Extracted segments should cover the speech region (~5-8.5s)
+        let totalExtracted = extracted.reduce(Float(0)) { $0 + $1.duration }
+        XCTAssertGreaterThan(totalExtracted, 2.0,
+                             "Should extract at least 2s of speech (got \(totalExtracted)s)")
+
+        let firstStart = extracted.first!.startTime
+        let lastEnd = extracted.last!.endTime
+        XCTAssertEqual(firstStart, 5.0, accuracy: 1.0,
+                       "Extraction should start around 5s (got \(firstStart)s)")
+        XCTAssertEqual(lastEnd, 8.5, accuracy: 1.0,
+                       "Extraction should end around 8.5s (got \(lastEnd)s)")
     }
 
     // MARK: - E2E: Embedding Subsegment Consistency

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -38,17 +38,19 @@ No speaker embeddings are produced — `--target-speaker` and `--embedding-engin
 ### Pyannote Pipeline
 
 ```
-Audio → [Segmentation + Activity Chaining] → [Post-hoc Embedding] → Diarized Segments
+Audio → [Segmentation] → [Per-Window Embedding] → [Constrained Clustering] → Diarized Segments
 ```
 
-**Stage 1 — Segmentation + Speaker Chaining**: Pyannote processes 10s sliding windows with 50% overlap. The `PowersetDecoder` extracts per-speaker probabilities from the 7-class powerset output:
+**Stage 1 — Segmentation**: Pyannote processes 10s sliding windows with 50% overlap. The `PowersetDecoder` extracts per-speaker probabilities from the 7-class powerset output:
 - spk1 = P(class 1) + P(class 4) + P(class 5)
 - spk2 = P(class 2) + P(class 4) + P(class 6)
 - spk3 = P(class 3) + P(class 5) + P(class 6)
 
-Adjacent windows share a 5-second overlap region. Speaker identity is propagated across windows by computing **Pearson correlation** between speaker probability tracks in the overlap zone, then applying greedy exclusive matching to assign consistent global speaker IDs. Tracks with mean probability < 5% are treated as inactive. Hysteresis binarization (onset/offset) produces final segments, clipped to each window's center zone.
+Hysteresis binarization (onset/offset) produces per-speaker speech segments within each window.
 
-**Stage 2 — Post-hoc Embedding**: After diarization is complete, WeSpeaker ResNet34-LM extracts a 256-dim centroid embedding per speaker (concatenating all their audio). These embeddings are used for target speaker extraction (`--target-speaker`) and returned in `DiarizationResult.speakerEmbeddings`. Embeddings do not drive the speaker assignment.
+**Stage 2 — Per-Window Embedding**: For each local speaker in each window, non-overlapping speech frames (where only this speaker is active) are extracted and passed through WeSpeaker ResNet34-LM to produce a 256-dim embedding. Speakers with < 0.5s of non-overlapping speech are skipped.
+
+**Stage 3 — Constrained Agglomerative Clustering**: Embeddings are clustered using centroid linkage with cosine distance. A **same-window constraint** ensures that speakers from the same window are never merged (they are known to be different). Merging stops when the minimum cosine distance between unconstrained pairs exceeds the threshold (default 0.715). Cluster IDs are mapped back to segments, clipped to center zones, and merged.
 
 ### WeSpeaker ResNet34-LM
 
@@ -214,7 +216,8 @@ Sources/SpeechVAD/
 ├── WeSpeaker.swift                    Public API: embed(), fromPretrained(), engine selection
 ├── CoreMLWeSpeakerInference.swift     CoreML inference (EnumeratedShapes, float16)
 ├── PowersetDecoder.swift              7-class powerset → per-speaker probs
-├── DiarizationPipeline.swift          Pyannote pipeline (activity chaining + speaker extraction)
+├── DiarizationHelpers.swift            Merge segments, compact IDs, constrained clustering
+├── DiarizationPipeline.swift          Pyannote pipeline (embedding clustering + speaker extraction)
 ├── SortformerConfig.swift             Sortformer model configuration
 ├── SortformerMelExtractor.swift       128-dim log-mel for Sortformer (Hann window)
 ├── SortformerModel.swift              CoreML wrapper for Sortformer inference


### PR DESCRIPTION
## Summary

- Replace heuristic activity-correlation speaker chaining with per-window embedding clustering (pyannote reference algorithm)
- Constrained agglomerative clustering: centroid linkage, cosine distance, same-window constraint prevents merging speakers from the same segmentation window
- VoxConverse DER: **71% → ~8%** (3-file sample: 10.2%, 6.2%, 7.6%)

## Changes

- `DiarizationHelpers`: add `constrainedAgglomerativeClustering()`, `cosineDistance()`, `ClusterItem`
- `DiarizationPipeline`: new `runEmbeddingClusteredDiarization()` replacing `runActivityChainedDiarization()`, `refineWithEmbeddings()`, `activityCorrelation()`
- `DiarizeCommand`: default `--cluster-threshold` changed from 1.0 to 0.715 (cosine distance)
- E2E tests tightened: assert `numSpeakers == 1` for single-speaker audio, speech region bounds, centroid L2 norms
- 10 new clustering unit tests (empty, single, merge, same-window constraint, threshold, centroid linkage, transitive constraints, multi-speaker)

## Test plan

- [x] 33 DiarizationHelpers unit tests pass
- [x] 18 WeSpeaker unit tests pass
- [x] E2E diarization, single-speaker, speaker extraction tests pass with tightened assertions
- [x] VoxConverse DER benchmark: 10.2%, 6.2%, 7.6% on 3 files (was ~71%)
- [ ] Full VoxConverse benchmark (all files) with release build

Closes #145