### PR TITLE
Add custom system prompt support for PersonaPlex

### DIFF
--- a/Sources/AudioCLILib/RespondCommand.swift
+++ b/Sources/AudioCLILib/RespondCommand.swift
@@ -22,6 +22,9 @@ public struct RespondCommand: ParsableCommand {
     @Option(name: .long, help: "System prompt preset: assistant, focused, customer-service, teacher")
     public var systemPrompt: String = "assistant"
 
+    @Option(name: .long, help: "Custom system prompt text (overrides --system-prompt preset)")
+    public var systemPromptText: String?
+
     @Option(name: .long, help: "Maximum generation steps at 12.5Hz (default: 200 = ~16s)")
     public var maxSteps: Int = 200
 
@@ -116,10 +119,14 @@ public struct RespondCommand: ParsableCommand {
             throw ExitCode(1)
         }
 
-        guard let selectedPrompt = SystemPromptPreset(rawValue: systemPrompt) else {
-            print("Unknown system prompt: \(systemPrompt)")
-            print("Use --list-prompts to see available options.")
-            throw ExitCode(1)
+        var selectedPrompt: SystemPromptPreset?
+        if systemPromptText == nil {
+            guard let preset = SystemPromptPreset(rawValue: systemPrompt) else {
+                print("Unknown system prompt: \(systemPrompt)")
+                print("Use --list-prompts to see available options.")
+                throw ExitCode(1)
+            }
+            selectedPrompt = preset
         }
 
         try runAsync {
@@ -149,18 +156,22 @@ public struct RespondCommand: ParsableCommand {
                 print("  Warmup: \(String(format: "%.2f", warmTime))s")
             }
 
-            // Load SentencePiece decoder for transcript
-            var spmDecoder: SentencePieceDecoder?
-            if transcript || json {
-                do {
-                    let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-                    let spmPath = cacheDir.appendingPathComponent("tokenizer_spm_32k_3.model").path
-                    if FileManager.default.fileExists(atPath: spmPath) {
-                        spmDecoder = try SentencePieceDecoder(modelPath: spmPath)
-                    }
-                } catch {
-                    if !json { print("Warning: Could not load SentencePiece decoder: \(error)") }
+            // Use the model's built-in tokenizer for transcript decoding
+            let spmDecoder = model.tokenizer
+
+            // Resolve system prompt tokens
+            let promptTokens: [Int32]?
+            let promptLabel: String
+            if let customText = systemPromptText {
+                guard let tokens = model.tokenizeSystemPrompt(customText) else {
+                    print("Error: SentencePiece tokenizer not available for custom system prompt.")
+                    throw ExitCode(1)
                 }
+                promptTokens = tokens
+                promptLabel = "custom (\(tokens.count) tokens)"
+            } else {
+                promptTokens = selectedPrompt?.tokens
+                promptLabel = selectedPrompt?.rawValue ?? "default"
             }
 
             if !json { print("Loading input audio: \(input)") }
@@ -170,7 +181,7 @@ public struct RespondCommand: ParsableCommand {
             let duration = Double(audio.count) / 24000.0
             if !json {
                 print("  Duration: \(String(format: "%.2f", duration))s (\(audio.count) samples)")
-                print("Generating response with voice \(selectedVoice.rawValue), prompt: \(selectedPrompt.rawValue)")
+                print("Generating response with voice \(selectedVoice.rawValue), prompt: \(promptLabel)")
             }
             let startTime = CFAbsoluteTimeGetCurrent()
 
@@ -202,7 +213,7 @@ public struct RespondCommand: ParsableCommand {
 
                 let stream = model.respondRealtime(
                     voice: selectedVoice,
-                    systemPromptTokens: selectedPrompt.tokens,
+                    systemPromptTokens: promptTokens,
                     userAudioBuffer: ringBuffer,
                     maxSteps: maxSteps,
                     verbose: verbose
@@ -237,7 +248,7 @@ public struct RespondCommand: ParsableCommand {
                 let audioStream = model.respondStream(
                     userAudio: audio,
                     voice: selectedVoice,
-                    systemPromptTokens: selectedPrompt.tokens,
+                    systemPromptTokens: promptTokens,
                     maxSteps: maxSteps,
                     streaming: streamingConfig,
                     verbose: verbose)
@@ -256,7 +267,7 @@ public struct RespondCommand: ParsableCommand {
                 let result = model.respond(
                     userAudio: audio,
                     voice: selectedVoice,
-                    systemPromptTokens: selectedPrompt.tokens,
+                    systemPromptTokens: promptTokens,
                     maxSteps: maxSteps,
                     verbose: verbose)
                 responseSamples = result.audio
@@ -280,7 +291,7 @@ public struct RespondCommand: ParsableCommand {
                 var result: [String: Any] = [
                     "audio": output,
                     "voice": selectedVoice.rawValue,
-                    "system_prompt": selectedPrompt.rawValue,
+                    "system_prompt": promptLabel,
                     "input_duration": round(duration * 100) / 100,
                     "output_duration": round(responseDuration * 100) / 100,
                     "elapsed": round(elapsed * 100) / 100,

--- a/Sources/PersonaPlex/PersonaPlex.swift
+++ b/Sources/PersonaPlex/PersonaPlex.swift
@@ -21,6 +21,9 @@ public final class PersonaPlexModel: Module {
     /// Model ID used to load this instance (for resolving voice files etc.)
     public private(set) var modelId: String = defaultModelId
 
+    /// SentencePiece tokenizer for encoding/decoding text (loaded from model directory).
+    public private(set) var tokenizer: SentencePieceDecoder?
+
     @ModuleInfo public var temporal: TemporalTransformer
     @ModuleInfo public var depformer: Depformer
     public let mimi: Mimi
@@ -33,6 +36,53 @@ public final class PersonaPlexModel: Module {
         self._temporal = ModuleInfo(wrappedValue: TemporalTransformer(cfg: cfg.temporal))
         self._depformer = ModuleInfo(wrappedValue: Depformer(cfg: cfg.depformer, temporalDim: cfg.temporal.dim))
         self.mimi = Mimi(cfg: cfg.mimi)
+    }
+
+    // MARK: - String System Prompt Convenience
+
+    /// Tokenize a system prompt string using the built-in SentencePiece tokenizer.
+    /// Wraps the text with `<system>` tags as required by PersonaPlex.
+    /// Returns nil if the tokenizer is not loaded.
+    public func tokenizeSystemPrompt(_ text: String) -> [Int32]? {
+        return tokenizer?.encodeSystemPrompt(text)
+    }
+
+    /// Generate a response using a plain-text system prompt string.
+    public func respond(
+        userAudio: [Float],
+        voice: PersonaPlexVoice = .NATM0,
+        systemPrompt: String,
+        maxSteps: Int = 500,
+        verbose: Bool = false
+    ) -> (audio: [Float], textTokens: [Int32]) {
+        let tokens = tokenizeSystemPrompt(systemPrompt)
+        return respond(
+            userAudio: userAudio,
+            voice: voice,
+            systemPromptTokens: tokens,
+            maxSteps: maxSteps,
+            verbose: verbose
+        )
+    }
+
+    /// Stream a response using a plain-text system prompt string.
+    public func respondStream(
+        userAudio: [Float],
+        voice: PersonaPlexVoice = .NATM0,
+        systemPrompt: String,
+        maxSteps: Int = 500,
+        streaming: PersonaPlexStreamingConfig = .default,
+        verbose: Bool = false
+    ) -> AsyncThrowingStream<AudioChunk, Error> {
+        let tokens = tokenizeSystemPrompt(systemPrompt)
+        return respondStream(
+            userAudio: userAudio,
+            voice: voice,
+            systemPromptTokens: tokens,
+            maxSteps: maxSteps,
+            streaming: streaming,
+            verbose: verbose
+        )
     }
 
     // MARK: - Offline Inference
@@ -1584,6 +1634,12 @@ public final class PersonaPlexModel: Module {
             from: modelDir
         ) { progress, status in
             progressHandler?(0.80 + progress * 0.15, status)
+        }
+
+        // Load SentencePiece tokenizer
+        let spmPath = modelDir.appendingPathComponent("tokenizer_spm_32k_3.model").path
+        if FileManager.default.fileExists(atPath: spmPath) {
+            model.tokenizer = try? SentencePieceDecoder(modelPath: spmPath)
         }
 
         model.train(false)

--- a/Sources/PersonaPlex/SentencePieceDecoder.swift
+++ b/Sources/PersonaPlex/SentencePieceDecoder.swift
@@ -16,10 +16,13 @@ import Foundation
 ///   }
 public struct SentencePieceDecoder: Sendable {
     private let vocab: [Int: String]
+    private let pieceToId: [String: Int]
+    private let scores: [Int: Float]
 
     public init(modelPath: String) throws {
         let data = try Data(contentsOf: URL(fileURLWithPath: modelPath))
         var pieces: [String] = []
+        var pieceScores: [Float] = []
         var offset = 0
 
         while offset < data.count {
@@ -32,8 +35,9 @@ public struct SentencePieceDecoder: Sendable {
                 offset = dataOffset
                 let end = offset + length
 
-                // Parse submessage to extract piece string (field 1)
+                // Parse submessage to extract piece string (field 1) and score (field 2)
                 var piece: String?
+                var score: Float = 0
                 var subOffset = offset
                 while subOffset < end {
                     let (subField, subWire, subNewOffset) = Self.readTag(data: data, offset: subOffset)
@@ -47,6 +51,10 @@ public struct SentencePieceDecoder: Sendable {
                             piece = s
                         }
                         subOffset += strLen
+                    } else if subField == 2 && subWire == 5 {
+                        // Float field (32-bit / wire type 5)
+                        score = data[subOffset..<(subOffset + 4)].withUnsafeBytes { $0.load(as: Float.self) }
+                        subOffset += 4
                     } else {
                         // Skip other fields
                         subOffset = Self.skipField(data: data, offset: subOffset, wireType: subWire)
@@ -54,6 +62,7 @@ public struct SentencePieceDecoder: Sendable {
                 }
 
                 pieces.append(piece ?? "")
+                pieceScores.append(score)
                 offset = end
             } else {
                 // Skip non-piece fields
@@ -62,10 +71,16 @@ public struct SentencePieceDecoder: Sendable {
         }
 
         var v: [Int: String] = [:]
-        for (i, p) in pieces.enumerated() {
-            v[i] = p
+        var p2i: [String: Int] = [:]
+        var s: [Int: Float] = [:]
+        for (i, piece) in pieces.enumerated() {
+            v[i] = piece
+            p2i[piece] = i
+            s[i] = pieceScores[i]
         }
         self.vocab = v
+        self.pieceToId = p2i
+        self.scores = s
     }
 
     /// Text padding token ID used by PersonaPlex (generated when model is producing audio but not text)
@@ -83,6 +98,45 @@ public struct SentencePieceDecoder: Sendable {
         }
         // SentencePiece uses U+2581 (▁) as word boundary / space
         return result.replacingOccurrences(of: "\u{2581}", with: " ").trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Encode a string into SentencePiece token IDs using greedy unigram segmentation.
+    /// Prepends the SentencePiece word-boundary marker (U+2581) to the input and segments
+    /// by choosing the longest matching piece at each position.
+    public func encode(_ text: String) -> [Int32] {
+        // SentencePiece prepends ▁ (U+2581) to represent leading space / word boundary
+        let normalized = "\u{2581}" + text.replacingOccurrences(of: " ", with: "\u{2581}")
+        var tokens: [Int32] = []
+        var i = normalized.startIndex
+
+        while i < normalized.endIndex {
+            var bestLen = 0
+            var bestId: Int32 = 0 // <unk>
+            // Try longest match first
+            for len in stride(from: min(32, normalized.distance(from: i, to: normalized.endIndex)), through: 1, by: -1) {
+                let end = normalized.index(i, offsetBy: len)
+                let candidate = String(normalized[i..<end])
+                if let id = pieceToId[candidate] {
+                    bestLen = len
+                    bestId = Int32(id)
+                    break
+                }
+            }
+            if bestLen == 0 {
+                // Unknown character — emit <unk> and advance one character
+                tokens.append(0)
+                i = normalized.index(after: i)
+            } else {
+                tokens.append(bestId)
+                i = normalized.index(i, offsetBy: bestLen)
+            }
+        }
+        return tokens
+    }
+
+    /// Encode a system prompt string, wrapping it with `<system>` tags as required by PersonaPlex.
+    public func encodeSystemPrompt(_ text: String) -> [Int32] {
+        return encode("<system> " + text + "<system>")
     }
 
     // MARK: - Protobuf Wire Format Helpers

--- a/Tests/PersonaPlexTests/PersonaPlexTests.swift
+++ b/Tests/PersonaPlexTests/PersonaPlexTests.swift
@@ -159,6 +159,82 @@ final class PersonaPlexTests: XCTestCase {
         XCTAssertTrue(decoded.lowercased().contains("helpful"), "Decoded text should contain 'helpful': got '\(decoded)'")
     }
 
+    // MARK: - SentencePiece Encoder Tests
+
+    func testSentencePieceEncoderRoundTrip() throws {
+        let modelId = "aufklarer/PersonaPlex-7B-MLX-4bit"
+        let cacheDir: URL
+        do {
+            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        } catch {
+            throw XCTSkip("Cannot resolve cache directory")
+        }
+
+        let spmPath = cacheDir.appendingPathComponent("tokenizer_spm_32k_3.model").path
+        guard FileManager.default.fileExists(atPath: spmPath) else {
+            throw XCTSkip("SentencePiece model not cached at \(spmPath)")
+        }
+
+        let decoder = try SentencePieceDecoder(modelPath: spmPath)
+
+        // Encode and decode should round-trip
+        let text = "You are a helpful assistant."
+        let tokens = decoder.encode(text)
+        XCTAssertFalse(tokens.isEmpty, "Encoded tokens should not be empty")
+        let decoded = decoder.decode(tokens)
+        XCTAssertEqual(decoded, text, "Round-trip should preserve text: got '\(decoded)'")
+    }
+
+    func testSentencePieceEncodeSystemPrompt() throws {
+        let modelId = "aufklarer/PersonaPlex-7B-MLX-4bit"
+        let cacheDir: URL
+        do {
+            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        } catch {
+            throw XCTSkip("Cannot resolve cache directory")
+        }
+
+        let spmPath = cacheDir.appendingPathComponent("tokenizer_spm_32k_3.model").path
+        guard FileManager.default.fileExists(atPath: spmPath) else {
+            throw XCTSkip("SentencePiece model not cached at \(spmPath)")
+        }
+
+        let decoder = try SentencePieceDecoder(modelPath: spmPath)
+
+        // encodeSystemPrompt should wrap with <system> tags
+        let tokens = decoder.encodeSystemPrompt("You are a helpful assistant.")
+        let decoded = decoder.decode(tokens)
+        XCTAssertEqual(decoded, "You are a helpful assistant.", "System prompt decode should strip <system> tags")
+
+        // Verify <system> tag tokens are present (first and last non-trivial tokens)
+        XCTAssertTrue(tokens.count > 5, "System prompt should produce multiple tokens")
+    }
+
+    func testSentencePieceEncodeMatchesPreset() throws {
+        let modelId = "aufklarer/PersonaPlex-7B-MLX-4bit"
+        let cacheDir: URL
+        do {
+            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        } catch {
+            throw XCTSkip("Cannot resolve cache directory")
+        }
+
+        let spmPath = cacheDir.appendingPathComponent("tokenizer_spm_32k_3.model").path
+        guard FileManager.default.fileExists(atPath: spmPath) else {
+            throw XCTSkip("SentencePiece model not cached at \(spmPath)")
+        }
+
+        let decoder = try SentencePieceDecoder(modelPath: spmPath)
+
+        // Encoding the assistant preset text should produce identical tokens
+        let presetTokens = SystemPromptPreset.assistant.tokens
+        let encodedTokens = decoder.encodeSystemPrompt("You are a helpful assistant. Answer questions clearly and concisely.")
+        XCTAssertEqual(
+            encodedTokens, presetTokens,
+            "Encoded tokens should match pre-tokenized assistant preset.\n  Expected: \(presetTokens)\n  Got:      \(encodedTokens)"
+        )
+    }
+
     // MARK: - Silence Early Stop Config Tests
 
     func testAudioChunkTextTokensDefault() {
@@ -429,6 +505,46 @@ final class E2EPersonaPlexTests: XCTestCase {
 
         let responseDuration = Double(response.count) / Double(sampleRate)
         print("Response: \(response.count) samples (\(String(format: "%.2f", responseDuration))s)")
+    }
+
+    func testRespondWithCustomSystemPrompt() throws {
+        let model = try self.model
+
+        // Verify tokenizer is loaded
+        XCTAssertNotNil(model.tokenizer, "Model should have built-in tokenizer")
+
+        // Generate test audio (0.5s sine wave)
+        let numSamples = 12000
+        var testAudio = [Float](repeating: 0, count: numSamples)
+        for i in 0..<numSamples {
+            testAudio[i] = sin(2 * .pi * 440 * Float(i) / 24000.0) * 0.5
+        }
+
+        // Use the string-based system prompt API
+        let (response, textTokens) = model.respond(
+            userAudio: testAudio,
+            voice: .NATM0,
+            systemPrompt: "You enjoy having a good conversation.",
+            maxSteps: 10,
+            verbose: true
+        )
+
+        XCTAssertFalse(response.isEmpty, "Should produce response audio with custom prompt")
+        print("Custom prompt response: \(response.count) samples, \(textTokens.count) text tokens")
+    }
+
+    func testTokenizeSystemPromptMatchesPreset() throws {
+        let model = try self.model
+
+        // Verify the model's tokenizer produces the same tokens as the preset
+        guard let tokens = model.tokenizeSystemPrompt(
+            "You are a helpful assistant. Answer questions clearly and concisely."
+        ) else {
+            XCTFail("tokenizeSystemPrompt returned nil")
+            return
+        }
+        let presetTokens = SystemPromptPreset.assistant.tokens
+        XCTAssertEqual(tokens, presetTokens, "Model tokenizer should match preset tokens")
     }
 
     func testRespondNonSilent() throws {


### PR DESCRIPTION
## Summary
- Add SentencePiece `encode()` and `encodeSystemPrompt()` methods to tokenize plain-text system prompts at runtime
- `PersonaPlexModel` now loads the tokenizer automatically in `fromPretrained()` and exposes `tokenizer` property
- New `respond(systemPrompt: String)` and `respondStream(systemPrompt: String)` convenience overloads
- New `--system-prompt-text` CLI flag for custom prompts (overrides `--system-prompt` preset)
- CLI transcript decoding now uses the model's built-in tokenizer

**Before** (required external Python script):
```python
sp.Load("tokenizer_spm_32k_3.model")
tokens = sp.EncodeAsIds("<system> You enjoy having a good conversation.<system>")
# manually paste token IDs into Swift code
```

**After** (plain string):
```swift
let (response, _) = model.respond(
    userAudio: audio,
    systemPrompt: "You enjoy having a good conversation."
)
```

## Test plan
- [x] `testSentencePieceEncoderRoundTrip` — encode→decode preserves text
- [x] `testSentencePieceEncodeSystemPrompt` — verifies `<system>` tag wrapping
- [x] `testSentencePieceEncodeMatchesPreset` — encoded tokens match hardcoded preset
- [x] `testRespondWithCustomSystemPrompt` (E2E) — full inference with string prompt
- [x] `testTokenizeSystemPromptMatchesPreset` (E2E) — model tokenizer matches preset
- [x] All existing unit tests pass (`swift test --skip E2E`)
- [x] Build succeeds

Closes #167