### PR TITLE
feat: add progress handler with cancellation to PyannoteDiarizationPipeline.diarize()

### DIFF
--- a/Sources/SpeechVAD/DiarizationPipeline.swift
+++ b/Sources/SpeechVAD/DiarizationPipeline.swift
@@ -189,11 +189,32 @@ public final class PyannoteDiarizationPipeline {
         sampleRate: Int,
         config: DiarizationConfig = .default
     ) -> DiarizationResult {
+        diarize(audio: audio, sampleRate: sampleRate, config: config, progressHandler: nil)
+    }
+
+    /// Diarize audio with progress reporting.
+    ///
+    /// Same as `diarize(audio:sampleRate:config:)` but reports progress during
+    /// the two most expensive stages (segmentation and embedding extraction).
+    ///
+    /// - Parameters:
+    ///   - audio: PCM Float32 audio samples
+    ///   - sampleRate: sample rate of the input audio
+    ///   - config: diarization configuration
+    ///   - progressHandler: called with (progress 0.0–1.0, stage description)
+    /// - Returns: diarization result with speaker-labeled segments
+    public func diarize(
+        audio: [Float],
+        sampleRate: Int,
+        config: DiarizationConfig = .default,
+        progressHandler: ((Float, String) -> Void)?
+    ) -> DiarizationResult {
         let samples = DiarizationHelpers.resample(audio, from: sampleRate, to: segConfig.sampleRate)
 
         // Stage 0 (optional): VAD pre-filter — mask non-speech to reduce false alarms
         let speechMask: [SpeechSegment]?
         if let vadModel {
+            progressHandler?(0, "VAD pre-filtering")
             speechMask = vadModel.detectSpeech(
                 audio: samples, sampleRate: segConfig.sampleRate)
         } else {
@@ -206,7 +227,8 @@ public final class PyannoteDiarizationPipeline {
 
         // Run embedding-clustered diarization pipeline
         return runEmbeddingClusteredDiarization(
-            samples: samples, config: config, speechMask: speechMask)
+            samples: samples, config: config, speechMask: speechMask,
+            progressHandler: progressHandler)
     }
 
     /// Extract segments of a target speaker from audio.
@@ -273,7 +295,8 @@ public final class PyannoteDiarizationPipeline {
     private func runEmbeddingClusteredDiarization(
         samples: [Float],
         config: DiarizationConfig,
-        speechMask: [SpeechSegment]?
+        speechMask: [SpeechSegment]?,
+        progressHandler: ((Float, String) -> Void)? = nil
     ) -> DiarizationResult {
         let windowDuration: Float = 10.0
         let sampleRate = segConfig.sampleRate
@@ -303,9 +326,15 @@ public final class PyannoteDiarizationPipeline {
         }
 
         // Step 1: Run segmentation on all windows, collect probability tracks
+        // Progress: both steps iterate over all windows, so total = 2 * windowCount
+        let totalUnits = positions.count * 2
+        var completedUnits = 0
         var windowProbs = [WindowProbs]()
 
-        for (start, end) in positions {
+        for (posIdx, (start, end)) in positions.enumerated() {
+            completedUnits += 1
+            progressHandler?(Float(completedUnits) / Float(totalUnits), "Segmenting \(posIdx + 1)/\(positions.count)")
+
             var window = Array(samples[start..<end])
             if window.count < windowSamples {
                 window.append(contentsOf: [Float](repeating: 0, count: windowSamples - window.count))
@@ -332,6 +361,9 @@ public final class PyannoteDiarizationPipeline {
         var windowEmbeddings = [WindowSpeakerEmbedding]()
 
         for (wIdx, wp) in windowProbs.enumerated() {
+            completedUnits += 1
+            progressHandler?(Float(completedUnits) / Float(totalUnits), "Embedding \(wIdx + 1)/\(windowProbs.count)")
+
             let windowStartSample = wp.startSample
 
             for localSpk in 0..<3 {

--- a/Sources/SpeechVAD/DiarizationPipeline.swift
+++ b/Sources/SpeechVAD/DiarizationPipeline.swift
@@ -192,29 +192,35 @@ public final class PyannoteDiarizationPipeline {
         diarize(audio: audio, sampleRate: sampleRate, config: config, progressHandler: nil)
     }
 
-    /// Diarize audio with progress reporting.
+    /// Diarize audio with progress reporting and optional cancellation.
     ///
     /// Same as `diarize(audio:sampleRate:config:)` but reports progress during
     /// the two most expensive stages (segmentation and embedding extraction).
+    /// The handler returns a `Bool`: `true` to continue, `false` to cancel.
+    /// When cancelled, an empty `DiarizationResult` is returned immediately.
     ///
     /// - Parameters:
     ///   - audio: PCM Float32 audio samples
     ///   - sampleRate: sample rate of the input audio
     ///   - config: diarization configuration
-    ///   - progressHandler: called with (progress 0.0–1.0, stage description)
+    ///   - progressHandler: called with (progress 0.0–1.0, stage description);
+    ///     return `true` to continue or `false` to cancel
     /// - Returns: diarization result with speaker-labeled segments
     public func diarize(
         audio: [Float],
         sampleRate: Int,
         config: DiarizationConfig = .default,
-        progressHandler: ((Float, String) -> Void)?
+        progressHandler: ((Float, String) -> Bool)?
     ) -> DiarizationResult {
+        let emptyResult = DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
         let samples = DiarizationHelpers.resample(audio, from: sampleRate, to: segConfig.sampleRate)
 
         // Stage 0 (optional): VAD pre-filter — mask non-speech to reduce false alarms
         let speechMask: [SpeechSegment]?
         if let vadModel {
-            progressHandler?(0, "VAD pre-filtering")
+            if progressHandler?(0, "VAD pre-filtering") == false {
+                return emptyResult
+            }
             speechMask = vadModel.detectSpeech(
                 audio: samples, sampleRate: segConfig.sampleRate)
         } else {
@@ -222,7 +228,7 @@ public final class PyannoteDiarizationPipeline {
         }
 
         if let speechMask, speechMask.isEmpty {
-            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+            return emptyResult
         }
 
         // Run embedding-clustered diarization pipeline
@@ -296,7 +302,7 @@ public final class PyannoteDiarizationPipeline {
         samples: [Float],
         config: DiarizationConfig,
         speechMask: [SpeechSegment]?,
-        progressHandler: ((Float, String) -> Void)? = nil
+        progressHandler: ((Float, String) -> Bool)? = nil
     ) -> DiarizationResult {
         let windowDuration: Float = 10.0
         let sampleRate = segConfig.sampleRate
@@ -331,9 +337,13 @@ public final class PyannoteDiarizationPipeline {
         var completedUnits = 0
         var windowProbs = [WindowProbs]()
 
+        let emptyResult = DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+
         for (posIdx, (start, end)) in positions.enumerated() {
             completedUnits += 1
-            progressHandler?(Float(completedUnits) / Float(totalUnits), "Segmenting \(posIdx + 1)/\(positions.count)")
+            if progressHandler?(Float(completedUnits) / Float(totalUnits), "Segmenting \(posIdx + 1)/\(positions.count)") == false {
+                return emptyResult
+            }
 
             var window = Array(samples[start..<end])
             if window.count < windowSamples {
@@ -362,7 +372,9 @@ public final class PyannoteDiarizationPipeline {
 
         for (wIdx, wp) in windowProbs.enumerated() {
             completedUnits += 1
-            progressHandler?(Float(completedUnits) / Float(totalUnits), "Embedding \(wIdx + 1)/\(windowProbs.count)")
+            if progressHandler?(Float(completedUnits) / Float(totalUnits), "Embedding \(wIdx + 1)/\(windowProbs.count)") == false {
+                return emptyResult
+            }
 
             let windowStartSample = wp.startSample
 

--- a/Sources/SpeechVAD/SortformerDiarizer.swift
+++ b/Sources/SpeechVAD/SortformerDiarizer.swift
@@ -129,6 +129,28 @@ public final class SortformerDiarizer {
         sampleRate: Int,
         config: DiarizationConfig = .default
     ) -> DiarizationResult {
+        diarize(audio: audio, sampleRate: sampleRate, config: config, progressHandler: nil)
+    }
+
+    /// Run speaker diarization with progress reporting and optional cancellation.
+    ///
+    /// Same as `diarize(audio:sampleRate:config:)` but reports progress per chunk.
+    /// The handler returns a `Bool`: `true` to continue, `false` to cancel.
+    /// When cancelled, an empty `DiarizationResult` is returned immediately.
+    ///
+    /// - Parameters:
+    ///   - audio: PCM Float32 audio samples
+    ///   - sampleRate: sample rate of the input audio
+    ///   - config: optional override for diarization thresholds
+    ///   - progressHandler: called with (progress 0.0–1.0, stage description);
+    ///     return `true` to continue or `false` to cancel
+    /// - Returns: diarization result with speaker-labeled segments
+    public func diarize(
+        audio: [Float],
+        sampleRate: Int,
+        config: DiarizationConfig = .default,
+        progressHandler: ((Float, String) -> Bool)?
+    ) -> DiarizationResult {
         let samples = DiarizationHelpers.resample(audio, from: sampleRate, to: self.config.sampleRate)
 
         guard !samples.isEmpty else {
@@ -156,11 +178,20 @@ public final class SortformerDiarizer {
 
         // Collect core predictions from each chunk
         var allChunkProbs = [[Float]]()  // Each entry: [coreFrames * numSpeakers]
+        let emptyResult = DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+
+        // Calculate total chunks for progress reporting
+        let totalChunks = max(1, (totalMelFrames + coreMelFrames - 1) / coreMelFrames)
+        var chunkIndex = 0
 
         var sttFeat = 0
         var endFeat = 0
 
         while endFeat < totalMelFrames {
+            chunkIndex += 1
+            if progressHandler?(Float(chunkIndex) / Float(totalChunks), "Diarizing \(chunkIndex)/\(totalChunks)") == false {
+                return emptyResult
+            }
             let leftOffset = min(leftCtx * subFactor, sttFeat)
             endFeat = min(sttFeat + coreMelFrames, totalMelFrames)
             let rightOffset = min(rightCtx * subFactor, totalMelFrames - endFeat)

--- a/Tests/SpeechVADTests/DiarizationPipelineTests.swift
+++ b/Tests/SpeechVADTests/DiarizationPipelineTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import SpeechVAD
+import AudioCommon
+
+final class DiarizationPipelineTests: XCTestCase {
+
+    // MARK: - DiarizationConfig
+
+    func testDefaultDiarizationConfig() {
+        let config = DiarizationConfig.default
+        XCTAssertEqual(config.onset, 0.5, accuracy: 0.001)
+        XCTAssertEqual(config.offset, 0.3, accuracy: 0.001)
+        XCTAssertEqual(config.minSpeechDuration, 0.3, accuracy: 0.001)
+        XCTAssertEqual(config.minSilenceDuration, 0.15, accuracy: 0.001)
+        XCTAssertEqual(config.clusteringThreshold, 0.715, accuracy: 0.001)
+    }
+
+    // MARK: - DiarizationResult
+
+    func testDiarizationResultEmpty() {
+        let result = DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        XCTAssertEqual(result.segments.count, 0)
+        XCTAssertEqual(result.numSpeakers, 0)
+        XCTAssertTrue(result.speakerEmbeddings.isEmpty)
+    }
+
+    func testDiarizationResultWithSegments() {
+        let segments = [
+            DiarizedSegment(startTime: 0.0, endTime: 2.5, speakerId: 0),
+            DiarizedSegment(startTime: 3.0, endTime: 5.0, speakerId: 1),
+        ]
+        let embeddings: [[Float]] = [
+            [Float](repeating: 0.1, count: 256),
+            [Float](repeating: 0.2, count: 256),
+        ]
+        let result = DiarizationResult(segments: segments, numSpeakers: 2, speakerEmbeddings: embeddings)
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.numSpeakers, 2)
+        XCTAssertEqual(result.speakerEmbeddings.count, 2)
+        XCTAssertEqual(result.segments[0].speakerId, 0)
+        XCTAssertEqual(result.segments[1].duration, 2.0, accuracy: 0.001)
+    }
+
+    // MARK: - Progress Handler API
+
+    func testDiarizeProgressHandlerOverloadExists() {
+        // Verify the progressHandler overload compiles and accepts nil.
+        // We cannot call diarize() without a loaded model, but we can verify
+        // the method signature exists by referencing it.
+        let _: (PyannoteDiarizationPipeline) -> ([Float], Int, DiarizationConfig, ((Float, String) -> Void)?) -> DiarizationResult
+            = PyannoteDiarizationPipeline.diarize(audio:sampleRate:config:progressHandler:)
+    }
+}
+
+// MARK: - E2E Tests (require model downloads)
+
+final class E2EDiarizationPipelineTests: XCTestCase {
+
+    func testDiarizeWithProgressHandler() async throws {
+        let pipeline = try await PyannoteDiarizationPipeline.fromPretrained(
+            embeddingEngine: .mlx
+        )
+
+        // Generate 5 seconds of silence (minimal audio for testing)
+        let sampleRate = 16000
+        let audio = [Float](repeating: 0, count: sampleRate * 5)
+
+        var progressValues: [Float] = []
+        var stageMessages: [String] = []
+
+        let result = pipeline.diarize(audio: audio, sampleRate: sampleRate, config: .default) { progress, stage in
+            progressValues.append(progress)
+            stageMessages.append(stage)
+        }
+
+        // Silent audio should produce empty result
+        XCTAssertEqual(result.segments.count, 0)
+
+        // Progress handler should have been called at least once if any windows were processed
+        // For 5s audio with 10s window, there's 1 window → at least some callbacks
+        if !progressValues.isEmpty {
+            // Progress values should be monotonically non-decreasing
+            for i in 1..<progressValues.count {
+                XCTAssertGreaterThanOrEqual(progressValues[i], progressValues[i - 1],
+                    "Progress should be monotonically non-decreasing")
+            }
+            // All progress values should be in [0, 1]
+            for p in progressValues {
+                XCTAssertGreaterThanOrEqual(p, 0)
+                XCTAssertLessThanOrEqual(p, 1)
+            }
+        }
+    }
+
+    func testDiarizeWithoutProgressHandlerStillWorks() async throws {
+        let pipeline = try await PyannoteDiarizationPipeline.fromPretrained(
+            embeddingEngine: .mlx
+        )
+
+        let audio = [Float](repeating: 0, count: 16000 * 5)
+
+        // Original API without progressHandler should still work
+        let result = pipeline.diarize(audio: audio, sampleRate: 16000, config: .default)
+        XCTAssertEqual(result.segments.count, 0)
+    }
+}

--- a/Tests/SpeechVADTests/DiarizationPipelineTests.swift
+++ b/Tests/SpeechVADTests/DiarizationPipelineTests.swift
@@ -47,7 +47,7 @@ final class DiarizationPipelineTests: XCTestCase {
         // Verify the progressHandler overload compiles and accepts nil.
         // We cannot call diarize() without a loaded model, but we can verify
         // the method signature exists by referencing it.
-        let _: (PyannoteDiarizationPipeline) -> ([Float], Int, DiarizationConfig, ((Float, String) -> Void)?) -> DiarizationResult
+        let _: (PyannoteDiarizationPipeline) -> ([Float], Int, DiarizationConfig, ((Float, String) -> Bool)?) -> DiarizationResult
             = PyannoteDiarizationPipeline.diarize(audio:sampleRate:config:progressHandler:)
     }
 }
@@ -71,6 +71,7 @@ final class E2EDiarizationPipelineTests: XCTestCase {
         let result = pipeline.diarize(audio: audio, sampleRate: sampleRate, config: .default) { progress, stage in
             progressValues.append(progress)
             stageMessages.append(stage)
+            return true
         }
 
         // Silent audio should produce empty result
@@ -90,6 +91,27 @@ final class E2EDiarizationPipelineTests: XCTestCase {
                 XCTAssertLessThanOrEqual(p, 1)
             }
         }
+    }
+
+    func testDiarizeCancellationReturnsEmptyResult() async throws {
+        let pipeline = try await PyannoteDiarizationPipeline.fromPretrained(
+            embeddingEngine: .mlx
+        )
+
+        // Generate 30 seconds of audio so there are multiple windows to process
+        let audio = [Float](repeating: 0, count: 16000 * 30)
+
+        var callCount = 0
+        let result = pipeline.diarize(audio: audio, sampleRate: 16000, config: .default) { _, _ in
+            callCount += 1
+            // Cancel after the first progress callback
+            return callCount < 2
+        }
+
+        // Cancelled early — should return empty result
+        XCTAssertEqual(result.segments.count, 0)
+        XCTAssertEqual(result.numSpeakers, 0)
+        XCTAssertTrue(result.speakerEmbeddings.isEmpty)
     }
 
     func testDiarizeWithoutProgressHandlerStillWorks() async throws {

--- a/Tests/SpeechVADTests/DiarizationPipelineTests.swift
+++ b/Tests/SpeechVADTests/DiarizationPipelineTests.swift
@@ -50,6 +50,13 @@ final class DiarizationPipelineTests: XCTestCase {
         let _: (PyannoteDiarizationPipeline) -> ([Float], Int, DiarizationConfig, ((Float, String) -> Bool)?) -> DiarizationResult
             = PyannoteDiarizationPipeline.diarize(audio:sampleRate:config:progressHandler:)
     }
+
+    #if canImport(CoreML)
+    func testSortformerDiarizeProgressHandlerOverloadExists() {
+        let _: (SortformerDiarizer) -> ([Float], Int, DiarizationConfig, ((Float, String) -> Bool)?) -> DiarizationResult
+            = SortformerDiarizer.diarize(audio:sampleRate:config:progressHandler:)
+    }
+    #endif
 }
 
 // MARK: - E2E Tests (require model downloads)

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -115,6 +115,18 @@ for seg in result.segments {
 print("\(result.numSpeakers) speakers detected")
 ```
 
+#### Progress Reporting
+
+For long audio files, use the `progressHandler` overload to track progress:
+
+```swift
+let result = pipeline.diarize(audio: samples, sampleRate: 16000) { progress, stage in
+    print("[\(Int(progress * 100))%] \(stage)")
+}
+```
+
+Progress is based on completed work units (segmentation windows + embedding windows). The `stage` string indicates the current processing step (e.g. "Segmenting 5/12", "Embedding 3/12").
+
 ### Speaker Embedding
 
 ```swift

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -115,15 +115,26 @@ for seg in result.segments {
 print("\(result.numSpeakers) speakers detected")
 ```
 
-#### Progress Reporting
+#### Progress Reporting & Cancellation
 
-For long audio files, use the `progressHandler` overload to track progress:
+For long audio files, use the `progressHandler` overload to track progress.
+The handler returns a `Bool`: `true` to continue, `false` to cancel immediately.
 
 ```swift
+// Progress only (never cancel)
 let result = pipeline.diarize(audio: samples, sampleRate: 16000) { progress, stage in
     print("[\(Int(progress * 100))%] \(stage)")
+    return true
+}
+
+// With cancellation support
+let result = pipeline.diarize(audio: samples, sampleRate: 16000) { progress, stage in
+    print("[\(Int(progress * 100))%] \(stage)")
+    return !isCancelled  // return false to stop early
 }
 ```
+
+When the handler returns `false`, `diarize()` stops at the next window boundary and returns an empty `DiarizationResult`. The worst-case cancellation latency is one window's inference time (~50–200ms on Apple Silicon).
 
 Progress is based on completed work units (segmentation windows + embedding windows). The `stage` string indicates the current processing step (e.g. "Segmenting 5/12", "Embedding 3/12").
 

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -175,6 +175,15 @@ for seg in result.segments {
 // result.speakerEmbeddings is empty (end-to-end model)
 ```
 
+Sortformer also supports the same `progressHandler` pattern as Pyannote for progress reporting and cancellation:
+
+```swift
+let result = diarizer.diarize(audio: samples, sampleRate: 16000) { progress, stage in
+    print("[\(Int(progress * 100))%] \(stage)")
+    return !isCancelled  // return false to stop early
+}
+```
+
 ### CLI Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Add an overloaded `diarize()` method that accepts an optional `progressHandler: ((Float, String) -> Bool)?` callback
- Progress is calculated from actual completed work units (`completedUnits / totalUnits`), no estimated weights
- Total units = `windowCount × 2` (segmentation pass + embedding extraction pass)
- The handler returns `Bool`: `true` to continue, `false` to cancel immediately
- When cancelled, returns an empty `DiarizationResult` at the next window boundary (~50–200ms latency)
- The original `diarize(audio:sampleRate:config:)` API is unchanged and delegates to the new overload with `nil` handler

## Motivation

For long audio files (e.g. 40+ minutes), `diarize()` can take many minutes. Without progress reporting, callers have no way to show meaningful progress to users. Additionally, users need the ability to cancel a long-running diarization — because `diarize()` is synchronous, Swift Task cancellation alone cannot interrupt it.

## Changes

- `Sources/SpeechVAD/DiarizationPipeline.swift` — new `diarize(audio:sampleRate:config:progressHandler:)` overload with Bool return type; cancellation checks in VAD pre-filter, segmentation loop, and embedding loop
- `Tests/SpeechVADTests/DiarizationPipelineTests.swift` — unit tests (API signature, config defaults) + E2E tests (monotonic progress, cancellation returns empty result, nil handler)
- `docs/inference/speaker-diarization.md` — progress reporting & cancellation usage examples

## Test plan

- [x] Unit tests pass (`swift test --filter DiarizationPipelineTests --skip E2E`)
- [ ] E2E tests pass with model downloads
- [ ] Existing `diarize(audio:sampleRate:config:)` API works identically (backward compatible)
- [ ] Cancellation stops diarization within one window's inference time