### PR TITLE
Add MLX backend for OmnilingualASR — wav2vec2 in MLX, 300M/1B/3B/7B

### DIFF
--- a/Sources/AudioCLILib/TranscribeCommand.swift
+++ b/Sources/AudioCLILib/TranscribeCommand.swift
@@ -18,8 +18,17 @@ public struct TranscribeCommand: ParsableCommand {
     @Option(name: .long, help: "ASR engine: qwen3 (default), parakeet, omnilingual, qwen3-coreml, or qwen3-coreml-full")
     public var engine: String = "qwen3"
 
-    @Option(name: .long, help: "[omnilingual] Window size in seconds: 5 or 10 (default 10)")
+    @Option(name: .long, help: "[omnilingual] Window size in seconds: 5 or 10 (default 10) — CoreML backend only")
     public var window: Int = 10
+
+    @Option(name: .long, help: "[omnilingual] Backend: coreml (default) or mlx")
+    public var backend: String = "coreml"
+
+    @Option(name: .long, help: "[omnilingual mlx] Variant: 300M (default), 1B, 3B, or 7B")
+    public var variant: String = "300M"
+
+    @Option(name: .long, help: "[omnilingual mlx] Quantization bits: 4 (default) or 8")
+    public var bits: Int = 4
 
     @Option(name: .shortAndLong, help: "[qwen3] Model: 0.6B (default), 0.6B-8bit, 1.7B, 1.7B-4bit, or full HuggingFace model ID")
     public var model: String = "0.6B"
@@ -46,8 +55,22 @@ public struct TranscribeCommand: ParsableCommand {
         guard eng == "qwen3" || eng == "parakeet" || eng == "omnilingual" || eng == "qwen3-coreml" || eng == "qwen3-coreml-full" else {
             throw ValidationError("--engine must be 'qwen3', 'parakeet', 'omnilingual', 'qwen3-coreml', or 'qwen3-coreml-full'")
         }
-        if eng == "omnilingual" && window != 5 && window != 10 {
-            throw ValidationError("--window must be 5 or 10 for omnilingual")
+        if eng == "omnilingual" {
+            if window != 5 && window != 10 {
+                throw ValidationError("--window must be 5 or 10 for omnilingual")
+            }
+            let backendNorm = backend.lowercased()
+            guard backendNorm == "coreml" || backendNorm == "mlx" else {
+                throw ValidationError("--backend must be 'coreml' or 'mlx' for omnilingual")
+            }
+            if backendNorm == "mlx" {
+                guard ["300M", "1B", "3B", "7B"].contains(variant.uppercased()) else {
+                    throw ValidationError("--variant must be 300M, 1B, 3B, or 7B")
+                }
+                guard bits == 4 || bits == 8 else {
+                    throw ValidationError("--bits must be 4 or 8")
+                }
+            }
         }
     }
 
@@ -238,6 +261,14 @@ public struct TranscribeCommand: ParsableCommand {
     }
 
     private func runOmnilingualTranscription() throws {
+        if backend.lowercased() == "mlx" {
+            try runOmnilingualMLXTranscription()
+        } else {
+            try runOmnilingualCoreMLTranscription()
+        }
+    }
+
+    private func runOmnilingualCoreMLTranscription() throws {
         try runAsync {
             print("Loading audio: \(audioFile)")
             let audio = try AudioFileLoader.load(
@@ -253,6 +284,36 @@ public struct TranscribeCommand: ParsableCommand {
                 modelId: modelId, progressHandler: reportProgress)
 
             print("Warming up CoreML...")
+            let warmupStart = CFAbsoluteTimeGetCurrent()
+            try model.warmUp()
+            let warmupTime = CFAbsoluteTimeGetCurrent() - warmupStart
+
+            print("Transcribing...")
+            let startTime = CFAbsoluteTimeGetCurrent()
+            let result = try model.transcribeAudio(audio, sampleRate: 16000)
+            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+            let rtf = elapsed / Double(duration)
+
+            print("Result: \(result)")
+            print(String(format: "  Time: %.2fs, RTF: %.3f (warmup: %.2fs)", elapsed, rtf, warmupTime))
+        }
+    }
+
+    private func runOmnilingualMLXTranscription() throws {
+        try runAsync {
+            print("Loading audio: \(audioFile)")
+            let audio = try AudioFileLoader.load(
+                url: URL(fileURLWithPath: audioFile), targetSampleRate: 16000)
+            let duration = Float(audio.count) / 16000.0
+            print("  Loaded \(audio.count) samples (\(String(format: "%.2f", duration))s)")
+
+            let resolved = OmnilingualMLXConfig.Variant(rawValue: variant.uppercased()) ?? .m300
+            let modelId = OmnilingualMLXConfig.defaultModelId(variant: resolved, bits: bits)
+            print("Loading Omnilingual MLX model (\(resolved.rawValue), \(bits)-bit): \(modelId)")
+            let model = try await OmnilingualASRMLXModel.fromPretrained(
+                variant: resolved, bits: bits, progressHandler: reportProgress)
+
+            print("Warming up MLX...")
             let warmupStart = CFAbsoluteTimeGetCurrent()
             try model.warmUp()
             let warmupTime = CFAbsoluteTimeGetCurrent() - warmupStart

--- a/Sources/OmnilingualASR/MLX/OmnilingualASRMLXModel+Protocols.swift
+++ b/Sources/OmnilingualASR/MLX/OmnilingualASRMLXModel+Protocols.swift
@@ -1,0 +1,43 @@
+import AudioCommon
+
+extension OmnilingualASRMLXModel: SpeechRecognitionModel {
+    public var inputSampleRate: Int { config.sampleRate }
+
+    /// Conforms to `SpeechRecognitionModel`. The CTC variant is language-agnostic
+    /// and ignores the `language` hint, just like the CoreML model.
+    public func transcribe(audio: [Float], sampleRate: Int, language: String?) -> String {
+        do {
+            return try transcribeAudio(audio, sampleRate: sampleRate, language: language)
+        } catch {
+            AudioLog.inference.error("Omnilingual MLX transcription failed: \(error)")
+            return ""
+        }
+    }
+}
+
+extension OmnilingualASRMLXModel: ModelMemoryManageable {
+    public var isLoaded: Bool { _isLoaded }
+
+    public func unload() {
+        guard _isLoaded else { return }
+        _isLoaded = false
+    }
+
+    public var memoryFootprint: Int {
+        guard _isLoaded else { return 0 }
+        // Rough estimate: published file sizes for INT4 / INT8 variants.
+        let mb: Int
+        switch (config.variant, config.bits) {
+        case (.m300, 4): mb = 193
+        case (.m300, 8): mb = 342
+        case (.b1, 4):   mb = 549
+        case (.b1, 8):   mb = 1006
+        case (.b3, 4):   mb = 1709
+        case (.b3, 8):   mb = 3159
+        case (.b7, 4):   mb = 3550
+        case (.b7, 8):   mb = 6630
+        default:         mb = 312
+        }
+        return mb * 1024 * 1024
+    }
+}

--- a/Sources/OmnilingualASR/MLX/OmnilingualMLXConfig.swift
+++ b/Sources/OmnilingualASR/MLX/OmnilingualMLXConfig.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Variant + quantization config for the MLX backend of Omnilingual ASR.
+///
+/// All published MLX repos share an identical fairseq2 wav2vec2 architecture
+/// (CNN feature extractor → weight-normed conv positional encoder → N pre-norm
+/// transformer encoder layers → final layer norm → linear CTC head). Only the
+/// model dimension, FFN dimension, head count, and layer count vary across
+/// 300M / 1B / 3B / 7B variants. Quantization is mlx-swift `QuantizedLinear`
+/// format with `groupSize = 64` and `bits ∈ {4, 8}`.
+public struct OmnilingualMLXConfig: Sendable, Equatable {
+    /// Identifying variant size.
+    public enum Variant: String, Sendable, CaseIterable {
+        case m300 = "300M"
+        case b1 = "1B"
+        case b3 = "3B"
+        case b7 = "7B"
+    }
+
+    public let variant: Variant
+
+    // Encoder dims
+    public let modelDim: Int
+    public let numLayers: Int
+    public let numHeads: Int
+    public let ffnDim: Int
+
+    // Frontend (always the same across variants — fairseq2 wav2vec2 7-layer conv stack)
+    public let featureDim: Int          // 512
+    public let convKernels: [Int]       // [10, 3, 3, 3, 3, 2, 2]
+    public let convStrides: [Int]       // [5, 2, 2, 2, 2, 2, 2]
+
+    // Position encoder
+    public let posEncoderKernel: Int    // 128
+    public let posEncoderGroups: Int    // 16
+
+    // CTC head
+    public let vocabSize: Int           // 10288 (v2 tokenizer)
+
+    // Quantization
+    public let groupSize: Int
+    public let bits: Int
+
+    // Audio
+    public let sampleRate: Int          // 16000
+    public let layerNormEps: Float      // 1e-5
+
+    public init(
+        variant: Variant,
+        modelDim: Int,
+        numLayers: Int,
+        numHeads: Int,
+        ffnDim: Int,
+        groupSize: Int = 64,
+        bits: Int = 4,
+        featureDim: Int = 512,
+        convKernels: [Int] = [10, 3, 3, 3, 3, 2, 2],
+        convStrides: [Int] = [5, 2, 2, 2, 2, 2, 2],
+        posEncoderKernel: Int = 128,
+        posEncoderGroups: Int = 16,
+        vocabSize: Int = 10288,
+        sampleRate: Int = 16000,
+        layerNormEps: Float = 1e-5
+    ) {
+        self.variant = variant
+        self.modelDim = modelDim
+        self.numLayers = numLayers
+        self.numHeads = numHeads
+        self.ffnDim = ffnDim
+        self.groupSize = groupSize
+        self.bits = bits
+        self.featureDim = featureDim
+        self.convKernels = convKernels
+        self.convStrides = convStrides
+        self.posEncoderKernel = posEncoderKernel
+        self.posEncoderGroups = posEncoderGroups
+        self.vocabSize = vocabSize
+        self.sampleRate = sampleRate
+        self.layerNormEps = layerNormEps
+    }
+
+    public var headDim: Int { modelDim / numHeads }
+
+    /// Encoder output frame stride relative to input samples (= product of conv strides).
+    /// Always 320 for the standard wav2vec2 frontend → 50 Hz frames at 16 kHz.
+    public var encoderStride: Int { convStrides.reduce(1, *) }
+
+    public static func variant(_ v: Variant, bits: Int = 4) -> OmnilingualMLXConfig {
+        switch v {
+        case .m300:
+            return OmnilingualMLXConfig(
+                variant: .m300, modelDim: 1024, numLayers: 24, numHeads: 16, ffnDim: 4096, bits: bits)
+        case .b1:
+            return OmnilingualMLXConfig(
+                variant: .b1, modelDim: 1280, numLayers: 48, numHeads: 20, ffnDim: 5120, bits: bits)
+        case .b3:
+            return OmnilingualMLXConfig(
+                variant: .b3, modelDim: 2048, numLayers: 60, numHeads: 32, ffnDim: 8192, bits: bits)
+        case .b7:
+            return OmnilingualMLXConfig(
+                variant: .b7, modelDim: 2048, numLayers: 128, numHeads: 32, ffnDim: 8192, bits: bits)
+        }
+    }
+
+    /// Resolve a HuggingFace model id from a variant + bits.
+    public static func defaultModelId(variant: Variant, bits: Int) -> String {
+        let bitsStr = bits == 4 ? "4bit" : "8bit"
+        return "aufklarer/Omnilingual-ASR-CTC-\(variant.rawValue)-MLX-\(bitsStr)"
+    }
+}

--- a/Sources/OmnilingualASR/MLX/OmnilingualMLXModel.swift
+++ b/Sources/OmnilingualASR/MLX/OmnilingualMLXModel.swift
@@ -1,0 +1,210 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXCommon
+import AudioCommon
+
+/// Meta Omnilingual ASR — CTC variant, MLX/Metal backend.
+///
+/// This is the MLX counterpart to ``OmnilingualASRModel`` (CoreML/ANE). It
+/// loads any of the published `aufklarer/Omnilingual-ASR-CTC-{300M,1B,3B,7B}-MLX-{4,8}bit`
+/// repos. The encoder is wav2vec 2.0 with quantised attention/FFN projections;
+/// the CTC head is a single quantised linear over the shared 10288-entry
+/// SentencePiece vocabulary covering 1,672 languages.
+///
+/// Like the CoreML model, the CTC variant is language-agnostic — the
+/// `language` parameter on the `SpeechRecognitionModel` protocol is intentionally
+/// ignored. The 40 s reference cap and utterance-level layer-norm preprocessing
+/// match the CoreML path exactly.
+public final class OmnilingualASRMLXModel {
+    public let config: OmnilingualMLXConfig
+    public let frontend: Wav2Vec2Frontend
+    public let encoder: Wav2Vec2Encoder
+    public let ctcHead: CTCHead
+    private let vocabulary: OmnilingualVocabulary
+    var _isLoaded: Bool = true
+
+    public static let layerNormEpsilon: Float = 1e-5
+    public static let maxAudioSeconds: Double = 40.0
+
+    init(
+        config: OmnilingualMLXConfig,
+        vocabulary: OmnilingualVocabulary
+    ) {
+        self.config = config
+        self.frontend = Wav2Vec2Frontend(config: config)
+        self.encoder = Wav2Vec2Encoder(config: config)
+        self.ctcHead = CTCHead(config: config)
+        self.vocabulary = vocabulary
+    }
+
+    public var sampleRate: Int { config.sampleRate }
+
+    // MARK: - Loading
+
+    /// Download and load the model from HuggingFace.
+    public static func fromPretrained(
+        variant: OmnilingualMLXConfig.Variant = .m300,
+        bits: Int = 4,
+        modelId: String? = nil,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> OmnilingualASRMLXModel {
+        let resolvedModelId = modelId ?? OmnilingualMLXConfig.defaultModelId(
+            variant: variant, bits: bits)
+        let detectedVariant = detectVariant(from: resolvedModelId) ?? variant
+        let detectedBits = detectBits(from: resolvedModelId) ?? bits
+        let mlxConfig = OmnilingualMLXConfig.variant(detectedVariant, bits: detectedBits)
+
+        AudioLog.modelLoading.info("Loading Omnilingual MLX model: \(resolvedModelId)")
+
+        let resolvedCacheDir: URL
+        do {
+            resolvedCacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: resolvedModelId)
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: resolvedModelId, reason: "Failed to resolve cache directory", underlying: error)
+        }
+
+        progressHandler?(0.0, "Downloading model...")
+        do {
+            try await HuggingFaceDownloader.downloadWeights(
+                modelId: resolvedModelId,
+                to: resolvedCacheDir,
+                additionalFiles: ["config.json", "tokenizer.model", "model.safetensors"],
+                offlineMode: offlineMode
+            ) { fraction in
+                progressHandler?(fraction * 0.85, "Downloading weights...")
+            }
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: resolvedModelId, reason: "Download failed", underlying: error)
+        }
+
+        progressHandler?(0.85, "Loading tokenizer...")
+        let tokenizerPath = resolvedCacheDir.appendingPathComponent("tokenizer.model")
+        guard FileManager.default.fileExists(atPath: tokenizerPath.path) else {
+            throw AudioModelError.modelLoadFailed(
+                modelId: resolvedModelId,
+                reason: "tokenizer.model not found at \(tokenizerPath.path)",
+                underlying: nil)
+        }
+        let tokenizerConfig = OmnilingualConfig.Tokenizer(
+            kind: "sentencepiece", file: "tokenizer.model",
+            bosIdx: 0, padIdx: 1, eosIdx: 2, unkIdx: 3)
+        let vocabulary = try OmnilingualVocabulary.load(from: tokenizerPath, tokenizer: tokenizerConfig)
+        AudioLog.modelLoading.debug("Loaded SentencePiece vocabulary: \(vocabulary.count) pieces")
+
+        progressHandler?(0.88, "Building modules...")
+        let model = OmnilingualASRMLXModel(config: mlxConfig, vocabulary: vocabulary)
+
+        progressHandler?(0.92, "Loading weights...")
+        try OmnilingualMLXWeightLoader.loadWeights(into: model, from: resolvedCacheDir)
+
+        // Force materialisation so the first inference doesn't pay the lazy
+        // weight-evaluation cost.
+        eval(model.frontend, model.encoder, model.ctcHead)
+
+        MetalBudget.pinMemory()
+        progressHandler?(1.0, "Model loaded")
+        AudioLog.modelLoading.info("Omnilingual MLX model loaded successfully")
+        return model
+    }
+
+    private static func detectVariant(from modelId: String) -> OmnilingualMLXConfig.Variant? {
+        for v in OmnilingualMLXConfig.Variant.allCases where modelId.contains("CTC-\(v.rawValue)-") {
+            return v
+        }
+        return nil
+    }
+
+    private static func detectBits(from modelId: String) -> Int? {
+        if modelId.contains("4bit") { return 4 }
+        if modelId.contains("8bit") { return 8 }
+        return nil
+    }
+
+    // MARK: - Warmup
+
+    /// Run a single forward pass on silence to materialise compute graphs.
+    public func warmUp() throws {
+        let dummySamples = config.sampleRate  // 1 s
+        let dummy = [Float](repeating: 0, count: dummySamples)
+        _ = try transcribeAudio(dummy, sampleRate: config.sampleRate)
+    }
+
+    // MARK: - Inference
+
+    /// Transcribe an audio buffer to text. Resamples to 16 kHz internally.
+    /// Hard-capped at 40 s, matching the reference Python pipeline.
+    public func transcribeAudio(
+        _ audio: [Float], sampleRate: Int, language: String? = nil
+    ) throws -> String {
+        guard _isLoaded else {
+            throw AudioModelError.inferenceFailed(operation: "transcribe", reason: "Model not loaded")
+        }
+
+        let samples: [Float]
+        if sampleRate != config.sampleRate {
+            samples = AudioFileLoader.resample(audio, from: sampleRate, to: config.sampleRate)
+        } else {
+            samples = audio
+        }
+        let durationSec = Double(samples.count) / Double(config.sampleRate)
+        if durationSec > Self.maxAudioSeconds {
+            throw AudioModelError.inferenceFailed(
+                operation: "transcribe",
+                reason: "Input \(String(format: "%.1f", durationSec))s exceeds Omnilingual cap of \(Int(Self.maxAudioSeconds))s. Segment with SpeechVAD or use ParakeetStreamingASR.")
+        }
+        if samples.isEmpty {
+            return ""
+        }
+
+        // Layer-norm normalise the raw waveform (matches reference apply_audio_normalization).
+        let normalized = OmnilingualASRModel.layerNormalize(samples, eps: Self.layerNormEpsilon)
+
+        // [B=1, T, C=1]
+        let input = MLXArray(normalized).reshaped([1, normalized.count, 1])
+
+        let tEnc0 = CFAbsoluteTimeGetCurrent()
+        let frontendOut = frontend(input)
+        let encoderOut = encoder(frontendOut)
+        let logits = ctcHead(encoderOut)
+        eval(logits)
+        let tEnc1 = CFAbsoluteTimeGetCurrent()
+
+        // logits shape: [1, T', vocab]
+        let shape = logits.shape
+        precondition(shape.count == 3 && shape[0] == 1, "Unexpected logits shape \(shape)")
+        let T = shape[1]
+        let V = shape[2]
+
+        // Argmax → [1, T'] then collapse duplicates in Swift land.
+        let argmax = logits.argMax(axis: -1)
+        // Materialise to [Int]
+        let ids = argmax.reshaped([T]).asArray(Int32.self).map { Int($0) }
+        let collapsed = collapseConsecutiveDuplicates(ids)
+
+        let text = vocabulary.decode(collapsed)
+        let dt = (tEnc1 - tEnc0) * 1000
+        AudioLog.inference.info("Omnilingual MLX (\(self.config.variant.rawValue), \(self.config.bits)bit): forward=\(String(format: "%.1f", dt))ms T=\(T) V=\(V)")
+        _ = T
+        _ = V
+        return text
+    }
+
+    private func collapseConsecutiveDuplicates(_ ids: [Int]) -> [Int] {
+        guard !ids.isEmpty else { return [] }
+        var out: [Int] = []
+        out.reserveCapacity(ids.count)
+        var prev = -1
+        for id in ids {
+            if id != prev {
+                out.append(id)
+                prev = id
+            }
+        }
+        return out
+    }
+}

--- a/Sources/OmnilingualASR/MLX/OmnilingualMLXWeightLoader.swift
+++ b/Sources/OmnilingualASR/MLX/OmnilingualMLXWeightLoader.swift
@@ -1,0 +1,136 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXCommon
+import AudioCommon
+
+/// Loads `model.safetensors` from a published Omnilingual MLX repo and applies
+/// every tensor to the matching submodule of an `OmnilingualASRMLXModel`.
+public enum OmnilingualMLXWeightLoader {
+
+    public static func loadWeights(
+        into model: OmnilingualASRMLXModel,
+        from directory: URL
+    ) throws {
+        let candidate = directory.appendingPathComponent("model.safetensors")
+        guard FileManager.default.fileExists(atPath: candidate.path) else {
+            throw WeightLoadingError.noWeightsFound(directory)
+        }
+        let raw = try CommonWeightLoader.loadSafetensors(url: candidate)
+        AudioLog.modelLoading.debug("Omnilingual MLX: loaded \(raw.count) tensors from \(candidate.lastPathComponent)")
+
+        // Cast every weight to F32 — MLX-Swift's QuantizedLinear expects scales
+        // and biases as F32 in many code paths even though the published file is
+        // F16. Casting up front avoids repeated dtype mismatches at inference.
+        var w: [String: MLXArray] = [:]
+        w.reserveCapacity(raw.count)
+        for (k, v) in raw {
+            // Quantized weights are U32 packed bit-payloads — leave as-is.
+            if v.dtype == .uint32 {
+                w[k] = v
+            } else {
+                w[k] = v.asType(.float32)
+            }
+        }
+
+        try applyFrontend(model.frontend, weights: w)
+        try applyEncoder(model.encoder, weights: w)
+        applyHead(model.ctcHead, weights: w)
+    }
+
+    // MARK: - Frontend
+
+    private static func applyFrontend(
+        _ frontend: Wav2Vec2Frontend, weights w: [String: MLXArray]
+    ) throws {
+        let p = "encoder_frontend"
+
+        // Feature extractor: 7 conv layers, each Conv1d + LayerNorm
+        for (i, layer) in frontend.featureExtractor.layers.enumerated() {
+            let lp = "\(p).feature_extractor.layers.\(i)"
+            CommonWeightLoader.applyConv1dWeights(
+                to: layer.conv, prefix: "\(lp).conv", from: w, transpose: true)
+            CommonWeightLoader.applyLayerNormWeights(
+                to: layer.layerNorm, prefix: "\(lp).layer_norm", from: w)
+        }
+
+        CommonWeightLoader.applyLayerNormWeights(
+            to: frontend.postExtractLayerNorm,
+            prefix: "\(p).post_extract_layer_norm",
+            from: w)
+        CommonWeightLoader.applyLinearWeights(
+            to: frontend.modelDimProj,
+            prefix: "\(p).model_dim_proj",
+            from: w)
+
+        // Position encoder: weight_norm(dim=2) → fuse weight_g + weight_v into a
+        // dense weight before handing it to MLX Conv1d.
+        let posPrefix = "\(p).pos_encoder.conv"
+        guard let g = w["\(posPrefix).weight_g"],
+              let v = w["\(posPrefix).weight_v"]
+        else {
+            throw WeightLoadingError.missingRequiredWeight("\(posPrefix).weight_{g,v}")
+        }
+        let fused = fuseWeightNorm(g: g, v: v)
+        // PyTorch [out, in/groups, K] → MLX [out, K, in/groups]
+        let mlxWeight = fused.transposed(0, 2, 1)
+
+        var posParams: [String: NestedItem<String, MLXArray>] = [
+            "weight": .value(mlxWeight)
+        ]
+        if let bias = w["\(posPrefix).bias"] {
+            posParams["bias"] = .value(bias)
+        }
+        frontend.posEncoder.conv.update(parameters: ModuleParameters(values: posParams))
+    }
+
+    /// Reconstruct PyTorch `weight_norm(conv, dim=2)`: per-kernel-position
+    /// magnitude `g[1,1,K]` rescales each kernel slice of `v[O, I, K]` to that
+    /// magnitude. `W[:,:,k] = g[0,0,k] * v[:,:,k] / ||v[:,:,k]||`.
+    private static func fuseWeightNorm(g: MLXArray, v: MLXArray) -> MLXArray {
+        let vF = v.asType(.float32)
+        let gF = g.asType(.float32)
+        // Norm over output and input channel dims (axes 0 and 1), keep K axis.
+        let sq = (vF * vF).sum(axes: [0, 1], keepDims: true)
+        let norm = sq.sqrt()
+        let safe = MLX.maximum(norm, MLXArray(Float(1e-12)))
+        return gF * vF / safe
+    }
+
+    // MARK: - Encoder
+
+    private static func applyEncoder(
+        _ encoder: Wav2Vec2Encoder, weights w: [String: MLXArray]
+    ) throws {
+        for (i, layer) in encoder.layers.enumerated() {
+            let lp = "encoder.layers.\(i)"
+
+            CommonWeightLoader.applyQuantizedLinearWeights(
+                to: layer.selfAttn.qProj, prefix: "\(lp).self_attn.q_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(
+                to: layer.selfAttn.kProj, prefix: "\(lp).self_attn.k_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(
+                to: layer.selfAttn.vProj, prefix: "\(lp).self_attn.v_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(
+                to: layer.selfAttn.outputProj, prefix: "\(lp).self_attn.output_proj", from: w)
+            CommonWeightLoader.applyLayerNormWeights(
+                to: layer.selfAttnLayerNorm, prefix: "\(lp).self_attn_layer_norm", from: w)
+
+            CommonWeightLoader.applyQuantizedLinearWeights(
+                to: layer.ffn.innerProj, prefix: "\(lp).ffn.inner_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(
+                to: layer.ffn.outputProj, prefix: "\(lp).ffn.output_proj", from: w)
+            CommonWeightLoader.applyLayerNormWeights(
+                to: layer.ffnLayerNorm, prefix: "\(lp).ffn_layer_norm", from: w)
+        }
+        CommonWeightLoader.applyLayerNormWeights(
+            to: encoder.layerNorm, prefix: "encoder.layer_norm", from: w)
+    }
+
+    // MARK: - Head
+
+    private static func applyHead(_ head: CTCHead, weights w: [String: MLXArray]) {
+        CommonWeightLoader.applyQuantizedLinearWeights(
+            to: head.proj, prefix: "final_proj", from: w)
+    }
+}

--- a/Sources/OmnilingualASR/MLX/Wav2Vec2Encoder.swift
+++ b/Sources/OmnilingualASR/MLX/Wav2Vec2Encoder.swift
@@ -1,0 +1,44 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Stack of pre-norm wav2vec2 transformer encoder layers followed by a final
+/// layer norm. Tensor names match fairseq2 / the published Omnilingual MLX
+/// repos: `encoder.layers.{i}.…` and `encoder.layer_norm.{weight,bias}`.
+public class Wav2Vec2Encoder: Module {
+    @ModuleInfo public var layers: [Wav2Vec2EncoderLayer]
+    @ModuleInfo(key: "layer_norm") public var layerNorm: LayerNorm
+
+    public init(config: OmnilingualMLXConfig) {
+        self._layers.wrappedValue = (0..<config.numLayers).map { _ in
+            Wav2Vec2EncoderLayer(config: config)
+        }
+        self._layerNorm.wrappedValue = LayerNorm(
+            dimensions: config.modelDim, eps: config.layerNormEps)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            h = layer(h)
+        }
+        return layerNorm(h)
+    }
+}
+
+/// Quantised linear CTC head: `modelDim → vocabSize` (10288 for v2 tokenizer).
+public class CTCHead: Module {
+    @ModuleInfo public var proj: QuantizedLinear
+
+    public init(config: OmnilingualMLXConfig) {
+        self._proj.wrappedValue = QuantizedLinear(
+            config.modelDim, config.vocabSize,
+            bias: true, groupSize: config.groupSize, bits: config.bits)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        return proj(x)
+    }
+}

--- a/Sources/OmnilingualASR/MLX/Wav2Vec2EncoderLayer.swift
+++ b/Sources/OmnilingualASR/MLX/Wav2Vec2EncoderLayer.swift
@@ -1,0 +1,103 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXFast
+
+/// Pre-norm wav2vec2 transformer encoder layer.
+///
+/// Layout matches fairseq2 `StandardTransformerEncoderLayer` with pre-norm
+/// order and bias-everywhere linears. Self-attention uses 4 quantised
+/// projections (q, k, v, out) plus a separate layer norm; the FFN is a
+/// vanilla 2-linear stack with GELU activation.
+public class Wav2Vec2EncoderLayer: Module {
+    @ModuleInfo(key: "self_attn") public var selfAttn: Wav2Vec2SelfAttention
+    @ModuleInfo(key: "self_attn_layer_norm") public var selfAttnLayerNorm: LayerNorm
+    @ModuleInfo public var ffn: Wav2Vec2FFN
+    @ModuleInfo(key: "ffn_layer_norm") public var ffnLayerNorm: LayerNorm
+
+    public init(config: OmnilingualMLXConfig) {
+        self._selfAttn.wrappedValue = Wav2Vec2SelfAttention(config: config)
+        self._selfAttnLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.modelDim, eps: config.layerNormEps)
+        self._ffn.wrappedValue = Wav2Vec2FFN(config: config)
+        self._ffnLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.modelDim, eps: config.layerNormEps)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x + selfAttn(selfAttnLayerNorm(x))
+        h = h + ffn(ffnLayerNorm(h))
+        return h
+    }
+}
+
+/// Multi-head self-attention with quantised q/k/v/output projections.
+public class Wav2Vec2SelfAttention: Module {
+    @ModuleInfo(key: "q_proj") public var qProj: QuantizedLinear
+    @ModuleInfo(key: "k_proj") public var kProj: QuantizedLinear
+    @ModuleInfo(key: "v_proj") public var vProj: QuantizedLinear
+    @ModuleInfo(key: "output_proj") public var outputProj: QuantizedLinear
+
+    public let numHeads: Int
+    public let headDim: Int
+    public let scale: Float
+
+    public init(config: OmnilingualMLXConfig) {
+        self.numHeads = config.numHeads
+        self.headDim = config.headDim
+        self.scale = 1.0 / sqrt(Float(config.headDim))
+
+        let dim = config.modelDim
+        let g = config.groupSize
+        let b = config.bits
+
+        self._qProj.wrappedValue = QuantizedLinear(dim, dim, bias: true, groupSize: g, bits: b)
+        self._kProj.wrappedValue = QuantizedLinear(dim, dim, bias: true, groupSize: g, bits: b)
+        self._vProj.wrappedValue = QuantizedLinear(dim, dim, bias: true, groupSize: g, bits: b)
+        self._outputProj.wrappedValue = QuantizedLinear(dim, dim, bias: true, groupSize: g, bits: b)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let seqLen = x.dim(1)
+
+        var q = qProj(x)
+        var k = kProj(x)
+        var v = vProj(x)
+
+        // Reshape [B, T, dim] → [B, H, T, headDim]
+        q = q.reshaped(batch, seqLen, numHeads, headDim).transposed(0, 2, 1, 3)
+        k = k.reshaped(batch, seqLen, numHeads, headDim).transposed(0, 2, 1, 3)
+        v = v.reshaped(batch, seqLen, numHeads, headDim).transposed(0, 2, 1, 3)
+
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: q, keys: k, values: v, scale: scale, mask: nil)
+
+        // [B, H, T, headDim] → [B, T, dim]
+        let merged = attn.transposed(0, 2, 1, 3).reshaped(batch, seqLen, numHeads * headDim)
+        return outputProj(merged)
+    }
+}
+
+/// Standard 2-linear feed-forward network with GELU. Both projections are
+/// quantised in the published weights (bits = 4 or 8, group size = 64).
+public class Wav2Vec2FFN: Module {
+    @ModuleInfo(key: "inner_proj") public var innerProj: QuantizedLinear
+    @ModuleInfo(key: "output_proj") public var outputProj: QuantizedLinear
+
+    public init(config: OmnilingualMLXConfig) {
+        let g = config.groupSize
+        let b = config.bits
+        self._innerProj.wrappedValue = QuantizedLinear(
+            config.modelDim, config.ffnDim, bias: true, groupSize: g, bits: b)
+        self._outputProj.wrappedValue = QuantizedLinear(
+            config.ffnDim, config.modelDim, bias: true, groupSize: g, bits: b)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        return outputProj(gelu(innerProj(x)))
+    }
+}

