### PR TITLE
Add --context flag to audio transcribe command

### DIFF
--- a/Sources/AudioCLILib/TranscribeCommand.swift
+++ b/Sources/AudioCLILib/TranscribeCommand.swift
@@ -23,6 +23,9 @@ public struct TranscribeCommand: ParsableCommand {
     @Option(name: .long, help: "Language hint (optional)")
     public var language: String?
 
+    @Option(name: .long, help: "Context string to bias recognition (e.g., 'Project: Foo, participants: Alice, Bob'). Improves proper-noun accuracy.")
+    public var context: String?
+
     @Flag(name: .long, help: "Enable streaming transcription with VAD")
     public var stream: Bool = false
 
@@ -75,7 +78,7 @@ public struct TranscribeCommand: ParsableCommand {
 
             print("Transcribing...")
             let startTime = CFAbsoluteTimeGetCurrent()
-            let result = asrModel.transcribe(audio: audio, sampleRate: 24000, language: language)
+            let result = asrModel.transcribe(audio: audio, sampleRate: 24000, language: language, context: context)
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
             let duration = Float(audio.count) / 24000.0
             let rtf = elapsed / Double(duration)
@@ -102,7 +105,8 @@ public struct TranscribeCommand: ParsableCommand {
             let config = StreamingASRConfig(
                 maxSegmentDuration: maxSegment,
                 language: language,
-                emitPartialResults: partial
+                emitPartialResults: partial,
+                context: context
             )
 
             print("Streaming transcription (VAD + ASR)...")


### PR DESCRIPTION
## Summary
Expose Qwen3-ASR's existing internal `context` parameter through the `audio transcribe` CLI via a new `--context` option. Wired to both the batch and streaming transcription paths.

Follows the same pattern as PR #177 (per-word confidence scores): small CLI enhancement exposing an existing internal ASR capability.

## Motivation
When transcribing domain-specific audio (meetings, technical calls), providing a short context string with participant names, project names, and relevant acronyms measurably improves proper-noun accuracy. The capability already exists inside `Qwen3ASR.transcribe(...)` and `StreamingASRConfig`; this PR just exposes it at the CLI.

## Example
```
audio transcribe meeting.wav \
  --context "Project: Meander WPCF, participants: Will, Adam. Terms: MSDS, ASI, MCC."
```

## Changes
- `Sources/AudioCLILib/TranscribeCommand.swift`: add `@Option --context`, wire to both batch (`asrModel.transcribe(..., context:)`) and streaming (`StreamingASRConfig(..., context:)`) paths.

Diff is 6 insertions, 2 deletions in a single file.

## Test plan
- [x] `swift build -c release --disable-sandbox` succeeds on upstream main + this commit
- [x] `audio transcribe --help` shows the new flag
- [x] Tested on a 73-minute meeting recording — provided context string improved recognition of project-specific proper nouns