### PR TITLE
Add transcribe --context parser tests and fix stale Qwen3-ASR test paths

### DIFF
--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -85,6 +85,21 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(transcribe.language, "zh")
     }
 
+    func testDefaultContextIsNil() throws {
+        let cmd = try AudioCLI.parseAsRoot(["transcribe", "audio.wav"])
+        let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)
+        XCTAssertNil(transcribe.context)
+    }
+
+    func testParsesContext() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "transcribe", "audio.wav",
+            "--context", "Project: Meander, participants: Will, Adam"
+        ])
+        let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)
+        XCTAssertEqual(transcribe.context, "Project: Meander, participants: Will, Adam")
+    }
+
     func testParsesFullModelId() throws {
         let cmd = try AudioCLI.parseAsRoot(["transcribe", "audio.wav", "-m", "org/my-custom-model"])
         let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)

--- a/Tests/Qwen3ASRTests/Qwen3ASRTests.swift
+++ b/Tests/Qwen3ASRTests/Qwen3ASRTests.swift
@@ -198,10 +198,7 @@ final class Qwen3ASRTests: XCTestCase {
     // MARK: - Tokenizer Tests
 
     func testTokenizerLoadsVocab() throws {
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("qwen3-asr")
-            .appendingPathComponent("aufklarer_Qwen3-ASR-0.6B-MLX-4bit")
-
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: "aufklarer/Qwen3-ASR-0.6B-MLX-4bit")
         let vocabPath = cacheDir.appendingPathComponent("vocab.json")
 
         guard FileManager.default.fileExists(atPath: vocabPath.path) else {
@@ -218,10 +215,7 @@ final class Qwen3ASRTests: XCTestCase {
     }
 
     func testTokenizerLoadsAddedTokens() throws {
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("qwen3-asr")
-            .appendingPathComponent("aufklarer_Qwen3-ASR-0.6B-MLX-4bit")
-
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: "aufklarer/Qwen3-ASR-0.6B-MLX-4bit")
         let vocabPath = cacheDir.appendingPathComponent("vocab.json")
 
         guard FileManager.default.fileExists(atPath: vocabPath.path) else {
@@ -242,10 +236,7 @@ final class Qwen3ASRTests: XCTestCase {
     }
 
     func testTokenizerDecodeWithASRMarker() throws {
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("qwen3-asr")
-            .appendingPathComponent("aufklarer_Qwen3-ASR-0.6B-MLX-4bit")
-
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: "aufklarer/Qwen3-ASR-0.6B-MLX-4bit")
         let vocabPath = cacheDir.appendingPathComponent("vocab.json")
 
         guard FileManager.default.fileExists(atPath: vocabPath.path) else {
@@ -460,10 +451,7 @@ final class Qwen3ASRTests: XCTestCase {
     }
 
     func testTokenizerSkipsSpecialTokensWithPipes() throws {
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("qwen3-asr")
-            .appendingPathComponent("aufklarer_Qwen3-ASR-0.6B-MLX-4bit")
-
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: "aufklarer/Qwen3-ASR-0.6B-MLX-4bit")
         let vocabPath = cacheDir.appendingPathComponent("vocab.json")
 
         guard FileManager.default.fileExists(atPath: vocabPath.path) else {

--- a/Tests/Qwen3ASRTests/SecurityHardeningTests.swift
+++ b/Tests/Qwen3ASRTests/SecurityHardeningTests.swift
@@ -208,10 +208,9 @@ final class DownloadSecurityTests: XCTestCase {
         let legacyKey = modelId.replacingOccurrences(of: "/", with: "_")
         XCTAssertEqual(key, legacyKey, "New sanitized key should match legacy format for standard model IDs")
 
-        // Check the cached directory actually exists if model was downloaded
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("qwen3-asr")
-            .appendingPathComponent(key)
+        // Resolve the actual cache directory via the downloader (handles both
+        // legacy flat layout and the current Hub-style nested layout).
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
         if FileManager.default.fileExists(atPath: cacheDir.path) {
             // Verify expected files are present
             let vocabPath = cacheDir.appendingPathComponent("vocab.json")
@@ -222,9 +221,11 @@ final class DownloadSecurityTests: XCTestCase {
             try tokenizer.load(from: vocabPath)
             XCTAssertEqual(tokenizer.getTokenId(for: "<|im_start|>"), 151644)
 
-            // Verify file validation passes on real cached files
+            // Verify file validation passes on real cached files. Skip hidden
+            // entries like HuggingFace Hub's `.cache/` metadata directory —
+            // those are local bookkeeping, not downloaded artifacts.
             let contents = try FileManager.default.contentsOfDirectory(at: cacheDir, includingPropertiesForKeys: nil)
-            for file in contents {
+            for file in contents where !file.lastPathComponent.hasPrefix(".") {
                 let name = file.lastPathComponent
                 XCTAssertNoThrow(try Qwen3ASRModel.validatedRemoteFileName(name),
                     "Cached file '\(name)' should pass validation")

--- a/Tests/Qwen3ASRTests/SecurityHardeningTests.swift
+++ b/Tests/Qwen3ASRTests/SecurityHardeningTests.swift
@@ -210,11 +210,11 @@ final class DownloadSecurityTests: XCTestCase {
 
         // Resolve the actual cache directory via the downloader (handles both
         // legacy flat layout and the current Hub-style nested layout).
+        // Note: getCacheDirectory creates the dir as a side effect, so check
+        // for vocab.json — not just dir existence — to detect a real cache.
         let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        if FileManager.default.fileExists(atPath: cacheDir.path) {
-            // Verify expected files are present
-            let vocabPath = cacheDir.appendingPathComponent("vocab.json")
-            XCTAssertTrue(FileManager.default.fileExists(atPath: vocabPath.path), "vocab.json should exist in cache")
+        let vocabPath = cacheDir.appendingPathComponent("vocab.json")
+        if FileManager.default.fileExists(atPath: vocabPath.path) {
 
             // Verify tokenizer loads from the cached path
             let tokenizer = Qwen3Tokenizer()


### PR DESCRIPTION
## Summary
Two related test improvements:

**1. Parser tests for the new `--context` flag** (follow-up to #196)
Adds `testDefaultContextIsNil` and `testParsesContext` to `TranscribeCommandTests`, matching the existing one-test-per-flag pattern. Closes the only test gap from #196's review.

**2. Fix stale Qwen3-ASR cache paths in tests**
Three tokenizer tests in `Qwen3ASRTests.swift` and one in `SecurityHardeningTests.swift` still hardcoded `~/Library/Caches/qwen3-asr/aufklarer_<model>/`, the legacy flat cache layout. The downloader moved to `~/Library/Caches/qwen3-speech/models/<owner>/<repo>/` (Hub-style) some time ago, so these tests always silently `XCTSkip`'d — even with a fully populated cache.

- Replace hardcoded paths with `HuggingFaceDownloader.getCacheDirectory(for:)`, the same API the runtime uses. Handles legacy *and* current layouts via the existing fallback logic.
- Skip hidden entries (`.cache/` HF Hub metadata) when iterating cached files in `testSanitizedCacheKeyMatchesExistingCache`.

## Test plan
- [x] `swift test --filter TranscribeCommandTests` → 11/11 pass (was 9)
- [x] `swift test --filter Qwen3ASRTests` → 100/100 pass with cache populated (3 previously-skipped tests now run)
- [x] `swift test --skip E2E` with `COSYVOICE_WEIGHTS` set → **717/717 pass, 0 skipped** (was 16 skipped)
- [x] `swift test --skip E2E` without env var → 717 total, 14 CosyVoice tests still skip cleanly via the existing env-guard