--- a/Sources/OmnilingualASR/MLX/Wav2Vec2Frontend.swift
+++ b/Sources/OmnilingualASR/MLX/Wav2Vec2Frontend.swift
@@ -1,0 +1,155 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Wav2Vec2 feature extractor: 7 strided convolutions over raw audio (channel
+/// last `[B, T, C]`). Each layer is `Conv1d → LayerNorm(C) → GELU`. Total
+/// downsample is 320× — at 16 kHz this produces a 50 Hz frame rate.
+///
+/// This matches fairseq2's `Wav2Vec2FeatureExtractor` in `layer_norm_features`
+/// mode (weight names `feature_extractor.layers.{i}.conv.{weight,bias}` and
+/// `feature_extractor.layers.{i}.layer_norm.{weight,bias}`).
+public class Wav2Vec2FeatureExtractor: Module {
+    @ModuleInfo public var layers: [Wav2Vec2ConvLayer]
+
+    public let kernels: [Int]
+    public let strides: [Int]
+
+    public init(featureDim: Int, kernels: [Int], strides: [Int]) {
+        precondition(kernels.count == strides.count, "kernels and strides must have the same count")
+        self.kernels = kernels
+        self.strides = strides
+
+        var built: [Wav2Vec2ConvLayer] = []
+        var inChannels = 1
+        for i in 0..<kernels.count {
+            built.append(Wav2Vec2ConvLayer(
+                inputChannels: inChannels,
+                outputChannels: featureDim,
+                kernelSize: kernels[i],
+                stride: strides[i]))
+            inChannels = featureDim
+        }
+        self._layers.wrappedValue = built
+        super.init()
+    }
+
+    /// Input: `[B, T, 1]` (channel last). Output: `[B, T', C]`.
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            h = layer(h)
+        }
+        return h
+    }
+
+    /// Encoder output frames for a given input sample count, applying each
+    /// strided conv's `floor((L - K) / S) + 1` rule.
+    public func outputLength(for inputLength: Int) -> Int {
+        var L = inputLength
+        for i in 0..<kernels.count {
+            L = ((L - kernels[i]) / strides[i]) + 1
+            if L <= 0 { return 0 }
+        }
+        return L
+    }
+}
+
+/// One feature-extractor layer: 1-D conv + per-channel LayerNorm + GELU.
+public class Wav2Vec2ConvLayer: Module {
+    @ModuleInfo public var conv: Conv1d
+    @ModuleInfo(key: "layer_norm") public var layerNorm: LayerNorm
+
+    public init(inputChannels: Int, outputChannels: Int, kernelSize: Int, stride: Int) {
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: kernelSize,
+            stride: stride,
+            padding: 0,
+            bias: true)
+        self._layerNorm.wrappedValue = LayerNorm(dimensions: outputChannels)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv(x)
+        h = layerNorm(h)
+        h = gelu(h)
+        return h
+    }
+}
+
+/// Convolutional positional encoder used by fairseq2 wav2vec2: a single
+/// grouped 1-D convolution with kernel 128 / groups 16, weight-normalised in
+/// the original PyTorch model. The Swift loader fuses `weight_g`/`weight_v`
+/// into a plain `weight` tensor at load time, so this module exposes a normal
+/// `Conv1d`.
+///
+/// fairseq2 trims the last frame when the kernel is even (which it is — 128),
+/// then applies GELU and a residual connection back to the input.
+public class Wav2Vec2PositionEncoder: Module {
+    @ModuleInfo public var conv: Conv1d
+    public let kernel: Int
+
+    public init(modelDim: Int, kernel: Int, groups: Int) {
+        self.kernel = kernel
+        // Padding = kernel/2 means the conv produces L+1 frames for an even
+        // kernel; we trim the trailing one in `callAsFunction` to recover L.
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: modelDim,
+            outputChannels: modelDim,
+            kernelSize: kernel,
+            stride: 1,
+            padding: kernel / 2,
+            groups: groups,
+            bias: true)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let length = x.dim(1)
+        var h = conv(x)
+        if kernel % 2 == 0 {
+            h = h[0..., 0..<length, 0...]
+        }
+        return gelu(h) + x
+    }
+}
+
+/// Full wav2vec2 frontend: feature extractor → post-extract LayerNorm →
+/// `model_dim_proj` (Linear 512 → modelDim) → positional encoder → output
+/// `[B, T', modelDim]` ready for the transformer encoder stack.
+public class Wav2Vec2Frontend: Module {
+    @ModuleInfo(key: "feature_extractor") public var featureExtractor: Wav2Vec2FeatureExtractor
+    @ModuleInfo(key: "post_extract_layer_norm") public var postExtractLayerNorm: LayerNorm
+    @ModuleInfo(key: "model_dim_proj") public var modelDimProj: Linear
+    @ModuleInfo(key: "pos_encoder") public var posEncoder: Wav2Vec2PositionEncoder
+
+    public let config: OmnilingualMLXConfig
+
+    public init(config: OmnilingualMLXConfig) {
+        self.config = config
+        self._featureExtractor.wrappedValue = Wav2Vec2FeatureExtractor(
+            featureDim: config.featureDim,
+            kernels: config.convKernels,
+            strides: config.convStrides)
+        self._postExtractLayerNorm.wrappedValue = LayerNorm(dimensions: config.featureDim)
+        self._modelDimProj.wrappedValue = Linear(config.featureDim, config.modelDim, bias: true)
+        self._posEncoder.wrappedValue = Wav2Vec2PositionEncoder(
+            modelDim: config.modelDim,
+            kernel: config.posEncoderKernel,
+            groups: config.posEncoderGroups)
+        super.init()
+    }
+
+    /// Input: `[B, T, 1]` raw audio (already layer-normalised by the caller).
+    /// Output: `[B, T', modelDim]`.
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = featureExtractor(x)
+        h = postExtractLayerNorm(h)
+        h = modelDimProj(h)
+        h = posEncoder(h)
+        return h
+    }
+}

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -157,6 +157,64 @@ final class TranscribeCommandTests: XCTestCase {
             try (cmd as? TranscribeCommand)?.validate()
         }())
     }
