### PR TITLE
Auto-select iOS Parakeet encoder to fix OOM

### DIFF
--- a/Examples/iOSEchoDemo/iOSEchoDemo/CompanionChatViewModel.swift
+++ b/Examples/iOSEchoDemo/iOSEchoDemo/CompanionChatViewModel.swift
@@ -125,8 +125,7 @@ final class CompanionChatViewModel {
             loadingStatus = "Downloading ASR model..."
             loadProgress = 0.2
             sttModel = try await Task.detached {
-                try await ParakeetASRModel.fromPretrained(
-                    modelId: ParakeetASRModel.defaultModelId) { progress, status in
+                try await ParakeetASRModel.fromPretrained { progress, status in
                     DispatchQueue.main.async { [weak self] in
                         self?.loadProgress = 0.2 + progress * 0.4
                         if !status.isEmpty { self?.loadingStatus = "ASR: \(status)" }
@@ -173,7 +172,7 @@ final class CompanionChatViewModel {
         config.mode = .echo  // ASR → TTS, no LLM
         config.allowInterruptions = false  // No AEC — can't distinguish user from speaker
         config.minSilenceDuration = 0.6
-        config.maxUtteranceDuration = 5.0   // Force-submit to STT after 5s (longer causes OOM without ANE)
+        config.maxUtteranceDuration = 5.0   // Matches iOS Parakeet encoder (5s max, single fixed shape)
         config.maxResponseDuration = 5.0   // Cap TTS output to prevent repetition loops
         config.eagerSTT = true  // Start transcribing during speech, don't wait for silence
         config.warmupSTT = false

--- a/Sources/ParakeetASR/ParakeetASR.swift
+++ b/Sources/ParakeetASR/ParakeetASR.swift
@@ -13,8 +13,12 @@ public class ParakeetASRModel {
     /// Model configuration.
     public let config: ParakeetConfig
 
-    /// Default HuggingFace model ID (INT8 quantized encoder).
+    /// Default HuggingFace model ID (INT8 quantized encoder, 30s max).
     public static let defaultModelId = "aufklarer/Parakeet-TDT-v3-CoreML-INT8"
+
+    /// iOS-optimized model: single 500-frame shape (5s max), no EnumeratedShapes overhead.
+    /// Saves ~600MB runtime memory vs the default model.
+    public static let iosModelId = "aufklarer/Parakeet-TDT-v3-CoreML-INT8-iOS-5s"
 
     /// Whether the model is loaded and ready for inference.
     var _isLoaded = true
@@ -172,25 +176,36 @@ public class ParakeetASRModel {
     ///   - progressHandler: Optional callback for download/load progress `(fraction, status)`
     /// - Returns: Initialized model ready for transcription
     public static func fromPretrained(
-        modelId: String = defaultModelId,
+        modelId: String? = nil,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> ParakeetASRModel {
-        AudioLog.modelLoading.info("Loading Parakeet model: \(modelId)")
+        let effectiveModelId: String
+        if let modelId {
+            effectiveModelId = modelId
+        } else {
+            #if os(iOS)
+            effectiveModelId = iosModelId
+            #else
+            effectiveModelId = defaultModelId
+            #endif
+        }
+
+        AudioLog.modelLoading.info("Loading Parakeet model: \(effectiveModelId)")
 
         // Step 1: Get/create cache directory
         let cacheDir: URL
         do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: effectiveModelId)
         } catch {
             throw AudioModelError.modelLoadFailed(
-                modelId: modelId, reason: "Failed to resolve cache directory", underlying: error)
+                modelId: effectiveModelId, reason: "Failed to resolve cache directory", underlying: error)
         }
 
         // Step 2: Download model files (no preprocessor needed — mel is computed in Swift)
         progressHandler?(0.0, "Downloading model...")
         do {
             try await HuggingFaceDownloader.downloadWeights(
-                modelId: modelId,
+                modelId: effectiveModelId,
                 to: cacheDir,
                 additionalFiles: [
                     "encoder.mlmodelc/**",
@@ -204,7 +219,7 @@ public class ParakeetASRModel {
             }
         } catch {
             throw AudioModelError.modelLoadFailed(
-                modelId: modelId, reason: "Download failed", underlying: error)
+                modelId: effectiveModelId, reason: "Download failed", underlying: error)
         }
 
         // Step 3: Load config
@@ -229,7 +244,7 @@ public class ParakeetASRModel {
             AudioLog.modelLoading.debug("Loaded vocabulary: \(vocabulary.count) tokens")
         } catch {
             throw AudioModelError.modelLoadFailed(
-                modelId: modelId, reason: "Failed to load vocabulary", underlying: error)
+                modelId: effectiveModelId, reason: "Failed to load vocabulary", underlying: error)
         }
 
         // Step 5: Load CoreML models (encoder, decoder, joint — no preprocessor)


### PR DESCRIPTION
## Summary
- Add `iosModelId` for Parakeet: `Parakeet-TDT-v3-CoreML-INT8-iOS-5s` (single 500-frame fixed shape, 5s max)
- Auto-select iOS variant on `#if os(iOS)` in `fromPretrained()` — no explicit model ID needed
- iOSEchoDemo uses default (auto-selects iOS variant), matches existing `maxUtteranceDuration = 5.0`

## Problem
Default Parakeet encoder uses EnumeratedShapes [100..3000] frames. CoreML pre-allocates buffers for all shapes. On CPU+GPU (ANE fails on iPhone 17 Pro), this consumes ~1GB extra runtime memory → OOM when combined with Kokoro TTS.

## Fix
| Config | Encoder Shapes | Estimated Peak | Notes |
|--------|---------------|---------------|-------|
| Before (30s) | EnumeratedShapes [100..3000] | ~1.1 GB | OOM on iPhone |
| After (5s) | Single [1, 128, 500] | ~400-500 MB | Safe on 4-6 GB devices |

Ref speech-models#10

## Test plan
- [x] 683 unit tests pass, 0 failures
- [x] macOS still uses 30s default model (no behavior change)
- [ ] iOS device: verify 5s model downloads and transcribes correctly
- [ ] iOS device: no OOM on Kokoro + Parakeet concurrent session