### PR TITLE
Update README translations with custom system prompt docs

### DIFF
--- a/README_de.md
+++ b/README_de.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### Systemaufforderungen
 
-Die Systemaufforderung steuert das Gesprächsverhalten des Modells. Die `focused`-Standardeinstellung hält Antworten beim Thema:
+Die Systemaufforderung steuert das Gesprächsverhalten des Modells. Sie können eine beliebige benutzerdefinierte Aufforderung als Zeichenkette übergeben:
 
 ```swift
-// Eine Voreinstellung verwenden
+// Benutzerdefinierte Systemaufforderung (automatisch tokenisiert)
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// Oder eine Voreinstellung verwenden
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # JSON-Ausgabe (Audiopfad, Transkript, Latenzmetriken)
 .build/release/audio respond --input question.wav --json
+
+# Benutzerdefinierter Systemaufforderungstext
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # Stimme und Systemaufforderungs-Voreinstellung wählen
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_es.md
+++ b/README_es.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### Prompts de sistema
 
-El prompt de sistema guía el comportamiento conversacional del modelo. El prompt por defecto `focused` mantiene las respuestas centradas en el tema:
+El prompt de sistema guía el comportamiento conversacional del modelo. Puedes pasar cualquier prompt personalizado como una cadena de texto:
 
 ```swift
-// Usar un preset
+// Prompt de sistema personalizado (tokenizado automáticamente)
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// O usar un preset
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # Salida JSON (ruta del audio, transcripción, métricas de latencia)
 .build/release/audio respond --input question.wav --json
+
+# Texto de prompt de sistema personalizado
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # Elegir una voz y preset de prompt de sistema
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_fr.md
+++ b/README_fr.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### Prompts systeme
 
-Le prompt systeme oriente le comportement conversationnel du modele. Le preset `focused` par defaut maintient les reponses sur le sujet :
+Le prompt systeme oriente le comportement conversationnel du modele. Vous pouvez passer n'importe quel prompt personnalise sous forme de chaine de caracteres :
 
 ```swift
-// Utiliser un preset
+// Prompt systeme personnalise (tokenise automatiquement)
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// Ou utiliser un preset
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # Sortie JSON (chemin audio, transcription, metriques de latence)
 .build/release/audio respond --input question.wav --json
+
+# Texte de prompt systeme personnalise
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # Choisir une voix et un preset de prompt systeme
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_hi.md
+++ b/README_hi.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### सिस्टम प्रॉम्प्ट
 
-सिस्टम प्रॉम्प्ट मॉडल के वार्तालाप व्यवहार को निर्देशित करता है। `focused` डिफ़ॉल्ट प्रतिक्रियाओं को विषय पर केंद्रित रखता है:
+सिस्टम प्रॉम्प्ट मॉडल के वार्तालाप व्यवहार को निर्देशित करता है। कोई भी कस्टम प्रॉम्प्ट सादे स्ट्रिंग के रूप में पास करें:
 
 ```swift
-// प्रीसेट का उपयोग करें
+// कस्टम सिस्टम प्रॉम्प्ट (स्वचालित रूप से टोकनाइज़ होता है)
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// या प्रीसेट का उपयोग करें
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # JSON आउटपुट (ऑडियो पाथ, ट्रांसक्रिप्ट, लेटेंसी मेट्रिक्स)
 .build/release/audio respond --input question.wav --json
+
+# कस्टम सिस्टम प्रॉम्प्ट टेक्स्ट
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # वॉयस और सिस्टम प्रॉम्प्ट प्रीसेट चुनें
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_ja.md
+++ b/README_ja.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### システムプロンプト
 