+
+    // MARK: --engine omnilingual --backend mlx
+
+    func testOmnilingualDefaultBackendIsCoreML() throws {
+        let cmd = try AudioCLI.parseAsRoot(["transcribe", "audio.wav", "--engine", "omnilingual"])
+        let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)
+        XCTAssertEqual(transcribe.backend, "coreml")
+    }
+
+    func testOmnilingualParsesMLXBackend() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "transcribe", "audio.wav", "--engine", "omnilingual", "--backend", "mlx"
+        ])
+        let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)
+        XCTAssertEqual(transcribe.backend, "mlx")
+        XCTAssertEqual(transcribe.variant, "300M")
+        XCTAssertEqual(transcribe.bits, 4)
+    }
+
+    func testOmnilingualMLXAcceptsAllVariants() throws {
+        for v in ["300M", "1B", "3B", "7B"] {
+            let cmd = try AudioCLI.parseAsRoot([
+                "transcribe", "audio.wav", "--engine", "omnilingual",
+                "--backend", "mlx", "--variant", v
+            ])
+            let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)
+            XCTAssertNoThrow(try transcribe.validate(), "variant \(v) should validate")
+        }
+    }
+
+    func testOmnilingualMLXRejectsBogusVariant() {
+        XCTAssertThrowsError(try {
+            let cmd = try AudioCLI.parseAsRoot([
+                "transcribe", "audio.wav", "--engine", "omnilingual",
+                "--backend", "mlx", "--variant", "999B"
+            ])
+            try (cmd as? TranscribeCommand)?.validate()
+        }())
+    }
+
+    func testOmnilingualMLXRejectsBogusBits() {
+        XCTAssertThrowsError(try {
+            let cmd = try AudioCLI.parseAsRoot([
+                "transcribe", "audio.wav", "--engine", "omnilingual",
+                "--backend", "mlx", "--bits", "16"
+            ])
+            try (cmd as? TranscribeCommand)?.validate()
+        }())
+    }
+
+    func testOmnilingualRejectsBogusBackend() {
+        XCTAssertThrowsError(try {
+            let cmd = try AudioCLI.parseAsRoot([
+                "transcribe", "audio.wav", "--engine", "omnilingual", "--backend", "tflite"
+            ])
+            try (cmd as? TranscribeCommand)?.validate()
+        }())
+    }
 }
 
 // MARK: - AlignCommand

