### PR TITLE
fix: replace NSLock with os_unfair_lock in AudioRingBuffer

### DIFF
--- a/Sources/AudioCommon/AudioRingBuffer.swift
+++ b/Sources/AudioCommon/AudioRingBuffer.swift
@@ -1,13 +1,17 @@
 import Foundation
+import os
 
 /// Thread-safe ring buffer for passing audio between the audio capture thread and the MLX
 /// inference thread. Writes drop oldest data when full; reads return zeros on underrun.
+///
+/// Uses `os_unfair_lock` for priority inheritance — safe to call `write` from a real-time
+/// Core Audio I/O thread without risking priority inversion.
 public final class AudioRingBuffer: @unchecked Sendable {
     private var buffer: [Float]
     private var readPos = 0
     private var writePos = 0
     private var count = 0
-    private let lock = NSLock()
+    private var _lock = os_unfair_lock()
     private let capacity: Int
 
     public init(capacity: Int) {
@@ -17,8 +21,8 @@ public final class AudioRingBuffer: @unchecked Sendable {
 
     /// Called from audio capture thread — non-blocking; drops oldest data if full.
     public func write(_ samples: [Float]) {
-        lock.lock()
-        defer { lock.unlock() }
+        os_unfair_lock_lock(&_lock)
+        defer { os_unfair_lock_unlock(&_lock) }
         for sample in samples {
             if count == capacity {
                 // Drop oldest sample
@@ -31,10 +35,26 @@ public final class AudioRingBuffer: @unchecked Sendable {
         }
     }
 
+    /// Zero-copy write from a raw pointer — preferred on real-time audio threads
+    /// to avoid heap allocation from `Array(UnsafeBufferPointer(...))`.
+    public func write(from pointer: UnsafePointer<Float>, count sampleCount: Int) {
+        os_unfair_lock_lock(&_lock)
+        defer { os_unfair_lock_unlock(&_lock) }
+        for i in 0..<sampleCount {
+            if count == capacity {
+                readPos = (readPos + 1) % capacity
+                count -= 1
+            }
+            buffer[writePos] = pointer[i]
+            writePos = (writePos + 1) % capacity
+            count += 1
+        }
+    }
+
     /// Called from MLX inference thread — returns zeros on underrun; never blocks.
     public func read(_ n: Int) -> [Float] {
-        lock.lock()
-        defer { lock.unlock() }
+        os_unfair_lock_lock(&_lock)
+        defer { os_unfair_lock_unlock(&_lock) }
         var result = [Float](repeating: 0, count: n)
         let available = min(n, count)
         for i in 0..<available {
@@ -48,8 +68,8 @@ public final class AudioRingBuffer: @unchecked Sendable {
 
     /// Number of samples currently available to read.
     public var available: Int {
-        lock.lock()
-        defer { lock.unlock() }
+        os_unfair_lock_lock(&_lock)
+        defer { os_unfair_lock_unlock(&_lock) }
         return count
     }
 }

--- a/Tests/AudioCommonTests/AudioRingBufferTests.swift
+++ b/Tests/AudioCommonTests/AudioRingBufferTests.swift
@@ -121,4 +121,57 @@ final class AudioRingBufferTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(buf.available, 0)
         XCTAssertLessThanOrEqual(buf.available, 512)
     }
+
+    // MARK: - Pointer-based write
+
+    func testWriteFromPointer() {
+        let buf = AudioRingBuffer(capacity: 8)
+        let samples: [Float] = [1, 2, 3, 4]
+        samples.withUnsafeBufferPointer { ptr in
+            buf.write(from: ptr.baseAddress!, count: ptr.count)
+        }
+        XCTAssertEqual(buf.available, 4)
+        let result = buf.read(4)
+        XCTAssertEqual(result, [1, 2, 3, 4])
+    }
+
+    func testWriteFromPointerOverwriteDropsOldest() {
+        let buf = AudioRingBuffer(capacity: 4)
+        let first: [Float] = [1, 2, 3, 4]
+        first.withUnsafeBufferPointer { ptr in
+            buf.write(from: ptr.baseAddress!, count: ptr.count)
+        }
+        let second: [Float] = [5, 6]
+        second.withUnsafeBufferPointer { ptr in
+            buf.write(from: ptr.baseAddress!, count: ptr.count)
+        }
+        XCTAssertEqual(buf.available, 4)
+        let result = buf.read(4)
+        XCTAssertEqual(result, [3, 4, 5, 6])
+    }
+
+    func testWriteFromPointerConcurrentWithRead() {
+        let buf = AudioRingBuffer(capacity: 1024)
+        let iterations = 10_000
+        let expectation = XCTestExpectation(description: "pointer concurrent")
+        expectation.expectedFulfillmentCount = 2
+
+        DispatchQueue.global().async {
+            let sample: [Float] = [42]
+            sample.withUnsafeBufferPointer { ptr in
+                for _ in 0..<iterations {
+                    buf.write(from: ptr.baseAddress!, count: 1)
+                }
+            }
+            expectation.fulfill()
+        }
+        DispatchQueue.global().async {
+            for _ in 0..<iterations { _ = buf.read(1) }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+        XCTAssertGreaterThanOrEqual(buf.available, 0)
+        XCTAssertLessThanOrEqual(buf.available, 1024)
+    }
 }


### PR DESCRIPTION
## Summary

- Replace `NSLock` with `os_unfair_lock` in `AudioRingBuffer` to support priority inheritance, preventing priority inversion when `write()` is called from real-time Core Audio I/O threads
- Add `write(from:count:)` accepting `UnsafePointer<Float>` so callers on real-time threads can avoid heap allocation from `Array(UnsafeBufferPointer(...))` construction
- Add 3 tests for the new pointer-based write API (basic, overwrite, concurrent)

## Context

`AudioRingBuffer` is documented as being called from audio capture threads. `NSLock` does not support priority inheritance on macOS — when the reader thread (e.g. MLX inference) holds the lock and gets preempted, the real-time audio thread blocks indefinitely waiting for the lock. `os_unfair_lock` is Apple's recommended replacement that supports priority inheritance.

## Test plan

- [x] All 13 `AudioRingBufferTests` pass (`swift test --filter AudioRingBufferTests`)
- [x] Existing tests unchanged and passing
- [x] New pointer-based write tests cover: basic read/write, overwrite-drops-oldest, concurrent read+write