-システムプロンプトはモデルの会話動作を制御します。`focused`デフォルトは応答をトピックに集中させます：
+システムプロンプトはモデルの会話動作を制御します。任意のカスタムプロンプトをプレーンな文字列として渡すことができます：
 
 ```swift
-// プリセットを使用
+// カスタムシステムプロンプト（自動的にトークン化されます）
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// またはプリセットを使用
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # JSON出力 (音声パス、トランスクリプト、レイテンシーメトリクス)
 .build/release/audio respond --input question.wav --json
+
+# カスタムシステムプロンプトテキスト
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # ボイスとシステムプロンプトプリセットを選択
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_ko.md
+++ b/README_ko.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### 시스템 프롬프트
 
-시스템 프롬프트는 모델의 대화 동작을 조정합니다. `focused` 기본값은 응답이 주제에서 벗어나지 않도록 합니다:
+시스템 프롬프트는 모델의 대화 동작을 조정합니다. 임의의 커스텀 프롬프트를 일반 문자열로 전달할 수 있습니다:
 
 ```swift
-// 프리셋 사용
+// 커스텀 시스템 프롬프트 (자동 토큰화)
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// 또는 프리셋 사용
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # JSON 출력 (오디오 경로, 트랜스크립트, 지연 시간 메트릭)
 .build/release/audio respond --input question.wav --json
+
+# 커스텀 시스템 프롬프트 텍스트
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # 음색 및 시스템 프롬프트 프리셋 선택
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_pt.md
+++ b/README_pt.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### Prompts de Sistema
 
-O prompt de sistema direciona o comportamento conversacional do modelo. O padrao `focused` mantem as respostas no topico:
+O prompt de sistema direciona o comportamento conversacional do modelo. Passe qualquer prompt personalizado como uma string simples:
 
 ```swift
-// Usar um preset
+// Prompt de sistema personalizado (tokenizado automaticamente)
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// Ou usar um preset
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # Saida JSON (caminho do audio, transcricao, metricas de latencia)
 .build/release/audio respond --input question.wav --json
+
+# Texto de prompt de sistema personalizado
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # Escolher uma voz e preset de prompt de sistema
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_ru.md
+++ b/README_ru.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### Системные промпты
 
-Системный промпт определяет поведение модели в диалоге. Промпт `focused` по умолчанию удерживает ответы в рамках темы:
+Системный промпт определяет поведение модели в диалоге. Можно передать любой пользовательский промпт в виде обычной строки:
 
 ```swift
-// Использование пресета
+// Пользовательский системный промпт (токенизируется автоматически)
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// Или использование пресета
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # JSON-вывод (путь к аудио, транскрипт, метрики задержки)
 .build/release/audio respond --input question.wav --json
+
+# Пользовательский текст системного промпта
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # Выбор голоса и пресета системного промпта
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused

--- a/README_zh.md
+++ b/README_zh.md
@@ -525,10 +525,17 @@ for try await chunk in stream {
 
 ### 系统提示词
 
-系统提示词引导模型的对话行为。默认的 `focused` 提示词使回复保持主题聚焦：
+系统提示词引导模型的对话行为。可以将任意自定义提示词作为纯字符串传入：
 
 ```swift
-// 使用预设
+// 自定义系统提示词（自动分词）
+let response = model.respond(
+    userAudio: audio,
+    voice: .NATM0,
+    systemPrompt: "You enjoy having a good conversation."
+)
+
+// 或使用预设
 let response = model.respond(
     userAudio: audio,
     voice: .NATM0,
@@ -551,6 +558,9 @@ make build
 
 # JSON 输出（音频路径、转录、延迟指标）
 .build/release/audio respond --input question.wav --json
+
+# 自定义系统提示词文本
+.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
 
 # 选择音色和系统提示词预设
 .build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused


### PR DESCRIPTION
## Summary
- Add custom `systemPrompt: String` API example to PersonaPlex section in all 9 translations
- Add `--system-prompt-text` CLI flag example to all 9 translations
- Translated comments and descriptions in zh, ja, ko, es, de, fr, hi, pt, ru

Follows up on #170 (custom system prompt support).

## Test plan
- [x] All 9 translations updated consistently
- [x] Code blocks unchanged (Swift/bash not translated)
- [x] Translated descriptions match English README