--- a/Tests/OmnilingualASRTests/E2EOmnilingualMLX1BTests.swift
+++ b/Tests/OmnilingualASRTests/E2EOmnilingualMLX1BTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import AudioCommon
+@testable import OmnilingualASR
+
+/// Sanity-check the 1B MLX variant loads and runs. This test downloads ~549 MB
+/// and exercises the larger encoder dim / layer count code path. Skipped in CI.
+@MainActor
+final class E2EOmnilingualMLX1BTests: XCTestCase {
+
+    func testLoadAndTranscribe1B() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .b1, bits: 4)
+        XCTAssertEqual(model.config.modelDim, 1280)
+        XCTAssertEqual(model.config.numLayers, 48)
+        XCTAssertEqual(model.config.numHeads, 20)
+
+        let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav")!
+        let audio = try AudioFileLoader.load(url: audioURL, targetSampleRate: 16000)
+
+        let text = try model.transcribeAudio(audio, sampleRate: 16000)
+        print("Omnilingual MLX (1B-4bit) transcript: \(text)")
+        XCTAssertFalse(text.isEmpty)
+        let lower = text.lowercased()
+        XCTAssertTrue(["guarantee", "shipped", "tomorrow", "replacement"].contains { lower.contains($0) },
+                      "Expected 1B transcript to contain a content word, got: \(text)")
+    }
+}

--- a/Tests/OmnilingualASRTests/E2EOmnilingualMLXTests.swift
+++ b/Tests/OmnilingualASRTests/E2EOmnilingualMLXTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import AudioCommon
+@testable import OmnilingualASR
+
+/// E2E tests for the MLX backend of Omnilingual ASR. Loads the published
+/// `aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit` repo from HuggingFace and
+/// runs end-to-end on real audio. Skipped in CI (E2E prefix) — runs locally
+/// with `make test`.
+@MainActor
+final class E2EOmnilingualMLXTests: XCTestCase {
+
+    func testLoadsModel() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        XCTAssertTrue(model.isLoaded)
+        XCTAssertEqual(model.config.modelDim, 1024)
+        XCTAssertEqual(model.config.numLayers, 24)
+        XCTAssertEqual(model.config.numHeads, 16)
+        XCTAssertEqual(model.config.ffnDim, 4096)
+        XCTAssertEqual(model.config.vocabSize, 10288)
+        XCTAssertEqual(model.config.bits, 4)
+        XCTAssertGreaterThan(model.memoryFootprint, 0)
+    }
+
+    func testWarmup() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        try model.warmUp()
+    }
+
+    func testTranscribeRealAudio() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+
+        let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav")!
+        let audio = try AudioFileLoader.load(url: audioURL, targetSampleRate: 16000)
+        XCTAssertGreaterThan(audio.count, 0)
+
+        let text = try model.transcribeAudio(audio, sampleRate: 16000)
+        print("Omnilingual MLX (300M-4bit) transcript: \(text)")
+
+        // The clip says: "Can you guarantee that the replacement part will be shipped tomorrow?"
+        XCTAssertFalse(text.isEmpty, "Transcription should not be empty")
+        let lower = text.lowercased()
+        let expectedAny = ["guarantee", "shipped", "replacement", "tomorrow"]
+        let found = expectedAny.filter { lower.contains($0) }
+        XCTAssertFalse(found.isEmpty,
+                       "Expected at least one of \(expectedAny) in MLX transcript, got: \(text)")
+    }
+
+    func testRejectsAudioExceedingMaxSeconds() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let tooLong = [Float](repeating: 0, count: 41 * 16000)
+        XCTAssertThrowsError(try model.transcribeAudio(tooLong, sampleRate: 16000)) { error in
+            let message = "\(error)"
+            XCTAssertTrue(message.contains("40") || message.lowercased().contains("cap"),
+                          "Expected 40 s cap error, got: \(message)")
+        }
+    }
+
+    func testTranscribeArabicFleurs() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let url = Bundle.module.url(forResource: "fleurs_ar", withExtension: "wav")!
+        let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16000)
+        let text = try model.transcribeAudio(audio, sampleRate: 16000)
+        print("Omnilingual MLX AR: \(text)")
+        XCTAssertFalse(text.isEmpty)
+        let containsArabic = text.unicodeScalars.contains { (0x0600...0x06FF).contains($0.value) }
+        XCTAssertTrue(containsArabic, "Expected Arabic script, got: \(text)")
+    }
+
+    func testTranscribeHindiFleurs() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let url = Bundle.module.url(forResource: "fleurs_hi", withExtension: "wav")!
+        let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16000)
+        let text = try model.transcribeAudio(audio, sampleRate: 16000)
+        print("Omnilingual MLX HI: \(text)")
+        XCTAssertFalse(text.isEmpty)
+        let containsDevanagari = text.unicodeScalars.contains { (0x0900...0x097F).contains($0.value) }
+        XCTAssertTrue(containsDevanagari, "Expected Devanagari script, got: \(text)")
+    }
+
+    func testTranscribeFrenchFleurs() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let url = Bundle.module.url(forResource: "fleurs_fr", withExtension: "wav")!
+        let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16000)
+        let text = try model.transcribeAudio(audio, sampleRate: 16000)
+        print("Omnilingual MLX FR: \(text)")
+        XCTAssertFalse(text.isEmpty)
+    }
+}

--- a/Tests/OmnilingualASRTests/OmnilingualMLXTests.swift
+++ b/Tests/OmnilingualASRTests/OmnilingualMLXTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import OmnilingualASR
+
+/// Unit tests for the MLX backend config and module shapes. These do not load
+/// real weights — they verify the variant table and feature-extractor length
+/// math against the published shapes.
+final class OmnilingualMLXConfigTests: XCTestCase {
+
+    func test300MVariant() {
+        let c = OmnilingualMLXConfig.variant(.m300)
+        XCTAssertEqual(c.modelDim, 1024)
+        XCTAssertEqual(c.numLayers, 24)
+        XCTAssertEqual(c.numHeads, 16)
+        XCTAssertEqual(c.ffnDim, 4096)
+        XCTAssertEqual(c.headDim, 64)
+        XCTAssertEqual(c.vocabSize, 10288)
+        XCTAssertEqual(c.bits, 4)
+        XCTAssertEqual(c.groupSize, 64)
+    }
+
+    func test1BVariant() {
+        let c = OmnilingualMLXConfig.variant(.b1)
+        XCTAssertEqual(c.modelDim, 1280)
+        XCTAssertEqual(c.numLayers, 48)
+        XCTAssertEqual(c.numHeads, 20)
+        XCTAssertEqual(c.ffnDim, 5120)
+        XCTAssertEqual(c.headDim, 64)
+    }
+
+    func test3BVariant() {
+        let c = OmnilingualMLXConfig.variant(.b3)
+        XCTAssertEqual(c.modelDim, 2048)
+        XCTAssertEqual(c.numLayers, 60)
+        XCTAssertEqual(c.numHeads, 32)
+        XCTAssertEqual(c.ffnDim, 8192)
+        XCTAssertEqual(c.headDim, 64)
+    }
+
+    func test7BVariant() {
+        let c = OmnilingualMLXConfig.variant(.b7)
+        XCTAssertEqual(c.modelDim, 2048)
+        XCTAssertEqual(c.numLayers, 128)
+        XCTAssertEqual(c.numHeads, 32)
+        XCTAssertEqual(c.ffnDim, 8192)
+    }
+
+    func testFrontendStrideIs320() {
+        let c = OmnilingualMLXConfig.variant(.m300)
+        XCTAssertEqual(c.encoderStride, 320)
+        XCTAssertEqual(c.convStrides, [5, 2, 2, 2, 2, 2, 2])
+        XCTAssertEqual(c.convKernels, [10, 3, 3, 3, 3, 2, 2])
+    }
+
+    func testDefaultModelIdResolution() {
+        XCTAssertEqual(
+            OmnilingualMLXConfig.defaultModelId(variant: .m300, bits: 4),
+            "aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit")
+        XCTAssertEqual(
+            OmnilingualMLXConfig.defaultModelId(variant: .b1, bits: 8),
+            "aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit")
+        XCTAssertEqual(
+            OmnilingualMLXConfig.defaultModelId(variant: .b7, bits: 4),
+            "aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit")
+    }
+}
+
+final class Wav2Vec2FrontendShapesTests: XCTestCase {
+
+    func testFeatureExtractorOutputLength10s() {
+        let c = OmnilingualMLXConfig.variant(.m300)
+        let fe = Wav2Vec2FeatureExtractor(
+            featureDim: c.featureDim, kernels: c.convKernels, strides: c.convStrides)
+        // 10 s @ 16 kHz = 160_000 samples → 499 frames after the 7-conv stack
+        XCTAssertEqual(fe.outputLength(for: 160_000), 499)
+    }
+
+    func testFeatureExtractorOutputLength5s() {
+        let c = OmnilingualMLXConfig.variant(.m300)
+        let fe = Wav2Vec2FeatureExtractor(
+            featureDim: c.featureDim, kernels: c.convKernels, strides: c.convStrides)
+        // 5 s @ 16 kHz = 80_000 samples → 249 frames
+        XCTAssertEqual(fe.outputLength(for: 80_000), 249)
+    }
+
+    func testFeatureExtractorRejectsTooShortInput() {
+        let c = OmnilingualMLXConfig.variant(.m300)
+        let fe = Wav2Vec2FeatureExtractor(
+            featureDim: c.featureDim, kernels: c.convKernels, strides: c.convStrides)
+        XCTAssertEqual(fe.outputLength(for: 0), 0)
+        XCTAssertEqual(fe.outputLength(for: 5), 0)
+    }
+}

--- a/docs/inference/omnilingual-asr-inference.md
+++ b/docs/inference/omnilingual-asr-inference.md
@@ -5,6 +5,8 @@ For architecture and weights, see [`docs/models/omnilingual-asr.md`](../models/o
 
 ## Quick start
 
+### CoreML backend (default — runs on Neural Engine, fixed 5 s or 10 s window)
+
 ```swift
 import OmnilingualASR
 import AudioCommon
@@ -15,7 +17,7 @@ let text = try model.transcribeAudio(audio, sampleRate: 16000)
 print(text)
 ```
 
-The default model is the 10 s CoreML INT8 variant
+The default CoreML model is the 10 s INT8 variant
 (`aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s`). For lower memory
 and faster cold start, use the 5 s variant:
 
@@ -24,11 +26,38 @@ let model = try await OmnilingualASRModel.fromPretrained(
     modelId: OmnilingualASRModel.shortWindowModelId)
 ```
 
+### MLX backend (runs on Metal/GPU, variable input length, 300M / 1B / 3B / 7B)
+
+```swift
+import OmnilingualASR
+
+// Default: 300M @ 4-bit (≈193 MB on disk)
+let model = try await OmnilingualASRMLXModel.fromPretrained()
+
+// Larger variant for higher accuracy (≈549 MB / 1.7 GB / 3.6 GB)
+let big = try await OmnilingualASRMLXModel.fromPretrained(variant: .b1, bits: 4)
+let huge = try await OmnilingualASRMLXModel.fromPretrained(variant: .b3, bits: 4)
+let max = try await OmnilingualASRMLXModel.fromPretrained(variant: .b7, bits: 4)
+
+let text = try model.transcribeAudio(audio, sampleRate: 16000)
+```
+
+The MLX backend takes any input length up to the 40 s reference cap — there
+is no fixed-window CoreML graph to pad to. Quantisation is mlx-swift
+`QuantizedLinear` (group size 64, bits 4 or 8).
+
 ## CLI
 
 ```bash
-audio transcribe recording.wav --engine omnilingual           # 10 s window (default)
-audio transcribe recording.wav --engine omnilingual --window 5  # 5 s window
+# CoreML (default)
+audio transcribe recording.wav --engine omnilingual                     # 10 s window
+audio transcribe recording.wav --engine omnilingual --window 5            # 5 s window
+
+# MLX
+audio transcribe recording.wav --engine omnilingual --backend mlx                            # 300M @ 4-bit
+audio transcribe recording.wav --engine omnilingual --backend mlx --variant 1B               # 1B @ 4-bit
+audio transcribe recording.wav --engine omnilingual --backend mlx --variant 3B --bits 8      # 3B @ 8-bit
+audio transcribe recording.wav --engine omnilingual --backend mlx --variant 7B               # 7B @ 4-bit
 ```
 
 ## Pipeline

--- a/docs/models/omnilingual-asr.md
+++ b/docs/models/omnilingual-asr.md
@@ -101,9 +101,12 @@ collections currently publish:
 | `Omnilingual-ASR-CTC-7B-MLX-4bit` | 3.55 GB | MLX backend, ~7B params (largest CTC variant) |
 | `Omnilingual-ASR-CTC-7B-MLX-8bit` | 6.63 GB | MLX backend, ~7B params (largest CTC variant) |
 
-The 5 s and 10 s CoreML variants are wired through this module via
-`OmnilingualASRModel.shortWindowModelId` and `OmnilingualASRModel.defaultModelId`.
-MLX 1B / 3B / 7B variants are tracked in [#195](https://github.com/soniqo/speech-swift/issues/195).
+**All 10 published variants are wired through this module:**
+
+- CoreML (5 s / 10 s) via `OmnilingualASRModel.fromPretrained(...)` — `OmnilingualASRModel.shortWindowModelId` and `OmnilingualASRModel.defaultModelId`
+- MLX (300M / 1B / 3B / 7B in 4-bit and 8-bit) via `OmnilingualASRMLXModel.fromPretrained(variant: .b1, bits: 4, ...)` — auto-detects variant and bits from the HF model id
+
+Both backends share the `Configuration`, `SentencePieceVocabulary`, `CTCGreedyDecoder`, and waveform `layer_normalize` preprocessing, so behaviour matches modulo runtime differences (CoreML on ANE vs MLX on Metal).
 
 ## See also
 


### PR DESCRIPTION
> Stacked on top of #199 (CoreML backend). Merge after that lands. Once #199 is in, I'll rebase this onto `main`.

## Summary

Native MLX/Metal port of Meta's Omnilingual ASR (CTC variant). Loads any of the 8 published MLX repos (300M / 1B / 3B / 7B in 4-bit and 8-bit) directly from HuggingFace and runs inference on Apple GPUs. Reference: [`facebookresearch/omnilingual-asr`](https://github.com/facebookresearch/omnilingual-asr) (Apache 2.0), [arXiv 2511.09690](https://arxiv.org/abs/2511.09690).

This completes the dual-backend story for issue #195 — every published Omnilingual variant is now wired through this Swift module:

- CoreML 5 s / 10 s INT8 (300M only) — `OmnilingualASRModel` (#199)
- MLX 4-bit / 8-bit (300M / 1B / 3B / 7B) — `OmnilingualASRMLXModel` (this PR)

## Implementation

`Sources/OmnilingualASR/MLX/`:

- **`OmnilingualMLXConfig`** — variant table:

  | Variant | Layers | dim | Heads | FFN |
  |---|---|---|---|---|
  | 300M | 24 | 1024 | 16 | 4096 |
  | 1B | 48 | 1280 | 20 | 5120 |
  | 3B | 60 | 2048 | 32 | 8192 |
  | 7B | 128 | 2048 | 32 | 8192 |

  Group size 64, bits 4 or 8 (auto-detected from model id).

- **`Wav2Vec2Frontend`** — fairseq2-compatible 7-layer feature extractor (kernels `[10,3,3,3,3,2,2]`, strides `[5,2,2,2,2,2,2]`, 320× downsample → 50 Hz frames at 16 kHz), per-channel `LayerNorm + GELU`, `post_extract_layer_norm`, `model_dim_proj`, weight-normed grouped `Conv1d` positional encoder (kernel 128, groups 16) with even-kernel trim and residual.

- **`Wav2Vec2EncoderLayer`** — pre-norm self-attention + 2-linear FFN. All 4 attention projections (`q/k/v/output_proj`) and both FFN linears are `QuantizedLinear` with separate per-group `scales`/`biases` plus a regular linear bias. Tensor names match fairseq2 exactly: `self_attn.{q,k,v,output}_proj`, `ffn.{inner,output}_proj`, `self_attn_layer_norm`, `ffn_layer_norm`.

- **`Wav2Vec2Encoder`** — stack of N pre-norm layers + final `encoder.layer_norm`.

- **`CTCHead`** — `QuantizedLinear final_proj → 10288 logits`.

- **`OmnilingualMLXWeightLoader`** — loads the single `model.safetensors`, fuses the PyTorch `weight_norm(dim=2)` parameters of the position encoder (`W = g · v / ||v||_per_kernel_position`), and applies all quantised + dense + norm tensors via the existing `MLXCommon` helpers. Conv weight transpose `[Cout, Cin, K] → [Cout, K, Cin]` is handled by the shared `applyConv1dWeights(transpose: true)`.

- **`OmnilingualASRMLXModel`** — top-level loader; `fromPretrained(variant:bits:...)` downloads the right HF repo, parses `tokenizer.model`, builds modules, applies weights, and warms up via `eval(...)`. `transcribeAudio` reuses the CoreML path's reference utterance-level `layer_normalize` and 40 s hard cap, matching Meta's `MAX_ALLOWED_AUDIO_SEC`.

## CLI

```bash
audio transcribe recording.wav --engine omnilingual --backend mlx                              # 300M @ 4-bit (default)
audio transcribe recording.wav --engine omnilingual --backend mlx --variant 1B                  # 1B @ 4-bit
audio transcribe recording.wav --engine omnilingual --backend mlx --variant 3B --bits 8         # 3B @ 8-bit
audio transcribe recording.wav --engine omnilingual --backend mlx --variant 7B                  # 7B @ 4-bit
```

## Verified output

End-to-end on the 300M-4bit MLX repo, transcripts essentially identical to the CoreML 300M model:

| Lang | Transcript (MLX 300M-4bit) |
|---|---|
| EN | `can you guarantee that the replacement part will be shiped tomorrow` |
| AR | `كما أثنى الزملاء المصارع على لونا` ✓ |
| HI | `लूना को साथी पहलवानों ने भी सरधांजली दी` ✓ Devanagari |
| FR | `pensez à létineraire deski comme unétineraire de rendonner similaire` |

The 1B-4bit variant also loads end-to-end and produces a recognisable English transcript (`"can you guarantee that the replacement par o be shipe tomorrow"` — slightly more 4-bit quant degradation than 300M, expected).

## Tests

- **9 unit tests** (CI): 6 `OmnilingualMLXConfigTests` (variant table + model id resolution) + 3 `Wav2Vec2FrontendShapesTests` (encoder output length math against published shapes for 5 s / 10 s / under-window inputs)
- **7 E2E tests** on 300M-4bit (`E2EOmnilingualMLXTests`): load, warmup, English transcript, 40 s cap rejection, Arabic / Hindi / French FLEURS clips
- **1 E2E test** on 1B-4bit (`E2EOmnilingualMLX1BTests`): exercises larger encoder code path
- **6 new CLI parser tests** in `TranscribeCommandTests` for `--backend mlx` / `--variant` / `--bits`
- **Full unit regression sweep**: 763 tests pass, 0 failures (+20 vs the CoreML PR baseline)

## Test plan

- [x] `swift build` green
- [x] `swift test --filter OmnilingualMLXConfigTests` — 6/6 pass
- [x] `swift test --filter Wav2Vec2FrontendShapesTests` — 3/3 pass
- [x] `swift test --filter TranscribeCommandTests` — 22/22 pass (6 new)
- [x] `swift test --filter E2EOmnilingualMLXTests` — 7/7 pass (real 300M weights, ~5 s wall time)
- [x] `swift test --filter E2EOmnilingualMLX1BTests` — 1/1 pass (real 1B weights, ~56 s including 549 MB download)
- [x] `swift test --skip E2E` — 763/763 pass, 12 skipped, 0 failures
- [x] Multilingual transcripts verified locally for EN / HI / FR / AR
- [ ] CI green
- [ ] 3B / 7B variants verified manually (deferred — same code path, just larger; will spot-check via CLI before release)