### PR TITLE
Add OmnilingualASR (1,672 languages) and trim README to soniqo.audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,24 @@ AI speech models for Apple Silicon, powered by MLX Swift and CoreML.
 
 On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs locally on Apple Silicon — no cloud, no API keys, no data leaves your device.
 
-[Install via Homebrew](#homebrew) or add as a Swift Package dependency.
+**[📚 Full Documentation →](https://soniqo.audio)** · **[🤗 HuggingFace Models](https://huggingface.co/aufklarer)** · **[📝 Blog](https://blog.ivan.digital)**
 
-**[Documentation](https://soniqo.audio)** · **[HuggingFace Models](https://huggingface.co/aufklarer)** · **[Blog](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Speech-to-text (automatic speech recognition, 52 languages, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — Speech-to-text via CoreML (Neural Engine, NVIDIA FastConformer + TDT decoder, 25 languages)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Speech-to-text (Meta wav2vec2 + CTC, **1,672 languages** across 32 scripts, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[Streaming Dictation](https://soniqo.audio/guides/dictate)** — Real-time dictation with partials and end-of-utterance detection (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — Word-level timestamp alignment (audio + text → timestamps)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — Text-to-speech (highest quality, streaming, custom speakers, 10 languages)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — Streaming TTS with voice cloning, multi-speaker dialogue, emotion tags (9 languages)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — On-device TTS (82M, CoreML/Neural Engine, 54 voices, iOS-ready, 10 languages)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — On-device LLM chat (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybrid, streaming tokens)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — Full-duplex speech-to-speech (7B, audio in → audio out, 18 voice presets)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Real-time noise suppression (2.1M params, 48 kHz)
+- **[VAD](https://soniqo.audio/guides/vad)** — Voice activity detection (Silero streaming, Pyannote offline, FireRedVAD 100+ languages)
+- **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — Who spoke when (Pyannote pipeline, Sortformer end-to-end on Neural Engine)
+- **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), CAM++ (192-dim)
 
-- **Qwen3-ASR** — Speech-to-text / speech recognition (automatic speech recognition, 52 languages)
-- **Parakeet TDT** — Speech-to-text via CoreML (Neural Engine, NVIDIA FastConformer + TDT decoder, 25 languages)
-- **Omnilingual ASR** — Speech-to-text via CoreML (Meta wav2vec2 + CTC, **1,672 languages** across 150+ families, 5/10 s windows, INT8 palettized, ANE)
-- **Qwen3-ForcedAligner** — Word-level timestamp alignment (audio + text → timestamps)
-- **Qwen3-TTS** — Text-to-speech synthesis (highest quality, streaming, custom speakers, 10 languages)
-- **CosyVoice TTS** — Text-to-speech with streaming, voice cloning, multi-speaker dialogue, and emotion tags (9 languages, DiT flow matching, CAM++ speaker encoder)
-- **Kokoro TTS** — On-device text-to-speech (82M params, CoreML/Neural Engine, 54 voices, iOS-ready, 10 languages)
-- **Qwen3-TTS CoreML** — Text-to-speech (0.6B, CoreML 6-model pipeline, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** — On-device LLM chat (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybrid, streaming tokens)
-- **PersonaPlex** — Full-duplex speech-to-speech conversation (7B, audio in → audio out, 18 voice presets)
-- **DeepFilterNet3** — Speech enhancement / noise suppression (2.1M params, real-time 48kHz)
-- **FireRedVAD** — Offline voice activity detection (DFSMN, CoreML, 100+ languages, 97.6% F1)
-- **Silero VAD** — Streaming voice activity detection (32ms chunks, sub-millisecond latency)
-- **Pyannote VAD** — Offline voice activity detection (10s windows, multi-speaker overlap)
-- **Speaker Diarization** — Who spoke when (Pyannote segmentation + activity-based speaker chaining, or end-to-end Sortformer on Neural Engine)
-- **Speaker Embeddings** — Speaker verification and identification (WeSpeaker ResNet34, 256-dim vectors)
-
-Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## Roadmap
-
-See [Roadmap discussion](https://github.com/soniqo/speech-swift/discussions/81) for what's planned — comments and suggestions welcome!
+Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## News
 
@@ -45,7 +37,7 @@ See [Roadmap discussion](https://github.com/soniqo/speech-swift/discussions/81) 
 Add the package to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
 Import only the modules you need — every model is its own SPM library, so you don't pay for what you don't use:
@@ -102,65 +94,25 @@ Available SPM products: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`,
 
 ## Models
 
-| Model | Task | Streaming | Languages | Sizes |
-|-------|------|-----------|-----------|-------|
-| Qwen3-ASR-0.6B | Speech → Text | No | 52 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | Speech → Text | No | 52 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | Speech → Text | No | 25 European languages | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | Speech → Text | Yes (streaming + EOU) | 25 European languages | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | Speech → Text | No (5/10 s window) | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | Speech → Text | No | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | Speech → Text | No | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | Speech → Text | No | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | Audio + Text → Timestamps | No | Multi | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | Text → Speech | Yes (~120ms) | 10 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | Text → Speech | Yes (~120ms) | 10 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | Text → Speech | Yes (~120ms) | 10 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | Text → Speech | Yes (~150ms) | 9 languages | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | Text → Speech | No | 10 languages | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | Speech → Speech | Yes (~2s chunks) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | Voice Activity Detection | No (offline) | 100+ languages | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | Voice Activity Detection | Yes (32ms chunks) | Language-agnostic | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + Speaker Segmentation | No (10s windows) | Language-agnostic | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | Speech Enhancement | Yes (10ms frames) | Language-agnostic | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | Speaker Embedding (256-dim) | No | Language-agnostic | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | Speaker Embedding (192-dim) | No | Language-agnostic | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | Speaker Diarization (end-to-end) | Yes (chunked) | Language-agnostic | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+Compact view below. **[Full model catalogue with sizes, quantisations, download URLs, and memory tables → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### Memory Requirements
-
-Weight memory is the GPU (MLX) or ANE (CoreML) memory consumed by model parameters. Peak inference includes KV caches, activations, and intermediate tensors.
-
-| Model | Weight Memory | Peak Inference |
-|-------|--------------|----------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### When to Use Which TTS
-
-- **Qwen3-TTS**: Best quality, streaming (~120ms), 9 built-in speakers, 10 languages, batch synthesis
-- **CosyVoice TTS**: Streaming (~150ms), 9 languages, voice cloning (CAM++ speaker encoder), multi-speaker dialogue (`[S1] ... [S2] ...`), inline emotion/style tags (`(happy)`, `(whispers)`), DiT flow matching + HiFi-GAN vocoder
-- **Kokoro TTS**: Lightweight iOS-ready TTS (82M params), CoreML/Neural Engine, 54 voices, 10 languages, end-to-end model
-- **PersonaPlex**: Full-duplex speech-to-speech (audio in → audio out), streaming (~2s chunks), 18 voice presets, based on Moshi architecture
+| Model | Task | Backends | Sizes | Languages |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Speech → Text | MLX, CoreML (hybrid) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Speech → Text | CoreML (ANE) | 0.6B | 25 European |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | Speech → Text (streaming) | CoreML (ANE) | 120M | 25 European |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | Speech → Text | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1,672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | Audio + Text → Timestamps | MLX, CoreML | 0.6B | Multi |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | Text → Speech | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | Text → Speech | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | Text → Speech | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Text → Text (LLM) | MLX, CoreML | 0.8B | Multi |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | Speech → Speech | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | Voice Activity Detection | MLX, CoreML | 309K | Agnostic |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarization | MLX | 1.5M | Agnostic |
+| [Sortformer](https://soniqo.audio/guides/diarize) | Diarization (E2E) | CoreML (ANE) | — | Agnostic |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Speech Enhancement | CoreML | 2.1M | Agnostic |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Speaker Embedding | MLX, CoreML | 6.6M | Agnostic |
 
 ## Installation
 
@@ -173,51 +125,48 @@ brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-Then use:
+Then:
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (Neural Engine)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> For interactive voice conversation with microphone input, see **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**.
+**[Full CLI reference →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-Add to your `Package.swift`:
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-Import the module you need:
+Import only what you need — every model is its own SPM target:
 
 ```swift
-import Qwen3ASR      // Speech recognition (MLX)
-import ParakeetASR   // Speech recognition (CoreML)
-import Qwen3TTS      // Text-to-speech (Qwen3)
-import CosyVoiceTTS  // Text-to-speech (streaming)
-import KokoroTTS     // Text-to-speech (CoreML, iOS-ready)
-import Qwen3Chat     // On-device LLM chat (CoreML)
-import PersonaPlex   // Speech-to-speech (full-duplex)
-import SpeechVAD          // Voice activity detection (pyannote + Silero)
-import SpeechEnhancement  // Noise suppression (DeepFilterNet3)
-import AudioCommon        // Shared utilities
+import Qwen3ASR             // Speech recognition (MLX)
+import ParakeetASR          // Speech recognition (CoreML, batch)
+import ParakeetStreamingASR // Streaming dictation with partials + EOU
+import OmnilingualASR       // 1,672 languages (CoreML + MLX)
+import Qwen3TTS             // Text-to-speech
+import CosyVoiceTTS         // Text-to-speech with voice cloning
+import KokoroTTS            // Text-to-speech (iOS-ready)
+import Qwen3Chat            // On-device LLM chat
+import PersonaPlex          // Full-duplex speech-to-speech
+import SpeechVAD            // VAD + speaker diarization + embeddings
+import SpeechEnhancement    // Noise suppression
+import SpeechUI             // SwiftUI components for streaming transcripts
+import AudioCommon          // Shared protocols and utilities
 ```
 
 ### Requirements
 
-- Swift 5.9+
-- macOS 14+ or iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (with Metal Toolchain — run `xcodebuild -downloadComponent MetalToolchain` if missing)
+- Swift 5.9+, Xcode 15+ (with Metal Toolchain)
+- macOS 14+ or iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
-### Build from Source
+### Build from source
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1023 +174,159 @@ cd speech-swift
 make build
 ```
 
-This compiles the Swift package **and** the MLX Metal shader library in one step. The Metal library (`mlx.metallib`) is required for GPU inference — without it you'll get `Failed to load the default metallib` at runtime.
+`make build` compiles the Swift package **and** the MLX Metal shader library. The Metal library is required for GPU inference — without it you'll see `Failed to load the default metallib` at runtime. `make debug` for debug builds, `make test` for the test suite.
 
-For debug builds: `make debug`. To run unit tests: `make test`.
+**[Full build and install guide →](https://soniqo.audio/getting-started)**
 
-## Try the Voice Assistant
+## Demo apps
 
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** is a ready-to-run macOS voice assistant — tap to talk, get spoken responses in real-time. Uses microphone input with Silero VAD for automatic speech detection, Qwen3-ASR for transcription, and PersonaPlex 7B for speech-to-speech generation. Multi-turn conversation with 18 voice presets and inner monologue transcript display.
-
-```bash
-make build  # from repo root — builds everything including MLX metallib
-cd Examples/PersonaPlexDemo
-# See Examples/PersonaPlexDemo/README.md for .app bundle instructions
-```
-
-> RTF ~0.94 on M2 Max (faster than real-time). Models download automatically on first run (~5.5 GB PersonaPlex + ~400 MB ASR).
-
-## Demo Apps
-
-- **[DictateDemo](Examples/DictateDemo/)** ([docs](https://soniqo.audio/guides/dictate/)) — macOS menu-bar streaming dictation with live partials, VAD-driven end-of-utterance detection, and one-click copy. Runs as a background menu-bar agent (Parakeet-EOU-120M + Silero VAD).
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS echo demo (Parakeet ASR + Kokoro TTS, speak and hear it back). Device and simulator.
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Conversational voice assistant (mic input, VAD, multi-turn). macOS.
+- **[DictateDemo](Examples/DictateDemo/)** ([docs](https://soniqo.audio/guides/dictate)) — macOS menu-bar streaming dictation with live partials, VAD-driven end-of-utterance detection, and one-click copy. Runs as a background agent (Parakeet-EOU-120M + Silero VAD).
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS echo demo (Parakeet ASR + Kokoro TTS). Device and simulator.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Conversational voice assistant with mic input, VAD, and multi-turn context. macOS. RTF ~0.94 on M2 Max (faster than real-time).
 - **[SpeechDemo](Examples/SpeechDemo/)** — Dictation and TTS synthesis in a tabbed interface. macOS.
 
-Build and run — see each demo's README for instructions.
+Each demo's README has build instructions.
 
-## Speech-to-Text (ASR) — Transcribe Audio in Swift
+## Code examples
 
-### Basic Transcription
+The snippets below show the minimal path for each domain. Every section links to a full guide on [soniqo.audio](https://soniqo.audio) with configuration options, multiple backends, streaming patterns, and CLI recipes.
 
-```swift
-import Qwen3ASR
-
-// Default: 0.6B model
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// Or use the larger 1.7B model for better accuracy
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// Audio can be any sample rate — automatically resampled to 16kHz internally
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### CoreML Encoder (Neural Engine)
-
-Hybrid mode: CoreML encoder on Neural Engine + MLX text decoder on GPU. Lower power, frees GPU for the encoder pass.
+### Speech-to-Text — [full guide →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-INT8 (180 MB, default) and INT4 (90 MB) variants available. INT8 recommended (cosine similarity > 0.999 vs FP32).
+Alternative backends: [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× realtime), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1,672 languages, CoreML or MLX), [Streaming dictation](https://soniqo.audio/guides/dictate) (live partials).
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-Runs on Neural Engine via CoreML — frees the GPU for concurrent workloads. 25 European languages, ~315 MB.
-
-### ASR CLI
-
-```bash
-make build  # or: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# Default (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# Use 1.7B model
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# CoreML encoder (Neural Engine + MLX decoder)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## Forced Alignment
-
-### Word-Level Timestamps
+### Forced Alignment — [full guide →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// Downloads ~979 MB on first run
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### Forced Alignment CLI
-
-```bash
-swift build -c release
-
-# Align with provided text
-.build/release/audio align audio.wav --text "Hello world"
-
-# Transcribe first, then align
-.build/release/audio align audio.wav
-```
-
-Output:
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-Non-autoregressive — single forward pass, no sampling loop. See [Forced Aligner](docs/inference/forced-aligner.md) for architecture details.
-
-## Text-to-Speech (TTS) — Generate Speech in Swift
-
-### Basic Synthesis
+### Text-to-Speech — [full guide →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // for WAVWriter
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// Downloads ~1.7 GB on first run (model + codec weights)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// Output is 24kHz mono float samples
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### TTS CLI
+Alternative TTS engines: [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (streaming + voice cloning + emotion tags), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (iOS-ready, 54 voices), [Voice cloning](https://soniqo.audio/guides/voice-cloning).
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### Custom Voice / Speaker Selection
-
-The **CustomVoice** model variant supports 9 built-in speaker voices and natural language instructions for tone/style control. Load it by passing the CustomVoice model ID:
-
-```swift
-import Qwen3TTS
-
-// Load the CustomVoice model (downloads ~1.7 GB on first run)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// Synthesize with a specific speaker
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// List available speakers
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# Use CustomVoice model with a speaker
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# List available speakers
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### Voice Cloning (Base model)
-
-Clone a speaker's voice from a reference audio file. Two modes:
-
-**ICL mode** (recommended) — encodes reference audio into codec tokens with transcript. Higher quality, reliable EOS:
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**X-vector mode** — speaker embedding only, no transcript needed but lower quality:
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### Tone / Style Instructions (CustomVoice only)
-
-The CustomVoice model accepts a natural language `instruct` parameter to control speaking style, tone, emotion, and pacing. The instruction is prepended to the model input in ChatML format.
-
-```swift
-// Cheerful tone
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// Slow and serious
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// Whispering
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# With style instruction
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# Default instruct ("Speak naturally.") is applied automatically when using CustomVoice
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-When no `--instruct` is provided with the CustomVoice model, `"Speak naturally."` is applied automatically to prevent rambling output. The Base model does not support instruct.
-
-### Batch Synthesis
-
-Synthesize multiple texts in a single batched forward pass for higher throughput:
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] is 24kHz mono float samples for texts[i]
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### Batch CLI
-
-```bash
-# Create a file with one text per line
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# Produces output_0.wav, output_1.wav, ...
-```
-
-> Batch mode amortizes model weight loads across items. Expect ~1.5-2.5x throughput improvement for B=4 on Apple Silicon. Best results when texts produce similar-length audio.
-
-### Sampling Options
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### Streaming Synthesis
-
-Emit audio chunks incrementally for low first-packet latency:
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // ~120ms to first audio chunk
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: true on last chunk
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# Default streaming (3-frame first chunk, ~225ms latency)
-.build/release/audio speak "Hello world" --stream
-
-# Low-latency (1-frame first chunk, ~120ms latency)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## Speech-to-Speech — Full-Duplex Voice Conversation
-
-> For an interactive voice assistant with microphone input, see **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — tap to talk, multi-turn conversation with automatic speech detection.
-
-### Speech-to-Speech
+### Speech-to-Speech — [full guide →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // for WAVWriter, AudioFileLoader
 
 let model = try await PersonaPlexModel.fromPretrained()
-// Downloads ~5.5 GB on first run (temporal 4-bit + depformer + Mimi codec + voice presets)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: 24kHz mono float samples
-// textTokens: model's inner monologue (SentencePiece token IDs)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// 24 kHz mono Float32 output ready for playback
 ```
 
-### Inner Monologue (Text Output)
-
-PersonaPlex generates text tokens alongside audio — the model's internal reasoning. Decode them with the built-in SentencePiece decoder:
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // e.g. "Sure, I can help you with that..."
-```
-
-### Streaming Speech-to-Speech
-
-```swift
-// Receive audio chunks as they're generated (~2s per chunk)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // play immediately, 24kHz mono
-    // chunk.textTokens has this chunk's text; final chunk has all tokens
-    if chunk.isFinal { break }
-}
-```
-
-### Voice Selection
-
-18 voice presets available:
-- **Natural Female**: NATF0, NATF1, NATF2, NATF3
-- **Natural Male**: NATM0, NATM1, NATM2, NATM3
-- **Variety Female**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **Variety Male**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### System Prompts
-
-The system prompt steers the model's conversational behavior. Pass any custom prompt as a plain string:
-
-```swift
-// Custom system prompt (tokenized automatically)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// Or use a preset
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-Available presets: `focused` (default), `assistant`, `customerService`, `teacher`.
-
-### PersonaPlex CLI
-
-```bash
-make build
-
-# Basic speech-to-speech
-.build/release/audio respond --input question.wav --output response.wav
-
-# With transcript (decodes inner monologue text)
-.build/release/audio respond --input question.wav --transcript
-
-# JSON output (audio path, transcript, latency metrics)
-.build/release/audio respond --input question.wav --json
-
-# Custom system prompt text
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# Choose a voice and system prompt preset
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# Tune sampling parameters
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# Enable text entropy early stopping (stops if text collapses)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# List available voices and prompts
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — Streaming Text-to-Speech with Voice Cloning
-
-### Basic Synthesis
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // for WAVWriter
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// Downloads ~1.9 GB on first run (LLM + DiT + HiFi-GAN weights)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// Output is 24kHz mono float samples
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### Streaming Synthesis
-
-```swift
-// Streaming: receive audio chunks as they're generated (~150ms to first chunk)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // play immediately
-}
-```
-
-### Voice Cloning (CosyVoice)
-
-Clone a speaker's voice using the CAM++ speaker encoder (192-dim, CoreML Neural Engine):
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// Downloads ~14 MB CAM++ CoreML model on first use
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: [Float] of length 192
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CosyVoice TTS CLI
-
-```bash
-make build
-
-# Basic synthesis
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# Voice cloning (downloads CAM++ speaker encoder on first use)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# Multi-speaker dialogue with voice cloning
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# Inline emotion/style tags
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# Combined: dialogue + emotions + voice cloning
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# Custom style instruction
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# Streaming synthesis
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — Lightweight On-Device Text-to-Speech (iOS + macOS)
-
-### Basic Synthesis
-
-```swift
-import KokoroTTS
-import AudioCommon  // for WAVWriter
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// Downloads ~170 MB on first run (CoreML models + voice embeddings + dictionaries)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// Output is 24kHz mono float samples
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-54 preset voices across 10 languages. End-to-end CoreML model, non-autoregressive, no sampling loop. Runs on Neural Engine, frees the GPU entirely.
-
-### Kokoro TTS CLI
-
-```bash
-make build
-
-# Basic synthesis
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# Choose language
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# List available voices
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-6-model autoregressive pipeline (TextProjector → CodeDecoder → MultiCodeDecoder → SpeechDecoder) running on CoreML. W8A16 palettized weights.
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (On-Device LLM)
+### LLM Chat — [full guide →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// Downloads ~318 MB on first run (INT4 CoreML model + tokenizer)
-
-// Single response
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// Streaming tokens
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B INT4 quantized for CoreML. Runs on Neural Engine with ~2 tok/s on iPhone, ~15 tok/s on M-series. Supports multi-turn conversation with KV cache, thinking mode (`<think>` tokens), and configurable sampling (temperature, top-k, top-p, repetition penalty).
-
-## Voice Activity Detection (VAD) — Detect Speech in Audio
-
-### Streaming VAD (Silero)
-
-Silero VAD v5 processes 32ms audio chunks with sub-millisecond latency — ideal for real-time speech detection from microphones or streams.
+### Voice Activity Detection — [full guide →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// Or use CoreML (Neural Engine, lower power):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// Streaming: process 512-sample chunks (32ms @ 16kHz)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // call between different audio streams
-
-// Or detect all segments at once
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Speech: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### Event-Driven Streaming
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// Feed audio of any length — events emitted as speech is confirmed
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Speech started at \(time)s")
-    case .speechEnded(let segment):
-        print("Speech: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// Flush at end of stream
-let final = processor.flush()
-```
-
-### VAD CLI
-
-```bash
-make build
-
-# Streaming Silero VAD (32ms chunks)
-.build/release/audio vad-stream audio.wav
-
-# CoreML backend (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# With custom thresholds
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# JSON output
-.build/release/audio vad-stream audio.wav --json
-
-# Batch pyannote VAD (10s sliding windows)
-.build/release/audio vad audio.wav
-```
-
-## Speaker Diarization — Who Spoke When
-
-### Diarization Pipeline
+### Speaker Diarization — [full guide →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// Or use CoreML embeddings (Neural Engine, frees GPU):
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) speakers detected")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### Speaker Embedding
+### Speech Enhancement — [full guide →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// Or: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: [Float] of length 256, L2-normalized
+import SpeechEnhancement
 
-// Compare speakers
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### Speaker Extraction
-
-Extract only a specific speaker's segments using a reference recording:
+### Voice Pipeline (ASR → LLM → TTS) — [full guide →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Sortformer Diarization (End-to-End, CoreML)
+`VoicePipeline` is the real-time voice-agent state machine (powered by [speech-core](https://github.com/soniqo/speech-core)) with VAD-driven turn detection, interruption handling, and eager STT. It connects any `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`.
 
-NVIDIA Sortformer predicts per-frame speaker activity for up to 4 speakers directly — no embedding or clustering needed. Runs on Neural Engine.
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### Diarization CLI
+### HTTP API server
 
 ```bash
-make build
-
-# Pyannote diarization (default)
-.build/release/audio diarize meeting.wav
-
-# Sortformer diarization (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# CoreML embeddings (Neural Engine, pyannote only)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# JSON output
-.build/release/audio diarize meeting.wav --json
-
-# Extract a specific speaker (pyannote only)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# Speaker embedding
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-See [Speaker Diarization](docs/inference/speaker-diarization.md) for architecture details.
-
-## Speech Enhancement — Noise Suppression and Audio Cleanup
-
-### Noise Suppression
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // for WAVWriter
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// Downloads ~4.3 MB on first run (Core ML FP16 model + auxiliary data)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### Denoise CLI
-
-```bash
-make build
-
-# Basic noise removal
-.build/release/audio denoise noisy.wav
-
-# Custom output path
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-See [Speech Enhancement](docs/inference/speech-enhancement.md) for architecture details.
-
-## Pipelines — Compose Multiple Models
-
-All models conform to shared protocols (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel`, etc.) and can be composed into pipelines:
-
-### Noisy Speech Recognition (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// Enhance at 48kHz, then transcribe at 16kHz
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### Voice-to-Voice Relay (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// Detect speech segments, transcribe, re-synthesize
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: 24kHz mono float samples
-}
-```
-
-### Meeting Transcription (Diarization + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Speaker \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-See [Shared Protocols](docs/shared-protocols.md) for the full protocol reference.
-
-## HTTP API Server
-
-A standalone HTTP server exposes all models via REST and WebSocket endpoints. Models are loaded lazily on first request.
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# Transcribe audio
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# Text-to-speech
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# Speech-to-speech (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# Speech enhancement
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# Preload all models on startup
-.build/release/audio-server --preload --port 8080
-```
-
-### WebSocket Streaming
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-The primary WebSocket endpoint implements the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) protocol — all messages are JSON with a `type` field, audio is base64-encoded PCM16 24kHz mono.
-
-**Client → Server events:**
-
-| Event | Description |
-|-------|-------------|
-| `session.update` | Configure engine, language, audio format |
-| `input_audio_buffer.append` | Send base64 PCM16 audio chunk |
-| `input_audio_buffer.commit` | Transcribe accumulated audio (ASR) |
-| `input_audio_buffer.clear` | Clear audio buffer |
-| `response.create` | Request TTS synthesis |
-
-**Server → Client events:**
-
-| Event | Description |
-|-------|-------------|
-| `session.created` | Session initialized |
-| `session.updated` | Configuration confirmed |
-| `input_audio_buffer.committed` | Audio committed for transcription |
-| `conversation.item.input_audio_transcription.completed` | ASR result |
-| `response.audio.delta` | Base64 PCM16 audio chunk (TTS) |
-| `response.audio.done` | Audio streaming complete |
-| `response.done` | Response complete with metadata |
-| `error` | Error with type and message |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: send audio, get transcription
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → receives: conversation.item.input_audio_transcription.completed
-
-// TTS: send text, get streamed audio
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → receives: response.audio.delta (base64 chunks), response.audio.done, response.done
-```
-
-An example HTML client is at `Examples/websocket-client.html` — open it in a browser while the server is running.
-
-The server is a separate `AudioServer` module and `audio-server` executable — it does not add Hummingbird/WebSocket to the main `audio` CLI.
-
-## Latency (M2 Max, 64 GB)
-
-### ASR
-
-| Model | Backend | RTF | 10s audio processed in |
-|-------|---------|-----|------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 cold, ~0.03 warm | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### Forced Alignment
-
-| Model | Framework | 20s audio | RTF |
-|-------|-----------|-----------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> Single non-autoregressive forward pass — no sampling loop. Audio encoder dominates (~328ms), decoder single-pass is ~37ms. **55x faster than real-time.**
-
-### TTS
-
-| Model | Framework | Short (1s) | Medium (3s) | Long (6s) | Streaming First-Packet |
-|-------|-----------|-----------|-------------|------------|----------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1-frame) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (non-autoregressive) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTS generates natural, expressive speech with prosody and emotion, running **faster than real-time** (RTF < 1.0). Streaming synthesis delivers the first audio chunk in ~120ms. Kokoro-82M runs entirely on Neural Engine with an end-to-end model (RTFx ~0.7), ideal for iOS. Apple's built-in TTS is faster but produces robotic, monotone speech.
-
-### PersonaPlex (Speech-to-Speech)
-
-| Model | Framework | ms/step | RTF | Notes |
-|-------|-----------|---------|-----|-------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | Recommended — coherent responses, 30% faster than 4-bit |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | Not recommended — garbled output quality |
-
-> **Use 8-bit.** INT8 is both faster (112 ms/step vs 158 ms/step) and produces coherent full-duplex responses. INT4 quantization degrades generation quality, producing incoherent speech ("I go tea my coffee brewing..."). INT8 runs at ~112ms/step on M2 Max — above the 80ms real-time threshold but close to usable for streaming, and the output quality difference is decisive.
-
-### VAD & Speaker Embedding
-
-| Model | Backend | Per-call Latency | RTF | Notes |
-|-------|---------|-----------------|-----|-------|
-| Silero-VAD-v5 | MLX | ~2.1ms / chunk | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / chunk | 0.008 | Neural Engine, **7.7x faster** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20s audio | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20s audio | 0.021 | Neural Engine, frees GPU |
-
-> Silero VAD CoreML runs on the Neural Engine at 7.7x the speed of MLX, making it ideal for always-on microphone input. WeSpeaker MLX is faster on GPU, but CoreML frees the GPU for concurrent workloads (TTS, ASR). Both backends produce equivalent results.
-
-### Speech Enhancement
-
-| Model | Backend | Duration | Latency | RTF |
-|-------|---------|----------|---------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Real-Time Factor (lower is better, < 1.0 = faster than real-time). GRU cost scales ~O(n²).
-
-### MLX vs CoreML
-
-Both backends produce equivalent results. Choose based on your workload:
-
-| | MLX | CoreML |
-|---|---|---|
-| **Hardware** | GPU (Metal shaders) | Neural Engine + CPU |
-| **Best for** | Maximum throughput, single-model workloads | Multi-model pipelines, background tasks |
-| **Power** | Higher GPU utilization | Lower power, frees GPU |
-| **Latency** | Faster for large models (WeSpeaker) | Faster for small models (Silero VAD) |
-
-**Desktop inference**: MLX is the default — fastest single-model performance on Apple Silicon. Switch to CoreML when running multiple models concurrently (e.g., VAD + ASR + TTS) to avoid GPU contention, or for battery-sensitive workloads on laptops.
-
-CoreML models are available for Qwen3-ASR encoder, Silero VAD, and WeSpeaker. For Qwen3-ASR, use `--engine qwen3-coreml` (hybrid: CoreML encoder on ANE + MLX text decoder on GPU). For VAD/embeddings, pass `engine: .coreml` at construction time — inference API is identical.
-
-## Accuracy Benchmarks
-
-### ASR — Word Error Rate ([details](docs/benchmarks/asr-wer.md))
-
-| Model | WER% (LibriSpeech test-clean) | RTF |
-|-------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit beats Whisper Large v3 Turbo (2.5%) at comparable size. Multilingual: 10 languages benchmarked on FLEURS.
-
-### TTS — Round-Trip Intelligibility ([details](docs/benchmarks/tts-roundtrip.md))
-
-| Engine | WER% | RTF |
-|--------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — Speech Detection ([details](docs/benchmarks/vad-detection.md))
-
-| Engine | F1% (FLEURS) | RTF |
-|--------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+Exposes every model via HTTP REST + WebSocket endpoints, including an OpenAI Realtime API-compatible WebSocket at `/v1/realtime`. See [`Sources/AudioServer/`](Sources/AudioServer/).
 
 ## Architecture
 
-**Models:** [ASR Model](docs/models/asr-model.md), [TTS Model](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift is split into one SPM target per model so consumers only pay for what they import. Shared infrastructure lives in `AudioCommon` (protocols, audio I/O, HuggingFace downloader, `SentencePieceModel`) and `MLXCommon` (weight loading, `QuantizedLinear` helpers, `SDPA` multi-head attention helper).
 
-**Inference:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Speaker Diarization](docs/inference/speaker-diarization.md), [Speech Enhancement](docs/inference/speech-enhancement.md)
+**[Full architecture diagram with backends, memory tables, and module map → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[API reference → soniqo.audio/api](https://soniqo.audio/api)** · **[Benchmarks → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**Audio:** [Streaming Playback](docs/audio/playback.md), [Voice Pipeline](docs/audio/voice-pipeline.md)
+Local docs (repo):
+- **Models:** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **Inference:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [Speaker Diarization](docs/inference/speaker-diarization.md) · [Speech Enhancement](docs/inference/speech-enhancement.md)
+- **Reference:** [Shared Protocols](docs/shared-protocols.md)
 
-**Benchmarks:** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD Detection](docs/benchmarks/vad-detection.md)
+## Cache configuration
 
-**Reference:** [Shared Protocols](docs/shared-protocols.md)
+Model weights download from HuggingFace on first use and cache to `~/Library/Caches/qwen3-speech/`. Override with `QWEN3_CACHE_DIR` (CLI) or `cacheDir:` (Swift API). All `fromPretrained()` entry points also accept `offlineMode: true` to skip network when weights are already cached.
 
-## Cache Configuration
+See [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md) for full details including sandboxed iOS container paths.
 
-Model weights are cached locally in `~/Library/Caches/qwen3-speech/`.
+## MLX Metal library
 
-**CLI** — override with an environment variable:
-
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
-
-**Swift API** — all `fromPretrained()` methods accept `cacheDir` and `offlineMode`:
-
-```swift
-// Custom cache directory (sandboxed apps, iOS containers)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// Offline mode — skip network when weights are already cached
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-See [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md) for full details.
-
-## MLX Metal Library
-
-If you see `Failed to load the default metallib` at runtime, the Metal shader library is missing. Run `make build` (or `./scripts/build_mlx_metallib.sh release` after a manual `swift build`) to compile it. If the Metal Toolchain is missing, install it first:
+If you see `Failed to load the default metallib` at runtime, the Metal shader library is missing. Run `make build` or `./scripts/build_mlx_metallib.sh release` after a manual `swift build`. If the Metal Toolchain is missing, install it first:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1249,117 +334,18 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## Testing
 
-Unit tests (config, sampling, text preprocessing, timestamp correction) run without model downloads:
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # full suite (unit + E2E with model downloads)
+swift test --skip E2E                # unit only (CI-safe, no downloads)
+swift test --filter Qwen3ASRTests    # specific module
 ```
 
-Integration tests require model weights (downloaded automatically on first run):
-
-```bash
-# TTS round-trip: synthesize text, save WAV, transcribe back with ASR
-swift test --filter TTSASRRoundTripTests
-
-# ASR only: transcribe test audio
-swift test --filter Qwen3ASRIntegrationTests
-
-# Forced Aligner E2E: word-level timestamps (~979 MB download)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E: speech-to-speech pipeline (~5.5 GB download)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **Note:** MLX Metal library must be built before running tests that use MLX operations.
-> See [MLX Metal Library](#mlx-metal-library) for instructions.
-
-## Supported Languages
-
-| Model | Languages |
-|-------|-----------|
-| Qwen3-ASR | 52 languages (CN, EN, Cantonese, DE, FR, ES, JA, KO, RU, + 22 Chinese dialects, ...) |
-| Parakeet TDT | 25 European languages (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1,672 languages** across 150+ families. Includes all of Meta's "served directly" set (~1,100) plus 500+ low-resource languages added via community data. Selected: EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (full list: [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)). The CTC head is language-agnostic — no language hint is required at inference time. |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ Beijing/Sichuan dialects via CustomVoice) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## How It Compares
-
-### Speech-to-Text (ASR): speech-swift vs Alternatives
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **Runtime** | On-device (MLX/CoreML) | On-device (CPU/GPU) | On-device or cloud | Cloud only |
-| **Languages** | 52 | 100+ | ~70 (on-device: limited) | 125+ |
-| **RTF (10s audio, M2 Max)** | 0.06 (17x real-time) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **Streaming** | No (batch) | No (batch) | Yes | Yes |
-| **Custom models** | Yes (swap HuggingFace weights) | Yes (GGML models) | No | No |
-| **Swift API** | Native async/await | C++ with Swift bridge | Native | REST/gRPC |
-| **Privacy** | Fully on-device | Fully on-device | Depends on config | Data sent to cloud |
-| **Word timestamps** | Yes (Forced Aligner) | Yes | Limited | Yes |
-| **Cost** | Free (Apache 2.0) | Free (MIT) | Free (on-device) | Pay per minute |
-
-### Text-to-Speech (TTS): speech-swift vs Alternatives
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / Cloud TTS** |
-|---|---|---|---|---|
-| **Quality** | Neural, expressive | Neural, natural | Robotic, monotone | Neural, highest quality |
-| **Runtime** | On-device (MLX) | On-device (CoreML) | On-device | Cloud only |
-| **Streaming** | Yes (~120ms first chunk) | No (single pass, ~45ms) | No | Yes |
-| **Voice cloning** | Yes | No | No | Yes |
-| **Voices** | 9 built-in + clone any | 50 preset voices | ~50 system voices | 1000+ |
-| **Languages** | 10 | 10 | 60+ | 30+ |
-| **iOS support** | macOS only | iOS + macOS | iOS + macOS | Any (API) |
-| **Cost** | Free (Apache 2.0) | Free (Apache 2.0) | Free | Pay per character |
-
-### When to Use speech-swift
-
-- **Privacy-critical apps** — medical, legal, enterprise where audio cannot leave the device
-- **Offline use** — no internet connection needed after initial model download
-- **Cost-sensitive** — no per-minute or per-character API charges
-- **Apple Silicon optimization** — built specifically for M-series GPU (Metal) and Neural Engine
-- **Full pipeline** — combine ASR + TTS + VAD + diarization + enhancement in a single Swift package
-
-## FAQ
-
-**Does speech-swift work on iOS?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3, and WeSpeaker all run on iOS 17+ via CoreML on the Neural Engine. MLX-based models (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex) require macOS 14+ on Apple Silicon.
-
-**Does it require an internet connection?**
-Only for the initial model download from HuggingFace (automatic, cached in `~/Library/Caches/qwen3-speech/`). After that, all inference runs fully offline with no network access.
-
-**How does speech-swift compare to Whisper?**
-Qwen3-ASR-0.6B achieves RTF 0.06 on M2 Max — 40% faster than Whisper-large-v3 via whisper.cpp (RTF 0.10) — with comparable accuracy across 52 languages. speech-swift provides a native Swift async/await API, while whisper.cpp requires a C++ bridge.
-
-**Can I use it in a commercial app?**
-Yes. speech-swift is licensed under Apache 2.0. The underlying model weights have their own licenses (check each model's HuggingFace page).
-
-**What Apple Silicon chips are supported?**
-All M-series chips: M1, M2, M3, M4 and their Pro/Max/Ultra variants. Requires macOS 14+ (Sonoma) or iOS 17+.
-
-**How much memory does it need?**
-From ~3 MB (Silero VAD) to ~6.5 GB (PersonaPlex 7B). Kokoro TTS uses ~500 MB, Qwen3-ASR ~2.2 GB. See the [Memory Requirements](#memory-requirements) table for full details.
-
-**Can I run multiple models simultaneously?**
-Yes. Use CoreML models on the Neural Engine alongside MLX models on the GPU to avoid contention — for example, Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX).
-
-**Is there a REST API?**
-Yes. The `audio-server` binary exposes all models via HTTP REST and WebSocket endpoints, including an OpenAI Realtime API-compatible WebSocket at `/v1/realtime`.
+E2E test classes use the `E2E` prefix so CI can filter them out with `--skip E2E`. See [CLAUDE.md](CLAUDE.md#testing) for the full testing convention.
 
 ## Contributing
 
-We welcome contributions! Whether it's a bug fix, new model integration, or documentation improvement — PRs are appreciated.
-
-**To get started:**
-1. Fork the repo and create a feature branch
-2. `make build` to compile (requires Xcode + Metal Toolchain)
-3. `make test` to run the test suite
-4. Open a PR against `main`
+PRs welcome — bug fixes, new model integrations, documentation. Fork, create a feature branch, `make build && make test`, open a PR against `main`.
 
 ## License
 
 Apache 2.0
-

--- a/README_de.md
+++ b/README_de.md
@@ -6,56 +6,48 @@ KI-Sprachmodelle für Apple Silicon, basierend auf MLX Swift und CoreML.
 
 Spracherkennung, -synthese und -verständnis auf dem Gerät für Mac und iOS. Läuft vollständig lokal auf Apple Silicon — keine Cloud, keine API-Schlüssel, keine Daten verlassen das Gerät.
 
-[Installation über Homebrew](#homebrew) oder als Swift-Package-Abhängigkeit.
+**[📚 Vollständige Dokumentation →](https://soniqo.audio)** · **[🤗 HuggingFace-Modelle](https://huggingface.co/aufklarer)** · **[📝 Blog](https://blog.ivan.digital)**
 
-**[Dokumentation](https://soniqo.audio)** · **[HuggingFace-Modelle](https://huggingface.co/aufklarer)** · **[Blog](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Sprache-zu-Text (automatische Spracherkennung, 52 Sprachen, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — Sprache-zu-Text über CoreML (Neural Engine, NVIDIA FastConformer + TDT-Decoder, 25 Sprachen)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Sprache-zu-Text (Meta wav2vec2 + CTC, **1.672 Sprachen** in 32 Schriften, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[Streaming-Diktat](https://soniqo.audio/guides/dictate)** — Echtzeit-Diktat mit Teilergebnissen und Äußerungsende-Erkennung (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — Wortgenaue Zeitstempel-Zuordnung (Audio + Text → Zeitstempel)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — Sprachsynthese (höchste Qualität, Streaming, benutzerdefinierte Sprecher, 10 Sprachen)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — Streaming-TTS mit Stimmklonen, Mehrsprecherdialog, Emotions-Tags (9 Sprachen)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — TTS auf dem Gerät (82M, CoreML/Neural Engine, 54 Stimmen, iOS-tauglich, 10 Sprachen)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — LLM-Chat auf dem Gerät (0.8B, MLX INT4 + CoreML INT8, DeltaNet-Hybrid, Token-Streaming)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — Vollduplex-Sprache-zu-Sprache (7B, Audio rein → Audio raus, 18 Stimmvoreinstellungen)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Echtzeit-Rauschunterdrückung (2,1M Parameter, 48 kHz)
+- **[VAD](https://soniqo.audio/guides/vad)** — Sprachaktivitätserkennung (Silero Streaming, Pyannote Offline, FireRedVAD 100+ Sprachen)
+- **[Sprecherdiarisierung](https://soniqo.audio/guides/diarize)** — Wer hat wann gesprochen (Pyannote-Pipeline, durchgängiger Sortformer auf der Neural Engine)
+- **[Sprechereinbettungen](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), CAM++ (192-dim)
 
-- **Qwen3-ASR** — Sprache-zu-Text / Spracherkennung (automatische Spracherkennung, 52 Sprachen)
-- **Parakeet TDT** — Sprache-zu-Text über CoreML (Neural Engine, NVIDIA FastConformer + TDT-Decoder, 25 Sprachen)
-- **Omnilingual ASR** — Sprache-zu-Text über CoreML (Meta wav2vec2 + CTC, **1.672 Sprachen** aus 150+ Sprachfamilien, 5/10 s Fenster, INT8 palettiert, ANE)
-- **Qwen3-ForcedAligner** — Wortgenaue Zeitstempel-Zuordnung (Audio + Text → Zeitstempel)
-- **Qwen3-TTS** — Sprachsynthese (höchste Qualität, Streaming, benutzerdefinierte Sprecher, 10 Sprachen)
-- **CosyVoice TTS** — Sprachsynthese mit Streaming, Stimmklonen, Mehrsprecherdialog und Emotions-Tags (9 Sprachen, DiT Flow Matching, CAM++ Sprecherencoder)
-- **Kokoro TTS** — Sprachsynthese auf dem Gerät (82M Parameter, CoreML/Neural Engine, 54 Stimmen, iOS-tauglich, 10 Sprachen)
-- **Qwen3-TTS CoreML** — Sprachsynthese (0.6B, CoreML-6-Modell-Pipeline, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** — LLM-Chat auf dem Gerät (0.8B, MLX + CoreML, INT4 + CoreML INT8, DeltaNet-Hybrid, Token-Streaming)
-- **PersonaPlex** — Vollduplex-Sprache-zu-Sprache-Konversation (7B, Audio rein → Audio raus, 18 Stimmvoreinstellungen)
-- **DeepFilterNet3** — Sprachverbesserung / Rauschunterdrückung (2,1M Parameter, Echtzeit 48kHz)
-- **FireRedVAD** — Offline-Sprachaktivitätserkennung (DFSMN, CoreML, 100+ Sprachen, 97,6% F1)
-- **Silero VAD** — Streaming-Sprachaktivitätserkennung (32ms-Blöcke, Latenz unter einer Millisekunde)
-- **Pyannote VAD** — Offline-Sprachaktivitätserkennung (10s-Fenster, Mehrsprecher-Überlappung)
-- **Sprecherdiarisierung** — Wer hat wann gesprochen (Pyannote-Segmentierung + aktivitätsbasierte Sprecherzuordnung, oder durchgängiger Sortformer auf der Neural Engine)
-- **Sprechereinbettungen** — Sprecherverifizierung und -identifikation (WeSpeaker ResNet34, 256-dimensionale Vektoren)
-
-Paper: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## Roadmap
-
-Siehe [Roadmap-Diskussion](https://github.com/soniqo/speech-swift/discussions/81) für geplante Funktionen — Kommentare und Vorschläge sind willkommen!
+Paper: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## Neuigkeiten
 
-- **20. März 2026** — [We Beat Whisper Large v3 with a 600M Model Running Entirely on Your Mac](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
-- **26. Feb. 2026** — [Speaker Diarization and Voice Activity Detection on Apple Silicon — Native Swift with MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
-- **23. Feb. 2026** — [NVIDIA PersonaPlex 7B on Apple Silicon — Full-Duplex Speech-to-Speech in Native Swift with MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
-- **12. Feb. 2026** — [Qwen3-ASR Swift: On-Device ASR + TTS for Apple Silicon — Architecture and Benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
+- **20. März 2026** — [Wir schlagen Whisper Large v3 mit einem 600M-Modell, das vollständig auf deinem Mac läuft](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
+- **26. Feb. 2026** — [Sprecherdiarisierung und Sprachaktivitätserkennung auf Apple Silicon — natives Swift mit MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
+- **23. Feb. 2026** — [NVIDIA PersonaPlex 7B auf Apple Silicon — Vollduplex-Sprache-zu-Sprache in nativem Swift mit MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
+- **12. Feb. 2026** — [Qwen3-ASR Swift: ASR + TTS auf dem Gerät für Apple Silicon — Architektur und Benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
 
 ## Schnellstart
 
-Fügen Sie das Paket zu Ihrer `Package.swift` hinzu:
+Füge das Paket zu deiner `Package.swift` hinzu:
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-Importieren Sie nur die Module, die Sie benötigen — jedes Modell ist eine eigene SPM-Bibliothek:
+Importiere nur die Module, die du benötigst — jedes Modell ist eine eigene SPM-Bibliothek, du zahlst nicht für das, was du nicht nutzt:
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
 .product(name: "SpeechUI",             package: "speech-swift"),  // optionale SwiftUI-Views
 ```
 
-**Audio-Buffer in 3 Zeilen transkribieren:**
+**Audio-Puffer in 3 Zeilen transkribieren:**
 
 ```swift
 import ParakeetStreamingASR
@@ -72,7 +64,7 @@ for await partial in model.transcribeStream(audio: samples, sampleRate: 16000) {
 }
 ```
 
-**SwiftUI-Diktatansicht in ~10 Zeilen:**
+**SwiftUI-Diktat-View in ~10 Zeilen:**
 
 ```swift
 import SwiftUI
@@ -96,128 +88,85 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI` enthält nur `TranscriptionView` (Endgültige + Teilergebnisse) und `TranscriptionStore` (Streaming-ASR-Adapter). Für Audio-Visualisierung und -Wiedergabe verwenden Sie AVFoundation.
+`SpeechUI` liefert nur `TranscriptionView` (finale + partielle Ergebnisse) und `TranscriptionStore` (Streaming-ASR-Adapter). Verwende AVFoundation für Audio-Visualisierung und Wiedergabe.
 
 Verfügbare SPM-Produkte: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modelle
 
-| Modell | Aufgabe | Streaming | Sprachen | Größen |
-|--------|---------|-----------|----------|--------|
-| Qwen3-ASR-0.6B | Sprache → Text | Nein | 52 Sprachen | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | Sprache → Text | Nein | 52 Sprachen | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | Sprache → Text | Nein | 25 europäische Sprachen | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | Sprache → Text | Ja (Streaming + EOU) | 25 europäische Sprachen | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | Sprache → Text | Nein (5/10 s Fenster) | [1.672 Sprachen](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | Sprache → Text | Nein | [1.672 Sprachen](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | Sprache → Text | Nein | [1.672 Sprachen](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | Sprache → Text | Nein | [1.672 Sprachen](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | Audio + Text → Zeitstempel | Nein | Mehrsprachig | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | Text → Sprache | Ja (~120ms) | 10 Sprachen | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | Text → Sprache | Ja (~120ms) | 10 Sprachen | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | Text → Sprache | Ja (~120ms) | 10 Sprachen | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | Text → Sprache | Ja (~150ms) | 9 Sprachen | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | Text → Sprache | Nein | 10 Sprachen | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | Sprache → Sprache | Ja (~2s-Blöcke) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | Sprachaktivitätserkennung | Nein (offline) | 100+ Sprachen | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | Sprachaktivitätserkennung | Ja (32ms-Blöcke) | Sprachunabhängig | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + Sprechersegmentierung | Nein (10s-Fenster) | Sprachunabhängig | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | Sprachverbesserung | Ja (10ms-Frames) | Sprachunabhängig | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | Sprechereinbettung (256-dim) | Nein | Sprachunabhängig | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | Sprechereinbettung (192-dim) | Nein | Sprachunabhängig | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | Sprecherdiarisierung (durchgängig) | Ja (blockweise) | Sprachunabhängig | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantisierungen, Download-URLs und Speichertabellen → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### Speicheranforderungen
-
-Gewichtsspeicher ist der GPU- (MLX) oder ANE-Speicher (CoreML), der von Modellparametern belegt wird. Spitzenverbrauch bei Inferenz umfasst KV-Caches, Aktivierungen und Zwischentensoren.
-
-| Modell | Gewichtsspeicher | Spitze bei Inferenz |
-|--------|-----------------|---------------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### Welches TTS-Modell für welchen Einsatz
-
-- **Qwen3-TTS**: Beste Qualität, Streaming (~120ms), 9 eingebaute Sprecher, 10 Sprachen, Stapelverarbeitung
-- **CosyVoice TTS**: Streaming (~150ms), 9 Sprachen, Stimmklonen (CAM++ Sprecherencoder), Mehrsprecherdialog (`[S1] ... [S2] ...`), Inline-Emotions-/Stil-Tags (`(happy)`, `(whispers)`), DiT Flow Matching + HiFi-GAN Vocoder
-- **Kokoro TTS**: Leichtgewichtige iOS-taugliche TTS (82M Parameter), CoreML/Neural Engine, 54 Stimmen, 10 Sprachen, End-to-End-Modell
-- **PersonaPlex**: Vollduplex-Sprache-zu-Sprache (Audio rein → Audio raus), Streaming (~2s-Blöcke), 18 Stimmvoreinstellungen, basiert auf der Moshi-Architektur
+| Modell | Aufgabe | Backends | Größen | Sprachen |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Sprache → Text | MLX, CoreML (hybrid) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Sprache → Text | CoreML (ANE) | 0.6B | 25 europäisch |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | Sprache → Text (Streaming) | CoreML (ANE) | 120M | 25 europäisch |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | Sprache → Text | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1.672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | Audio + Text → Zeitstempel | MLX, CoreML | 0.6B | Multi |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | Text → Sprache | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | Text → Sprache | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | Text → Sprache | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Text → Text (LLM) | MLX, CoreML | 0.8B | Multi |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | Sprache → Sprache | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | Sprachaktivitätserkennung | MLX, CoreML | 309K | Sprachunabhängig |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarisierung | MLX | 1.5M | Sprachunabhängig |
+| [Sortformer](https://soniqo.audio/guides/diarize) | Diarisierung (E2E) | CoreML (ANE) | — | Sprachunabhängig |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Sprachverbesserung | CoreML | 2.1M | Sprachunabhängig |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Sprechereinbettung | MLX, CoreML | 6.6M | Sprachunabhängig |
 
 ## Installation
 
 ### Homebrew
 
-Erfordert natives ARM Homebrew (`/opt/homebrew`). Rosetta/x86_64 Homebrew wird nicht unterstützt.
+Erfordert natives ARM-Homebrew (`/opt/homebrew`). Rosetta/x86_64-Homebrew wird nicht unterstützt.
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-Anschließend verwenden:
+Dann:
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (Neural Engine)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> Für interaktive Sprachkonversation mit Mikrofoneingabe siehe **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**.
+**[Vollständige CLI-Referenz →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-Zu `Package.swift` hinzufügen:
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-Das benötigte Modul importieren:
+Importiere nur, was du brauchst — jedes Modell hat sein eigenes SPM-Target:
 
 ```swift
-import Qwen3ASR      // Spracherkennung (MLX)
-import ParakeetASR   // Spracherkennung (CoreML)
-import Qwen3TTS      // Sprachsynthese (Qwen3)
-import CosyVoiceTTS  // Sprachsynthese (Streaming)
-import KokoroTTS     // Sprachsynthese (CoreML, iOS-tauglich)
-import Qwen3Chat     // LLM-Chat auf dem Gerät (CoreML)
-import PersonaPlex   // Sprache-zu-Sprache (Vollduplex)
-import SpeechVAD          // Sprachaktivitätserkennung (Pyannote + Silero)
-import SpeechEnhancement  // Rauschunterdrückung (DeepFilterNet3)
-import AudioCommon        // Gemeinsame Hilfsfunktionen
+import Qwen3ASR             // Spracherkennung (MLX)
+import ParakeetASR          // Spracherkennung (CoreML, Batch)
+import ParakeetStreamingASR // Streaming-Diktat mit Teilergebnissen + EOU
+import OmnilingualASR       // 1.672 Sprachen (CoreML + MLX)
+import Qwen3TTS             // Sprachsynthese
+import CosyVoiceTTS         // Sprachsynthese mit Stimmklonen
+import KokoroTTS            // Sprachsynthese (iOS-tauglich)
+import Qwen3Chat            // LLM-Chat auf dem Gerät
+import PersonaPlex          // Vollduplex-Sprache-zu-Sprache
+import SpeechVAD            // VAD + Sprecherdiarisierung + Einbettungen
+import SpeechEnhancement    // Rauschunterdrückung
+import SpeechUI             // SwiftUI-Komponenten für Streaming-Transkripte
+import AudioCommon          // Geteilte Protokolle und Utilities
 ```
 
 ### Voraussetzungen
 
-- Swift 5.9+
-- macOS 14+ oder iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (mit Metal Toolchain — bei Bedarf `xcodebuild -downloadComponent MetalToolchain` ausführen)
+- Swift 5.9+, Xcode 15+ (mit Metal Toolchain)
+- macOS 14+ oder iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
-### Aus Quellcode kompilieren
+### Aus dem Quellcode bauen
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-Dies kompiliert das Swift-Paket **und** die MLX-Metal-Shader-Bibliothek in einem Schritt. Die Metal-Bibliothek (`mlx.metallib`) wird für GPU-Inferenz benötigt — ohne sie erscheint zur Laufzeit der Fehler `Failed to load the default metallib`.
+`make build` kompiliert das Swift-Paket **und** die MLX-Metal-Shader-Bibliothek. Die Metal-Bibliothek ist für GPU-Inferenz erforderlich — ohne sie siehst du zur Laufzeit `Failed to load the default metallib`. `make debug` für Debug-Builds, `make test` für die Test-Suite.
 
-Für Debug-Builds: `make debug`. Um Unit-Tests auszuführen: `make test`.
-
-## Sprachassistent ausprobieren
-
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** ist ein sofort lauffähiger macOS-Sprachassistent — tippen zum Sprechen, Antworten in Echtzeit. Nutzt Mikrofoneingabe mit Silero VAD zur automatischen Spracherkennung, Qwen3-ASR für Transkription und PersonaPlex 7B für Sprache-zu-Sprache-Generierung. Mehrrundenkonversation mit 18 Stimmvoreinstellungen und Anzeige des inneren Monologs.
-
-```bash
-make build  # im Repo-Stammverzeichnis — kompiliert alles einschließlich MLX metallib
-cd Examples/PersonaPlexDemo
-# Siehe Examples/PersonaPlexDemo/README.md für Anweisungen zum .app-Bundle
-```
-
-> RTF ~0,94 auf M2 Max (schneller als Echtzeit). Modelle werden beim ersten Start automatisch heruntergeladen (~5,5 GB PersonaPlex + ~400 MB ASR).
+**[Vollständige Build- und Installationsanleitung →](https://soniqo.audio/getting-started)**
 
 ## Demo-Apps
 
-- **[DictateDemo](Examples/DictateDemo/)** ([Doku](https://soniqo.audio/guides/dictate/)) — macOS-Menueleisten-Streaming-Diktat mit Live-Teilergebnissen, VAD-gesteuerter Satzende-Erkennung und Ein-Klick-Kopieren. Laeuft als Hintergrund-Menueleisten-Agent (Parakeet-EOU-120M + Silero VAD).
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS-Echo-Demo (Parakeet ASR + Kokoro TTS, sprechen und zurückhören). Gerät und Simulator.
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Konversationeller Sprachassistent (Mikrofoneingabe, VAD, Mehrrunden). macOS.
-- **[SpeechDemo](Examples/SpeechDemo/)** — Diktat und Sprachsynthese in einer Tab-Oberfläche. macOS.
+- **[DictateDemo](Examples/DictateDemo/)** ([Docs](https://soniqo.audio/guides/dictate)) — macOS-Menüleisten-Streaming-Diktat mit Live-Teilergebnissen, VAD-basierter Äußerungsende-Erkennung und Ein-Klick-Kopieren. Läuft als Hintergrund-agent (Parakeet-EOU-120M + Silero VAD).
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS-Echo-Demo (Parakeet ASR + Kokoro TTS). Gerät und Simulator.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Konversationeller Sprachassistent mit Mikrofoneingang, VAD und Multi-Turn-Kontext. macOS. RTF ~0.94 auf M2 Max (schneller als Echtzeit).
+- **[SpeechDemo](Examples/SpeechDemo/)** — Diktat und TTS-Synthese in einer Tab-Oberfläche. macOS.
 
-Kompilieren und ausführen — siehe die README jeder Demo für Anleitungen.
+Die README jedes Demos enthält Bauanleitungen.
 
-## Sprache-zu-Text (ASR) — Audio in Swift transkribieren
+## Codebeispiele
 
-### Einfache Transkription
+Die folgenden Snippets zeigen den minimalen Pfad für jede Domäne. Jeder Abschnitt verlinkt auf eine vollständige Anleitung auf [soniqo.audio](https://soniqo.audio) mit Konfigurationsoptionen, mehreren Backends, Streaming-Mustern und CLI-Rezepten.
 
-```swift
-import Qwen3ASR
-
-// Standard: 0.6B-Modell
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// Oder das größere 1.7B-Modell für bessere Genauigkeit
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// Audio kann jede Abtastrate haben — wird intern automatisch auf 16kHz resampled
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### CoreML-Encoder (Neural Engine)
-
-Hybridmodus: CoreML-Encoder auf der Neural Engine + MLX-Textdecoder auf der GPU. Geringerer Stromverbrauch, entlastet die GPU beim Encoder-Durchlauf.
+### Sprache-zu-Text — [vollständige Anleitung →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-INT8- (180 MB, Standard) und INT4-Varianten (90 MB) verfügbar. INT8 empfohlen (Kosinusähnlichkeit > 0,999 gegenüber FP32).
+Alternative Backends: [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× Echtzeit), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1.672 Sprachen, CoreML oder MLX), [Streaming-Diktat](https://soniqo.audio/guides/dictate) (Live-Teilergebnisse).
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-Läuft auf der Neural Engine über CoreML — hält die GPU für gleichzeitige Aufgaben frei. 25 europäische Sprachen, ~315 MB.
-
-### ASR CLI
-
-```bash
-make build  # oder: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# Standard (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# 1.7B-Modell verwenden
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# CoreML-Encoder (Neural Engine + MLX-Decoder)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## Gezwungene Ausrichtung (Forced Alignment)
-
-### Wortgenaue Zeitstempel
+### Forced Alignment — [vollständige Anleitung →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// Lädt beim ersten Start ~979 MB herunter
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### Forced Alignment CLI
-
-```bash
-swift build -c release
-
-# Mit vorgegebenem Text ausrichten
-.build/release/audio align audio.wav --text "Hello world"
-
-# Erst transkribieren, dann ausrichten
-.build/release/audio align audio.wav
-```
-
-Ausgabe:
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-End-to-End-Modell, nicht-autoregressiv, keine Sampling-Schleife. Siehe [Forced Aligner](docs/inference/forced-aligner.md) für Architekturdetails.
-
-## Text-zu-Sprache (TTS) — Sprachsynthese in Swift
-
-### Einfache Synthese
+### Text-zu-Sprache — [vollständige Anleitung →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // für WAVWriter
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// Lädt beim ersten Start ~1,7 GB herunter (Modell- + Codec-Gewichte)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// Ausgabe: 24kHz Mono-Float-Samples
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### TTS CLI
+Alternative TTS-Engines: [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (Streaming + Stimmklonen + Emotions-Tags), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (iOS-tauglich, 54 Stimmen), [Stimmklonen](https://soniqo.audio/guides/voice-cloning).
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### Benutzerdefinierte Stimme / Sprecherauswahl
-
-Die **CustomVoice**-Modellvariante unterstützt 9 eingebaute Sprecherstimmen und natürlichsprachliche Anweisungen zur Steuerung von Ton und Stil. Laden Sie sie durch Angabe der CustomVoice-Modell-ID:
-
-```swift
-import Qwen3TTS
-
-// CustomVoice-Modell laden (lädt beim ersten Start ~1,7 GB herunter)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// Mit einem bestimmten Sprecher synthetisieren
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// Verfügbare Sprecher auflisten
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# CustomVoice-Modell mit einem Sprecher verwenden
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# Verfügbare Sprecher auflisten
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### Stimmklonen (Base-Modell)
-
-Klonen Sie die Stimme eines Sprechers aus einer Referenzaudiodatei. Zwei Modi:
-
-**ICL-Modus** (empfohlen) — kodiert Referenzaudio mit Transkript in Codec-Tokens. Höhere Qualität, zuverlässiges EOS:
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**X-Vektor-Modus** — nur Sprechereinbettung, kein Transkript nötig, aber geringere Qualität:
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### Ton- / Stilanweisungen (nur CustomVoice)
-
-Das CustomVoice-Modell akzeptiert einen natürlichsprachlichen `instruct`-Parameter zur Steuerung von Sprechstil, Ton, Emotion und Tempo. Die Anweisung wird dem Modellinput im ChatML-Format vorangestellt.
-
-```swift
-// Fröhlicher Ton
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// Langsam und ernst
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// Flüstern
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# Mit Stilanweisung
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# Standard-Instruct ("Speak naturally.") wird automatisch angewendet bei CustomVoice
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-Wenn bei dem CustomVoice-Modell kein `--instruct` angegeben wird, wird automatisch `"Speak naturally."` angewendet, um abschweifende Ausgabe zu vermeiden. Das Base-Modell unterstützt kein Instruct.
-
-### Stapelverarbeitung (Batch Synthesis)
-
-Mehrere Texte in einem einzelnen gebündelten Vorwärtsdurchlauf für höheren Durchsatz synthetisieren:
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] enthält 24kHz-Mono-Float-Samples für texts[i]
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### Batch CLI
-
-```bash
-# Datei mit einem Text pro Zeile erstellen
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# Erzeugt output_0.wav, output_1.wav, ...
-```
-
-> Der Stapelmodus amortisiert das Laden der Modellgewichte über die Elemente. Erwarten Sie eine ~1,5-2,5-fache Durchsatzverbesserung bei B=4 auf Apple Silicon. Beste Ergebnisse bei Texten mit ähnlicher Audiolänge.
-
-### Sampling-Optionen
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### Streaming-Synthese
-
-Audioblöcke inkrementell für niedrige First-Packet-Latenz ausgeben:
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // ~120ms bis zum ersten Audioblock
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: true beim letzten Block
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# Standard-Streaming (3-Frame erster Block, ~225ms Latenz)
-.build/release/audio speak "Hello world" --stream
-
-# Niedrige Latenz (1-Frame erster Block, ~120ms Latenz)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## Sprache-zu-Sprache — Vollduplex-Sprachkonversation
-
-> Für einen interaktiven Sprachassistenten mit Mikrofoneingabe siehe **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — tippen zum Sprechen, Mehrrundenkonversation mit automatischer Spracherkennung.
-
-### Sprache-zu-Sprache
+### Sprache-zu-Sprache — [vollständige Anleitung →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // für WAVWriter, AudioFileLoader
 
 let model = try await PersonaPlexModel.fromPretrained()
-// Lädt beim ersten Start ~5,5 GB herunter (Temporal 4-bit + Depformer + Mimi-Codec + Stimmvoreinstellungen)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: 24kHz-Mono-Float-Samples
-// textTokens: innerer Monolog des Modells (SentencePiece Token-IDs)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// 24 kHz Mono Float32-Ausgabe, bereit zur Wiedergabe
 ```
 
-### Innerer Monolog (Textausgabe)
-
-PersonaPlex erzeugt parallel zum Audio auch Text-Tokens — das interne Denken des Modells. Dekodieren Sie diese mit dem integrierten SentencePiece-Decoder:
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // z.B. "Sure, I can help you with that..."
-```
-
-### Streaming Sprache-zu-Sprache
-
-```swift
-// Audioblöcke empfangen, während sie erzeugt werden (~2s pro Block)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // sofort abspielen, 24kHz Mono
-    // chunk.textTokens enthält den Text dieses Blocks; letzter Block enthält alle Tokens
-    if chunk.isFinal { break }
-}
-```
-
-### Stimmauswahl
-
-18 Stimmvoreinstellungen verfügbar:
-- **Natürlich weiblich**: NATF0, NATF1, NATF2, NATF3
-- **Natürlich männlich**: NATM0, NATM1, NATM2, NATM3
-- **Vielfalt weiblich**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **Vielfalt männlich**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### Systemaufforderungen
-
-Die Systemaufforderung steuert das Gesprächsverhalten des Modells. Sie können eine beliebige benutzerdefinierte Aufforderung als Zeichenkette übergeben:
-
-```swift
-// Benutzerdefinierte Systemaufforderung (automatisch tokenisiert)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// Oder eine Voreinstellung verwenden
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-Verfügbare Voreinstellungen: `focused` (Standard), `assistant`, `customerService`, `teacher`.
-
-### PersonaPlex CLI
-
-```bash
-make build
-
-# Einfache Sprache-zu-Sprache
-.build/release/audio respond --input question.wav --output response.wav
-
-# Mit Transkript (dekodiert inneren Monolog)
-.build/release/audio respond --input question.wav --transcript
-
-# JSON-Ausgabe (Audiopfad, Transkript, Latenzmetriken)
-.build/release/audio respond --input question.wav --json
-
-# Benutzerdefinierter Systemaufforderungstext
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# Stimme und Systemaufforderungs-Voreinstellung wählen
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# Sampling-Parameter anpassen
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# Text-Entropie-Frühstopp aktivieren (stoppt bei Textkollaps)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# Verfügbare Stimmen und Aufforderungen auflisten
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — Streaming-Sprachsynthese mit Stimmklonen
-
-### Einfache Synthese
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // für WAVWriter
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// Lädt beim ersten Start ~1,9 GB herunter (LLM + DiT + HiFi-GAN-Gewichte)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// Ausgabe: 24kHz-Mono-Float-Samples
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### Streaming-Synthese
-
-```swift
-// Streaming: Audioblöcke empfangen, während sie erzeugt werden (~150ms bis zum ersten Block)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // sofort abspielen
-}
-```
-
-### Stimmklonen (CosyVoice)
-
-Klonen Sie eine Sprecherstimme mit dem CAM++ Sprecherencoder (192-dim, CoreML Neural Engine):
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// Lädt beim ersten Gebrauch das ~14 MB CAM++ CoreML-Modell herunter
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: [Float] der Länge 192
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CosyVoice TTS CLI
-
-```bash
-make build
-
-# Einfache Synthese
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# Stimmklonen (lädt CAM++ Sprecherencoder beim ersten Gebrauch herunter)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# Mehrsprecherdialog mit Stimmklonen
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# Inline-Emotions-/Stil-Tags
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# Kombiniert: Dialog + Emotionen + Stimmklonen
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# Benutzerdefinierte Stilanweisung
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# Streaming-Synthese
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — Leichtgewichtige Sprachsynthese auf dem Gerät (iOS + macOS)
-
-### Einfache Synthese
-
-```swift
-import KokoroTTS
-import AudioCommon  // für WAVWriter
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// Lädt beim ersten Start ~170 MB herunter (CoreML-Modelle + Stimmeinbettungen + Wörterbücher)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// Ausgabe: 24kHz-Mono-Float-Samples
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-54 voreingestellte Stimmen in 10 Sprachen. End-to-End-CoreML-Modell, nicht-autoregressiv, keine Sampling-Schleife. Läuft auf der Neural Engine, entlastet die GPU vollständig.
-
-### Kokoro TTS CLI
-
-```bash
-make build
-
-# Einfache Synthese
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# Sprache wählen
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# Verfügbare Stimmen auflisten
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-Autoregressive 6-Modell-Pipeline auf CoreML. W8A16-palettierte Gewichte.
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (LLM auf dem Gerät)
+### LLM-Chat — [vollständige Anleitung →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// Lädt beim ersten Start ~318 MB herunter (INT4 CoreML-Modell + Tokenizer)
-
-// Einzelne Antwort
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// Token-Streaming
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B INT4-quantisiert für CoreML. Läuft auf der Neural Engine mit ~2 Tok/s auf dem iPhone, ~15 Tok/s auf M-Serie. Unterstützt Mehrrunden-Konversation mit KV-Cache, Denkmodus (`<think>`-Tokens) und konfigurierbare Sampling-Parameter (Temperatur, Top-k, Top-p, Wiederholungsstrafe).
-
-## Sprachaktivitätserkennung (VAD) — Sprache in Audio erkennen
-
-### Streaming-VAD (Silero)
-
-Silero VAD v5 verarbeitet 32ms-Audioblöcke mit Latenz unter einer Millisekunde — ideal für Echtzeit-Spracherkennung von Mikrofonen oder Streams.
+### Sprachaktivitätserkennung — [vollständige Anleitung →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// Oder CoreML verwenden (Neural Engine, geringerer Stromverbrauch):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// Streaming: 512-Sample-Blöcke verarbeiten (32ms @ 16kHz)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // zwischen verschiedenen Audiostreams aufrufen
-
-// Oder alle Segmente auf einmal erkennen
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Sprache: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### Ereignisgesteuertes Streaming
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// Audio beliebiger Länge einspeisen — Ereignisse werden ausgelöst, wenn Sprache bestätigt wird
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Sprache begonnen um \(time)s")
-    case .speechEnded(let segment):
-        print("Sprache: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// Am Ende des Streams leeren
-let final = processor.flush()
-```
-
-### VAD CLI
-
-```bash
-make build
-
-# Streaming Silero VAD (32ms-Blöcke)
-.build/release/audio vad-stream audio.wav
-
-# CoreML-Backend (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# Mit benutzerdefinierten Schwellenwerten
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# JSON-Ausgabe
-.build/release/audio vad-stream audio.wav --json
-
-# Batch-Pyannote-VAD (10s gleitende Fenster)
-.build/release/audio vad audio.wav
-```
-
-## Sprecherdiarisierung — Wer hat wann gesprochen
-
-### Diarisierungs-Pipeline
+### Sprecherdiarisierung — [vollständige Anleitung →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// Oder CoreML-Einbettungen verwenden (Neural Engine, entlastet die GPU):
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Sprecher \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) Sprecher erkannt")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### Sprechereinbettung
+### Sprachverbesserung — [vollständige Anleitung →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// Oder: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: [Float] der Länge 256, L2-normalisiert
+import SpeechEnhancement
 
-// Sprecher vergleichen
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### Sprecherextraktion
-
-Nur die Segmente eines bestimmten Sprechers anhand einer Referenzaufnahme extrahieren:
+### Voice Pipeline (ASR → LLM → TTS) — [vollständige Anleitung →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Sortformer-Diarisierung (durchgängig, CoreML)
+`VoicePipeline` ist die Echtzeit-Voice-agent-Zustandsmaschine (angetrieben von [speech-core](https://github.com/soniqo/speech-core)) mit VAD-basierter Sprecherwechsel-Erkennung, Unterbrechungsbehandlung und eager STT. Sie verbindet beliebige `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`.
 
-NVIDIA Sortformer sagt die Sprecheraktivität pro Frame für bis zu 4 Sprecher direkt vorher — ohne Einbettung oder Clustering. Läuft auf der Neural Engine.
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Sprecher \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### Diarisierungs-CLI
+### HTTP-API-Server
 
 ```bash
-make build
-
-# Pyannote-Diarisierung (Standard)
-.build/release/audio diarize meeting.wav
-
-# Sortformer-Diarisierung (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# CoreML-Einbettungen (Neural Engine, nur Pyannote)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# JSON-Ausgabe
-.build/release/audio diarize meeting.wav --json
-
-# Bestimmten Sprecher extrahieren (nur Pyannote)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# Sprechereinbettung
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-Siehe [Sprecherdiarisierung](docs/inference/speaker-diarization.md) für Architekturdetails.
-
-## Sprachverbesserung — Rauschunterdrückung und Audiobereinigung
-
-### Rauschunterdrückung
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // für WAVWriter
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// Lädt beim ersten Start ~4,3 MB herunter (CoreML FP16-Modell + Hilfsdaten)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### Denoise CLI
-
-```bash
-make build
-
-# Einfache Rauschentfernung
-.build/release/audio denoise noisy.wav
-
-# Benutzerdefinierter Ausgabepfad
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-Siehe [Sprachverbesserung](docs/inference/speech-enhancement.md) für Architekturdetails.
-
-## Pipelines — Mehrere Modelle kombinieren
-
-Alle Modelle entsprechen gemeinsamen Protokollen (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel` usw.) und können zu Pipelines kombiniert werden:
-
-### Verrauschte Spracherkennung (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// Bei 48kHz verbessern, dann bei 16kHz transkribieren
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### Stimme-zu-Stimme-Weiterleitung (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// Sprachsegmente erkennen, transkribieren, neu synthetisieren
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: 24kHz-Mono-Float-Samples
-}
-```
-
-### Meeting-Transkription (Diarisierung + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Sprecher \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-Siehe [Gemeinsame Protokolle](docs/shared-protocols.md) für die vollständige Protokollreferenz.
-
-## HTTP-API-Server
-
-Ein eigenständiger HTTP-Server stellt alle Modelle über REST- und WebSocket-Endpunkte bereit. Modelle werden beim ersten Zugriff verzögert geladen.
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# Audio transkribieren
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# Text-zu-Sprache
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# Sprache-zu-Sprache (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# Sprachverbesserung
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# Alle Modelle beim Start vorladen
-.build/release/audio-server --preload --port 8080
-```
-
-### WebSocket-Streaming
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-Der primäre WebSocket-Endpunkt implementiert das [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime)-Protokoll — alle Nachrichten sind JSON mit einem `type`-Feld, Audio ist base64-kodiertes PCM16 24kHz Mono.
-
-**Client → Server-Ereignisse:**
-
-| Ereignis | Beschreibung |
-|----------|-------------|
-| `session.update` | Engine, Sprache, Audioformat konfigurieren |
-| `input_audio_buffer.append` | Base64-PCM16-Audioblock senden |
-| `input_audio_buffer.commit` | Angesammeltes Audio transkribieren (ASR) |
-| `input_audio_buffer.clear` | Audiopuffer leeren |
-| `response.create` | TTS-Synthese anfordern |
-
-**Server → Client-Ereignisse:**
-
-| Ereignis | Beschreibung |
-|----------|-------------|
-| `session.created` | Sitzung initialisiert |
-| `session.updated` | Konfiguration bestätigt |
-| `input_audio_buffer.committed` | Audio zur Transkription übermittelt |
-| `conversation.item.input_audio_transcription.completed` | ASR-Ergebnis |
-| `response.audio.delta` | Base64-PCM16-Audioblock (TTS) |
-| `response.audio.done` | Audio-Streaming abgeschlossen |
-| `response.done` | Antwort mit Metadaten abgeschlossen |
-| `error` | Fehler mit Typ und Nachricht |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: Audio senden, Transkription erhalten
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → empfängt: conversation.item.input_audio_transcription.completed
-
-// TTS: Text senden, gestreamtes Audio erhalten
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → empfängt: response.audio.delta (Base64-Blöcke), response.audio.done, response.done
-```
-
-Ein Beispiel-HTML-Client befindet sich unter `Examples/websocket-client.html` — öffnen Sie ihn im Browser, während der Server läuft.
-
-Der Server ist ein separates `AudioServer`-Modul und ein eigenständiges `audio-server`-Executable — er fügt dem Haupt-CLI `audio` kein Hummingbird/WebSocket hinzu.
-
-## Latenz (M2 Max, 64 GB)
-
-### ASR
-
-| Modell | Backend | RTF | 10s Audio verarbeitet in |
-|--------|---------|-----|--------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 kalt, ~0.03 warm | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### Gezwungene Ausrichtung (Forced Alignment)
-
-| Modell | Framework | 20s Audio | RTF |
-|--------|-----------|-----------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> Einzelner nicht-autoregressiver Vorwärtsdurchlauf — keine Sampling-Schleife. Der Audio-Encoder dominiert (~328ms), der Decoder-Einzeldurchlauf benötigt ~37ms. **55x schneller als Echtzeit.**
-
-### TTS
-
-| Modell | Framework | Kurz (1s) | Mittel (3s) | Lang (6s) | Streaming First-Packet |
-|--------|-----------|-----------|-------------|-----------|------------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1-Frame) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (nicht-autoregressiv) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTS erzeugt natürliche, ausdrucksstarke Sprache mit Prosodie und Emotion und läuft **schneller als Echtzeit** (RTF < 1.0). Streaming-Synthese liefert den ersten Audioblock in ~120ms. Kokoro-82M läuft vollständig auf der Neural Engine mit einem End-to-End-Modell (RTFx ~0.7), ideal für iOS. Apples eingebaute TTS ist schneller, erzeugt aber roboterhafte, monotone Sprache.
-
-### PersonaPlex (Sprache-zu-Sprache)
-
-| Modell | Framework | ms/Schritt | RTF | Anmerkungen |
-|--------|-----------|------------|-----|-------------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | Empfohlen — kohärente Antworten, 30% schneller als 4-bit |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | Nicht empfohlen — beeinträchtigte Ausgabequalität |
-
-> **8-bit verwenden.** INT8 ist sowohl schneller (112 ms/Schritt vs. 158 ms/Schritt) als auch erzeugt kohärente Vollduplex-Antworten. INT4-Quantisierung verschlechtert die Generierungsqualität und produziert unverständliche Sprache. INT8 läuft mit ~112ms/Schritt auf M2 Max.
-
-### VAD & Sprechereinbettung
-
-| Modell | Backend | Latenz pro Aufruf | RTF | Anmerkungen |
-|--------|---------|-------------------|-----|-------------|
-| Silero-VAD-v5 | MLX | ~2.1ms / Block | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / Block | 0.008 | Neural Engine, **7,7x schneller** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20s Audio | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20s Audio | 0.021 | Neural Engine, entlastet GPU |
-
-> Silero VAD CoreML läuft auf der Neural Engine mit 7,7-facher Geschwindigkeit gegenüber MLX und eignet sich damit ideal für Dauerüberwachung per Mikrofon. WeSpeaker MLX ist auf der GPU schneller, aber CoreML entlastet die GPU für gleichzeitige Aufgaben (TTS, ASR). Beide Backends liefern gleichwertige Ergebnisse.
-
-### Sprachverbesserung
-
-| Modell | Backend | Dauer | Latenz | RTF |
-|--------|---------|-------|--------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Echtzeitfaktor (niedriger ist besser, < 1.0 = schneller als Echtzeit). GRU-Kosten skalieren ~O(n^2).
-
-### MLX vs CoreML
-
-Beide Backends liefern gleichwertige Ergebnisse. Wählen Sie basierend auf Ihrem Anwendungsfall:
-
-| | MLX | CoreML |
-|---|---|---|
-| **Hardware** | GPU (Metal-Shader) | Neural Engine + CPU |
-| **Geeignet für** | Maximaler Durchsatz, Einzelmodell-Aufgaben | Mehrmodell-Pipelines, Hintergrundaufgaben |
-| **Stromverbrauch** | Höhere GPU-Auslastung | Geringerer Verbrauch, entlastet GPU |
-| **Latenz** | Schneller bei großen Modellen (WeSpeaker) | Schneller bei kleinen Modellen (Silero VAD) |
-
-**Desktop-Inferenz**: MLX ist der Standard — schnellste Einzelmodell-Leistung auf Apple Silicon. Wechseln Sie zu CoreML, wenn mehrere Modelle gleichzeitig laufen (z.B. VAD + ASR + TTS), um GPU-Konflikte zu vermeiden, oder für batteriesensible Aufgaben auf Laptops.
-
-CoreML-Modelle sind für den Qwen3-ASR-Encoder, Silero VAD und WeSpeaker verfügbar. Für Qwen3-ASR verwenden Sie `--engine qwen3-coreml` (Hybrid: CoreML-Encoder auf ANE + MLX-Textdecoder auf GPU). Für VAD/Einbettungen übergeben Sie `engine: .coreml` bei der Erstellung — die Inferenz-API ist identisch.
-
-## Genauigkeits-Benchmarks
-
-### ASR — Word Error Rate ([Details](docs/benchmarks/asr-wer.md))
-
-| Modell | WER% (LibriSpeech test-clean) | RTF |
-|--------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit übertrifft Whisper Large v3 Turbo (2,5%) bei vergleichbarer Größe. Mehrsprachig: 10 Sprachen auf FLEURS gemessen.
-
-### TTS — Round-Trip-Verständlichkeit ([Details](docs/benchmarks/tts-roundtrip.md))
-
-| Engine | WER% | RTF |
-|--------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — Spracherkennung ([Details](docs/benchmarks/vad-detection.md))
-
-| Engine | F1% (FLEURS) | RTF |
-|--------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+Stellt jedes Modell über HTTP-REST- + WebSocket-Endpunkte bereit, einschließlich eines mit OpenAI Realtime API kompatiblen WebSocket unter `/v1/realtime`. Siehe [`Sources/AudioServer/`](Sources/AudioServer/).
 
 ## Architektur
 
-**Modelle:** [ASR-Modell](docs/models/asr-model.md), [TTS-Modell](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift ist in ein SPM-Target pro Modell aufgeteilt, sodass Konsumenten nur für das bezahlen, was sie importieren. Geteilte Infrastruktur lebt in `AudioCommon` (Protokolle, Audio-I/O, HuggingFace-Downloader, `SentencePieceModel`) und `MLXCommon` (Gewichtsladen, `QuantizedLinear`-Helfer, `SDPA`-Multi-Head-Attention-Helfer).
 
-**Inferenz:** [ASR-Inferenz](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS-Inferenz](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Sprecherdiarisierung](docs/inference/speaker-diarization.md), [Sprachverbesserung](docs/inference/speech-enhancement.md), [Audio-Wiedergabe](docs/audio/playback.md)
+**[Vollständiges Architekturdiagramm mit Backends, Speichertabellen und Modulkarte → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[API-Referenz → soniqo.audio/api](https://soniqo.audio/api)** · **[Benchmarks → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**Benchmarks:** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD-Erkennung](docs/benchmarks/vad-detection.md)
-
-**Referenz:** [Gemeinsame Protokolle](docs/shared-protocols.md)
+Lokale Docs (Repo):
+- **Modelle:** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **Inferenz:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [Sprecherdiarisierung](docs/inference/speaker-diarization.md) · [Sprachverbesserung](docs/inference/speech-enhancement.md)
+- **Referenz:** [Geteilte Protokolle](docs/shared-protocols.md)
 
 ## Cache-Konfiguration
 
-Modellgewichte werden lokal in `~/Library/Caches/qwen3-speech/` zwischengespeichert.
+Modellgewichte werden beim ersten Gebrauch von HuggingFace heruntergeladen und in `~/Library/Caches/qwen3-speech/` zwischengespeichert. Überschreibe mit `QWEN3_CACHE_DIR` (CLI) oder `cacheDir:` (Swift-API). Alle `fromPretrained()`-Einstiegspunkte akzeptieren `offlineMode: true`, um das Netzwerk zu überspringen, wenn die Gewichte bereits im Cache sind.
 
-**CLI** — Verzeichnis per Umgebungsvariable ändern:
+Siehe [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md) für vollständige Details einschließlich sandboxed iOS-Container-Pfade.
 
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
+## MLX-Metal-Bibliothek
 
-**Swift API** — alle `fromPretrained()`-Methoden unterstützen `cacheDir` und `offlineMode`:
-
-```swift
-// Benutzerdefiniertes Cache-Verzeichnis (Sandbox-Apps, iOS-Container)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// Offline-Modus — Netzwerk überspringen wenn Gewichte bereits im Cache
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-Details unter [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md).
-
-## MLX Metal-Bibliothek
-
-Falls zur Laufzeit `Failed to load the default metallib` erscheint, fehlt die Metal-Shader-Bibliothek. Führen Sie `make build` aus (oder `./scripts/build_mlx_metallib.sh release` nach einem manuellen `swift build`), um sie zu kompilieren. Falls die Metal Toolchain fehlt, installieren Sie diese zuerst:
+Wenn du zur Laufzeit `Failed to load the default metallib` siehst, fehlt die Metal-Shader-Bibliothek. Führe nach einem manuellen `swift build` `make build` oder `./scripts/build_mlx_metallib.sh release` aus. Falls das Metal Toolchain fehlt, installiere es zuerst:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## Tests
 
-Unit-Tests (Konfiguration, Sampling, Textvorverarbeitung, Zeitstempelkorrektur) laufen ohne Modell-Downloads:
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # Vollständige Suite (Unit + E2E mit Modell-Downloads)
+swift test --skip E2E                # Nur Unit (CI-sicher, keine Downloads)
+swift test --filter Qwen3ASRTests    # Bestimmtes Modul
 ```
 
-Integrationstests erfordern Modellgewichte (werden beim ersten Start automatisch heruntergeladen):
-
-```bash
-# TTS Round-Trip: Text synthetisieren, WAV speichern, mit ASR zurück transkribieren
-swift test --filter TTSASRRoundTripTests
-
-# Nur ASR: Test-Audio transkribieren
-swift test --filter Qwen3ASRIntegrationTests
-
-# Forced Aligner E2E: Wortgenaue Zeitstempel (~979 MB Download)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E: Sprache-zu-Sprache-Pipeline (~5,5 GB Download)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **Hinweis:** Die MLX-Metal-Bibliothek muss vor der Ausführung von Tests, die MLX-Operationen verwenden, kompiliert sein.
-> Siehe [MLX Metal-Bibliothek](#mlx-metal-bibliothek) für Anweisungen.
-
-## Unterstützte Sprachen
-
-| Modell | Sprachen |
-|--------|----------|
-| Qwen3-ASR | 52 Sprachen (CN, EN, Kantonesisch, DE, FR, ES, JA, KO, RU, + 22 chinesische Dialekte, ...) |
-| Parakeet TDT | 25 europäische Sprachen (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1.672 Sprachen** aus über 150 Sprachfamilien. Umfasst Metas gesamten "direkt bedienten" Satz (~1.100) sowie 500+ ressourcenarme Sprachen, die durch Community-Daten hinzugefügt wurden. Auswahl: EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (vollständige Liste: [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)). Der CTC-Kopf ist sprachagnostisch — zur Inferenzzeit ist kein Sprachhinweis erforderlich. |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ Peking-/Sichuan-Dialekte über CustomVoice) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## Im Vergleich
-
-### Sprache-zu-Text (ASR): speech-swift vs. Alternativen
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **Laufzeitumgebung** | Auf dem Gerät (MLX/CoreML) | Auf dem Gerät (CPU/GPU) | Auf dem Gerät oder Cloud | Nur Cloud |
-| **Sprachen** | 52 | 100+ | ~70 (auf dem Gerät: eingeschränkt) | 125+ |
-| **RTF (10s Audio, M2 Max)** | 0.06 (17x Echtzeit) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **Streaming** | Nein (Batch) | Nein (Batch) | Ja | Ja |
-| **Eigene Modelle** | Ja (HuggingFace-Gewichte austauschen) | Ja (GGML-Modelle) | Nein | Nein |
-| **Swift-API** | Natives async/await | C++ mit Swift-Bridge | Nativ | REST/gRPC |
-| **Datenschutz** | Vollständig auf dem Gerät | Vollständig auf dem Gerät | Abhängig von Konfiguration | Daten werden an Cloud gesendet |
-| **Wortzeitstempel** | Ja (Forced Aligner) | Ja | Eingeschränkt | Ja |
-| **Kosten** | Kostenlos (Apache 2.0) | Kostenlos (MIT) | Kostenlos (auf dem Gerät) | Bezahlung pro Minute |
-
-### Text-zu-Sprache (TTS): speech-swift vs. Alternativen
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / Cloud TTS** |
-|---|---|---|---|---|
-| **Qualität** | Neural, ausdrucksstark | Neural, natürlich | Roboterhaft, monoton | Neural, höchste Qualität |
-| **Laufzeitumgebung** | Auf dem Gerät (MLX) | Auf dem Gerät (CoreML) | Auf dem Gerät | Nur Cloud |
-| **Streaming** | Ja (~120ms erster Block) | Nein (End-to-End-Modell) | Nein | Ja |
-| **Stimmklonen** | Ja | Nein | Nein | Ja |
-| **Stimmen** | 9 eingebaut + beliebige klonen | 54 voreingestellte Stimmen | ~50 Systemstimmen | 1000+ |
-| **Sprachen** | 10 | 10 | 60+ | 30+ |
-| **iOS-Unterstützung** | Nur macOS | iOS + macOS | iOS + macOS | Beliebig (API) |
-| **Kosten** | Kostenlos (Apache 2.0) | Kostenlos (Apache 2.0) | Kostenlos | Bezahlung pro Zeichen |
-
-### Wann speech-swift verwenden
-
-- **Datenschutzkritische Apps** — Medizin, Recht, Unternehmen, wo Audio das Gerät nicht verlassen darf
-- **Offline-Nutzung** — nach dem erstmaligen Modell-Download keine Internetverbindung erforderlich
-- **Kostensensibel** — keine Gebühren pro Minute oder pro Zeichen
-- **Apple-Silicon-Optimierung** — speziell für M-Serie-GPU (Metal) und Neural Engine entwickelt
-- **Vollständige Pipeline** — ASR + TTS + VAD + Diarisierung + Verbesserung in einem einzigen Swift-Paket kombinieren
-
-## FAQ
-
-**Funktioniert speech-swift auf iOS?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3 und WeSpeaker laufen alle auf iOS 17+ über CoreML auf der Neural Engine. MLX-basierte Modelle (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex) erfordern macOS 14+ auf Apple Silicon.
-
-**Wird eine Internetverbindung benötigt?**
-Nur für den erstmaligen Modell-Download von HuggingFace (automatisch, zwischengespeichert in `~/Library/Caches/qwen3-speech/`). Danach läuft alle Inferenz vollständig offline ohne Netzwerkzugriff.
-
-**Wie schneidet speech-swift im Vergleich zu Whisper ab?**
-Qwen3-ASR-0.6B erreicht RTF 0,06 auf M2 Max — 40% schneller als Whisper-large-v3 über whisper.cpp (RTF 0,10) — bei vergleichbarer Genauigkeit in 52 Sprachen. speech-swift bietet eine native Swift-async/await-API, während whisper.cpp eine C++-Bridge erfordert.
-
-**Kann ich es in einer kommerziellen App verwenden?**
-Ja. speech-swift ist unter Apache 2.0 lizenziert. Die zugrunde liegenden Modellgewichte haben eigene Lizenzen (siehe die HuggingFace-Seite jedes Modells).
-
-**Welche Apple-Silicon-Chips werden unterstützt?**
-Alle M-Serie-Chips: M1, M2, M3, M4 und deren Pro/Max/Ultra-Varianten. Erfordert macOS 14+ (Sonoma) oder iOS 17+.
-
-**Wie viel Speicher wird benötigt?**
-Von ~3 MB (Silero VAD) bis ~6,5 GB (PersonaPlex 7B). Kokoro TTS benötigt ~500 MB, Qwen3-ASR ~2,2 GB. Siehe die Tabelle [Speicheranforderungen](#speicheranforderungen) für alle Details.
-
-**Können mehrere Modelle gleichzeitig laufen?**
-Ja. Verwenden Sie CoreML-Modelle auf der Neural Engine zusammen mit MLX-Modellen auf der GPU, um Konflikte zu vermeiden — zum Beispiel Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX).
-
-**Gibt es eine REST-API?**
-Ja. Das `audio-server`-Binary stellt alle Modelle über HTTP-REST- und WebSocket-Endpunkte bereit, einschließlich eines OpenAI-Realtime-API-kompatiblen WebSocket unter `/v1/realtime`.
+E2E-Testklassen verwenden das Präfix `E2E`, damit CI sie mit `--skip E2E` ausfiltern kann. Siehe [CLAUDE.md](CLAUDE.md#testing) für die vollständige Testkonvention.
 
 ## Mitwirken
 
-Wir freuen uns über Beiträge! Ob Fehlerbehebung, neue Modellintegration oder Verbesserung der Dokumentation — Pull Requests sind willkommen.
-
-**So starten Sie:**
-1. Forken Sie das Repository und erstellen Sie einen Feature-Branch
-2. `make build` zum Kompilieren (erfordert Xcode + Metal Toolchain)
-3. `make test` zum Ausführen der Testsuite
-4. Öffnen Sie einen PR gegen `main`
+PRs willkommen — Bugfixes, neue Modellintegrationen, Dokumentation. Fork, Feature-Branch anlegen, `make build && make test`, PR gegen `main` eröffnen.
 
 ## Lizenz
 

--- a/README_es.md
+++ b/README_es.md
@@ -6,56 +6,48 @@ Modelos de IA de voz para Apple Silicon, impulsados por MLX Swift y CoreML.
 
 Reconocimiento, síntesis y comprensión de voz en el dispositivo para Mac e iOS. Se ejecuta localmente en Apple Silicon — sin nube, sin claves de API, ningún dato sale del dispositivo.
 
-[Instala mediante Homebrew](#homebrew) o añádelo como dependencia de Swift Package.
+**[📚 Documentación completa →](https://soniqo.audio)** · **[🤗 Modelos en HuggingFace](https://huggingface.co/aufklarer)** · **[📝 Blog](https://blog.ivan.digital)**
 
-**[Documentación](https://soniqo.audio)** · **[Modelos en HuggingFace](https://huggingface.co/aufklarer)** · **[Blog](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Voz a texto (reconocimiento automático del habla, 52 idiomas, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — Voz a texto vía CoreML (Neural Engine, NVIDIA FastConformer + decodificador TDT, 25 idiomas)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Voz a texto (Meta wav2vec2 + CTC, **1.672 idiomas** en 32 escrituras, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[Dictado en streaming](https://soniqo.audio/guides/dictate)** — Dictado en tiempo real con resultados parciales y detección de fin de enunciado (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — Alineación de marcas temporales a nivel de palabra (audio + texto → marcas temporales)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — Síntesis de texto a voz (máxima calidad, streaming, hablantes personalizados, 10 idiomas)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — TTS con streaming, clonación de voz, diálogo multi-hablante y etiquetas de emoción (9 idiomas)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — TTS en el dispositivo (82M, CoreML/Neural Engine, 54 voces, listo para iOS, 10 idiomas)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — Chat LLM en el dispositivo (0.8B, MLX INT4 + CoreML INT8, DeltaNet híbrido, tokens en streaming)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — Voz a voz full-duplex (7B, audio de entrada → audio de salida, 18 presets de voz)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Supresión de ruido en tiempo real (2.1M parámetros, 48 kHz)
+- **[VAD](https://soniqo.audio/guides/vad)** — Detección de actividad vocal (Silero streaming, Pyannote offline, FireRedVAD 100+ idiomas)
+- **[Diarización de hablantes](https://soniqo.audio/guides/diarize)** — Quién habló cuándo (pipeline Pyannote, Sortformer de extremo a extremo en Neural Engine)
+- **[Embeddings de hablante](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), CAM++ (192 dim)
 
-- **Qwen3-ASR** — Voz a texto / reconocimiento de voz (reconocimiento automático del habla, 52 idiomas)
-- **Parakeet TDT** — Voz a texto vía CoreML (Neural Engine, NVIDIA FastConformer + decodificador TDT, 25 idiomas)
-- **Omnilingual ASR** — Voz a texto vía CoreML (Meta wav2vec2 + CTC, **1.672 idiomas** en más de 150 familias, ventanas de 5/10 s, INT8 paletizado, ANE)
-- **Qwen3-ForcedAligner** — Alineación de marcas temporales a nivel de palabra (audio + texto → marcas temporales)
-- **Qwen3-TTS** — Síntesis de texto a voz (máxima calidad, streaming, hablantes personalizados, 10 idiomas)
-- **CosyVoice TTS** — Texto a voz con streaming, clonación de voz, diálogo multi-hablante y etiquetas de emoción (9 idiomas, DiT flow matching, codificador de hablante CAM++)
-- **Kokoro TTS** — Texto a voz en el dispositivo (82M parámetros, CoreML/Neural Engine, 54 voces, listo para iOS, 10 idiomas)
-- **Qwen3-TTS CoreML** — Texto a voz (0.6B, pipeline CoreML de 6 modelos, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** — Chat LLM en el dispositivo (0.8B, MLX + CoreML, INT4 + CoreML INT8, DeltaNet hibrido, tokens en streaming)
-- **PersonaPlex** — Conversación de voz a voz en full-duplex (7B, audio de entrada → audio de salida, 18 presets de voz)
-- **DeepFilterNet3** — Mejora de voz / supresión de ruido (2.1M parámetros, tiempo real 48kHz)
-- **FireRedVAD** — Detección de actividad vocal offline (DFSMN, CoreML, más de 100 idiomas, 97.6% F1)
-- **Silero VAD** — Detección de actividad vocal en streaming (fragmentos de 32ms, latencia sub-milisegundo)
-- **Pyannote VAD** — Detección de actividad vocal offline (ventanas de 10s, superposición de múltiples hablantes)
-- **Speaker Diarization** — Quién habló cuándo (segmentación Pyannote + encadenamiento de hablantes basado en actividad, o Sortformer de extremo a extremo en Neural Engine)
-- **Speaker Embeddings** — Verificación e identificación de hablantes (WeSpeaker ResNet34, vectores de 256 dimensiones)
-
-Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## Hoja de ruta
-
-Consulta la [discusión sobre la hoja de ruta](https://github.com/soniqo/speech-swift/discussions/81) para ver lo planificado — ¡comentarios y sugerencias son bienvenidos!
+Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## Novedades
 
-- **20 Mar 2026** — [We Beat Whisper Large v3 with a 600M Model Running Entirely on Your Mac](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
-- **26 Feb 2026** — [Speaker Diarization and Voice Activity Detection on Apple Silicon — Native Swift with MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
-- **23 Feb 2026** — [NVIDIA PersonaPlex 7B on Apple Silicon — Full-Duplex Speech-to-Speech in Native Swift with MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
-- **12 Feb 2026** — [Qwen3-ASR Swift: On-Device ASR + TTS for Apple Silicon — Architecture and Benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
+- **20 mar 2026** — [Superamos a Whisper Large v3 con un modelo de 600M ejecutándose completamente en tu Mac](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
+- **26 feb 2026** — [Diarización de hablantes y detección de actividad vocal en Apple Silicon — Swift nativo con MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
+- **23 feb 2026** — [NVIDIA PersonaPlex 7B en Apple Silicon — Voz a voz full-duplex en Swift nativo con MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
+- **12 feb 2026** — [Qwen3-ASR Swift: ASR + TTS en el dispositivo para Apple Silicon — Arquitectura y benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
 
 ## Inicio rápido
 
-Agrega el paquete a tu `Package.swift`:
+Añade el paquete a tu `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-Importa solo los módulos que necesites — cada modelo es su propia biblioteca SPM:
+Importa solo los módulos que necesites — cada modelo es una librería SPM independiente, así no pagas por lo que no uses:
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
 .product(name: "SpeechUI",             package: "speech-swift"),  // vistas SwiftUI opcionales
 ```
 
-**Transcribir un buffer de audio en 3 líneas:**
+**Transcribe un buffer de audio en 3 líneas:**
 
 ```swift
 import ParakeetStreamingASR
@@ -96,126 +88,83 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI` incluye solo `TranscriptionView` (finales + parciales) y `TranscriptionStore` (adaptador para ASR en streaming). Usa AVFoundation para visualización y reproducción de audio.
+`SpeechUI` solo incluye `TranscriptionView` (finales + parciales) y `TranscriptionStore` (adaptador de ASR en streaming). Usa AVFoundation para la visualización y reproducción de audio.
 
 Productos SPM disponibles: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modelos
 
-| Modelo | Tarea | Streaming | Idiomas | Tamaños |
-|--------|-------|-----------|---------|---------|
-| Qwen3-ASR-0.6B | Voz → Texto | No | 52 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | Voz → Texto | No | 52 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | Voz → Texto | No | 25 idiomas europeos | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | Voz → Texto | Sí (streaming + EOU) | 25 idiomas europeos | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | Voz → Texto | No (ventana de 5/10 s) | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | Voz → Texto | No | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | Voz → Texto | No | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | Voz → Texto | No | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | Audio + Texto → Marcas temporales | No | Multi | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | Texto → Voz | Sí (~120ms) | 10 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | Texto → Voz | Sí (~120ms) | 10 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | Texto → Voz | Sí (~120ms) | 10 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | Texto → Voz | Sí (~150ms) | 9 idiomas | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | Texto → Voz | No | 10 idiomas | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | Voz → Voz | Sí (~2s fragmentos) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | Detección de actividad vocal | No (offline) | Más de 100 idiomas | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | Detección de actividad vocal | Sí (fragmentos de 32ms) | Independiente del idioma | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + Segmentación de hablantes | No (ventanas de 10s) | Independiente del idioma | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | Mejora de voz | Sí (tramas de 10ms) | Independiente del idioma | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | Embedding de hablante (256-dim) | No | Independiente del idioma | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | Embedding de hablante (192-dim) | No | Independiente del idioma | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | Diarización de hablantes (extremo a extremo) | Sí (fragmentado) | Independiente del idioma | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, cuantizaciones, URLs de descarga y tablas de memoria → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### Requisitos de memoria
-
-La memoria de pesos es la memoria de GPU (MLX) o ANE (CoreML) consumida por los parámetros del modelo. La inferencia pico incluye cachés KV, activaciones y tensores intermedios.
-
-| Modelo | Memoria de pesos | Inferencia pico |
-|--------|-----------------|-----------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### Cuándo usar cada TTS
-
-- **Qwen3-TTS**: Mejor calidad, streaming (~120ms), 9 hablantes integrados, 10 idiomas, síntesis por lotes
-- **CosyVoice TTS**: Streaming (~150ms), 9 idiomas, clonación de voz (codificador de hablante CAM++), diálogo multi-hablante (`[S1] ... [S2] ...`), etiquetas de emoción/estilo en línea (`(happy)`, `(whispers)`), DiT flow matching + vocoder HiFi-GAN
-- **Kokoro TTS**: TTS ligero listo para iOS (82M parámetros), CoreML/Neural Engine, 54 voces, 10 idiomas, modelo de extremo a extremo
-- **PersonaPlex**: Voz a voz en full-duplex (audio de entrada → audio de salida), streaming (~2s fragmentos), 18 presets de voz, basado en la arquitectura Moshi
+| Modelo | Tarea | Backends | Tamaños | Idiomas |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Voz → Texto | MLX, CoreML (híbrido) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Voz → Texto | CoreML (ANE) | 0.6B | 25 europeos |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | Voz → Texto (streaming) | CoreML (ANE) | 120M | 25 europeos |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | Voz → Texto | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1.672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | Audio + Texto → Marcas temp. | MLX, CoreML | 0.6B | Multi |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | Texto → Voz | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | Texto → Voz | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | Texto → Voz | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Texto → Texto (LLM) | MLX, CoreML | 0.8B | Multi |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | Voz → Voz | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | Detección de actividad vocal | MLX, CoreML | 309K | Agnóstico |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarización | MLX | 1.5M | Agnóstico |
+| [Sortformer](https://soniqo.audio/guides/diarize) | Diarización (E2E) | CoreML (ANE) | — | Agnóstico |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Mejora de voz | CoreML | 2.1M | Agnóstico |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Embedding de hablante | MLX, CoreML | 6.6M | Agnóstico |
 
 ## Instalación
 
 ### Homebrew
 
-Requiere Homebrew nativo ARM (`/opt/homebrew`). Homebrew bajo Rosetta/x86_64 no es compatible.
+Requiere Homebrew ARM nativo (`/opt/homebrew`). Homebrew Rosetta/x86_64 no está soportado.
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-Luego usa:
+Luego:
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (Motor Neural)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> Para conversación de voz interactiva con entrada de micrófono, consulta **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**.
+**[Referencia completa de la CLI →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-Añádelo a tu `Package.swift`:
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-Importa el módulo que necesites:
+Importa solo lo que necesites — cada modelo es su propio target SPM:
 
 ```swift
-import Qwen3ASR      // Reconocimiento de voz (MLX)
-import ParakeetASR   // Reconocimiento de voz (CoreML)
-import Qwen3TTS      // Texto a voz (Qwen3)
-import CosyVoiceTTS  // Texto a voz (streaming)
-import KokoroTTS     // Texto a voz (CoreML, listo para iOS)
-import Qwen3Chat     // Chat LLM en el dispositivo (CoreML)
-import PersonaPlex   // Voz a voz (full-duplex)
-import SpeechVAD          // Detección de actividad vocal (pyannote + Silero)
-import SpeechEnhancement  // Supresión de ruido (DeepFilterNet3)
-import AudioCommon        // Utilidades compartidas
+import Qwen3ASR             // Reconocimiento de voz (MLX)
+import ParakeetASR          // Reconocimiento de voz (CoreML, batch)
+import ParakeetStreamingASR // Dictado en streaming con parciales + EOU
+import OmnilingualASR       // 1.672 idiomas (CoreML + MLX)
+import Qwen3TTS             // Síntesis de voz
+import CosyVoiceTTS         // Síntesis de voz con clonación
+import KokoroTTS            // Síntesis de voz (listo para iOS)
+import Qwen3Chat            // Chat LLM en el dispositivo
+import PersonaPlex          // Voz a voz full-duplex
+import SpeechVAD            // VAD + diarización + embeddings
+import SpeechEnhancement    // Supresión de ruido
+import SpeechUI             // Componentes SwiftUI para transcripciones en streaming
+import AudioCommon          // Protocolos y utilidades compartidas
 ```
 
 ### Requisitos
 
-- Swift 5.9+
-- macOS 14+ o iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (con Metal Toolchain — ejecuta `xcodebuild -downloadComponent MetalToolchain` si falta)
+- Swift 5.9+, Xcode 15+ (con Metal Toolchain)
+- macOS 14+ o iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
 ### Compilar desde el código fuente
 
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-Esto compila el paquete Swift **y** la biblioteca de shaders Metal de MLX en un solo paso. La biblioteca Metal (`mlx.metallib`) es necesaria para la inferencia en GPU — sin ella obtendrás `Failed to load the default metallib` en tiempo de ejecución.
+`make build` compila el paquete Swift **y** la librería de shaders MLX Metal. La librería Metal es necesaria para la inferencia en GPU — sin ella verás `Failed to load the default metallib` en tiempo de ejecución. `make debug` para builds de depuración, `make test` para la suite de pruebas.
 
-Para compilaciones de depuración: `make debug`. Para ejecutar pruebas unitarias: `make test`.
-
-## Prueba el asistente de voz
-
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** es un asistente de voz para macOS listo para ejecutar — toca para hablar y obtén respuestas habladas en tiempo real. Utiliza entrada de micrófono con Silero VAD para detección automática del habla, Qwen3-ASR para transcripción y PersonaPlex 7B para generación de voz a voz. Conversación multi-turno con 18 presets de voz y visualización de la transcripción del monólogo interno.
-
-```bash
-make build  # desde la raíz del repositorio — compila todo incluyendo el metallib de MLX
-cd Examples/PersonaPlexDemo
-# Consulta Examples/PersonaPlexDemo/README.md para instrucciones del bundle .app
-```
-
-> RTF ~0.94 en M2 Max (más rápido que tiempo real). Los modelos se descargan automáticamente en la primera ejecución (~5.5 GB PersonaPlex + ~400 MB ASR).
+**[Guía completa de compilación e instalación →](https://soniqo.audio/getting-started)**
 
 ## Aplicaciones de demostración
 
-- **[DictateDemo](Examples/DictateDemo/)** ([docs](https://soniqo.audio/guides/dictate/)) — Dictado en streaming en la barra de menus de macOS con parciales en vivo, deteccion de fin de enunciado por VAD y copia con un clic. Se ejecuta como agente de barra de menus en segundo plano (Parakeet-EOU-120M + Silero VAD).
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — Demo de eco para iOS (Parakeet ASR + Kokoro TTS, habla y escucha la respuesta). Dispositivo y simulador.
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Asistente de voz conversacional (entrada de micrófono, VAD, multi-turno). macOS.
-- **[SpeechDemo](Examples/SpeechDemo/)** — Dictado y síntesis de texto a voz en una interfaz con pestañas. macOS.
+- **[DictateDemo](Examples/DictateDemo/)** ([documentación](https://soniqo.audio/guides/dictate)) — Dictado en streaming en la barra de menús de macOS con parciales en vivo, detección de fin de enunciado basada en VAD y copia con un clic. Se ejecuta como agent en segundo plano (Parakeet-EOU-120M + Silero VAD).
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — Demo de eco iOS (Parakeet ASR + Kokoro TTS). Dispositivo y simulador.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Asistente de voz conversacional con entrada de micrófono, VAD y contexto multi-turno. macOS. RTF ~0.94 en M2 Max (más rápido que tiempo real).
+- **[SpeechDemo](Examples/SpeechDemo/)** — Dictado y síntesis TTS en una interfaz de pestañas. macOS.
 
-Compila y ejecuta — consulta el README de cada demo para instrucciones.
+El README de cada demo tiene instrucciones de compilación.
 
-## Voz a texto (ASR) — Transcribir audio en Swift
+## Ejemplos de código
 
-### Transcripción básica
+Los fragmentos siguientes muestran el camino mínimo para cada dominio. Cada sección enlaza a una guía completa en [soniqo.audio](https://soniqo.audio) con opciones de configuración, múltiples backends, patrones de streaming y recetas de CLI.
 
-```swift
-import Qwen3ASR
-
-// Por defecto: modelo 0.6B
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// O usa el modelo más grande 1.7B para mejor precisión
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// El audio puede tener cualquier tasa de muestreo — se remuestrea automáticamente a 16kHz internamente
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### Codificador CoreML (Neural Engine)
-
-Modo híbrido: codificador CoreML en Neural Engine + decodificador de texto MLX en GPU. Menor consumo energético, libera la GPU para el paso del codificador.
+### Voz a texto — [guía completa →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-Variantes INT8 (180 MB, por defecto) e INT4 (90 MB) disponibles. Se recomienda INT8 (similitud coseno > 0.999 respecto a FP32).
+Backends alternativos: [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× tiempo real), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1.672 idiomas, CoreML o MLX), [Dictado en streaming](https://soniqo.audio/guides/dictate) (parciales en vivo).
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-Se ejecuta en el Neural Engine vía CoreML — libera la GPU para cargas de trabajo simultáneas. 25 idiomas europeos, ~315 MB.
-
-### CLI de ASR
-
-```bash
-make build  # o: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# Por defecto (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# Usar el modelo 1.7B
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# Codificador CoreML (Neural Engine + decodificador MLX)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## Alineación forzada
-
-### Marcas temporales a nivel de palabra
+### Alineación forzada — [guía completa →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// Descarga ~979 MB en la primera ejecución
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### CLI de alineación forzada
-
-```bash
-swift build -c release
-
-# Alinear con texto proporcionado
-.build/release/audio align audio.wav --text "Hello world"
-
-# Transcribir primero, luego alinear
-.build/release/audio align audio.wav
-```
-
-Salida:
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-Modelo de extremo a extremo, no autorregresivo, sin bucle de muestreo. Consulta [Forced Aligner](docs/inference/forced-aligner.md) para detalles de la arquitectura.
-
-## Texto a voz (TTS) — Generar voz en Swift
-
-### Síntesis básica
+### Texto a voz — [guía completa →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // para WAVWriter
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// Descarga ~1.7 GB en la primera ejecución (modelo + pesos del códec)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// La salida son muestras float mono a 24kHz
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### CLI de TTS
+Motores TTS alternativos: [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (streaming + clonación + etiquetas de emoción), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (listo para iOS, 54 voces), [Clonación de voz](https://soniqo.audio/guides/voice-cloning).
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### Voz personalizada / Selección de hablante
-
-La variante del modelo **CustomVoice** admite 9 voces de hablantes integradas e instrucciones en lenguaje natural para controlar tono y estilo. Cárgalo pasando el ID del modelo CustomVoice:
-
-```swift
-import Qwen3TTS
-
-// Cargar el modelo CustomVoice (descarga ~1.7 GB en la primera ejecución)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// Sintetizar con un hablante específico
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// Listar hablantes disponibles
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# Usar el modelo CustomVoice con un hablante
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# Listar hablantes disponibles
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### Clonación de voz (modelo Base)
-
-Clona la voz de un hablante a partir de un archivo de audio de referencia. Dos modos:
-
-**Modo ICL** (recomendado) — codifica el audio de referencia en tokens de códec con transcripción. Mayor calidad, EOS fiable:
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**Modo X-vector** — solo embedding del hablante, no necesita transcripción pero menor calidad:
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### Instrucciones de tono / estilo (solo CustomVoice)
-
-El modelo CustomVoice acepta un parámetro `instruct` en lenguaje natural para controlar el estilo de habla, tono, emoción y ritmo. La instrucción se antepone a la entrada del modelo en formato ChatML.
-
-```swift
-// Tono alegre
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// Lento y serio
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// Susurrando
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# Con instrucción de estilo
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# La instrucción por defecto ("Speak naturally.") se aplica automáticamente al usar CustomVoice
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-Cuando no se proporciona `--instruct` con el modelo CustomVoice, se aplica `"Speak naturally."` automáticamente para evitar salida divagante. El modelo Base no admite instruct.
-
-### Síntesis por lotes
-
-Sintetiza múltiples textos en un solo paso forward por lotes para mayor rendimiento:
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] son muestras float mono a 24kHz para texts[i]
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### CLI por lotes
-
-```bash
-# Crea un archivo con un texto por línea
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# Produce output_0.wav, output_1.wav, ...
-```
-
-> El modo por lotes amortiza las cargas de pesos del modelo entre elementos. Se espera una mejora de rendimiento de ~1.5-2.5x para B=4 en Apple Silicon. Mejores resultados cuando los textos producen audio de duración similar.
-
-### Opciones de muestreo
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### Síntesis en streaming
-
-Emite fragmentos de audio incrementalmente para baja latencia del primer paquete:
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // ~120ms hasta el primer fragmento de audio
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: true en el último fragmento
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# Streaming por defecto (primer fragmento de 3 tramas, ~225ms de latencia)
-.build/release/audio speak "Hello world" --stream
-
-# Baja latencia (primer fragmento de 1 trama, ~120ms de latencia)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## Voz a voz — Conversación de voz en full-duplex
-
-> Para un asistente de voz interactivo con entrada de micrófono, consulta **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — toca para hablar, conversación multi-turno con detección automática del habla.
-
-### Voz a voz
+### Voz a voz — [guía completa →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // para WAVWriter, AudioFileLoader
 
 let model = try await PersonaPlexModel.fromPretrained()
-// Descarga ~5.5 GB en la primera ejecución (temporal 4-bit + depformer + códec Mimi + presets de voz)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: muestras float mono a 24kHz
-// textTokens: monólogo interno del modelo (IDs de tokens SentencePiece)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// Salida Float32 mono 24 kHz lista para reproducir
 ```
 
-### Monólogo interno (salida de texto)
-
-PersonaPlex genera tokens de texto junto con el audio — el razonamiento interno del modelo. Decodifícalos con el decodificador SentencePiece integrado:
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // ej. "Sure, I can help you with that..."
-```
-
-### Voz a voz en streaming
-
-```swift
-// Recibe fragmentos de audio conforme se generan (~2s por fragmento)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // reproduce inmediatamente, mono 24kHz
-    // chunk.textTokens tiene el texto de este fragmento; el fragmento final tiene todos los tokens
-    if chunk.isFinal { break }
-}
-```
-
-### Selección de voz
-
-18 presets de voz disponibles:
-- **Natural Femenina**: NATF0, NATF1, NATF2, NATF3
-- **Natural Masculina**: NATM0, NATM1, NATM2, NATM3
-- **Variedad Femenina**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **Variedad Masculina**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### Prompts de sistema
-
-El prompt de sistema guía el comportamiento conversacional del modelo. Puedes pasar cualquier prompt personalizado como una cadena de texto:
-
-```swift
-// Prompt de sistema personalizado (tokenizado automáticamente)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// O usar un preset
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-Presets disponibles: `focused` (por defecto), `assistant`, `customerService`, `teacher`.
-
-### CLI de PersonaPlex
-
-```bash
-make build
-
-# Voz a voz básico
-.build/release/audio respond --input question.wav --output response.wav
-
-# Con transcripción (decodifica el texto del monólogo interno)
-.build/release/audio respond --input question.wav --transcript
-
-# Salida JSON (ruta del audio, transcripción, métricas de latencia)
-.build/release/audio respond --input question.wav --json
-
-# Texto de prompt de sistema personalizado
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# Elegir una voz y preset de prompt de sistema
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# Ajustar parámetros de muestreo
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# Activar parada temprana por entropía de texto (detiene si el texto colapsa)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# Listar voces y prompts disponibles
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — Texto a voz en streaming con clonación de voz
-
-### Síntesis básica
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // para WAVWriter
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// Descarga ~1.9 GB en la primera ejecución (pesos LLM + DiT + HiFi-GAN)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// La salida son muestras float mono a 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### Síntesis en streaming
-
-```swift
-// Streaming: recibe fragmentos de audio conforme se generan (~150ms hasta el primer fragmento)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // reproduce inmediatamente
-}
-```
-
-### Clonación de voz (CosyVoice)
-
-Clona la voz de un hablante usando el codificador de hablante CAM++ (192-dim, CoreML Neural Engine):
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// Descarga ~14 MB del modelo CoreML CAM++ en el primer uso
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: [Float] de longitud 192
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CLI de CosyVoice TTS
-
-```bash
-make build
-
-# Síntesis básica
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# Clonación de voz (descarga el codificador de hablante CAM++ en el primer uso)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# Diálogo multi-hablante con clonación de voz
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# Etiquetas de emoción/estilo en línea
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# Combinado: diálogo + emociones + clonación de voz
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# Instrucción de estilo personalizada
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# Síntesis en streaming
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — Texto a voz ligero en el dispositivo (iOS + macOS)
-
-### Síntesis básica
-
-```swift
-import KokoroTTS
-import AudioCommon  // para WAVWriter
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// Descarga ~170 MB en la primera ejecución (modelos CoreML + embeddings de voz + diccionarios)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// La salida son muestras float mono a 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-54 voces preconfiguradas en 10 idiomas. Modelo CoreML de extremo a extremo, no autorregresivo, sin bucle de muestreo. Se ejecuta en el Neural Engine, libera completamente la GPU.
-
-### CLI de Kokoro TTS
-
-```bash
-make build
-
-# Síntesis básica
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# Elegir idioma
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# Listar voces disponibles
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-Pipeline autorregresivo de 6 modelos ejecutandose en CoreML. Pesos paletizados W8A16.
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (LLM en el dispositivo)
+### Chat LLM — [guía completa →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// Descarga ~318 MB en la primera ejecución (modelo CoreML INT4 + tokenizador)
-
-// Respuesta única
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// Tokens en streaming
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B cuantizado a INT4 para CoreML. Se ejecuta en el Neural Engine con ~2 tok/s en iPhone, ~15 tok/s en chips M-series. Admite conversación multi-turno con caché KV, modo de razonamiento (tokens `<think>`), y muestreo configurable (temperature, top-k, top-p, repetition penalty).
-
-## Detección de actividad vocal (VAD) — Detectar voz en audio
-
-### VAD en streaming (Silero)
-
-Silero VAD v5 procesa fragmentos de audio de 32ms con latencia sub-milisegundo — ideal para detección de voz en tiempo real desde micrófonos o flujos de audio.
+### Detección de actividad vocal — [guía completa →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// O usa CoreML (Neural Engine, menor consumo):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// Streaming: procesa fragmentos de 512 muestras (32ms @ 16kHz)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // llamar entre diferentes flujos de audio
-
-// O detecta todos los segmentos de una vez
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Speech: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### Streaming basado en eventos
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// Alimenta audio de cualquier longitud — los eventos se emiten cuando se confirma el habla
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Speech started at \(time)s")
-    case .speechEnded(let segment):
-        print("Speech: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// Vaciar al final del flujo
-let final = processor.flush()
-```
-
-### CLI de VAD
-
-```bash
-make build
-
-# Silero VAD en streaming (fragmentos de 32ms)
-.build/release/audio vad-stream audio.wav
-
-# Backend CoreML (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# Con umbrales personalizados
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# Salida JSON
-.build/release/audio vad-stream audio.wav --json
-
-# VAD por lotes con Pyannote (ventanas deslizantes de 10s)
-.build/release/audio vad audio.wav
-```
-
-## Diarización de hablantes — Quién habló cuándo
-
-### Pipeline de diarización
+### Diarización de hablantes — [guía completa →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// O usa embeddings CoreML (Neural Engine, libera la GPU):
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) speakers detected")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### Embedding de hablante
+### Mejora de voz — [guía completa →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// O: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: [Float] de longitud 256, normalizado L2
+import SpeechEnhancement
 
-// Comparar hablantes
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### Extracción de hablante
-
-Extrae solo los segmentos de un hablante específico usando una grabación de referencia:
+### Pipeline de voz (ASR → LLM → TTS) — [guía completa →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Diarización con Sortformer (extremo a extremo, CoreML)
+`VoicePipeline` es la máquina de estados de agent de voz en tiempo real (impulsada por [speech-core](https://github.com/soniqo/speech-core)) con detección de turnos basada en VAD, manejo de interrupciones y STT eager. Conecta cualquier `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`.
 
-NVIDIA Sortformer predice la actividad de hablante por trama para hasta 4 hablantes directamente — sin necesidad de embedding ni clustering. Se ejecuta en el Neural Engine.
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### CLI de diarización
+### Servidor API HTTP
 
 ```bash
-make build
-
-# Diarización con Pyannote (por defecto)
-.build/release/audio diarize meeting.wav
-
-# Diarización con Sortformer (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# Embeddings CoreML (Neural Engine, solo pyannote)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# Salida JSON
-.build/release/audio diarize meeting.wav --json
-
-# Extraer un hablante específico (solo pyannote)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# Embedding de hablante
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-Consulta [Speaker Diarization](docs/inference/speaker-diarization.md) para detalles de la arquitectura.
-
-## Mejora de voz — Supresión de ruido y limpieza de audio
-
-### Supresión de ruido
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // para WAVWriter
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// Descarga ~4.3 MB en la primera ejecución (modelo Core ML FP16 + datos auxiliares)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### CLI de eliminación de ruido
-
-```bash
-make build
-
-# Eliminación básica de ruido
-.build/release/audio denoise noisy.wav
-
-# Ruta de salida personalizada
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-Consulta [Speech Enhancement](docs/inference/speech-enhancement.md) para detalles de la arquitectura.
-
-## Pipelines — Componer múltiples modelos
-
-Todos los modelos se ajustan a protocolos compartidos (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel`, etc.) y pueden componerse en pipelines:
-
-### Reconocimiento de voz ruidosa (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// Mejorar a 48kHz, luego transcribir a 16kHz
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### Relé de voz a voz (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// Detectar segmentos de voz, transcribir, re-sintetizar
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: muestras float mono a 24kHz
-}
-```
-
-### Transcripción de reuniones (Diarización + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Speaker \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-Consulta [Shared Protocols](docs/shared-protocols.md) para la referencia completa de protocolos.
-
-## Servidor HTTP API
-
-Un servidor HTTP independiente expone todos los modelos mediante endpoints REST y WebSocket. Los modelos se cargan bajo demanda en la primera solicitud.
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# Transcribir audio
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# Texto a voz
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# Voz a voz (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# Mejora de voz
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# Precargar todos los modelos al inicio
-.build/release/audio-server --preload --port 8080
-```
-
-### Streaming por WebSocket
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-El endpoint principal de WebSocket implementa el protocolo [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) — todos los mensajes son JSON con un campo `type`, el audio es PCM16 24kHz mono codificado en base64.
-
-**Eventos del cliente al servidor:**
-
-| Evento | Descripción |
-|--------|-------------|
-| `session.update` | Configurar motor, idioma, formato de audio |
-| `input_audio_buffer.append` | Enviar fragmento de audio PCM16 en base64 |
-| `input_audio_buffer.commit` | Transcribir audio acumulado (ASR) |
-| `input_audio_buffer.clear` | Limpiar búfer de audio |
-| `response.create` | Solicitar síntesis TTS |
-
-**Eventos del servidor al cliente:**
-
-| Evento | Descripción |
-|--------|-------------|
-| `session.created` | Sesión inicializada |
-| `session.updated` | Configuración confirmada |
-| `input_audio_buffer.committed` | Audio enviado para transcripción |
-| `conversation.item.input_audio_transcription.completed` | Resultado de ASR |
-| `response.audio.delta` | Fragmento de audio PCM16 en base64 (TTS) |
-| `response.audio.done` | Streaming de audio completado |
-| `response.done` | Respuesta completa con metadatos |
-| `error` | Error con tipo y mensaje |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: enviar audio, obtener transcripción
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → recibe: conversation.item.input_audio_transcription.completed
-
-// TTS: enviar texto, obtener audio en streaming
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → recibe: response.audio.delta (fragmentos base64), response.audio.done, response.done
-```
-
-Un cliente HTML de ejemplo se encuentra en `Examples/websocket-client.html` — ábrelo en un navegador mientras el servidor está en ejecución.
-
-El servidor es un módulo separado `AudioServer` y un ejecutable `audio-server` — no añade Hummingbird/WebSocket al CLI principal `audio`.
-
-## Latencia (M2 Max, 64 GB)
-
-### ASR
-
-| Modelo | Backend | RTF | 10s de audio procesados en |
-|--------|---------|-----|---------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 frío, ~0.03 caliente | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### Alineación forzada
-
-| Modelo | Framework | 20s de audio | RTF |
-|--------|-----------|-------------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> Un solo paso forward no autorregresivo — sin bucle de muestreo. El codificador de audio domina (~328ms), el paso único del decodificador es ~37ms. **55x más rápido que tiempo real.**
-
-### TTS
-
-| Modelo | Framework | Corto (1s) | Medio (3s) | Largo (6s) | Primer paquete en streaming |
-|--------|-----------|-----------|------------|-----------|---------------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1-frame) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (no autorregresivo) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTS genera voz natural y expresiva con prosodia y emoción, ejecutándose **más rápido que tiempo real** (RTF < 1.0). La síntesis en streaming entrega el primer fragmento de audio en ~120ms. Kokoro-82M se ejecuta completamente en el Neural Engine con un modelo de extremo a extremo (RTFx ~0.7), ideal para iOS. El TTS integrado de Apple es más rápido pero produce voz robótica y monótona.
-
-### PersonaPlex (voz a voz)
-
-| Modelo | Framework | ms/paso | RTF | Notas |
-|--------|-----------|---------|-----|-------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | Recomendado — respuestas coherentes, 30% mas rapido que 4-bit |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | No recomendado — calidad de salida degradada |
-
-> **Use 8-bit.** INT8 es mas rapido (112 ms/paso vs. 158 ms/paso) y produce respuestas full-duplex coherentes. La cuantizacion INT4 degrada la calidad de generacion, produciendo habla incoherente. INT8 se ejecuta a ~112ms/paso en M2 Max.
-
-### VAD y embedding de hablante
-
-| Modelo | Backend | Latencia por llamada | RTF | Notas |
-|--------|---------|---------------------|-----|-------|
-| Silero-VAD-v5 | MLX | ~2.1ms / fragmento | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / fragmento | 0.008 | Neural Engine, **7.7x más rápido** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20s de audio | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20s de audio | 0.021 | Neural Engine, libera la GPU |
-
-> Silero VAD CoreML se ejecuta en el Neural Engine a 7.7x la velocidad de MLX, lo que lo hace ideal para entrada de micrófono siempre activa. WeSpeaker MLX es más rápido en GPU, pero CoreML libera la GPU para cargas de trabajo simultáneas (TTS, ASR). Ambos backends producen resultados equivalentes.
-
-### Mejora de voz
-
-| Modelo | Backend | Duración | Latencia | RTF |
-|--------|---------|----------|----------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Factor de Tiempo Real (menor es mejor, < 1.0 = más rápido que tiempo real). El coste de GRU escala ~O(n^2).
-
-### MLX vs CoreML
-
-Ambos backends producen resultados equivalentes. Elige según tu carga de trabajo:
-
-| | MLX | CoreML |
-|---|---|---|
-| **Hardware** | GPU (shaders Metal) | Neural Engine + CPU |
-| **Ideal para** | Máximo rendimiento, cargas de un solo modelo | Pipelines multi-modelo, tareas en segundo plano |
-| **Consumo** | Mayor uso de GPU | Menor consumo, libera la GPU |
-| **Latencia** | Más rápido para modelos grandes (WeSpeaker) | Más rápido para modelos pequeños (Silero VAD) |
-
-**Inferencia en escritorio**: MLX es el predeterminado — el rendimiento más rápido para un solo modelo en Apple Silicon. Cambia a CoreML cuando ejecutes múltiples modelos simultáneamente (ej., VAD + ASR + TTS) para evitar contención de GPU, o para cargas de trabajo sensibles a la batería en portátiles.
-
-Los modelos CoreML están disponibles para el codificador Qwen3-ASR, Silero VAD y WeSpeaker. Para Qwen3-ASR, usa `--engine qwen3-coreml` (híbrido: codificador CoreML en ANE + decodificador de texto MLX en GPU). Para VAD/embeddings, pasa `engine: .coreml` al construir — la API de inferencia es idéntica.
-
-## Benchmarks de precisión
-
-### ASR — Tasa de error de palabras ([detalles](docs/benchmarks/asr-wer.md))
-
-| Modelo | WER% (LibriSpeech test-clean) | RTF |
-|--------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit supera a Whisper Large v3 Turbo (2.5%) con un tamaño comparable. Multilingüe: 10 idiomas evaluados en FLEURS.
-
-### TTS — Inteligibilidad de ida y vuelta ([detalles](docs/benchmarks/tts-roundtrip.md))
-
-| Motor | WER% | RTF |
-|-------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — Detección de voz ([detalles](docs/benchmarks/vad-detection.md))
-
-| Motor | F1% (FLEURS) | RTF |
-|-------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+Expone cada modelo a través de endpoints HTTP REST + WebSocket, incluyendo un WebSocket compatible con OpenAI Realtime API en `/v1/realtime`. Ver [`Sources/AudioServer/`](Sources/AudioServer/).
 
 ## Arquitectura
 
-**Modelos:** [ASR Model](docs/models/asr-model.md), [TTS Model](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift está dividido en un target SPM por modelo para que los consumidores solo paguen por lo que importan. La infraestructura compartida vive en `AudioCommon` (protocolos, E/S de audio, descargador de HuggingFace, `SentencePieceModel`) y `MLXCommon` (carga de pesos, helpers `QuantizedLinear`, helper de atención multi-head `SDPA`).
 
-**Inferencia:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS Inference](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Speaker Diarization](docs/inference/speaker-diarization.md), [Speech Enhancement](docs/inference/speech-enhancement.md), [Reproducción de Audio](docs/audio/playback.md)
+**[Diagrama completo de arquitectura con backends, tablas de memoria y mapa de módulos → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[Referencia de API → soniqo.audio/api](https://soniqo.audio/api)** · **[Benchmarks → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**Benchmarks:** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD Detection](docs/benchmarks/vad-detection.md)
-
-**Referencia:** [Shared Protocols](docs/shared-protocols.md)
+Docs locales (repositorio):
+- **Modelos:** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **Inferencia:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [Diarización](docs/inference/speaker-diarization.md) · [Mejora de voz](docs/inference/speech-enhancement.md)
+- **Referencia:** [Protocolos compartidos](docs/shared-protocols.md)
 
 ## Configuración de caché
 
-Los pesos de los modelos se almacenan en caché en `~/Library/Caches/qwen3-speech/`.
+Los pesos del modelo se descargan desde HuggingFace en el primer uso y se almacenan en `~/Library/Caches/qwen3-speech/`. Puedes sobrescribir con `QWEN3_CACHE_DIR` (CLI) o `cacheDir:` (API Swift). Todos los puntos de entrada `fromPretrained()` aceptan `offlineMode: true` para omitir la red cuando los pesos ya están en caché.
 
-**CLI** — cambiar la ubicación con una variable de entorno:
+Consulta [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md) para los detalles completos, incluyendo rutas de contenedor iOS sandboxed.
 
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
+## Librería MLX Metal
 
-**Swift API** — todos los métodos `fromPretrained()` aceptan `cacheDir` y `offlineMode`:
-
-```swift
-// Directorio de caché personalizado (apps en sandbox, contenedores iOS)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// Modo offline — omitir red cuando los pesos ya están en caché
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-Ver [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md) para más detalles.
-
-## Biblioteca Metal de MLX
-
-Si ves `Failed to load the default metallib` en tiempo de ejecución, la biblioteca de shaders Metal falta. Ejecuta `make build` (o `./scripts/build_mlx_metallib.sh release` después de un `swift build` manual) para compilarla. Si falta el Metal Toolchain, instálalo primero:
+Si ves `Failed to load the default metallib` en tiempo de ejecución, falta la librería de shaders Metal. Ejecuta `make build` o `./scripts/build_mlx_metallib.sh release` después de un `swift build` manual. Si falta el Metal Toolchain, instálalo primero:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## Pruebas
 
-Las pruebas unitarias (configuración, muestreo, preprocesamiento de texto, corrección de marcas temporales) se ejecutan sin necesidad de descargar modelos:
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # suite completa (unidad + E2E con descargas de modelos)
+swift test --skip E2E                # solo unidad (seguro para CI, sin descargas)
+swift test --filter Qwen3ASRTests    # módulo específico
 ```
 
-Las pruebas de integración requieren pesos del modelo (se descargan automáticamente en la primera ejecución):
+Las clases de test E2E usan el prefijo `E2E` para que CI pueda filtrarlas con `--skip E2E`. Consulta [CLAUDE.md](CLAUDE.md#testing) para la convención completa de pruebas.
 
-```bash
-# Ida y vuelta TTS: sintetizar texto, guardar WAV, transcribir de vuelta con ASR
-swift test --filter TTSASRRoundTripTests
+## Contribuir
 
-# Solo ASR: transcribir audio de prueba
-swift test --filter Qwen3ASRIntegrationTests
-
-# Forced Aligner E2E: marcas temporales a nivel de palabra (~979 MB de descarga)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E: pipeline de voz a voz (~5.5 GB de descarga)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **Nota:** La biblioteca Metal de MLX debe compilarse antes de ejecutar pruebas que usen operaciones MLX.
-> Consulta [Biblioteca Metal de MLX](#biblioteca-metal-de-mlx) para instrucciones.
-
-## Idiomas soportados
-
-| Modelo | Idiomas |
-|--------|---------|
-| Qwen3-ASR | 52 idiomas (CN, EN, Cantonés, DE, FR, ES, JA, KO, RU, + 22 dialectos chinos, ...) |
-| Parakeet TDT | 25 idiomas europeos (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1.672 idiomas** en más de 150 familias. Incluye todo el conjunto "servido directamente" de Meta (~1.100) más 500+ idiomas de bajos recursos añadidos mediante datos de la comunidad. Seleccionados: EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (lista completa: [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)). El cabezal CTC es agnóstico al idioma: no se requiere una pista de idioma en la inferencia. |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ dialectos de Beijing/Sichuan vía CustomVoice) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## Comparativa
-
-### Voz a texto (ASR): speech-swift vs alternativas
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **Ejecución** | En el dispositivo (MLX/CoreML) | En el dispositivo (CPU/GPU) | En el dispositivo o nube | Solo en la nube |
-| **Idiomas** | 52 | 100+ | ~70 (en dispositivo: limitado) | 125+ |
-| **RTF (10s audio, M2 Max)** | 0.06 (17x tiempo real) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **Streaming** | No (por lotes) | No (por lotes) | Sí | Sí |
-| **Modelos personalizados** | Sí (intercambiar pesos de HuggingFace) | Sí (modelos GGML) | No | No |
-| **API Swift** | Nativa async/await | C++ con puente Swift | Nativa | REST/gRPC |
-| **Privacidad** | Totalmente en el dispositivo | Totalmente en el dispositivo | Depende de la configuración | Datos enviados a la nube |
-| **Marcas temporales de palabras** | Sí (Forced Aligner) | Sí | Limitado | Sí |
-| **Coste** | Gratuito (Apache 2.0) | Gratuito (MIT) | Gratuito (en dispositivo) | Pago por minuto |
-
-### Texto a voz (TTS): speech-swift vs alternativas
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / Cloud TTS** |
-|---|---|---|---|---|
-| **Calidad** | Neural, expresiva | Neural, natural | Robótica, monótona | Neural, máxima calidad |
-| **Ejecución** | En el dispositivo (MLX) | En el dispositivo (CoreML) | En el dispositivo | Solo en la nube |
-| **Streaming** | Sí (~120ms primer fragmento) | No (modelo de extremo a extremo) | No | Sí |
-| **Clonación de voz** | Sí | No | No | Sí |
-| **Voces** | 9 integradas + clonar cualquiera | 54 voces preconfiguradas | ~50 voces del sistema | 1000+ |
-| **Idiomas** | 10 | 10 | 60+ | 30+ |
-| **Soporte iOS** | Solo macOS | iOS + macOS | iOS + macOS | Cualquiera (API) |
-| **Coste** | Gratuito (Apache 2.0) | Gratuito (Apache 2.0) | Gratuito | Pago por carácter |
-
-### Cuándo usar speech-swift
-
-- **Aplicaciones con requisitos de privacidad** — médicas, legales, empresariales donde el audio no puede salir del dispositivo
-- **Uso sin conexión** — no se necesita conexión a internet después de la descarga inicial del modelo
-- **Sensible al coste** — sin cargos por minuto o por carácter de API
-- **Optimización para Apple Silicon** — desarrollado específicamente para GPU M-series (Metal) y Neural Engine
-- **Pipeline completo** — combina ASR + TTS + VAD + diarización + mejora de voz en un solo paquete Swift
-
-## Preguntas frecuentes
-
-**¿Funciona speech-swift en iOS?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3 y WeSpeaker funcionan en iOS 17+ vía CoreML en el Neural Engine. Los modelos basados en MLX (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex) requieren macOS 14+ en Apple Silicon.
-
-**¿Requiere conexión a internet?**
-Solo para la descarga inicial del modelo desde HuggingFace (automática, almacenada en caché en `~/Library/Caches/qwen3-speech/`). Después de eso, toda la inferencia se ejecuta completamente sin conexión y sin acceso a la red.
-
-**¿Cómo se compara speech-swift con Whisper?**
-Qwen3-ASR-0.6B alcanza un RTF de 0.06 en M2 Max — un 40% más rápido que Whisper-large-v3 mediante whisper.cpp (RTF 0.10) — con precisión comparable en 52 idiomas. speech-swift proporciona una API nativa Swift con async/await, mientras que whisper.cpp requiere un puente C++.
-
-**¿Puedo usarlo en una aplicación comercial?**
-Sí. speech-swift tiene licencia Apache 2.0. Los pesos de los modelos subyacentes tienen sus propias licencias (consulta la página de HuggingFace de cada modelo).
-
-**¿Qué chips Apple Silicon son compatibles?**
-Todos los chips de la serie M: M1, M2, M3, M4 y sus variantes Pro/Max/Ultra. Requiere macOS 14+ (Sonoma) o iOS 17+.
-
-**¿Cuánta memoria necesita?**
-Desde ~3 MB (Silero VAD) hasta ~6.5 GB (PersonaPlex 7B). Kokoro TTS usa ~500 MB, Qwen3-ASR ~2.2 GB. Consulta la tabla de [Requisitos de memoria](#requisitos-de-memoria) para todos los detalles.
-
-**¿Puedo ejecutar múltiples modelos simultáneamente?**
-Sí. Usa modelos CoreML en el Neural Engine junto con modelos MLX en la GPU para evitar contención — por ejemplo, Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX).
-
-**¿Hay una API REST?**
-Sí. El binario `audio-server` expone todos los modelos mediante endpoints HTTP REST y WebSocket, incluyendo un WebSocket compatible con la OpenAI Realtime API en `/v1/realtime`.
-
-## Contribuciones
-
-¡Las contribuciones son bienvenidas! Ya sea una corrección de errores, integración de un nuevo modelo o mejora de la documentación — los PRs son apreciados.
-
-**Para empezar:**
-1. Haz un fork del repositorio y crea una rama de funcionalidad
-2. `make build` para compilar (requiere Xcode + Metal Toolchain)
-3. `make test` para ejecutar la suite de pruebas
-4. Abre un PR contra `main`
+PRs bienvenidos — correcciones de bugs, integraciones de nuevos modelos, documentación. Fork, crea una rama de feature, `make build && make test`, abre un PR contra `main`.
 
 ## Licencia
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -4,51 +4,43 @@ Modeles IA de parole pour Apple Silicon, propulses par MLX Swift et CoreML.
 
 📖 Read in: [English](README.md) · [中文](README_zh.md) · [日本語](README_ja.md) · [한국어](README_ko.md) · [Español](README_es.md) · [Deutsch](README_de.md) · [Français](README_fr.md) · [हिन्दी](README_hi.md) · [Português](README_pt.md) · [Русский](README_ru.md)
 
-Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'execute entierement en local sur Apple Silicon — sans cloud, sans cle API, aucune donnee ne quitte l'appareil.
+Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'execute entierement en local sur Apple Silicon -- sans cloud, sans cle API, aucune donnee ne quitte l'appareil.
 
-[Installation via Homebrew](#homebrew) ou ajout en tant que dependance Swift Package.
+**[📚 Documentation complete →](https://soniqo.audio)** · **[🤗 Modeles HuggingFace](https://huggingface.co/aufklarer)** · **[📝 Blog](https://blog.ivan.digital)**
 
-**[Documentation](https://soniqo.audio)** · **[Modeles HuggingFace](https://huggingface.co/aufklarer)** · **[Blog](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** -- Reconnaissance vocale (reconnaissance automatique de la parole, 52 langues, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** -- Reconnaissance vocale via CoreML (Neural Engine, NVIDIA FastConformer + decodeur TDT, 25 langues)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** -- Reconnaissance vocale (Meta wav2vec2 + CTC, **1 672 langues** reparties dans 32 ecritures, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[Dictee en streaming](https://soniqo.audio/guides/dictate)** -- Dictee en temps reel avec resultats partiels et detection de fin d'enonce (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** -- Alignement temporel au niveau du mot (audio + texte → horodatages)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** -- Synthese vocale (qualite maximale, streaming, locuteurs personnalises, 10 langues)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** -- TTS en streaming avec clonage vocal, dialogue multi-locuteurs, balises d'emotion (9 langues)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** -- TTS embarque (82M, CoreML/Neural Engine, 54 voix, compatible iOS, 10 langues)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** -- Chat LLM embarque (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybride, tokens en streaming)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** -- Parole-a-parole en full-duplex (7B, audio entrant → audio sortant, 18 preselections de voix)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** -- Suppression de bruit en temps reel (2,1M parametres, 48 kHz)
+- **[VAD](https://soniqo.audio/guides/vad)** -- Detection d'activite vocale (Silero streaming, Pyannote hors ligne, FireRedVAD 100+ langues)
+- **[Diarisation de locuteurs](https://soniqo.audio/guides/diarize)** -- Qui a parle quand (pipeline Pyannote, Sortformer de bout en bout sur Neural Engine)
+- **[Empreintes de locuteur](https://soniqo.audio/guides/embed-speaker)** -- WeSpeaker ResNet34 (256 dim), CAM++ (192 dim)
 
-- **Qwen3-ASR** -- Reconnaissance vocale (reconnaissance automatique de la parole, 52 langues)
-- **Parakeet TDT** -- Reconnaissance vocale via CoreML (Neural Engine, NVIDIA FastConformer + decodeur TDT, 25 langues)
-- **Omnilingual ASR** -- Reconnaissance vocale via CoreML (Meta wav2vec2 + CTC, **1 672 langues** reparties dans plus de 150 familles, fenetres de 5/10 s, INT8 palettise, ANE)
-- **Qwen3-ForcedAligner** -- Alignement temporel au niveau du mot (audio + texte → horodatages)
-- **Qwen3-TTS** -- Synthese vocale (qualite maximale, streaming, locuteurs personnalises, 10 langues)
-- **CosyVoice TTS** -- Synthese vocale avec streaming, clonage vocal, dialogue multi-locuteurs et balises d'emotion (9 langues, DiT flow matching, encodeur de locuteur CAM++)
-- **Kokoro TTS** -- Synthese vocale embarquee (82M parametres, CoreML/Neural Engine, 54 voix, compatible iOS, 10 langues)
-- **Qwen3-TTS CoreML** -- Synthese vocale (0.6B, pipeline CoreML a 6 modeles, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** -- Chat LLM embarque (0.8B, MLX + CoreML, INT4 + CoreML INT8, DeltaNet hybride, tokens en streaming)
-- **PersonaPlex** -- Conversation parole-a-parole en full-duplex (7B, audio entrant → audio sortant, 18 preselections de voix)
-- **DeepFilterNet3** -- Amelioration de la parole / suppression du bruit (2.1M parametres, temps reel 48kHz)
-- **FireRedVAD** -- Detection d'activite vocale hors ligne (DFSMN, CoreML, 100+ langues, 97.6% F1)
-- **Silero VAD** -- Detection d'activite vocale en streaming (blocs de 32ms, latence inferieure a la milliseconde)
-- **Pyannote VAD** -- Detection d'activite vocale hors ligne (fenetres de 10s, chevauchement multi-locuteurs)
-- **Diarisation de locuteurs** -- Qui a parle quand (segmentation Pyannote + chainage de locuteurs base sur l'activite, ou Sortformer de bout en bout sur Neural Engine)
-- **Empreintes vocales** -- Verification et identification de locuteurs (WeSpeaker ResNet34, vecteurs 256 dimensions)
-
-Articles : [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## Feuille de route
-
-Consultez la [discussion Feuille de route](https://github.com/soniqo/speech-swift/discussions/81) pour voir ce qui est prevu -- commentaires et suggestions bienvenus !
+Articles : [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## Actualites
 
-- **20 mars 2026** -- [We Beat Whisper Large v3 with a 600M Model Running Entirely on Your Mac](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
-- **26 fev. 2026** -- [Speaker Diarization and Voice Activity Detection on Apple Silicon — Native Swift with MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
-- **23 fev. 2026** -- [NVIDIA PersonaPlex 7B on Apple Silicon — Full-Duplex Speech-to-Speech in Native Swift with MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
-- **12 fev. 2026** -- [Qwen3-ASR Swift: On-Device ASR + TTS for Apple Silicon — Architecture and Benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
+- **20 mars 2026** -- [Nous battons Whisper Large v3 avec un modele de 600M tournant entierement sur votre Mac](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
+- **26 fev. 2026** -- [Diarisation de locuteurs et detection d'activite vocale sur Apple Silicon -- Swift natif avec MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
+- **23 fev. 2026** -- [NVIDIA PersonaPlex 7B sur Apple Silicon -- parole-a-parole full-duplex en Swift natif avec MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
+- **12 fev. 2026** -- [Qwen3-ASR Swift : ASR + TTS embarques pour Apple Silicon -- architecture et benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
 
 ## Demarrage rapide
 
 Ajoutez le package a votre `Package.swift` :
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-Importez uniquement les modules dont vous avez besoin -- chaque modele est sa propre bibliotheque SPM :
+N'importez que les modules dont vous avez besoin -- chaque modele est une bibliotheque SPM independante, vous ne payez donc pas pour ce que vous n'utilisez pas :
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
@@ -96,128 +88,85 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI` ne contient que `TranscriptionView` (finaux + partiels) et `TranscriptionStore` (adaptateur ASR en streaming). Utilisez AVFoundation pour la visualisation et la lecture audio.
+`SpeechUI` ne fournit que `TranscriptionView` (finaux + partiels) et `TranscriptionStore` (adaptateur ASR en streaming). Utilisez AVFoundation pour la visualisation et la lecture audio.
 
 Produits SPM disponibles : `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modeles
 
-| Modele | Tache | Streaming | Langues | Tailles |
-|--------|-------|-----------|---------|---------|
-| Qwen3-ASR-0.6B | Parole → Texte | Non | 52 langues | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | Parole → Texte | Non | 52 langues | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | Parole → Texte | Non | 25 langues europeennes | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | Parole → Texte | Oui (streaming + EOU) | 25 langues europeennes | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | Parole → Texte | Non (fenetre de 5/10 s) | [1 672 langues](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | Parole → Texte | Non | [1 672 langues](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | Parole → Texte | Non | [1 672 langues](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | Parole → Texte | Non | [1 672 langues](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | Audio + Texte → Horodatages | Non | Multi | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | Texte → Parole | Oui (~120ms) | 10 langues | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | Texte → Parole | Oui (~120ms) | 10 langues | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | Texte → Parole | Oui (~120ms) | 10 langues | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | Texte → Parole | Oui (~150ms) | 9 langues | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | Texte → Parole | Non | 10 langues | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | Parole → Parole | Oui (~2s par bloc) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | Detection d'activite vocale | Non (hors ligne) | 100+ langues | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | Detection d'activite vocale | Oui (blocs de 32ms) | Independant de la langue | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + Segmentation de locuteurs | Non (fenetres de 10s) | Independant de la langue | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | Amelioration de la parole | Oui (trames de 10ms) | Independant de la langue | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | Empreinte vocale (256 dim.) | Non | Independant de la langue | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | Empreinte vocale (192 dim.) | Non | Independant de la langue | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | Diarisation de locuteurs (de bout en bout) | Oui (par blocs) | Independant de la langue | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifications, URLs de telechargement et tableaux de memoire → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### Memoire requise
-
-La memoire des poids correspond a la memoire GPU (MLX) ou ANE (CoreML) consommee par les parametres du modele. Le pic d'inference inclut les caches KV, les activations et les tenseurs intermediaires.
-
-| Modele | Memoire des poids | Pic d'inference |
-|--------|-------------------|-----------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### Quel TTS choisir
-
-- **Qwen3-TTS** : Meilleure qualite, streaming (~120ms), 9 locuteurs integres, 10 langues, synthese par lots
-- **CosyVoice TTS** : Streaming (~150ms), 9 langues, clonage vocal (encodeur de locuteur CAM++), dialogue multi-locuteurs (`[S1] ... [S2] ...`), balises d'emotion/style en ligne (`(happy)`, `(whispers)`), DiT flow matching + vocodeur HiFi-GAN
-- **Kokoro TTS** : TTS leger pour iOS (82M parametres), CoreML/Neural Engine, 54 voix, 10 langues, modele de bout en bout
-- **PersonaPlex** : Conversation parole-a-parole en full-duplex (audio entrant → audio sortant), streaming (~2s par bloc), 18 preselections de voix, base sur l'architecture Moshi
+| Modele | Tache | Backends | Tailles | Langues |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Parole → Texte | MLX, CoreML (hybride) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Parole → Texte | CoreML (ANE) | 0.6B | 25 europeennes |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | Parole → Texte (streaming) | CoreML (ANE) | 120M | 25 europeennes |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | Parole → Texte | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1 672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | Audio + Texte → Horodatages | MLX, CoreML | 0.6B | Multi |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | Texte → Parole | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | Texte → Parole | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | Texte → Parole | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Texte → Texte (LLM) | MLX, CoreML | 0.8B | Multi |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | Parole → Parole | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | Detection d'activite vocale | MLX, CoreML | 309K | Agnostique |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarisation | MLX | 1.5M | Agnostique |
+| [Sortformer](https://soniqo.audio/guides/diarize) | Diarisation (E2E) | CoreML (ANE) | — | Agnostique |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Amelioration de la parole | CoreML | 2.1M | Agnostique |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Empreinte de locuteur | MLX, CoreML | 6.6M | Agnostique |
 
 ## Installation
 
 ### Homebrew
 
-Necessite Homebrew natif ARM (`/opt/homebrew`). Homebrew Rosetta/x86_64 n'est pas supporte.
+Necessite un Homebrew ARM natif (`/opt/homebrew`). Homebrew Rosetta/x86_64 n'est pas supporte.
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-Utilisation :
+Ensuite :
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (Moteur Neuronal)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> Pour une conversation vocale interactive avec entree micro, voir **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**.
+**[Reference CLI complete →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-Ajoutez a votre `Package.swift` :
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-Importez le module dont vous avez besoin :
+N'importez que ce dont vous avez besoin -- chaque modele est sa propre cible SPM :
 
 ```swift
-import Qwen3ASR      // Reconnaissance vocale (MLX)
-import ParakeetASR   // Reconnaissance vocale (CoreML)
-import Qwen3TTS      // Synthese vocale (Qwen3)
-import CosyVoiceTTS  // Synthese vocale (streaming)
-import KokoroTTS     // Synthese vocale (CoreML, compatible iOS)
-import Qwen3Chat     // Chat LLM embarque (CoreML)
-import PersonaPlex   // Parole-a-parole (full-duplex)
-import SpeechVAD          // Detection d'activite vocale (pyannote + Silero)
-import SpeechEnhancement  // Suppression du bruit (DeepFilterNet3)
-import AudioCommon        // Utilitaires partages
+import Qwen3ASR             // Reconnaissance vocale (MLX)
+import ParakeetASR          // Reconnaissance vocale (CoreML, batch)
+import ParakeetStreamingASR // Dictee en streaming avec partiels + EOU
+import OmnilingualASR       // 1 672 langues (CoreML + MLX)
+import Qwen3TTS             // Synthese vocale
+import CosyVoiceTTS         // Synthese vocale avec clonage
+import KokoroTTS            // Synthese vocale (compatible iOS)
+import Qwen3Chat            // Chat LLM embarque
+import PersonaPlex          // Parole-a-parole full-duplex
+import SpeechVAD            // VAD + diarisation + empreintes
+import SpeechEnhancement    // Suppression de bruit
+import SpeechUI             // Composants SwiftUI pour transcriptions en streaming
+import AudioCommon          // Protocoles et utilitaires partages
 ```
 
-### Pre-requis
+### Prerequis
 
-- Swift 5.9+
-- macOS 14+ ou iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (avec Metal Toolchain -- executez `xcodebuild -downloadComponent MetalToolchain` si absent)
+- Swift 5.9+, Xcode 15+ (avec Metal Toolchain)
+- macOS 14+ ou iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
-### Compilation depuis les sources
+### Compiler depuis les sources
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-Ceci compile le package Swift **et** la bibliotheque Metal MLX en une seule etape. La bibliotheque Metal (`mlx.metallib`) est necessaire pour l'inference GPU -- sans elle, vous obtiendrez `Failed to load the default metallib` a l'execution.
+`make build` compile le package Swift **et** la bibliotheque de shaders MLX Metal. La bibliotheque Metal est necessaire pour l'inference GPU -- sans elle, vous verrez `Failed to load the default metallib` a l'execution. `make debug` pour les builds de debug, `make test` pour la suite de tests.
 
-Pour une compilation debug : `make debug`. Pour lancer les tests unitaires : `make test`.
-
-## Essayez l'assistant vocal
-
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** est un assistant vocal macOS pret a l'emploi -- appuyez pour parler, obtenez des reponses vocales en temps reel. Utilise l'entree microphone avec Silero VAD pour la detection automatique de la parole, Qwen3-ASR pour la transcription et PersonaPlex 7B pour la generation parole-a-parole. Conversation multi-tours avec 18 preselections de voix et affichage de la transcription du monologue interieur.
-
-```bash
-make build  # depuis la racine du depot -- compile tout, y compris la metallib MLX
-cd Examples/PersonaPlexDemo
-# Voir Examples/PersonaPlexDemo/README.md pour les instructions de creation du bundle .app
-```
-
-> RTF ~0.94 sur M2 Max (plus rapide que le temps reel). Les modeles se telechargent automatiquement au premier lancement (~5.5 Go PersonaPlex + ~400 Mo ASR).
+**[Guide complet de compilation et installation →](https://soniqo.audio/getting-started)**
 
 ## Applications de demonstration
 
-- **[DictateDemo](Examples/DictateDemo/)** ([docs](https://soniqo.audio/guides/dictate/)) -- Dictee en streaming dans la barre de menus macOS avec resultats partiels en direct, detection de fin d'enonce par VAD et copie en un clic. Fonctionne comme agent de barre de menus en arriere-plan (Parakeet-EOU-120M + Silero VAD).
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** -- Demo echo iOS (Parakeet ASR + Kokoro TTS, parlez et ecoutez la reponse). Appareil et simulateur.
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** -- Assistant vocal conversationnel (entree micro, VAD, multi-tours). macOS.
-- **[SpeechDemo](Examples/SpeechDemo/)** -- Dictee et synthese vocale dans une interface a onglets. macOS.
+- **[DictateDemo](Examples/DictateDemo/)** ([docs](https://soniqo.audio/guides/dictate)) -- Dictee en streaming dans la barre de menus macOS avec partiels en direct, detection de fin d'enonce basee sur VAD et copie en un clic. S'execute comme agent en arriere-plan (Parakeet-EOU-120M + Silero VAD).
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** -- Demo d'echo iOS (Parakeet ASR + Kokoro TTS). Appareil et simulateur.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** -- Assistant vocal conversationnel avec entree micro, VAD et contexte multi-tours. macOS. RTF ~0,94 sur M2 Max (plus rapide que le temps reel).
+- **[SpeechDemo](Examples/SpeechDemo/)** -- Dictee et synthese TTS dans une interface a onglets. macOS.
 
-Compilez et lancez -- consultez le README de chaque demo pour les instructions.
+Le README de chaque demo contient les instructions de compilation.
 
-## Reconnaissance vocale (ASR) -- Transcrire de l'audio en Swift
+## Exemples de code
 
-### Transcription de base
+Les extraits ci-dessous montrent le chemin minimal pour chaque domaine. Chaque section renvoie vers un guide complet sur [soniqo.audio](https://soniqo.audio) avec les options de configuration, plusieurs backends, les patrons de streaming et les recettes CLI.
 
-```swift
-import Qwen3ASR
-
-// Par defaut : modele 0.6B
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// Ou utilisez le modele 1.7B plus grand pour une meilleure precision
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// L'audio peut etre a n'importe quelle frequence d'echantillonnage -- reechantillonnage automatique a 16kHz en interne
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### Encodeur CoreML (Neural Engine)
-
-Mode hybride : encodeur CoreML sur le Neural Engine + decodeur texte MLX sur le GPU. Consommation reduite, libere le GPU pour la passe d'encodage.
+### Reconnaissance vocale -- [guide complet →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-Variantes INT8 (180 Mo, par defaut) et INT4 (90 Mo) disponibles. INT8 recommande (similarite cosinus > 0.999 par rapport au FP32).
+Backends alternatifs : [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× temps reel), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1 672 langues, CoreML ou MLX), [Dictee en streaming](https://soniqo.audio/guides/dictate) (partiels en direct).
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-S'execute sur le Neural Engine via CoreML -- libere le GPU pour d'autres taches simultanees. 25 langues europeennes, ~315 Mo.
-
-### CLI ASR
-
-```bash
-make build  # ou : swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# Par defaut (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# Utiliser le modele 1.7B
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# Encodeur CoreML (Neural Engine + decodeur MLX)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## Alignement force
-
-### Horodatages au niveau du mot
+### Alignement force -- [guide complet →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// Telecharge ~979 Mo au premier lancement
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### CLI Alignement force
-
-```bash
-swift build -c release
-
-# Aligner avec un texte fourni
-.build/release/audio align audio.wav --text "Hello world"
-
-# Transcrire d'abord, puis aligner
-.build/release/audio align audio.wav
-```
-
-Sortie :
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-Modele de bout en bout, non autoregressif, pas de boucle d'echantillonnage. Voir [Forced Aligner](docs/inference/forced-aligner.md) pour les details d'architecture.
-
-## Synthese vocale (TTS) -- Generer de la parole en Swift
-
-### Synthese de base
+### Synthese vocale -- [guide complet →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // pour WAVWriter
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// Telecharge ~1.7 Go au premier lancement (poids du modele + codec)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// Sortie : echantillons float mono 24kHz
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### CLI TTS
+Moteurs TTS alternatifs : [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (streaming + clonage + balises d'emotion), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (compatible iOS, 54 voix), [Clonage vocal](https://soniqo.audio/guides/voice-cloning).
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### Voix personnalisee / Selection de locuteur
-
-La variante **CustomVoice** prend en charge 9 voix de locuteurs integrees et des instructions en langage naturel pour controler le ton et le style. Chargez-la en passant l'identifiant du modele CustomVoice :
-
-```swift
-import Qwen3TTS
-
-// Charger le modele CustomVoice (telecharge ~1.7 Go au premier lancement)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// Synthetiser avec un locuteur specifique
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// Lister les locuteurs disponibles
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI :
-
-```bash
-# Utiliser le modele CustomVoice avec un locuteur
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# Lister les locuteurs disponibles
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### Clonage vocal (modele Base)
-
-Clonez la voix d'un locuteur a partir d'un fichier audio de reference. Deux modes :
-
-**Mode ICL** (recommande) -- encode l'audio de reference en tokens codec avec la transcription. Meilleure qualite, EOS fiable :
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**Mode X-vector** -- empreinte vocale uniquement, pas de transcription necessaire mais qualite moindre :
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI :
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### Instructions de ton / style (CustomVoice uniquement)
-
-Le modele CustomVoice accepte un parametre `instruct` en langage naturel pour controler le style de parole, le ton, l'emotion et le rythme. L'instruction est ajoutee en prefixe a l'entree du modele au format ChatML.
-
-```swift
-// Ton joyeux
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// Lent et serieux
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// Chuchotement
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI :
-
-```bash
-# Avec instruction de style
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# L'instruction par defaut ("Speak naturally.") est appliquee automatiquement avec CustomVoice
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-Lorsqu'aucun `--instruct` n'est fourni avec le modele CustomVoice, `"Speak naturally."` est applique automatiquement pour eviter une sortie decousue. Le modele Base ne prend pas en charge instruct.
-
-### Synthese par lots
-
-Synthetisez plusieurs textes en une seule passe groupee pour un debit plus eleve :
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] contient les echantillons float mono 24kHz pour texts[i]
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### CLI par lots
-
-```bash
-# Creer un fichier avec un texte par ligne
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# Produit output_0.wav, output_1.wav, ...
-```
-
-> Le mode par lots amortit le chargement des poids du modele sur tous les elements. Attendez une amelioration du debit d'environ 1.5-2.5x pour B=4 sur Apple Silicon. Meilleurs resultats lorsque les textes produisent des audios de longueur similaire.
-
-### Options d'echantillonnage
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### Synthese en streaming
-
-Emettez des blocs audio de maniere incrementale pour une faible latence du premier paquet :
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // ~120ms jusqu'au premier bloc audio
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: true sur le dernier bloc
-    playAudio(chunk.samples)
-}
-```
-
-CLI :
-
-```bash
-# Streaming par defaut (premier bloc de 3 trames, ~225ms de latence)
-.build/release/audio speak "Hello world" --stream
-
-# Faible latence (premier bloc de 1 trame, ~120ms de latence)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## Parole-a-parole -- Conversation vocale full-duplex
-
-> Pour un assistant vocal interactif avec entree micro, voir **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** -- appuyez pour parler, conversation multi-tours avec detection automatique de la parole.
-
-### Parole-a-parole
+### Parole-a-parole -- [guide complet →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // pour WAVWriter, AudioFileLoader
 
 let model = try await PersonaPlexModel.fromPretrained()
-// Telecharge ~5.5 Go au premier lancement (temporal 4-bit + depformer + codec Mimi + preselections de voix)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response : echantillons float mono 24kHz
-// textTokens : monologue interieur du modele (IDs de tokens SentencePiece)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// Sortie Float32 mono 24 kHz prete pour la lecture
 ```
 
-### Monologue interieur (sortie texte)
-
-PersonaPlex genere des tokens texte en parallele de l'audio -- le raisonnement interne du modele. Decodez-les avec le decodeur SentencePiece integre :
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // ex. : "Sure, I can help you with that..."
-```
-
-### Streaming parole-a-parole
-
-```swift
-// Recevoir les blocs audio au fur et a mesure de leur generation (~2s par bloc)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // lecture immediate, mono 24kHz
-    // chunk.textTokens contient le texte de ce bloc ; le dernier bloc contient tous les tokens
-    if chunk.isFinal { break }
-}
-```
-
-### Selection de voix
-
-18 preselections de voix disponibles :
-- **Femme naturelle** : NATF0, NATF1, NATF2, NATF3
-- **Homme naturel** : NATM0, NATM1, NATM2, NATM3
-- **Femme variee** : VARF0, VARF1, VARF2, VARF3, VARF4
-- **Homme varie** : VARM0, VARM1, VARM2, VARM3, VARM4
-
-### Prompts systeme
-
-Le prompt systeme oriente le comportement conversationnel du modele. Vous pouvez passer n'importe quel prompt personnalise sous forme de chaine de caracteres :
-
-```swift
-// Prompt systeme personnalise (tokenise automatiquement)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// Ou utiliser un preset
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-Presets disponibles : `focused` (par defaut), `assistant`, `customerService`, `teacher`.
-
-### CLI PersonaPlex
-
-```bash
-make build
-
-# Parole-a-parole de base
-.build/release/audio respond --input question.wav --output response.wav
-
-# Avec transcription (decode le texte du monologue interieur)
-.build/release/audio respond --input question.wav --transcript
-
-# Sortie JSON (chemin audio, transcription, metriques de latence)
-.build/release/audio respond --input question.wav --json
-
-# Texte de prompt systeme personnalise
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# Choisir une voix et un preset de prompt systeme
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# Ajuster les parametres d'echantillonnage
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# Activer l'arret anticipe par entropie textuelle (arrete si le texte s'effondre)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# Lister les voix et prompts disponibles
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS -- Synthese vocale en streaming avec clonage vocal
-
-### Synthese de base
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // pour WAVWriter
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// Telecharge ~1.9 Go au premier lancement (poids LLM + DiT + HiFi-GAN)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// Sortie : echantillons float mono 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### Synthese en streaming
-
-```swift
-// Streaming : recevez les blocs audio au fur et a mesure de leur generation (~150ms jusqu'au premier bloc)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // lecture immediate
-}
-```
-
-### Clonage vocal (CosyVoice)
-
-Clonez la voix d'un locuteur a l'aide de l'encodeur de locuteur CAM++ (192 dim., CoreML Neural Engine) :
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// Telecharge ~14 Mo du modele CoreML CAM++ a la premiere utilisation
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: [Float] de longueur 192
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CLI CosyVoice TTS
-
-```bash
-make build
-
-# Synthese de base
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# Clonage vocal (telecharge l'encodeur de locuteur CAM++ a la premiere utilisation)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# Dialogue multi-locuteurs avec clonage vocal
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# Balises d'emotion/style en ligne
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# Combine : dialogue + emotions + clonage vocal
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# Instruction de style personnalisee
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# Synthese en streaming
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS -- Synthese vocale legere embarquee (iOS + macOS)
-
-### Synthese de base
-
-```swift
-import KokoroTTS
-import AudioCommon  // pour WAVWriter
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// Telecharge ~170 Mo au premier lancement (modeles CoreML + empreintes vocales + dictionnaires)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// Sortie : echantillons float mono 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-54 voix predefinies dans 10 langues. Modele CoreML de bout en bout, non autoregressif, pas de boucle d'echantillonnage. S'execute sur le Neural Engine, libere entierement le GPU.
-
-### CLI Kokoro TTS
-
-```bash
-make build
-
-# Synthese de base
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# Choisir la langue
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# Lister les voix disponibles
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-Pipeline autoregressif a 6 modeles fonctionnant sur CoreML. Poids paletises W8A16.
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (LLM embarque)
+### Chat LLM -- [guide complet →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// Telecharge ~318 Mo au premier lancement (modele CoreML INT4 + tokenizer)
-
-// Reponse unique
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// Tokens en streaming
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B quantifie INT4 pour CoreML. S'execute sur le Neural Engine avec ~2 tok/s sur iPhone, ~15 tok/s sur les puces M. Prend en charge la conversation multi-tours avec cache KV, le mode reflexion (tokens `<think>`), et l'echantillonnage configurable (temperature, top-k, top-p, penalite de repetition).
-
-## Detection d'activite vocale (VAD) -- Detecter la parole dans l'audio
-
-### VAD en streaming (Silero)
-
-Silero VAD v5 traite des blocs audio de 32ms avec une latence inferieure a la milliseconde -- ideal pour la detection de parole en temps reel depuis des microphones ou des flux.
+### Detection d'activite vocale -- [guide complet →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// Ou utiliser CoreML (Neural Engine, consommation reduite) :
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// Streaming : traiter des blocs de 512 echantillons (32ms @ 16kHz)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // a appeler entre differents flux audio
-
-// Ou detecter tous les segments d'un coup
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Parole : \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### Streaming evenementiel
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// Alimentez l'audio de n'importe quelle longueur -- les evenements sont emis lorsque la parole est confirmee
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Parole commencee a \(time)s")
-    case .speechEnded(let segment):
-        print("Parole : \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// Vider le tampon en fin de flux
-let final = processor.flush()
-```
-
-### CLI VAD
-
-```bash
-make build
-
-# Silero VAD en streaming (blocs de 32ms)
-.build/release/audio vad-stream audio.wav
-
-# Backend CoreML (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# Avec des seuils personnalises
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# Sortie JSON
-.build/release/audio vad-stream audio.wav --json
-
-# VAD pyannote par lots (fenetres glissantes de 10s)
-.build/release/audio vad audio.wav
-```
-
-## Diarisation de locuteurs -- Qui a parle quand
-
-### Pipeline de diarisation
+### Diarisation de locuteurs -- [guide complet →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// Ou utiliser les empreintes CoreML (Neural Engine, libere le GPU) :
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Locuteur \(seg.speakerId) : [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) locuteurs detectes")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### Empreinte vocale
+### Amelioration de la parole -- [guide complet →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// Ou : let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: [Float] de longueur 256, normalise L2
+import SpeechEnhancement
 
-// Comparer des locuteurs
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### Extraction de locuteur
-
-Extrayez uniquement les segments d'un locuteur specifique a l'aide d'un enregistrement de reference :
+### Voice Pipeline (ASR → LLM → TTS) -- [guide complet →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Diarisation Sortformer (de bout en bout, CoreML)
+`VoicePipeline` est la machine a etats agent vocal temps reel (propulsee par [speech-core](https://github.com/soniqo/speech-core)) avec detection de tours basee sur VAD, gestion des interruptions et STT eager. Elle connecte n'importe quel `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`.
 
-NVIDIA Sortformer predit l'activite de locuteur par trame pour jusqu'a 4 locuteurs directement -- aucune empreinte ni regroupement necessaires. S'execute sur le Neural Engine.
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Locuteur \(seg.speakerId) : [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### CLI Diarisation
+### Serveur API HTTP
 
 ```bash
-make build
-
-# Diarisation pyannote (par defaut)
-.build/release/audio diarize meeting.wav
-
-# Diarisation Sortformer (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# Empreintes CoreML (Neural Engine, pyannote uniquement)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# Sortie JSON
-.build/release/audio diarize meeting.wav --json
-
-# Extraire un locuteur specifique (pyannote uniquement)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# Empreinte vocale
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-Voir [Speaker Diarization](docs/inference/speaker-diarization.md) pour les details d'architecture.
-
-## Amelioration de la parole -- Suppression du bruit et nettoyage audio
-
-### Suppression du bruit
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // pour WAVWriter
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// Telecharge ~4.3 Mo au premier lancement (modele Core ML FP16 + donnees auxiliaires)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### CLI Debruitage
-
-```bash
-make build
-
-# Suppression du bruit de base
-.build/release/audio denoise noisy.wav
-
-# Chemin de sortie personnalise
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-Voir [Speech Enhancement](docs/inference/speech-enhancement.md) pour les details d'architecture.
-
-## Pipelines -- Composer plusieurs modeles
-
-Tous les modeles sont conformes a des protocoles partages (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel`, etc.) et peuvent etre composes en pipelines :
-
-### Reconnaissance vocale sur audio bruite (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// Ameliorer a 48kHz, puis transcrire a 16kHz
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### Relais voix-a-voix (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// Detecter les segments de parole, transcrire, resynthetiser
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech : echantillons float mono 24kHz
-}
-```
-
-### Transcription de reunion (Diarisation + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Locuteur \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s] : \(text)")
-}
-```
-
-Voir [Shared Protocols](docs/shared-protocols.md) pour la reference complete des protocoles.
-
-## Serveur API HTTP
-
-Un serveur HTTP autonome expose tous les modeles via des endpoints REST et WebSocket. Les modeles sont charges a la demande lors de la premiere requete.
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# Transcrire de l'audio
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# Synthese vocale
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# Parole-a-parole (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# Amelioration de la parole
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# Precharger tous les modeles au demarrage
-.build/release/audio-server --preload --port 8080
-```
-
-### Streaming WebSocket
-
-#### API Realtime OpenAI (`/v1/realtime`)
-
-L'endpoint WebSocket principal implemente le protocole [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) -- tous les messages sont en JSON avec un champ `type`, l'audio est encode en PCM16 base64 mono 24kHz.
-
-**Evenements Client → Serveur :**
-
-| Evenement | Description |
-|-----------|-------------|
-| `session.update` | Configurer le moteur, la langue, le format audio |
-| `input_audio_buffer.append` | Envoyer un bloc audio PCM16 en base64 |
-| `input_audio_buffer.commit` | Transcrire l'audio accumule (ASR) |
-| `input_audio_buffer.clear` | Vider le tampon audio |
-| `response.create` | Demander une synthese TTS |
-
-**Evenements Serveur → Client :**
-
-| Evenement | Description |
-|-----------|-------------|
-| `session.created` | Session initialisee |
-| `session.updated` | Configuration confirmee |
-| `input_audio_buffer.committed` | Audio soumis pour transcription |
-| `conversation.item.input_audio_transcription.completed` | Resultat ASR |
-| `response.audio.delta` | Bloc audio PCM16 en base64 (TTS) |
-| `response.audio.done` | Streaming audio termine |
-| `response.done` | Reponse terminee avec metadonnees |
-| `error` | Erreur avec type et message |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR : envoyer l'audio, obtenir la transcription
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → recoit : conversation.item.input_audio_transcription.completed
-
-// TTS : envoyer du texte, recevoir l'audio en streaming
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → recoit : response.audio.delta (blocs base64), response.audio.done, response.done
-```
-
-Un exemple de client HTML se trouve dans `Examples/websocket-client.html` -- ouvrez-le dans un navigateur pendant que le serveur est en marche.
-
-Le serveur est un module `AudioServer` separe et un executable `audio-server` -- il n'ajoute pas Hummingbird/WebSocket au CLI principal `audio`.
-
-## Latence (M2 Max, 64 Go)
-
-### ASR
-
-| Modele | Backend | RTF | Audio de 10s traite en |
-|--------|---------|-----|------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 a froid, ~0.03 a chaud | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### Alignement force
-
-| Modele | Framework | Audio de 20s | RTF |
-|--------|-----------|--------------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> Passe unique non autoregressive -- pas de boucle d'echantillonnage. L'encodeur audio domine (~328ms), le decodeur en passe unique fait ~37ms. **55x plus rapide que le temps reel.**
-
-### TTS
-
-| Modele | Framework | Court (1s) | Moyen (3s) | Long (6s) | Premier paquet en streaming |
-|--------|-----------|-----------|------------|-----------|---------------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1 trame) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (non autoregressif) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTS genere une parole naturelle et expressive avec prosodie et emotion, fonctionnant **plus vite que le temps reel** (RTF < 1.0). La synthese en streaming delivre le premier bloc audio en ~120ms. Kokoro-82M s'execute entierement sur le Neural Engine avec un modele de bout en bout (RTFx ~0.7), ideal pour iOS. Le TTS integre d'Apple est plus rapide mais produit une parole robotique et monotone.
-
-### PersonaPlex (Parole-a-parole)
-
-| Modele | Framework | ms/etape | RTF | Notes |
-|--------|-----------|----------|-----|-------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | Recommande — reponses coherentes, 30% plus rapide que 4-bit |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | Non recommande — qualite de sortie degradee |
-
-> **Utilisez 8-bit.** INT8 est plus rapide (112 ms/etape vs. 158 ms/etape) et produit des reponses full-duplex coherentes. La quantification INT4 degrade la qualite de generation, produisant un discours incoherent. INT8 fonctionne a ~112ms/etape sur M2 Max.
-
-### VAD et empreinte vocale
-
-| Modele | Backend | Latence par appel | RTF | Notes |
-|--------|---------|-------------------|-----|-------|
-| Silero-VAD-v5 | MLX | ~2.1ms / bloc | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / bloc | 0.008 | Neural Engine, **7.7x plus rapide** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20s audio | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20s audio | 0.021 | Neural Engine, libere le GPU |
-
-> Silero VAD CoreML s'execute sur le Neural Engine a 7.7x la vitesse de MLX, ce qui le rend ideal pour une ecoute micro permanente. WeSpeaker MLX est plus rapide sur GPU, mais CoreML libere le GPU pour des taches simultanees (TTS, ASR). Les deux backends produisent des resultats equivalents.
-
-### Amelioration de la parole
-
-| Modele | Backend | Duree | Latence | RTF |
-|--------|---------|-------|---------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Real-Time Factor (plus bas est mieux, < 1.0 = plus rapide que le temps reel). Le cout du GRU evolue en ~O(n^2).
-
-### MLX vs CoreML
-
-Les deux backends produisent des resultats equivalents. Choisissez en fonction de votre charge de travail :
-
-| | MLX | CoreML |
-|---|---|---|
-| **Materiel** | GPU (shaders Metal) | Neural Engine + CPU |
-| **Ideal pour** | Debit maximum, taches mono-modele | Pipelines multi-modeles, taches en arriere-plan |
-| **Consommation** | Utilisation GPU elevee | Consommation reduite, libere le GPU |
-| **Latence** | Plus rapide pour les gros modeles (WeSpeaker) | Plus rapide pour les petits modeles (Silero VAD) |
-
-**Inference sur ordinateur** : MLX est le backend par defaut -- performance mono-modele la plus rapide sur Apple Silicon. Passez a CoreML lorsque vous executez plusieurs modeles simultanement (ex. : VAD + ASR + TTS) pour eviter la contention GPU, ou pour les charges sensibles a la batterie sur les portables.
-
-Des modeles CoreML sont disponibles pour l'encodeur Qwen3-ASR, Silero VAD et WeSpeaker. Pour Qwen3-ASR, utilisez `--engine qwen3-coreml` (hybride : encodeur CoreML sur ANE + decodeur texte MLX sur GPU). Pour VAD/empreintes, passez `engine: .coreml` a la construction -- l'API d'inference est identique.
-
-## Benchmarks de precision
-
-### ASR -- Taux d'erreur de mots ([details](docs/benchmarks/asr-wer.md))
-
-| Modele | WER% (LibriSpeech test-clean) | RTF |
-|--------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit depasse Whisper Large v3 Turbo (2.5%) a taille comparable. Multilingue : 10 langues evaluees sur FLEURS.
-
-### TTS -- Intelligibilite aller-retour ([details](docs/benchmarks/tts-roundtrip.md))
-
-| Moteur | WER% | RTF |
-|--------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD -- Detection de la parole ([details](docs/benchmarks/vad-detection.md))
-
-| Moteur | F1% (FLEURS) | RTF |
-|--------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+Expose chaque modele via des endpoints HTTP REST + WebSocket, y compris un WebSocket compatible OpenAI Realtime API sur `/v1/realtime`. Voir [`Sources/AudioServer/`](Sources/AudioServer/).
 
 ## Architecture
 
-**Modeles :** [ASR Model](docs/models/asr-model.md), [TTS Model](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift est decoupe en une cible SPM par modele, de sorte que les consommateurs ne paient que ce qu'ils importent. L'infrastructure partagee reside dans `AudioCommon` (protocoles, I/O audio, telechargeur HuggingFace, `SentencePieceModel`) et `MLXCommon` (chargement de poids, aides `QuantizedLinear`, aide d'attention multi-tete `SDPA`).
 
-**Inference :** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS Inference](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Speaker Diarization](docs/inference/speaker-diarization.md), [Speech Enhancement](docs/inference/speech-enhancement.md), [Lecture Audio](docs/audio/playback.md)
+**[Diagramme d'architecture complet avec backends, tableaux de memoire et carte des modules → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[Reference d'API → soniqo.audio/api](https://soniqo.audio/api)** · **[Benchmarks → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**Benchmarks :** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD Detection](docs/benchmarks/vad-detection.md)
-
-**Reference :** [Shared Protocols](docs/shared-protocols.md)
+Docs locales (depot) :
+- **Modeles :** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **Inference :** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [Diarisation](docs/inference/speaker-diarization.md) · [Amelioration de la parole](docs/inference/speech-enhancement.md)
+- **Reference :** [Protocoles partages](docs/shared-protocols.md)
 
 ## Configuration du cache
 
-Les poids des modèles sont mis en cache dans `~/Library/Caches/qwen3-speech/`.
+Les poids de modele sont telecharges depuis HuggingFace lors de la premiere utilisation et mis en cache dans `~/Library/Caches/qwen3-speech/`. Surchargez avec `QWEN3_CACHE_DIR` (CLI) ou `cacheDir:` (API Swift). Tous les points d'entree `fromPretrained()` acceptent `offlineMode: true` pour sauter le reseau lorsque les poids sont deja en cache.
 
-**CLI** — modifier via une variable d'environnement :
+Voir [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md) pour les details complets incluant les chemins de container iOS sandboxes.
 
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
+## Bibliotheque MLX Metal
 
-**Swift API** — toutes les méthodes `fromPretrained()` acceptent `cacheDir` et `offlineMode` :
-
-```swift
-// Répertoire de cache personnalisé (apps sandboxées, conteneurs iOS)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// Mode hors ligne — ignorer le réseau quand les poids sont déjà en cache
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-Voir [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md) pour plus de détails.
-
-## Bibliotheque Metal MLX
-
-Si vous voyez `Failed to load the default metallib` a l'execution, la bibliotheque de shaders Metal est manquante. Executez `make build` (ou `./scripts/build_mlx_metallib.sh release` apres un `swift build` manuel) pour la compiler. Si le Metal Toolchain est manquant, installez-le d'abord :
+Si vous voyez `Failed to load the default metallib` a l'execution, la bibliotheque de shaders Metal est manquante. Executez `make build` ou `./scripts/build_mlx_metallib.sh release` apres un `swift build` manuel. Si le Metal Toolchain est absent, installez-le d'abord :
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## Tests
 
-Les tests unitaires (configuration, echantillonnage, pretraitement de texte, correction d'horodatages) s'executent sans telechargement de modele :
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # suite complete (unite + E2E avec telechargements de modeles)
+swift test --skip E2E                # unite uniquement (CI-safe, sans telechargements)
+swift test --filter Qwen3ASRTests    # module specifique
 ```
 
-Les tests d'integration necessitent les poids des modeles (telecharges automatiquement au premier lancement) :
-
-```bash
-# Aller-retour TTS : synthetiser du texte, sauvegarder en WAV, retranscrire avec l'ASR
-swift test --filter TTSASRRoundTripTests
-
-# ASR uniquement : transcrire un audio de test
-swift test --filter Qwen3ASRIntegrationTests
-
-# Alignement force E2E : horodatages au niveau du mot (~979 Mo de telechargement)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E : pipeline parole-a-parole (~5.5 Go de telechargement)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **Remarque :** La bibliotheque Metal MLX doit etre compilee avant d'executer les tests qui utilisent des operations MLX.
-> Voir [Bibliotheque Metal MLX](#bibliotheque-metal-mlx) pour les instructions.
-
-## Langues prises en charge
-
-| Modele | Langues |
-|--------|---------|
-| Qwen3-ASR | 52 langues (CN, EN, cantonais, DE, FR, ES, JA, KO, RU, + 22 dialectes chinois, ...) |
-| Parakeet TDT | 25 langues europeennes (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1 672 langues** reparties dans plus de 150 familles. Comprend l'ensemble "servi directement" de Meta (~1 100) ainsi que plus de 500 langues a faibles ressources ajoutees via des donnees communautaires. Selection : EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (liste complete : [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)). La tete CTC est agnostique a la langue -- aucun indice de langue n'est requis au moment de l'inference. |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ dialectes de Pekin/Sichuan via CustomVoice) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## Comparatif
-
-### Reconnaissance vocale (ASR) : speech-swift vs alternatives
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **Execution** | Sur l'appareil (MLX/CoreML) | Sur l'appareil (CPU/GPU) | Sur l'appareil ou cloud | Cloud uniquement |
-| **Langues** | 52 | 100+ | ~70 (sur l'appareil : limite) | 125+ |
-| **RTF (audio 10s, M2 Max)** | 0.06 (17x temps reel) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **Streaming** | Non (par lots) | Non (par lots) | Oui | Oui |
-| **Modeles personnalises** | Oui (poids HuggingFace interchangeables) | Oui (modeles GGML) | Non | Non |
-| **API Swift** | async/await natif | C++ avec bridge Swift | Natif | REST/gRPC |
-| **Confidentialite** | Entierement sur l'appareil | Entierement sur l'appareil | Selon la config | Donnees envoyees au cloud |
-| **Horodatages des mots** | Oui (Forced Aligner) | Oui | Limite | Oui |
-| **Cout** | Gratuit (Apache 2.0) | Gratuit (MIT) | Gratuit (sur l'appareil) | Facturation a la minute |
-
-### Synthese vocale (TTS) : speech-swift vs alternatives
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / Cloud TTS** |
-|---|---|---|---|---|
-| **Qualite** | Neurale, expressive | Neurale, naturelle | Robotique, monotone | Neurale, qualite maximale |
-| **Execution** | Sur l'appareil (MLX) | Sur l'appareil (CoreML) | Sur l'appareil | Cloud uniquement |
-| **Streaming** | Oui (~120ms premier bloc) | Non (modele de bout en bout) | Non | Oui |
-| **Clonage vocal** | Oui | Non | Non | Oui |
-| **Voix** | 9 integrees + clonage | 54 voix predefinies | ~50 voix systeme | 1000+ |
-| **Langues** | 10 | 10 | 60+ | 30+ |
-| **Support iOS** | macOS uniquement | iOS + macOS | iOS + macOS | Tous (API) |
-| **Cout** | Gratuit (Apache 2.0) | Gratuit (Apache 2.0) | Gratuit | Facturation au caractere |
-
-### Quand utiliser speech-swift
-
-- **Applications sensibles a la confidentialite** -- medical, juridique, entreprise ou l'audio ne peut pas quitter l'appareil
-- **Usage hors ligne** -- aucune connexion internet necessaire apres le telechargement initial du modele
-- **Budget limite** -- pas de frais a la minute ou au caractere
-- **Optimisation Apple Silicon** -- concu specifiquement pour le GPU M-series (Metal) et le Neural Engine
-- **Pipeline complet** -- combinez ASR + TTS + VAD + diarisation + amelioration dans un seul package Swift
-
-## FAQ
-
-**Est-ce que speech-swift fonctionne sur iOS ?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3 et WeSpeaker fonctionnent tous sur iOS 17+ via CoreML sur le Neural Engine. Les modeles bases sur MLX (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex) necessitent macOS 14+ sur Apple Silicon.
-
-**Une connexion internet est-elle necessaire ?**
-Uniquement pour le telechargement initial du modele depuis HuggingFace (automatique, cache dans `~/Library/Caches/qwen3-speech/`). Ensuite, toute l'inference s'execute entierement hors ligne sans acces reseau.
-
-**Comment speech-swift se compare-t-il a Whisper ?**
-Qwen3-ASR-0.6B atteint un RTF de 0.06 sur M2 Max -- 40% plus rapide que Whisper-large-v3 via whisper.cpp (RTF 0.10) -- avec une precision comparable sur 52 langues. speech-swift fournit une API Swift native async/await, alors que whisper.cpp necessite un bridge C++.
-
-**Puis-je l'utiliser dans une application commerciale ?**
-Oui. speech-swift est sous licence Apache 2.0. Les poids des modeles sous-jacents ont leurs propres licences (verifiez la page HuggingFace de chaque modele).
-
-**Quelles puces Apple Silicon sont prises en charge ?**
-Toutes les puces de la serie M : M1, M2, M3, M4 et leurs variantes Pro/Max/Ultra. Necessite macOS 14+ (Sonoma) ou iOS 17+.
-
-**Quelle quantite de memoire est necessaire ?**
-De ~3 Mo (Silero VAD) a ~6.5 Go (PersonaPlex 7B). Kokoro TTS utilise ~500 Mo, Qwen3-ASR ~2.2 Go. Voir le tableau [Memoire requise](#memoire-requise) pour tous les details.
-
-**Peut-on executer plusieurs modeles simultanement ?**
-Oui. Utilisez les modeles CoreML sur le Neural Engine conjointement avec les modeles MLX sur le GPU pour eviter la contention -- par exemple, Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX).
-
-**Y a-t-il une API REST ?**
-Oui. L'executable `audio-server` expose tous les modeles via des endpoints HTTP REST et WebSocket, y compris un WebSocket compatible avec l'API OpenAI Realtime a `/v1/realtime`.
+Les classes de test E2E utilisent le prefixe `E2E` pour que la CI puisse les filtrer avec `--skip E2E`. Voir [CLAUDE.md](CLAUDE.md#testing) pour la convention complete de tests.
 
 ## Contribuer
 
-Les contributions sont les bienvenues ! Qu'il s'agisse d'une correction de bug, de l'integration d'un nouveau modele ou d'une amelioration de la documentation -- les PR sont appreciees.
-
-**Pour commencer :**
-1. Forkez le depot et creez une branche de fonctionnalite
-2. `make build` pour compiler (necessite Xcode + Metal Toolchain)
-3. `make test` pour lancer la suite de tests
-4. Ouvrez une PR contre `main`
+PR bienvenues -- corrections de bugs, nouvelles integrations de modeles, documentation. Fork, creez une branche de fonctionnalite, `make build && make test`, ouvrez une PR vers `main`.
 
 ## Licence
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -6,32 +6,24 @@ Apple Silicon के लिए AI स्पीच मॉडल, MLX Swift और
 
 Mac और iOS के लिए ऑन-डिवाइस स्पीच रिकग्निशन, सिंथेसिस और समझ। Apple Silicon पर पूरी तरह लोकली चलता है — कोई क्लाउड नहीं, कोई API key नहीं, कोई डेटा डिवाइस से बाहर नहीं जाता।
 
-[Homebrew से इंस्टॉल करें](#homebrew) या Swift Package डिपेंडेंसी के रूप में जोड़ें।
+**[📚 पूर्ण डॉक्यूमेंटेशन →](https://soniqo.audio)** · **[🤗 HuggingFace मॉडल](https://huggingface.co/aufklarer)** · **[📝 ब्लॉग](https://blog.ivan.digital)**
 
-**[डॉक्यूमेंटेशन](https://soniqo.audio)** · **[HuggingFace मॉडल](https://huggingface.co/aufklarer)** · **[ब्लॉग](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — स्पीच-टू-टेक्स्ट (ऑटोमैटिक स्पीच रिकग्निशन, 52 भाषाएँ, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — CoreML के माध्यम से स्पीच-टू-टेक्स्ट (Neural Engine, NVIDIA FastConformer + TDT decoder, 25 भाषाएँ)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — स्पीच-टू-टेक्स्ट (Meta wav2vec2 + CTC, **1,672 भाषाएँ** 32 लिपियों में, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[Streaming Dictation](https://soniqo.audio/guides/dictate)** — पार्शियल्स और एंड-ऑफ-अटरन्स डिटेक्शन के साथ रियल-टाइम डिक्टेशन (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — शब्द-स्तरीय टाइमस्टैम्प अलाइनमेंट (ऑडियो + टेक्स्ट → टाइमस्टैम्प)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — टेक्स्ट-टू-स्पीच (सर्वोच्च गुणवत्ता, स्ट्रीमिंग, कस्टम स्पीकर, 10 भाषाएँ)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — वॉयस क्लोनिंग, मल्टी-स्पीकर डायलॉग, इमोशन टैग के साथ स्ट्रीमिंग TTS (9 भाषाएँ)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — ऑन-डिवाइस TTS (82M, CoreML/Neural Engine, 54 वॉयस, iOS-ready, 10 भाषाएँ)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — ऑन-डिवाइस LLM चैट (0.8B, MLX INT4 + CoreML INT8, DeltaNet हाइब्रिड, स्ट्रीमिंग टोकन)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — फुल-डुप्लेक्स स्पीच-टू-स्पीच (7B, ऑडियो इन → ऑडियो आउट, 18 वॉयस प्रीसेट)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — रियल-टाइम नॉइज़ सप्रेशन (2.1M params, 48 kHz)
+- **[VAD](https://soniqo.audio/guides/vad)** — वॉयस एक्टिविटी डिटेक्शन (Silero स्ट्रीमिंग, Pyannote ऑफ़लाइन, FireRedVAD 100+ भाषाएँ)
+- **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — कौन कब बोला (Pyannote पाइपलाइन, Neural Engine पर एंड-टू-एंड Sortformer)
+- **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), CAM++ (192-dim)
 
-- **Qwen3-ASR** — स्पीच-टू-टेक्स्ट / स्पीच रिकग्निशन (ऑटोमैटिक स्पीच रिकग्निशन, 52 भाषाएँ)
-- **Parakeet TDT** — CoreML के माध्यम से स्पीच-टू-टेक्स्ट (Neural Engine, NVIDIA FastConformer + TDT decoder, 25 भाषाएँ)
-- **Omnilingual ASR** — CoreML के माध्यम से स्पीच-टू-टेक्स्ट (Meta wav2vec2 + CTC, **1,672 भाषाएँ** 150+ परिवारों में, 5/10 s विंडो, INT8 palettized, ANE)
-- **Qwen3-ForcedAligner** — शब्द-स्तरीय टाइमस्टैम्प अलाइनमेंट (ऑडियो + टेक्स्ट → टाइमस्टैम्प)
-- **Qwen3-TTS** — टेक्स्ट-टू-स्पीच सिंथेसिस (सर्वोच्च गुणवत्ता, स्ट्रीमिंग, कस्टम स्पीकर, 10 भाषाएँ)
-- **CosyVoice TTS** — स्ट्रीमिंग, वॉयस क्लोनिंग, मल्टी-स्पीकर डायलॉग, और इमोशन टैग के साथ टेक्स्ट-टू-स्पीच (9 भाषाएँ, DiT flow matching, CAM++ speaker encoder)
-- **Kokoro TTS** — ऑन-डिवाइस टेक्स्ट-टू-स्पीच (82M params, CoreML/Neural Engine, 54 वॉयस, iOS-ready, 10 भाषाएँ)
-- **Qwen3-TTS CoreML** — टेक्स्ट-टू-स्पीच (0.6B, CoreML 6-मॉडल पाइपलाइन, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** — ऑन-डिवाइस LLM चैट (0.8B, MLX + CoreML, INT4 + CoreML INT8, DeltaNet हाइब्रिड, स्ट्रीमिंग टोकन)
-- **PersonaPlex** — फुल-डुप्लेक्स स्पीच-टू-स्पीच वार्तालाप (7B, ऑडियो इन → ऑडियो आउट, 18 वॉयस प्रीसेट)
-- **DeepFilterNet3** — स्पीच एन्हांसमेंट / नॉइज़ सप्रेशन (2.1M params, रियल-टाइम 48kHz)
-- **FireRedVAD** — ऑफ़लाइन वॉयस एक्टिविटी डिटेक्शन (DFSMN, CoreML, 100+ भाषाएँ, 97.6% F1)
-- **Silero VAD** — स्ट्रीमिंग वॉयस एक्टिविटी डिटेक्शन (32ms chunks, सब-मिलीसेकंड लेटेंसी)
-- **Pyannote VAD** — ऑफ़लाइन वॉयस एक्टिविटी डिटेक्शन (10s विंडो, मल्टी-स्पीकर ओवरलैप)
-- **Speaker Diarization** — कौन कब बोला (Pyannote सेगमेंटेशन + एक्टिविटी-बेस्ड स्पीकर चेनिंग, या एंड-टू-एंड Sortformer Neural Engine पर)
-- **Speaker Embeddings** — स्पीकर वेरिफिकेशन और आइडेंटिफिकेशन (WeSpeaker ResNet34, 256-dim वेक्टर)
-
-पेपर: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## रोडमैप
-
-आगे की योजनाओं के लिए [रोडमैप चर्चा](https://github.com/soniqo/speech-swift/discussions/81) देखें — टिप्पणियाँ और सुझावों का स्वागत है!
+पेपर: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## समाचार
 
@@ -45,17 +37,17 @@ Mac और iOS के लिए ऑन-डिवाइस स्पीच रि
 अपने `Package.swift` में पैकेज जोड़ें:
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-केवल वही मॉड्यूल इम्पोर्ट करें जिनकी आपको ज़रूरत है — प्रत्येक मॉडल अपनी अलग SPM लाइब्रेरी है:
+केवल वही मॉड्यूल इम्पोर्ट करें जिनकी आपको ज़रूरत है — प्रत्येक मॉडल अपनी अलग SPM लाइब्रेरी है, इसलिए आप केवल उसी के लिए भुगतान करते हैं जो आप उपयोग करते हैं:
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
 .product(name: "SpeechUI",             package: "speech-swift"),  // वैकल्पिक SwiftUI व्यू
 ```
 
-**3 लाइनों में ऑडियो बफ़र को ट्रांसक्राइब करें:**
+**3 लाइनों में ऑडियो बफ़र ट्रांसक्राइब करें:**
 
 ```swift
 import ParakeetStreamingASR
@@ -64,7 +56,7 @@ let model = try await ParakeetStreamingASRModel.fromPretrained()
 let text = try model.transcribeAudio(audioSamples, sampleRate: 16000)
 ```
 
-**आंशिक परिणामों के साथ लाइव स्ट्रीमिंग:**
+**पार्शियल्स के साथ लाइव स्ट्रीमिंग:**
 
 ```swift
 for await partial in model.transcribeStream(audio: samples, sampleRate: 16000) {
@@ -96,71 +88,31 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI` में केवल `TranscriptionView` (फ़ाइनल + पार्शियल) और `TranscriptionStore` (स्ट्रीमिंग ASR एडाप्टर) शामिल हैं। ऑडियो विज़ुअलाइज़ेशन और प्लेबैक के लिए AVFoundation का उपयोग करें।
+`SpeechUI` केवल `TranscriptionView` (finals + partials) और `TranscriptionStore` (स्ट्रीमिंग ASR एडाप्टर) प्रदान करता है। ऑडियो विज़ुअलाइज़ेशन और प्लेबैक के लिए AVFoundation का उपयोग करें।
 
-उपलब्ध SPM प्रोडक्ट्स: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`।
+उपलब्ध SPM उत्पाद: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## मॉडल
 
-| Model | Task | Streaming | Languages | Sizes |
-|-------|------|-----------|-----------|-------|
-| Qwen3-ASR-0.6B | Speech → Text | No | 52 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | Speech → Text | No | 52 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | Speech → Text | No | 25 European languages | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | Speech → Text | Yes (streaming + EOU) | 25 European languages | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | Speech → Text | No (5/10 s window) | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | Speech → Text | No | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | Speech → Text | No | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | Speech → Text | No | [1,672 languages](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | Audio + Text → Timestamps | No | Multi | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | Text → Speech | Yes (~120ms) | 10 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | Text → Speech | Yes (~120ms) | 10 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | Text → Speech | Yes (~120ms) | 10 languages | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | Text → Speech | Yes (~150ms) | 9 languages | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | Text → Speech | No | 10 languages | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | Speech → Speech | Yes (~2s chunks) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | Voice Activity Detection | No (offline) | 100+ languages | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | Voice Activity Detection | Yes (32ms chunks) | Language-agnostic | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + Speaker Segmentation | No (10s windows) | Language-agnostic | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | Speech Enhancement | Yes (10ms frames) | Language-agnostic | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | Speaker Embedding (256-dim) | No | Language-agnostic | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | Speaker Embedding (192-dim) | No | Language-agnostic | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | Speaker Diarization (end-to-end) | Yes (chunked) | Language-agnostic | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+नीचे संक्षिप्त दृश्य। **[पूर्ण मॉडल कैटलॉग (आकार, क्वांटिज़ेशन, डाउनलोड URL, मेमोरी टेबल्स) → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### मेमोरी आवश्यकताएँ
-
-वेट मेमोरी वह GPU (MLX) या ANE (CoreML) मेमोरी है जो मॉडल पैरामीटर द्वारा उपयोग की जाती है। पीक इनफ़रेंस में KV कैश, एक्टिवेशन, और इंटरमीडिएट टेंसर शामिल हैं।
-
-| Model | Weight Memory | Peak Inference |
-|-------|--------------|----------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### कौन सा TTS कब उपयोग करें
-
-- **Qwen3-TTS**: सर्वोत्तम गुणवत्ता, स्ट्रीमिंग (~120ms), 9 बिल्ट-इन स्पीकर, 10 भाषाएँ, बैच सिंथेसिस
-- **CosyVoice TTS**: स्ट्रीमिंग (~150ms), 9 भाषाएँ, वॉयस क्लोनिंग (CAM++ speaker encoder), मल्टी-स्पीकर डायलॉग (`[S1] ... [S2] ...`), इनलाइन इमोशन/स्टाइल टैग (`(happy)`, `(whispers)`), DiT flow matching + HiFi-GAN vocoder
-- **Kokoro TTS**: हल्का iOS-ready TTS (82M params), CoreML/Neural Engine, 54 वॉयस, 10 भाषाएँ, एंड-टू-एंड मॉडल
-- **PersonaPlex**: फुल-डुप्लेक्स स्पीच-टू-स्पीच (ऑडियो इन → ऑडियो आउट), स्ट्रीमिंग (~2s chunks), 18 वॉयस प्रीसेट, Moshi आर्किटेक्चर पर आधारित
+| मॉडल | कार्य | बैकएंड | आकार | भाषाएँ |
+|------|------|--------|------|--------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | स्पीच → टेक्स्ट | MLX, CoreML (हाइब्रिड) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | स्पीच → टेक्स्ट | CoreML (ANE) | 0.6B | 25 यूरोपीय |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | स्पीच → टेक्स्ट (स्ट्रीमिंग) | CoreML (ANE) | 120M | 25 यूरोपीय |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | स्पीच → टेक्स्ट | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1,672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | ऑडियो + टेक्स्ट → टाइमस्टैम्प | MLX, CoreML | 0.6B | बहुभाषी |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | टेक्स्ट → स्पीच | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | टेक्स्ट → स्पीच | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | टेक्स्ट → स्पीच | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | टेक्स्ट → टेक्स्ट (LLM) | MLX, CoreML | 0.8B | बहुभाषी |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | स्पीच → स्पीच | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | वॉयस एक्टिविटी डिटेक्शन | MLX, CoreML | 309K | भाषा-तटस्थ |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarization | MLX | 1.5M | भाषा-तटस्थ |
+| [Sortformer](https://soniqo.audio/guides/diarize) | Diarization (E2E) | CoreML (ANE) | — | भाषा-तटस्थ |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | स्पीच एन्हांसमेंट | CoreML | 2.1M | भाषा-तटस्थ |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | स्पीकर एम्बेडिंग | MLX, CoreML | 6.6M | भाषा-तटस्थ |
 
 ## इंस्टॉलेशन
 
@@ -173,51 +125,48 @@ brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-फिर उपयोग करें:
+फिर:
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (न्यूरल इंजन)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> माइक्रोफ़ोन इनपुट के साथ इंटरैक्टिव वॉयस वार्तालाप के लिए, **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** देखें।
+**[पूर्ण CLI संदर्भ →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-अपने `Package.swift` में जोड़ें:
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-आवश्यक मॉड्यूल इम्पोर्ट करें:
+केवल वही इम्पोर्ट करें जो आपको चाहिए — प्रत्येक मॉडल अपना SPM target है:
 
 ```swift
-import Qwen3ASR      // Speech recognition (MLX)
-import ParakeetASR   // Speech recognition (CoreML)
-import Qwen3TTS      // Text-to-speech (Qwen3)
-import CosyVoiceTTS  // Text-to-speech (streaming)
-import KokoroTTS     // Text-to-speech (CoreML, iOS-ready)
-import Qwen3Chat     // On-device LLM chat (CoreML)
-import PersonaPlex   // Speech-to-speech (full-duplex)
-import SpeechVAD          // Voice activity detection (pyannote + Silero)
-import SpeechEnhancement  // Noise suppression (DeepFilterNet3)
-import AudioCommon        // Shared utilities
+import Qwen3ASR             // स्पीच रिकग्निशन (MLX)
+import ParakeetASR          // स्पीच रिकग्निशन (CoreML, बैच)
+import ParakeetStreamingASR // पार्शियल्स + EOU के साथ स्ट्रीमिंग डिक्टेशन
+import OmnilingualASR       // 1,672 भाषाएँ (CoreML + MLX)
+import Qwen3TTS             // टेक्स्ट-टू-स्पीच
+import CosyVoiceTTS         // वॉयस क्लोनिंग के साथ TTS
+import KokoroTTS            // टेक्स्ट-टू-स्पीच (iOS-ready)
+import Qwen3Chat            // ऑन-डिवाइस LLM चैट
+import PersonaPlex          // फुल-डुप्लेक्स स्पीच-टू-स्पीच
+import SpeechVAD            // VAD + स्पीकर डायराइज़ेशन + एम्बेडिंग
+import SpeechEnhancement    // नॉइज़ सप्रेशन
+import SpeechUI             // स्ट्रीमिंग ट्रांसक्रिप्ट के लिए SwiftUI कॉम्पोनेंट
+import AudioCommon          // शेयर्ड प्रोटोकॉल और यूटिलिटीज़
 ```
 
 ### आवश्यकताएँ
 
-- Swift 5.9+
-- macOS 14+ या iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (Metal Toolchain के साथ — यदि अनुपलब्ध हो तो `xcodebuild -downloadComponent MetalToolchain` चलाएँ)
+- Swift 5.9+, Xcode 15+ (Metal Toolchain के साथ)
+- macOS 14+ या iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
-### सोर्स से बिल्ड करें
+### सोर्स से बिल्ड
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-यह Swift पैकेज **और** MLX Metal shader लाइब्रेरी को एक साथ कंपाइल करता है। Metal लाइब्रेरी (`mlx.metallib`) GPU इनफ़रेंस के लिए आवश्यक है — इसके बिना रनटाइम पर `Failed to load the default metallib` एरर आएगी।
+`make build` Swift पैकेज **और** MLX Metal shader library दोनों को कंपाइल करता है। GPU इन्फ़रेंस के लिए Metal library आवश्यक है — इसके बिना आपको रनटाइम पर `Failed to load the default metallib` दिखेगा। `make debug` डीबग बिल्ड के लिए, `make test` टेस्ट सूट के लिए।
 
-डीबग बिल्ड के लिए: `make debug`। यूनिट टेस्ट चलाने के लिए: `make test`।
-
-## वॉयस असिस्टेंट आज़माएँ
-
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** एक रेडी-टू-रन macOS वॉयस असिस्टेंट है — बोलने के लिए टैप करें, रियल-टाइम में बोले गए जवाब पाएँ। माइक्रोफ़ोन इनपुट के साथ Silero VAD का उपयोग करता है ऑटोमैटिक स्पीच डिटेक्शन के लिए, ट्रांसक्रिप्शन के लिए Qwen3-ASR, और स्पीच-टू-स्पीच जनरेशन के लिए PersonaPlex 7B। 18 वॉयस प्रीसेट और इनर मोनोलॉग ट्रांसक्रिप्ट डिस्प्ले के साथ मल्टी-टर्न वार्तालाप।
-
-```bash
-make build  # repo root से — MLX metallib सहित सब कुछ बिल्ड करता है
-cd Examples/PersonaPlexDemo
-# .app बंडल के निर्देशों के लिए Examples/PersonaPlexDemo/README.md देखें
-```
-
-> M2 Max पर RTF ~0.94 (रियल-टाइम से तेज़)। पहली बार चलाने पर मॉडल स्वतः डाउनलोड होते हैं (~5.5 GB PersonaPlex + ~400 MB ASR)।
+**[पूर्ण बिल्ड और इंस्टॉल गाइड →](https://soniqo.audio/getting-started)**
 
 ## डेमो ऐप्स
 
-- **[DictateDemo](Examples/DictateDemo/)** ([दस्तावेज़](https://soniqo.audio/guides/dictate/)) — macOS मेनू बार स्ट्रीमिंग डिक्टेशन लाइव पार्शियल, VAD-संचालित एंड-ऑफ-अटरेंस डिटेक्शन और वन-क्लिक कॉपी के साथ। पृष्ठभूमि मेनू बार एजेंट के रूप में चलता है (Parakeet-EOU-120M + Silero VAD)।
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS इको डेमो (Parakeet ASR + Kokoro TTS, बोलें और वापस सुनें)। डिवाइस और सिम्युलेटर।
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — वार्तालाप वॉयस असिस्टेंट (माइक इनपुट, VAD, मल्टी-टर्न)। macOS।
-- **[SpeechDemo](Examples/SpeechDemo/)** — डिक्टेशन और टेक्स्ट-टू-स्पीच सिंथेसिस टैब्ड इंटरफ़ेस। macOS।
+- **[DictateDemo](Examples/DictateDemo/)** ([डॉक्स](https://soniqo.audio/guides/dictate)) — macOS मेनू-बार स्ट्रीमिंग डिक्टेशन, लाइव पार्शियल्स, VAD-संचालित एंड-ऑफ-अटरन्स डिटेक्शन, और वन-क्लिक कॉपी। बैकग्राउंड एजेंट के रूप में चलता है (Parakeet-EOU-120M + Silero VAD)।
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS इको डेमो (Parakeet ASR + Kokoro TTS)। डिवाइस और सिम्युलेटर।
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — माइक इनपुट, VAD, और मल्टी-टर्न संदर्भ के साथ संवादात्मक वॉयस असिस्टेंट। macOS। M2 Max पर RTF ~0.94 (रियल-टाइम से तेज़)।
+- **[SpeechDemo](Examples/SpeechDemo/)** — टैब्ड इंटरफ़ेस में डिक्टेशन और TTS सिंथेसिस। macOS।
 
-बिल्ड और रन करें — निर्देशों के लिए प्रत्येक डेमो का README देखें।
+प्रत्येक डेमो के README में बिल्ड निर्देश हैं।
 
-## स्पीच-टू-टेक्स्ट (ASR) — Swift में ऑडियो ट्रांसक्राइब करें
+## कोड उदाहरण
 
-### बेसिक ट्रांसक्रिप्शन
+नीचे दिए गए स्निपेट्स प्रत्येक डोमेन के लिए न्यूनतम पथ दिखाते हैं। प्रत्येक अनुभाग [soniqo.audio](https://soniqo.audio) पर पूर्ण गाइड से लिंक होता है जिसमें कॉन्फ़िगरेशन विकल्प, कई बैकएंड, स्ट्रीमिंग पैटर्न, और CLI रेसिपी शामिल हैं।
 
-```swift
-import Qwen3ASR
-
-// डिफ़ॉल्ट: 0.6B मॉडल
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// या बेहतर सटीकता के लिए बड़ा 1.7B मॉडल उपयोग करें
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// ऑडियो किसी भी सैंपल रेट पर हो सकता है — स्वतः 16kHz में रीसैंपल किया जाता है
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### CoreML Encoder (Neural Engine)
-
-हाइब्रिड मोड: Neural Engine पर CoreML encoder + GPU पर MLX text decoder। कम पावर, encoder पास के लिए GPU फ़्री करता है।
+### स्पीच-टू-टेक्स्ट — [पूर्ण गाइड →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-INT8 (180 MB, डिफ़ॉल्ट) और INT4 (90 MB) वेरिएंट उपलब्ध हैं। INT8 अनुशंसित है (FP32 के मुकाबले cosine similarity > 0.999)।
+वैकल्पिक बैकएंड: [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× रियल-टाइम), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1,672 भाषाएँ, CoreML या MLX), [स्ट्रीमिंग डिक्टेशन](https://soniqo.audio/guides/dictate) (लाइव पार्शियल्स)।
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-CoreML के माध्यम से Neural Engine पर चलता है — समवर्ती कार्यभार के लिए GPU फ़्री करता है। 25 यूरोपीय भाषाएँ, ~315 MB।
-
-### ASR CLI
-
-```bash
-make build  # या: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# डिफ़ॉल्ट (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# 1.7B मॉडल उपयोग करें
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# CoreML encoder (Neural Engine + MLX decoder)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## फ़ोर्स्ड अलाइनमेंट
-
-### शब्द-स्तरीय टाइमस्टैम्प
+### फ़ोर्स्ड अलाइनमेंट — [पूर्ण गाइड →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// पहली बार चलाने पर ~979 MB डाउनलोड होता है
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### फ़ोर्स्ड अलाइनमेंट CLI
-
-```bash
-swift build -c release
-
-# दिए गए टेक्स्ट के साथ अलाइन करें
-.build/release/audio align audio.wav --text "Hello world"
-
-# पहले ट्रांसक्राइब करें, फिर अलाइन करें
-.build/release/audio align audio.wav
-```
-
-आउटपुट:
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-एंड-टू-एंड मॉडल, नॉन-ऑटोरिग्रेसिव, कोई सैंपलिंग लूप नहीं। आर्किटेक्चर विवरण के लिए [Forced Aligner](docs/inference/forced-aligner.md) देखें।
-
-## टेक्स्ट-टू-स्पीच (TTS) — Swift में स्पीच जनरेट करें
-
-### बेसिक सिंथेसिस
+### टेक्स्ट-टू-स्पीच — [पूर्ण गाइड →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // WAVWriter के लिए
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// पहली बार चलाने पर ~1.7 GB डाउनलोड होता है (मॉडल + codec वेट)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// आउटपुट 24kHz मोनो float सैंपल है
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### TTS CLI
+वैकल्पिक TTS इंजन: [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (स्ट्रीमिंग + वॉयस क्लोनिंग + इमोशन टैग), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (iOS-ready, 54 वॉयस), [वॉयस क्लोनिंग](https://soniqo.audio/guides/voice-cloning)।
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### कस्टम वॉयस / स्पीकर चयन
-
-**CustomVoice** मॉडल वेरिएंट 9 बिल्ट-इन स्पीकर वॉयस और टोन/स्टाइल कंट्रोल के लिए नेचुरल लैंग्वेज निर्देशों का समर्थन करता है। CustomVoice मॉडल ID पास करके इसे लोड करें:
-
-```swift
-import Qwen3TTS
-
-// CustomVoice मॉडल लोड करें (पहली बार चलाने पर ~1.7 GB डाउनलोड होता है)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// किसी विशिष्ट स्पीकर के साथ सिंथेसाइज़ करें
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// उपलब्ध स्पीकर देखें
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# स्पीकर के साथ CustomVoice मॉडल उपयोग करें
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# उपलब्ध स्पीकर की सूची देखें
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### वॉयस क्लोनिंग (Base मॉडल)
-
-रेफ़रेंस ऑडियो फ़ाइल से स्पीकर की आवाज़ क्लोन करें। दो मोड:
-
-**ICL मोड** (अनुशंसित) — ट्रांसक्रिप्ट के साथ रेफ़रेंस ऑडियो को codec टोकन में एनकोड करता है। उच्च गुणवत्ता, विश्वसनीय EOS:
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**X-vector मोड** — केवल स्पीकर एम्बेडिंग, ट्रांसक्रिप्ट की आवश्यकता नहीं लेकिन गुणवत्ता कम:
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### टोन / स्टाइल निर्देश (केवल CustomVoice)
-
-CustomVoice मॉडल बोलने की शैली, टोन, भावना, और गति को नियंत्रित करने के लिए नेचुरल लैंग्वेज `instruct` पैरामीटर स्वीकार करता है। निर्देश ChatML प्रारूप में मॉडल इनपुट से पहले जोड़ा जाता है।
-
-```swift
-// खुशमिज़ाज़ टोन
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// धीमा और गंभीर
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// फुसफुसाहट
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# स्टाइल निर्देश के साथ
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# CustomVoice उपयोग करते समय डिफ़ॉल्ट instruct ("Speak naturally.") स्वतः लागू होता है
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-जब CustomVoice मॉडल के साथ कोई `--instruct` नहीं दिया जाता, तो बेकाबू आउटपुट रोकने के लिए `"Speak naturally."` स्वतः लागू होता है। Base मॉडल instruct को सपोर्ट नहीं करता।
-
-### बैच सिंथेसिस
-
-अधिक थ्रूपुट के लिए एक ही बैच्ड फ़ॉरवर्ड पास में कई टेक्स्ट सिंथेसाइज़ करें:
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] texts[i] के लिए 24kHz मोनो float सैंपल है
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### बैच CLI
-
-```bash
-# प्रति पंक्ति एक टेक्स्ट वाली फ़ाइल बनाएँ
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# output_0.wav, output_1.wav, ... बनता है
-```
-
-> बैच मोड आइटम्स में मॉडल वेट लोड को वितरित करता है। Apple Silicon पर B=4 के लिए ~1.5-2.5x थ्रूपुट सुधार की उम्मीद करें। सर्वोत्तम परिणाम तब मिलते हैं जब टेक्स्ट समान-लंबाई का ऑडियो उत्पन्न करते हैं।
-
-### सैंपलिंग विकल्प
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### स्ट्रीमिंग सिंथेसिस
-
-कम फ़र्स्ट-पैकेट लेटेंसी के लिए ऑडियो चंक्स क्रमिक रूप से भेजें:
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // पहले ऑडियो चंक तक ~120ms
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: अंतिम चंक पर true
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# डिफ़ॉल्ट स्ट्रीमिंग (3-frame पहला चंक, ~225ms लेटेंसी)
-.build/release/audio speak "Hello world" --stream
-
-# लो-लेटेंसी (1-frame पहला चंक, ~120ms लेटेंसी)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## स्पीच-टू-स्पीच — फुल-डुप्लेक्स वॉयस वार्तालाप
-
-> माइक्रोफ़ोन इनपुट के साथ इंटरैक्टिव वॉयस असिस्टेंट के लिए, **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** देखें — बोलने के लिए टैप करें, ऑटोमैटिक स्पीच डिटेक्शन के साथ मल्टी-टर्न वार्तालाप।
-
-### स्पीच-टू-स्पीच
+### स्पीच-टू-स्पीच — [पूर्ण गाइड →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // WAVWriter, AudioFileLoader के लिए
 
 let model = try await PersonaPlexModel.fromPretrained()
-// पहली बार चलाने पर ~5.5 GB डाउनलोड होता है (temporal 4-bit + depformer + Mimi codec + voice presets)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: 24kHz मोनो float सैंपल
-// textTokens: मॉडल का इनर मोनोलॉग (SentencePiece token IDs)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// 24 kHz मोनो Float32 आउटपुट — प्लेबैक के लिए तैयार
 ```
 
-### इनर मोनोलॉग (टेक्स्ट आउटपुट)
-
-PersonaPlex ऑडियो के साथ-साथ टेक्स्ट टोकन जनरेट करता है — मॉडल की आंतरिक तर्क प्रक्रिया। बिल्ट-इन SentencePiece डीकोडर से इन्हें डीकोड करें:
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // जैसे "Sure, I can help you with that..."
-```
-
-### स्ट्रीमिंग स्पीच-टू-स्पीच
-
-```swift
-// जनरेट होते ही ऑडियो चंक प्राप्त करें (~2s प्रति चंक)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // तुरंत चलाएँ, 24kHz मोनो
-    // chunk.textTokens में इस चंक का टेक्स्ट है; अंतिम चंक में सभी टोकन हैं
-    if chunk.isFinal { break }
-}
-```
-
-### वॉयस चयन
-
-18 वॉयस प्रीसेट उपलब्ध हैं:
-- **Natural Female**: NATF0, NATF1, NATF2, NATF3
-- **Natural Male**: NATM0, NATM1, NATM2, NATM3
-- **Variety Female**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **Variety Male**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### सिस्टम प्रॉम्प्ट
-
-सिस्टम प्रॉम्प्ट मॉडल के वार्तालाप व्यवहार को निर्देशित करता है। कोई भी कस्टम प्रॉम्प्ट सादे स्ट्रिंग के रूप में पास करें:
-
-```swift
-// कस्टम सिस्टम प्रॉम्प्ट (स्वचालित रूप से टोकनाइज़ होता है)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// या प्रीसेट का उपयोग करें
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-उपलब्ध प्रीसेट: `focused` (डिफ़ॉल्ट), `assistant`, `customerService`, `teacher`।
-
-### PersonaPlex CLI
-
-```bash
-make build
-
-# बेसिक स्पीच-टू-स्पीच
-.build/release/audio respond --input question.wav --output response.wav
-
-# ट्रांसक्रिप्ट के साथ (इनर मोनोलॉग टेक्स्ट डीकोड करता है)
-.build/release/audio respond --input question.wav --transcript
-
-# JSON आउटपुट (ऑडियो पाथ, ट्रांसक्रिप्ट, लेटेंसी मेट्रिक्स)
-.build/release/audio respond --input question.wav --json
-
-# कस्टम सिस्टम प्रॉम्प्ट टेक्स्ट
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# वॉयस और सिस्टम प्रॉम्प्ट प्रीसेट चुनें
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# सैंपलिंग पैरामीटर ट्यून करें
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# टेक्स्ट एन्ट्रॉपी अर्ली स्टॉपिंग सक्षम करें (टेक्स्ट कोलैप्स होने पर रुकता है)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# उपलब्ध वॉयस और प्रॉम्प्ट की सूची देखें
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — वॉयस क्लोनिंग के साथ स्ट्रीमिंग टेक्स्ट-टू-स्पीच
-
-### बेसिक सिंथेसिस
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // WAVWriter के लिए
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// पहली बार चलाने पर ~1.9 GB डाउनलोड होता है (LLM + DiT + HiFi-GAN वेट)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// आउटपुट 24kHz मोनो float सैंपल है
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### स्ट्रीमिंग सिंथेसिस
-
-```swift
-// स्ट्रीमिंग: जनरेट होते ही ऑडियो चंक प्राप्त करें (पहले चंक तक ~150ms)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // तुरंत चलाएँ
-}
-```
-
-### वॉयस क्लोनिंग (CosyVoice)
-
-CAM++ speaker encoder (192-dim, CoreML Neural Engine) का उपयोग करके स्पीकर की आवाज़ क्लोन करें:
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// पहले उपयोग पर ~14 MB CAM++ CoreML मॉडल डाउनलोड होता है
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: [Float] लंबाई 192
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CosyVoice TTS CLI
-
-```bash
-make build
-
-# बेसिक सिंथेसिस
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# वॉयस क्लोनिंग (पहले उपयोग पर CAM++ speaker encoder डाउनलोड होता है)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# वॉयस क्लोनिंग के साथ मल्टी-स्पीकर डायलॉग
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# इनलाइन इमोशन/स्टाइल टैग
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# संयुक्त: डायलॉग + इमोशन + वॉयस क्लोनिंग
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# कस्टम स्टाइल निर्देश
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# स्ट्रीमिंग सिंथेसिस
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — हल्का ऑन-डिवाइस टेक्स्ट-टू-स्पीच (iOS + macOS)
-
-### बेसिक सिंथेसिस
-
-```swift
-import KokoroTTS
-import AudioCommon  // WAVWriter के लिए
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// पहली बार चलाने पर ~170 MB डाउनलोड होता है (CoreML मॉडल + voice embeddings + dictionaries)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// आउटपुट 24kHz मोनो float सैंपल है
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-10 भाषाओं में 54 प्रीसेट वॉयस। एंड-टू-एंड CoreML मॉडल, नॉन-ऑटोरिग्रेसिव, कोई सैंपलिंग लूप नहीं। Neural Engine पर चलता है, GPU पूरी तरह फ़्री रहता है।
-
-### Kokoro TTS CLI
-
-```bash
-make build
-
-# बेसिक सिंथेसिस
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# भाषा चुनें
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# उपलब्ध वॉयस की सूची देखें
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-CoreML पर चलने वाली 6-मॉडल ऑटोरिग्रेसिव पाइपलाइन। W8A16 पैलेटाइज़्ड वेट।
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (ऑन-डिवाइस LLM)
+### LLM चैट — [पूर्ण गाइड →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// पहली बार चलाने पर ~318 MB डाउनलोड होता है (INT4 CoreML मॉडल + tokenizer)
-
-// सिंगल रिस्पॉन्स
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// स्ट्रीमिंग टोकन
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B CoreML के लिए INT4 क्वांटाइज़्ड। Neural Engine पर ~2 tok/s iPhone पर, ~15 tok/s M-series पर चलता है। KV cache के साथ मल्टी-टर्न वार्तालाप, थिंकिंग मोड (`<think>` टोकन), और कॉन्फ़िगर करने योग्य सैंपलिंग (temperature, top-k, top-p, repetition penalty) का समर्थन करता है।
-
-## वॉयस एक्टिविटी डिटेक्शन (VAD) — ऑडियो में स्पीच डिटेक्ट करें
-
-### स्ट्रीमिंग VAD (Silero)
-
-Silero VAD v5 सब-मिलीसेकंड लेटेंसी के साथ 32ms ऑडियो चंक प्रोसेस करता है — माइक्रोफ़ोन या स्ट्रीम से रियल-टाइम स्पीच डिटेक्शन के लिए आदर्श।
+### वॉयस एक्टिविटी डिटेक्शन — [पूर्ण गाइड →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// या CoreML उपयोग करें (Neural Engine, कम पावर):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// स्ट्रीमिंग: 512-सैंपल चंक प्रोसेस करें (16kHz पर 32ms)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // अलग-अलग ऑडियो स्ट्रीम के बीच कॉल करें
-
-// या सभी सेगमेंट एक बार में डिटेक्ट करें
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Speech: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### इवेंट-ड्रिवन स्ट्रीमिंग
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// किसी भी लंबाई का ऑडियो फ़ीड करें — स्पीच कन्फ़र्म होते ही इवेंट भेजे जाते हैं
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Speech started at \(time)s")
-    case .speechEnded(let segment):
-        print("Speech: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// स्ट्रीम के अंत में फ़्लश करें
-let final = processor.flush()
-```
-
-### VAD CLI
-
-```bash
-make build
-
-# स्ट्रीमिंग Silero VAD (32ms chunks)
-.build/release/audio vad-stream audio.wav
-
-# CoreML बैकएंड (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# कस्टम थ्रेशोल्ड के साथ
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# JSON आउटपुट
-.build/release/audio vad-stream audio.wav --json
-
-# बैच pyannote VAD (10s स्लाइडिंग विंडो)
-.build/release/audio vad audio.wav
-```
-
-## स्पीकर डायराइज़ेशन — कौन कब बोला
-
-### डायराइज़ेशन पाइपलाइन
+### स्पीकर डायराइज़ेशन — [पूर्ण गाइड →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// या CoreML embeddings (Neural Engine, GPU फ़्री करता है) उपयोग करें:
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) speakers detected")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### स्पीकर एम्बेडिंग
+### स्पीच एन्हांसमेंट — [पूर्ण गाइड →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// या: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: [Float] लंबाई 256, L2-normalized
+import SpeechEnhancement
 
-// स्पीकर की तुलना करें
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### स्पीकर एक्सट्रैक्शन
-
-रेफ़रेंस रिकॉर्डिंग का उपयोग करके केवल किसी विशिष्ट स्पीकर के सेगमेंट निकालें:
+### वॉयस पाइपलाइन (ASR → LLM → TTS) — [पूर्ण गाइड →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Sortformer डायराइज़ेशन (एंड-टू-एंड, CoreML)
+`VoicePipeline` रियल-टाइम वॉयस-एजेंट स्टेट मशीन है ([speech-core](https://github.com/soniqo/speech-core) द्वारा संचालित) जो VAD-संचालित टर्न डिटेक्शन, इंटरप्शन हैंडलिंग, और eager STT के साथ आता है। यह किसी भी `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider` को कनेक्ट करता है।
 
-NVIDIA Sortformer अधिकतम 4 स्पीकर के लिए प्रति-फ़्रेम स्पीकर एक्टिविटी सीधे प्रेडिक्ट करता है — कोई एम्बेडिंग या क्लस्टरिंग आवश्यक नहीं। Neural Engine पर चलता है।
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### डायराइज़ेशन CLI
+### HTTP API सर्वर
 
 ```bash
-make build
-
-# Pyannote डायराइज़ेशन (डिफ़ॉल्ट)
-.build/release/audio diarize meeting.wav
-
-# Sortformer डायराइज़ेशन (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# CoreML embeddings (Neural Engine, केवल pyannote)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# JSON आउटपुट
-.build/release/audio diarize meeting.wav --json
-
-# किसी विशिष्ट स्पीकर को एक्सट्रैक्ट करें (केवल pyannote)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# स्पीकर एम्बेडिंग
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-आर्किटेक्चर विवरण के लिए [Speaker Diarization](docs/inference/speaker-diarization.md) देखें।
-
-## स्पीच एन्हांसमेंट — नॉइज़ सप्रेशन और ऑडियो क्लीनअप
-
-### नॉइज़ सप्रेशन
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // WAVWriter के लिए
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// पहली बार चलाने पर ~4.3 MB डाउनलोड होता है (Core ML FP16 मॉडल + सहायक डेटा)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### Denoise CLI
-
-```bash
-make build
-
-# बेसिक नॉइज़ रिमूवल
-.build/release/audio denoise noisy.wav
-
-# कस्टम आउटपुट पाथ
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-आर्किटेक्चर विवरण के लिए [Speech Enhancement](docs/inference/speech-enhancement.md) देखें।
-
-## पाइपलाइन — कई मॉडल को मिलाएँ
-
-सभी मॉडल साझा प्रोटोकॉल (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel`, आदि) का पालन करते हैं और पाइपलाइन में जोड़े जा सकते हैं:
-
-### शोरयुक्त स्पीच रिकग्निशन (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// 48kHz पर एन्हांस करें, फिर 16kHz पर ट्रांसक्राइब करें
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### वॉयस-टू-वॉयस रिले (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// स्पीच सेगमेंट डिटेक्ट करें, ट्रांसक्राइब करें, पुनः सिंथेसाइज़ करें
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: 24kHz मोनो float सैंपल
-}
-```
-
-### मीटिंग ट्रांसक्रिप्शन (डायराइज़ेशन + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Speaker \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-पूर्ण प्रोटोकॉल संदर्भ के लिए [Shared Protocols](docs/shared-protocols.md) देखें।
-
-## HTTP API सर्वर
-
-एक स्टैंडअलोन HTTP सर्वर सभी मॉडल को REST और WebSocket एंडपॉइंट के माध्यम से उपलब्ध कराता है। मॉडल पहली रिक्वेस्ट पर लेज़ी लोड होते हैं।
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# ऑडियो ट्रांसक्राइब करें
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# टेक्स्ट-टू-स्पीच
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# स्पीच-टू-स्पीच (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# स्पीच एन्हांसमेंट
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# स्टार्टअप पर सभी मॉडल प्रीलोड करें
-.build/release/audio-server --preload --port 8080
-```
-
-### WebSocket स्ट्रीमिंग
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-प्राथमिक WebSocket एंडपॉइंट [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) प्रोटोकॉल को इम्प्लीमेंट करता है — सभी संदेश `type` फ़ील्ड के साथ JSON हैं, ऑडियो base64-encoded PCM16 24kHz mono है।
-
-**Client → Server इवेंट:**
-
-| Event | विवरण |
-|-------|-------------|
-| `session.update` | इंजन, भाषा, ऑडियो फ़ॉर्मेट कॉन्फ़िगर करें |
-| `input_audio_buffer.append` | base64 PCM16 ऑडियो चंक भेजें |
-| `input_audio_buffer.commit` | संचित ऑडियो ट्रांसक्राइब करें (ASR) |
-| `input_audio_buffer.clear` | ऑडियो बफ़र साफ़ करें |
-| `response.create` | TTS सिंथेसिस का अनुरोध करें |
-
-**Server → Client इवेंट:**
-
-| Event | विवरण |
-|-------|-------------|
-| `session.created` | सेशन इनिशियलाइज़ हुआ |
-| `session.updated` | कॉन्फ़िगरेशन पुष्टि |
-| `input_audio_buffer.committed` | ट्रांसक्रिप्शन के लिए ऑडियो कमिट हुआ |
-| `conversation.item.input_audio_transcription.completed` | ASR परिणाम |
-| `response.audio.delta` | Base64 PCM16 ऑडियो चंक (TTS) |
-| `response.audio.done` | ऑडियो स्ट्रीमिंग पूर्ण |
-| `response.done` | मेटाडेटा के साथ रिस्पॉन्स पूर्ण |
-| `error` | प्रकार और संदेश के साथ एरर |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: ऑडियो भेजें, ट्रांसक्रिप्शन प्राप्त करें
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → प्राप्त होता है: conversation.item.input_audio_transcription.completed
-
-// TTS: टेक्स्ट भेजें, स्ट्रीम्ड ऑडियो प्राप्त करें
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → प्राप्त होता है: response.audio.delta (base64 chunks), response.audio.done, response.done
-```
-
-एक उदाहरण HTML क्लाइंट `Examples/websocket-client.html` पर है — सर्वर चलते समय इसे ब्राउज़र में खोलें।
-
-सर्वर एक अलग `AudioServer` मॉड्यूल और `audio-server` एक्ज़ीक्यूटेबल है — यह मुख्य `audio` CLI में Hummingbird/WebSocket नहीं जोड़ता।
-
-## लेटेंसी (M2 Max, 64 GB)
-
-### ASR
-
-| Model | Backend | RTF | 10s ऑडियो प्रोसेसिंग समय |
-|-------|---------|-----|------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 cold, ~0.03 warm | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### फ़ोर्स्ड अलाइनमेंट
-
-| Model | Framework | 20s ऑडियो | RTF |
-|-------|-----------|-----------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> सिंगल नॉन-ऑटोरिग्रेसिव फ़ॉरवर्ड पास — कोई सैंपलिंग लूप नहीं। ऑडियो encoder प्रमुख है (~328ms), decoder सिंगल-पास ~37ms। **रियल-टाइम से 55x तेज़।**
-
-### TTS
-
-| Model | Framework | छोटा (1s) | मध्यम (3s) | लंबा (6s) | स्ट्रीमिंग फ़र्स्ट-पैकेट |
-|-------|-----------|-----------|-------------|------------|----------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1-frame) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (non-autoregressive) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTS प्रोसोडी और इमोशन के साथ प्राकृतिक, अभिव्यक्तिपूर्ण स्पीच जनरेट करता है, **रियल-टाइम से तेज़** (RTF < 1.0) चलता है। स्ट्रीमिंग सिंथेसिस पहला ऑडियो चंक ~120ms में देता है। Kokoro-82M पूरी तरह Neural Engine पर एंड-टू-एंड मॉडल से चलता है (RTFx ~0.7), iOS के लिए आदर्श। Apple का बिल्ट-इन TTS तेज़ है लेकिन रोबोटिक, एकस्वरीय स्पीच उत्पन्न करता है।
-
-### PersonaPlex (स्पीच-टू-स्पीच)
-
-| Model | Framework | ms/step | RTF | नोट्स |
-|-------|-----------|---------|-----|-------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | अनुशंसित — सुसंगत प्रतिक्रियाएँ, 4-bit से 30% तेज़ |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | अनुशंसित नहीं — आउटपुट गुणवत्ता में गिरावट |
-
-> **8-bit का उपयोग करें।** INT8 तेज़ (112 ms/step बनाम 158 ms/step) और सुसंगत फुल-डुप्लेक्स प्रतिक्रियाएँ उत्पन्न करता है। INT4 क्वांटाइज़ेशन जनरेशन गुणवत्ता को ख़राब करता है और अस्पष्ट भाषण उत्पन्न करता है। INT8 M2 Max पर ~112ms/step पर चलता है।
-
-### VAD और स्पीकर एम्बेडिंग
-
-| Model | Backend | प्रति-कॉल लेटेंसी | RTF | नोट्स |
-|-------|---------|-----------------|-----|-------|
-| Silero-VAD-v5 | MLX | ~2.1ms / chunk | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / chunk | 0.008 | Neural Engine, **7.7x तेज़** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20s audio | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20s audio | 0.021 | Neural Engine, GPU फ़्री करता है |
-
-> Silero VAD CoreML Neural Engine पर MLX से 7.7x तेज़ चलता है, जो हमेशा-चालू माइक्रोफ़ोन इनपुट के लिए आदर्श है। WeSpeaker MLX GPU पर तेज़ है, लेकिन CoreML समवर्ती कार्यभार (TTS, ASR) के लिए GPU फ़्री करता है। दोनों बैकएंड समतुल्य परिणाम देते हैं।
-
-### स्पीच एन्हांसमेंट
-
-| Model | Backend | अवधि | लेटेंसी | RTF |
-|-------|---------|----------|---------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Real-Time Factor (कम बेहतर है, < 1.0 = रियल-टाइम से तेज़)। GRU लागत ~O(n²) से बढ़ती है।
-
-### MLX vs CoreML
-
-दोनों बैकएंड समतुल्य परिणाम देते हैं। अपने कार्यभार के आधार पर चुनें:
-
-| | MLX | CoreML |
-|---|---|---|
-| **हार्डवेयर** | GPU (Metal shaders) | Neural Engine + CPU |
-| **सर्वोत्तम** | अधिकतम थ्रूपुट, सिंगल-मॉडल कार्यभार | मल्टी-मॉडल पाइपलाइन, बैकग्राउंड कार्य |
-| **पावर** | अधिक GPU उपयोग | कम पावर, GPU फ़्री करता है |
-| **लेटेंसी** | बड़े मॉडल (WeSpeaker) के लिए तेज़ | छोटे मॉडल (Silero VAD) के लिए तेज़ |
-
-**डेस्कटॉप इनफ़रेंस**: MLX डिफ़ॉल्ट है — Apple Silicon पर सबसे तेज़ सिंगल-मॉडल प्रदर्शन। GPU contention से बचने के लिए कई मॉडल एक साथ चलाते समय (जैसे, VAD + ASR + TTS) CoreML पर स्विच करें, या लैपटॉप पर बैटरी-संवेदनशील कार्यभार के लिए।
-
-CoreML मॉडल Qwen3-ASR encoder, Silero VAD, और WeSpeaker के लिए उपलब्ध हैं। Qwen3-ASR के लिए, `--engine qwen3-coreml` उपयोग करें (हाइब्रिड: ANE पर CoreML encoder + GPU पर MLX text decoder)। VAD/embeddings के लिए, निर्माण समय पर `engine: .coreml` पास करें — इनफ़रेंस API समान है।
-
-## सटीकता बेंचमार्क
-
-### ASR — Word Error Rate ([विवरण](docs/benchmarks/asr-wer.md))
-
-| Model | WER% (LibriSpeech test-clean) | RTF |
-|-------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit तुलनीय आकार में Whisper Large v3 Turbo (2.5%) को पछाड़ता है। बहुभाषी: FLEURS पर 10 भाषाओं का बेंचमार्क।
-
-### TTS — राउंड-ट्रिप इंटेलिजिबिलिटी ([विवरण](docs/benchmarks/tts-roundtrip.md))
-
-| Engine | WER% | RTF |
-|--------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — स्पीच डिटेक्शन ([विवरण](docs/benchmarks/vad-detection.md))
-
-| Engine | F1% (FLEURS) | RTF |
-|--------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+सभी मॉडलों को HTTP REST + WebSocket endpoints के माध्यम से एक्सपोज़ करता है, जिसमें `/v1/realtime` पर OpenAI Realtime API-संगत WebSocket शामिल है। देखें [`Sources/AudioServer/`](Sources/AudioServer/)।
 
 ## आर्किटेक्चर
 
-**मॉडल:** [ASR Model](docs/models/asr-model.md), [TTS Model](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift प्रति मॉडल एक SPM टारगेट में विभाजित है ताकि उपभोक्ता केवल उसी के लिए भुगतान करें जो वे इम्पोर्ट करते हैं। साझा इन्फ़्रास्ट्रक्चर `AudioCommon` (प्रोटोकॉल, ऑडियो I/O, HuggingFace डाउनलोडर, `SentencePieceModel`) और `MLXCommon` (वेट लोडिंग, `QuantizedLinear` हेल्पर्स, multi-head attention के लिए `SDPA` हेल्पर) में रहता है।
 
-**इनफ़रेंस:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS Inference](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Speaker Diarization](docs/inference/speaker-diarization.md), [Speech Enhancement](docs/inference/speech-enhancement.md), [ऑडियो प्लेबैक](docs/audio/playback.md)
+**[बैकएंड, मेमोरी टेबल्स, और मॉड्यूल मैप के साथ पूर्ण आर्किटेक्चर डायग्राम → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[API संदर्भ → soniqo.audio/api](https://soniqo.audio/api)** · **[बेंचमार्क → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**बेंचमार्क:** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD Detection](docs/benchmarks/vad-detection.md)
-
-**संदर्भ:** [Shared Protocols](docs/shared-protocols.md)
+स्थानीय डॉक्स (रिपॉज़िटरी):
+- **मॉडल:** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **इन्फ़रेंस:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [स्पीकर डायराइज़ेशन](docs/inference/speaker-diarization.md) · [स्पीच एन्हांसमेंट](docs/inference/speech-enhancement.md)
+- **संदर्भ:** [शेयर्ड प्रोटोकॉल](docs/shared-protocols.md)
 
 ## कैश कॉन्फ़िगरेशन
 
-मॉडल वेट `~/Library/Caches/qwen3-speech/` में लोकली कैश होते हैं।
+मॉडल वेट पहले उपयोग पर HuggingFace से डाउनलोड होते हैं और `~/Library/Caches/qwen3-speech/` में कैश होते हैं। `QWEN3_CACHE_DIR` (CLI) या `cacheDir:` (Swift API) से ओवरराइड करें। सभी `fromPretrained()` एंट्री पॉइंट `offlineMode: true` भी स्वीकार करते हैं ताकि वेट कैश होने पर नेटवर्क स्किप किया जा सके।
 
-**CLI** — एनवायरनमेंट वेरिएबल से ओवरराइड करें:
+सैंडबॉक्स्ड iOS कंटेनर पाथ सहित पूर्ण विवरण के लिए [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md) देखें।
 
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
+## MLX Metal library
 
-**Swift API** — सभी `fromPretrained()` मेथड `cacheDir` और `offlineMode` सपोर्ट करते हैं:
-
-```swift
-// कस्टम कैश डायरेक्टरी (सैंडबॉक्स ऐप्स, iOS कंटेनर)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// ऑफलाइन मोड — वेट कैश होने पर नेटवर्क स्किप करें
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-विवरण के लिए [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md) देखें।
-
-## MLX Metal लाइब्रेरी
-
-यदि रनटाइम पर `Failed to load the default metallib` एरर दिखता है, तो Metal shader लाइब्रेरी अनुपलब्ध है। `make build` (या मैन्युअल `swift build` के बाद `./scripts/build_mlx_metallib.sh release`) चलाएँ। यदि Metal Toolchain अनुपलब्ध है, तो पहले इसे इंस्टॉल करें:
+यदि आपको रनटाइम पर `Failed to load the default metallib` दिखता है, तो Metal shader library गुम है। मैनुअल `swift build` के बाद `make build` या `./scripts/build_mlx_metallib.sh release` चलाएँ। यदि Metal Toolchain गुम है, तो पहले इसे इंस्टॉल करें:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## टेस्टिंग
 
-यूनिट टेस्ट (config, sampling, text preprocessing, timestamp correction) मॉडल डाउनलोड के बिना चलते हैं:
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # पूर्ण सुइट (यूनिट + मॉडल डाउनलोड के साथ E2E)
+swift test --skip E2E                # केवल यूनिट (CI-सुरक्षित, कोई डाउनलोड नहीं)
+swift test --filter Qwen3ASRTests    # विशिष्ट मॉड्यूल
 ```
 
-इंटीग्रेशन टेस्ट के लिए मॉडल वेट आवश्यक हैं (पहली बार चलाने पर स्वतः डाउनलोड होते हैं):
-
-```bash
-# TTS राउंड-ट्रिप: टेक्स्ट सिंथेसाइज़ करें, WAV सेव करें, ASR से वापस ट्रांसक्राइब करें
-swift test --filter TTSASRRoundTripTests
-
-# केवल ASR: टेस्ट ऑडियो ट्रांसक्राइब करें
-swift test --filter Qwen3ASRIntegrationTests
-
-# Forced Aligner E2E: शब्द-स्तरीय टाइमस्टैम्प (~979 MB डाउनलोड)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E: स्पीच-टू-स्पीच पाइपलाइन (~5.5 GB डाउनलोड)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **नोट:** MLX ऑपरेशन उपयोग करने वाले टेस्ट चलाने से पहले MLX Metal लाइब्रेरी बिल्ड होनी चाहिए।
-> निर्देशों के लिए [MLX Metal लाइब्रेरी](#mlx-metal-लाइब्रेरी) देखें।
-
-## समर्थित भाषाएँ
-
-| Model | भाषाएँ |
-|-------|-----------|
-| Qwen3-ASR | 52 भाषाएँ (CN, EN, Cantonese, DE, FR, ES, JA, KO, RU, + 22 चीनी बोलियाँ, ...) |
-| Parakeet TDT | 25 यूरोपीय भाषाएँ (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1,672 भाषाएँ** 150+ परिवारों में फैली हुई। इसमें Meta के "सीधे सेवा प्रदान" सेट (~1,100) की सभी भाषाएँ और समुदाय डेटा के माध्यम से जोड़ी गई 500+ कम-संसाधन वाली भाषाएँ शामिल हैं। चुनी गई: EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (पूरी सूची: [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py))। CTC हेड भाषा-अज्ञेय है — अनुमान के समय किसी भाषा संकेत की आवश्यकता नहीं है। |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ CustomVoice द्वारा Beijing/Sichuan बोलियाँ) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## तुलना
-
-### स्पीच-टू-टेक्स्ट (ASR): speech-swift बनाम अन्य विकल्प
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **रनटाइम** | ऑन-डिवाइस (MLX/CoreML) | ऑन-डिवाइस (CPU/GPU) | ऑन-डिवाइस या क्लाउड | केवल क्लाउड |
-| **भाषाएँ** | 52 | 100+ | ~70 (ऑन-डिवाइस: सीमित) | 125+ |
-| **RTF (10s ऑडियो, M2 Max)** | 0.06 (17x real-time) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **स्ट्रीमिंग** | नहीं (बैच) | नहीं (बैच) | हाँ | हाँ |
-| **कस्टम मॉडल** | हाँ (HuggingFace वेट स्वैप करें) | हाँ (GGML मॉडल) | नहीं | नहीं |
-| **Swift API** | नेटिव async/await | C++ Swift ब्रिज के साथ | नेटिव | REST/gRPC |
-| **गोपनीयता** | पूर्णतः ऑन-डिवाइस | पूर्णतः ऑन-डिवाइस | कॉन्फ़िग पर निर्भर | डेटा क्लाउड पर भेजा जाता है |
-| **शब्द टाइमस्टैम्प** | हाँ (Forced Aligner) | हाँ | सीमित | हाँ |
-| **लागत** | मुफ़्त (Apache 2.0) | मुफ़्त (MIT) | मुफ़्त (ऑन-डिवाइस) | प्रति मिनट भुगतान |
-
-### टेक्स्ट-टू-स्पीच (TTS): speech-swift बनाम अन्य विकल्प
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / Cloud TTS** |
-|---|---|---|---|---|
-| **गुणवत्ता** | न्यूरल, अभिव्यक्तिपूर्ण | न्यूरल, प्राकृतिक | रोबोटिक, एकस्वरीय | न्यूरल, सर्वोच्च गुणवत्ता |
-| **रनटाइम** | ऑन-डिवाइस (MLX) | ऑन-डिवाइस (CoreML) | ऑन-डिवाइस | केवल क्लाउड |
-| **स्ट्रीमिंग** | हाँ (पहला चंक ~120ms) | नहीं (एंड-टू-एंड मॉडल) | नहीं | हाँ |
-| **वॉयस क्लोनिंग** | हाँ | नहीं | नहीं | हाँ |
-| **वॉयस** | 9 बिल्ट-इन + कोई भी क्लोन करें | 54 प्रीसेट वॉयस | ~50 सिस्टम वॉयस | 1000+ |
-| **भाषाएँ** | 10 | 10 | 60+ | 30+ |
-| **iOS सपोर्ट** | केवल macOS | iOS + macOS | iOS + macOS | कोई भी (API) |
-| **लागत** | मुफ़्त (Apache 2.0) | मुफ़्त (Apache 2.0) | मुफ़्त | प्रति अक्षर भुगतान |
-
-### speech-swift कब उपयोग करें
-
-- **गोपनीयता-महत्वपूर्ण ऐप्स** — मेडिकल, कानूनी, एंटरप्राइज़ जहाँ ऑडियो डिवाइस से बाहर नहीं जा सकता
-- **ऑफ़लाइन उपयोग** — प्रारंभिक मॉडल डाउनलोड के बाद इंटरनेट कनेक्शन आवश्यक नहीं
-- **लागत-संवेदनशील** — कोई प्रति-मिनट या प्रति-अक्षर API शुल्क नहीं
-- **Apple Silicon ऑप्टिमाइज़ेशन** — विशेष रूप से M-series GPU (Metal) और Neural Engine के लिए बनाया गया
-- **पूर्ण पाइपलाइन** — एक ही Swift पैकेज में ASR + TTS + VAD + डायराइज़ेशन + एन्हांसमेंट को मिलाएँ
-
-## अक्सर पूछे जाने वाले प्रश्न
-
-**क्या speech-swift iOS पर काम करता है?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3, और WeSpeaker सभी CoreML के माध्यम से Neural Engine पर iOS 17+ पर चलते हैं। MLX-आधारित मॉडल (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex) के लिए Apple Silicon पर macOS 14+ आवश्यक है।
-
-**क्या इंटरनेट कनेक्शन आवश्यक है?**
-केवल HuggingFace से प्रारंभिक मॉडल डाउनलोड के लिए (स्वचालित, `~/Library/Caches/qwen3-speech/` में कैश)। उसके बाद, सारा इनफ़रेंस बिना नेटवर्क एक्सेस के पूर्णतः ऑफ़लाइन चलता है।
-
-**speech-swift की तुलना Whisper से कैसे होती है?**
-Qwen3-ASR-0.6B M2 Max पर RTF 0.06 प्राप्त करता है — whisper.cpp (RTF 0.10) के माध्यम से Whisper-large-v3 से 40% तेज़ — 52 भाषाओं में तुलनीय सटीकता के साथ। speech-swift नेटिव Swift async/await API प्रदान करता है, जबकि whisper.cpp को C++ ब्रिज की आवश्यकता होती है।
-
-**क्या मैं इसे व्यावसायिक ऐप में उपयोग कर सकता हूँ?**
-हाँ। speech-swift Apache 2.0 के तहत लाइसेंस प्राप्त है। अंतर्निहित मॉडल वेट के अपने लाइसेंस हैं (प्रत्येक मॉडल का HuggingFace पेज देखें)।
-
-**कौन से Apple Silicon चिप समर्थित हैं?**
-सभी M-series चिप: M1, M2, M3, M4 और उनके Pro/Max/Ultra वेरिएंट। macOS 14+ (Sonoma) या iOS 17+ आवश्यक है।
-
-**कितनी मेमोरी चाहिए?**
-~3 MB (Silero VAD) से ~6.5 GB (PersonaPlex 7B) तक। Kokoro TTS ~500 MB उपयोग करता है, Qwen3-ASR ~2.2 GB। पूर्ण विवरण के लिए [मेमोरी आवश्यकताएँ](#मेमोरी-आवश्यकताएँ) तालिका देखें।
-
-**क्या कई मॉडल एक साथ चला सकते हैं?**
-हाँ। contention से बचने के लिए Neural Engine पर CoreML मॉडल GPU पर MLX मॉडल के साथ उपयोग करें — उदाहरण के लिए, Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX)।
-
-**क्या REST API उपलब्ध है?**
-हाँ। `audio-server` बाइनरी HTTP REST और WebSocket एंडपॉइंट के माध्यम से सभी मॉडल उपलब्ध कराती है, जिसमें `/v1/realtime` पर OpenAI Realtime API-संगत WebSocket शामिल है।
+E2E टेस्ट क्लासेस `E2E` उपसर्ग का उपयोग करती हैं ताकि CI उन्हें `--skip E2E` से फ़िल्टर कर सके। पूर्ण टेस्टिंग नियम के लिए [CLAUDE.md](CLAUDE.md#testing) देखें।
 
 ## योगदान
 
-हम योगदान का स्वागत करते हैं! चाहे वह बग फ़िक्स हो, नया मॉडल इंटीग्रेशन हो, या डॉक्यूमेंटेशन सुधार — PRs की सराहना की जाती है।
-
-**शुरू करने के लिए:**
-1. रेपो फ़ोर्क करें और फ़ीचर ब्रांच बनाएँ
-2. कंपाइल करने के लिए `make build` चलाएँ (Xcode + Metal Toolchain आवश्यक)
-3. टेस्ट सूट चलाने के लिए `make test`
-4. `main` के विरुद्ध PR खोलें
+PRs का स्वागत है — बग फ़िक्स, नए मॉडल इंटीग्रेशन, डॉक्यूमेंटेशन। फ़ॉर्क करें, feature ब्रांच बनाएँ, `make build && make test`, `main` के विरुद्ध PR खोलें।
 
 ## लाइसेंस
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -4,38 +4,30 @@ Apple Silicon向けAI音声モデル。MLX SwiftとCoreMLで動作します。
 
 📖 Read in: [English](README.md) · [中文](README_zh.md) · [日本語](README_ja.md) · [한국어](README_ko.md) · [Español](README_es.md) · [Deutsch](README_de.md) · [Français](README_fr.md) · [हिन्दी](README_hi.md) · [Português](README_pt.md) · [Русский](README_ru.md)
 
-Mac・iOS向けのオンデバイス音声認識・合成・理解。Apple Silicon上で完全にローカル動作——クラウド不要、APIキー不要、データはデバイスから外部に送信されません。
+Mac・iOS向けのオンデバイス音声認識・合成・理解。Apple Silicon上で完全にローカル動作します——クラウド不要、APIキー不要、データはデバイスから外部に送信されません。
 
-[Homebrewでインストール](#homebrew)するか、Swift Packageの依存関係として追加できます。
+**[📚 ドキュメント →](https://soniqo.audio)** · **[🤗 HuggingFaceモデル](https://huggingface.co/aufklarer)** · **[📝 ブログ](https://blog.ivan.digital)**
 
-**[ドキュメント](https://soniqo.audio)** · **[HuggingFace モデル](https://huggingface.co/aufklarer)** · **[ブログ](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — 音声認識（自動音声認識、52言語、MLX + CoreML）
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — CoreMLによる音声認識（Neural Engine、NVIDIA FastConformer + TDTデコーダー、25言語）
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — 音声認識（Meta wav2vec2 + CTC、**1,672言語**、32文字体系、CoreML 300M + MLX 300M/1B/3B/7B）
+- **[ストリーミングディクテーション](https://soniqo.audio/guides/dictate)** — 部分結果と発話終端検出付きのリアルタイムディクテーション（Parakeet-EOU-120M）
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — 単語レベルのタイムスタンプ整列（音声 + テキスト → タイムスタンプ）
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — 音声合成（最高品質、ストリーミング、カスタムスピーカー、10言語）
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — 音声クローン、マルチスピーカー対話、感情タグを備えたストリーミングTTS（9言語）
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — オンデバイスTTS（82M、CoreML/Neural Engine、54ボイス、iOS対応、10言語）
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — オンデバイスLLMチャット（0.8B、MLX INT4 + CoreML INT8、DeltaNetハイブリッド、ストリーミングトークン）
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — 全二重音声間会話（7B、音声入力 → 音声出力、18種類のボイスプリセット）
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — リアルタイムノイズ抑制（2.1Mパラメーター、48 kHz）
+- **[VAD](https://soniqo.audio/guides/vad)** — 音声区間検出（Sileroストリーミング、Pyannoteオフライン、FireRedVAD 100以上の言語）
+- **[話者ダイアライゼーション](https://soniqo.audio/guides/diarize)** — 誰がいつ話したか（Pyannoteパイプライン、Neural Engine上のエンドツーエンドSortformer）
+- **[話者埋め込み](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34（256次元）、CAM++（192次元）
 
-- **Qwen3-ASR** — 音声認識 (自動音声認識、52言語対応)
-- **Parakeet TDT** — CoreMLによる音声認識 (Neural Engine、NVIDIA FastConformer + TDTデコーダー、25言語対応)
-- **Omnilingual ASR** — CoreMLによる音声認識 (Meta wav2vec2 + CTC、**1,672言語**、150以上の語族、5/10秒ウィンドウ、INT8パレット化、ANE)
-- **Qwen3-ForcedAligner** — 単語レベルのタイムスタンプ整列 (音声 + テキスト → タイムスタンプ)
-- **Qwen3-TTS** — テキスト読み上げ (最高品質、ストリーミング、カスタムスピーカー、10言語対応)
-- **CosyVoice TTS** — ストリーミング対応テキスト読み上げ、音声クローン、マルチスピーカー対話、感情タグ (9言語、DiT flow matching、CAM++話者エンコーダー)
-- **Kokoro TTS** — オンデバイステキスト読み上げ (82Mパラメーター、CoreML/Neural Engine、54種類の声、iOS対応、10言語)
-- **Qwen3-TTS CoreML** — テキスト読み上げ (0.6B、CoreML 6モデルパイプライン、W8A16、iOS/macOS)
-- **Qwen3.5-Chat** — オンデバイスLLMチャット (0.8B、MLX + CoreML、INT4/INT8、DeltaNetハイブリッド、ストリーミングトークン)
-- **PersonaPlex** — 全二重音声間会話 (7B、音声入力 → 音声出力、18種類のボイスプリセット)
-- **DeepFilterNet3** — 音声強調 / ノイズ抑制 (2.1Mパラメーター、リアルタイム48kHz)
-- **FireRedVAD** — オフライン音声区間検出 (DFSMN、CoreML、100以上の言語、97.6% F1)
-- **Silero VAD** — ストリーミング音声区間検出 (32msチャンク、サブミリ秒レイテンシー)
-- **Pyannote VAD** — オフライン音声区間検出 (10秒ウィンドウ、マルチスピーカーオーバーラップ)
-- **話者ダイアライゼーション** — 誰がいつ話したか (Pyannoteセグメンテーション + アクティビティベース話者チェイニング、またはNeural Engine上のエンドツーエンドSortformer)
-- **話者埋め込み** — 話者検証・識別 (WeSpeaker ResNet34、256次元ベクトル)
-
-論文: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## ロードマップ
-
-今後の予定は[ロードマップディスカッション](https://github.com/soniqo/speech-swift/discussions/81)をご覧ください。コメントやご提案も歓迎です！
+論文：[Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## ニュース
 
-- **2026年3月20日** — [600Mモデルだけで、Mac上でWhisper Large v3を超えた](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
+- **2026年3月20日** — [600MモデルだけでMac上でWhisper Large v3を超えた](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
 - **2026年2月26日** — [Apple Silicon上の話者ダイアライゼーションと音声区間検出 — ネイティブSwift + MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
 - **2026年2月23日** — [Apple Silicon上のNVIDIA PersonaPlex 7B — ネイティブSwift + MLXによる全二重音声間変換](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
 - **2026年2月12日** — [Qwen3-ASR Swift: Apple Silicon向けオンデバイスASR + TTS — アーキテクチャとベンチマーク](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
@@ -45,10 +37,10 @@ Mac・iOS向けのオンデバイス音声認識・合成・理解。Apple Silic
 `Package.swift` にパッケージを追加します：
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-必要なモジュールだけをインポート — 各モデルは個別のSPMライブラリです：
+必要なモジュールだけをインポートします。各モデルは個別のSPMライブラリなので、使わないものにコストを払う必要はありません：
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
@@ -64,7 +56,7 @@ let model = try await ParakeetStreamingASRModel.fromPretrained()
 let text = try model.transcribeAudio(audioSamples, sampleRate: 16000)
 ```
 
-**部分結果を伴うライブストリーミング：**
+**部分結果付きのライブストリーミング：**
 
 ```swift
 for await partial in model.transcribeStream(audio: samples, sampleRate: 16000) {
@@ -72,7 +64,7 @@ for await partial in model.transcribeStream(audio: samples, sampleRate: 16000) {
 }
 ```
 
-**約10行で書けるSwiftUI ディクテーションビュー：**
+**約10行のSwiftUIディクテーションビュー：**
 
 ```swift
 import SwiftUI
@@ -98,124 +90,81 @@ struct DictateView: View {
 
 `SpeechUI` には `TranscriptionView`（確定 + 部分）と `TranscriptionStore`（ストリーミングASRアダプター）のみが含まれます。音声の可視化や再生には AVFoundation をお使いください。
 
-利用可能なSPM製品： `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`。
+利用可能なSPMプロダクト：`Qwen3ASR`、`Qwen3TTS`、`Qwen3TTSCoreML`、`ParakeetASR`、`ParakeetStreamingASR`、`OmnilingualASR`、`KokoroTTS`、`CosyVoiceTTS`、`PersonaPlex`、`SpeechVAD`、`SpeechEnhancement`、`Qwen3Chat`、`SpeechCore`、`SpeechUI`、`AudioCommon`。
 
 ## モデル
 
-| モデル | タスク | ストリーミング | 対応言語 | サイズ |
-|-------|------|-----------|-----------|-------|
-| Qwen3-ASR-0.6B | 音声 → テキスト | なし | 52言語 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | 音声 → テキスト | なし | 52言語 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | 音声 → テキスト | なし | ヨーロッパ25言語 | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | 音声 → テキスト | あり (ストリーミング + EOU) | ヨーロッパ25言語 | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | 音声 → テキスト | なし (5/10秒ウィンドウ) | [1,672言語](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | 音声 → テキスト | なし | [1,672言語](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | 音声 → テキスト | なし | [1,672言語](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | 音声 → テキスト | なし | [1,672言語](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | 音声 + テキスト → タイムスタンプ | なし | 多言語 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | テキスト → 音声 | あり (~120ms) | 10言語 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | テキスト → 音声 | あり (~120ms) | 10言語 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | テキスト → 音声 | あり (~120ms) | 10言語 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | テキスト → 音声 | あり (~150ms) | 9言語 | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | テキスト → 音声 | なし | 10言語 | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | 音声 → 音声 | あり (~2秒チャンク) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | 音声区間検出 | なし (オフライン) | 100以上の言語 | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | 音声区間検出 | あり (32msチャンク) | 言語非依存 | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + 話者セグメンテーション | なし (10秒ウィンドウ) | 言語非依存 | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | 音声強調 | あり (10msフレーム) | 言語非依存 | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | 話者埋め込み (256次元) | なし | 言語非依存 | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | 話者埋め込み (192次元) | なし | 言語非依存 | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | 話者ダイアライゼーション (エンドツーエンド) | あり (チャンク) | 言語非依存 | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+以下はコンパクト表示です。**[サイズ、量子化、ダウンロードURL、メモリ表を含む完全なモデルカタログ → soniqo.audio/architecture](https://soniqo.audio/architecture)**。
 
-### メモリ要件
-
-重みメモリは、モデルパラメーターが消費するGPU (MLX) またはANE (CoreML) のメモリです。ピーク推論にはKVキャッシュ、活性化値、中間テンソルが含まれます。
-
-| モデル | 重みメモリ | ピーク推論 |
-|-------|--------------|----------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### TTSの選び方
-
-- **Qwen3-TTS**: 最高品質、ストリーミング (~120ms)、9種類の内蔵スピーカー、10言語、バッチ合成
-- **CosyVoice TTS**: ストリーミング (~150ms)、9言語、音声クローン (CAM++話者エンコーダー)、マルチスピーカー対話 (`[S1] ... [S2] ...`)、インライン感情・スタイルタグ (`(happy)`, `(whispers)`)、DiT flow matching + HiFi-GANボコーダー
-- **Kokoro TTS**: 軽量iOS対応TTS (82Mパラメーター)、CoreML/Neural Engine、54種類の声、10言語、エンドツーエンドモデル
-- **PersonaPlex**: 全二重音声間変換 (音声入力 → 音声出力)、ストリーミング (~2秒チャンク)、18種類のボイスプリセット、Moshiアーキテクチャベース
+| モデル | タスク | バックエンド | サイズ | 言語 |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | 音声 → テキスト | MLX、CoreML（ハイブリッド） | 0.6B、1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | 音声 → テキスト | CoreML (ANE) | 0.6B | 25欧州言語 |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | 音声 → テキスト（ストリーミング） | CoreML (ANE) | 120M | 25欧州言語 |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | 音声 → テキスト | CoreML (ANE)、MLX | 300M / 1B / 3B / 7B | **[1,672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | 音声 + テキスト → タイムスタンプ | MLX、CoreML | 0.6B | 多言語 |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | テキスト → 音声 | MLX、CoreML | 0.6B、1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | テキスト → 音声 | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | テキスト → 音声 | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | テキスト → テキスト（LLM） | MLX、CoreML | 0.8B | 多言語 |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | 音声 → 音声 | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | 音声区間検出 | MLX、CoreML | 309K | 言語非依存 |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + ダイアライゼーション | MLX | 1.5M | 言語非依存 |
+| [Sortformer](https://soniqo.audio/guides/diarize) | ダイアライゼーション（E2E） | CoreML (ANE) | — | 言語非依存 |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | 音声強調 | CoreML | 2.1M | 言語非依存 |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | 話者埋め込み | MLX、CoreML | 6.6M | 言語非依存 |
 
 ## インストール
 
 ### Homebrew
 
-ネイティブARM Homebrew (`/opt/homebrew`) が必要です。Rosetta/x86_64 Homebrewはサポートされていません。
+ネイティブARM Homebrew（`/opt/homebrew`）が必要です。Rosetta/x86_64 Homebrewはサポートされません。
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-使い方：
+その後：
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML（ニューラルエンジン）
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> マイク入力によるインタラクティブな音声会話は **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** をご覧ください。
+**[完全なCLIリファレンス →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-`Package.swift`に追加：
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-必要なモジュールをインポート：
+必要なものだけをインポート。各モデルは個別のSPMターゲットです：
 
 ```swift
-import Qwen3ASR      // 音声認識 (MLX)
-import ParakeetASR   // 音声認識 (CoreML)
-import Qwen3TTS      // テキスト読み上げ (Qwen3)
-import CosyVoiceTTS  // テキスト読み上げ (ストリーミング)
-import KokoroTTS     // テキスト読み上げ (CoreML、iOS対応)
-import Qwen3Chat     // オンデバイスLLMチャット (CoreML)
-import PersonaPlex   // 音声間変換 (全二重)
-import SpeechVAD          // 音声区間検出 (pyannote + Silero)
-import SpeechEnhancement  // ノイズ抑制 (DeepFilterNet3)
-import AudioCommon        // 共有ユーティリティ
+import Qwen3ASR             // 音声認識 (MLX)
+import ParakeetASR          // 音声認識 (CoreML、バッチ)
+import ParakeetStreamingASR // 部分結果 + EOU付きストリーミングディクテーション
+import OmnilingualASR       // 1,672言語 (CoreML + MLX)
+import Qwen3TTS             // 音声合成
+import CosyVoiceTTS         // 音声クローン付き音声合成
+import KokoroTTS            // 音声合成 (iOS対応)
+import Qwen3Chat            // オンデバイスLLMチャット
+import PersonaPlex          // 全二重音声間変換
+import SpeechVAD            // VAD + 話者ダイアライゼーション + 埋め込み
+import SpeechEnhancement    // ノイズ抑制
+import SpeechUI             // ストリーミングトランスクリプト用SwiftUIコンポーネント
+import AudioCommon          // 共有プロトコルとユーティリティ
 ```
 
-### 要件
+### 動作要件
 
-- Swift 5.9以上
-- macOS 14以上またはiOS 17以上
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15以上 (Metal Toolchain付き — 不足している場合は `xcodebuild -downloadComponent MetalToolchain` を実行)
+- Swift 5.9+、Xcode 15+（Metal Toolchainを含む）
+- macOS 14+ または iOS 17+、Apple Silicon（M1/M2/M3/M4）
 
 ### ソースからビルド
 
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-SwiftパッケージとMLX Metal shaderライブラリをワンステップでコンパイルします。Metalライブラリ (`mlx.metallib`) はGPU推論に必要です。これがないと実行時に `Failed to load the default metallib` エラーが発生します。
+`make build` はSwiftパッケージ**と** MLX Metalシェーダーライブラリを同時にコンパイルします。Metalライブラリは GPU 推論に必要です——これがないと実行時に `Failed to load the default metallib` が出ます。`make debug` でデバッグビルド、`make test` でテストスイートを実行します。
 
-デバッグビルド: `make debug`。ユニットテスト実行: `make test`。
-
-## 音声アシスタントを試す
-
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** は、すぐに使えるmacOS音声アシスタントです。タップして話しかけると、リアルタイムで音声応答が返ります。マイク入力にSilero VADを使った自動音声検出、Qwen3-ASRによる文字起こし、PersonaPlex 7Bによる音声間生成を搭載。マルチターン会話、18種類のボイスプリセット、内部独白の字幕表示に対応しています。
-
-```bash
-make build  # リポジトリのルートから — MLX metallibを含むすべてをビルド
-cd Examples/PersonaPlexDemo
-# .appバンドルの手順はExamples/PersonaPlexDemo/README.mdを参照
-```
-
-> M2 MaxでRTF ~0.94 (リアルタイムより高速)。モデルは初回実行時に自動ダウンロード (~5.5 GB PersonaPlex + ~400 MB ASR)。
+**[完全なビルド・インストールガイド →](https://soniqo.audio/getting-started)**
 
 ## デモアプリ
 
-- **[DictateDemo](Examples/DictateDemo/)** ([ドキュメント](https://soniqo.audio/guides/dictate/)) — macOSメニューバーストリーミングディクテーション、リアルタイム部分結果、VAD駆動の発話終了検出、ワンクリックコピー対応。バックグラウンドメニューバーエージェントとして動作 (Parakeet-EOU-120M + Silero VAD)。
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOSエコーデモ (Parakeet ASR + Kokoro TTS、話した内容を聞き返す)。デバイスとシミュレーター対応。
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — 会話型音声アシスタント (マイク入力、VAD、マルチターン)。macOS。
-- **[SpeechDemo](Examples/SpeechDemo/)** — ディクテーションとテキスト読み上げのタブインターフェース。macOS。
+- **[DictateDemo](Examples/DictateDemo/)**（[ドキュメント](https://soniqo.audio/guides/dictate)）— macOSメニューバーのストリーミングディクテーション。ライブ部分結果、VADベースの発話終端検出、ワンクリックコピー付き。バックグラウンドagentとして動作（Parakeet-EOU-120M + Silero VAD）。
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOSエコーデモ（Parakeet ASR + Kokoro TTS）。実機・シミュレーター対応。
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — マイク入力、VAD、マルチターンコンテキスト付きの対話型音声アシスタント。macOS。M2 MaxでRTF約0.94（リアルタイムより高速）。
+- **[SpeechDemo](Examples/SpeechDemo/)** — タブ形式インターフェース上でのディクテーションとTTS合成。macOS。
 
-ビルドして実行 — 各デモのREADMEを参照してください。
+各デモのREADMEにビルド手順があります。
 
-## 音声認識 (ASR) — Swiftで音声を文字起こし
+## コード例
 
-### 基本的な文字起こし
+以下のスニペットは、各領域の最小限の使い方を示しています。各セクションは [soniqo.audio](https://soniqo.audio) 上の完全ガイドにリンクしており、設定オプション、複数のバックエンド、ストリーミングパターン、CLIレシピが載っています。
 
-```swift
-import Qwen3ASR
-
-// デフォルト: 0.6Bモデル
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// より高精度な1.7Bモデルを使用する場合
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// 任意のサンプルレートの音声を入力可能 — 内部で自動的に16kHzにリサンプリング
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### CoreMLエンコーダー (Neural Engine)
-
-ハイブリッドモード: Neural Engine上のCoreMLエンコーダー + GPU上のMLXテキストデコーダー。低消費電力で、エンコーダーパスのGPU負荷を軽減します。
+### 音声認識 — [完全ガイド →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-INT8 (180 MB、デフォルト) とINT4 (90 MB) のバリアントが利用可能。INT8推奨 (FP32とのコサイン類似度 > 0.999)。
+代替バックエンド：[Parakeet TDT](https://soniqo.audio/guides/parakeet)（CoreML、32×リアルタイム）、[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)（1,672言語、CoreMLまたはMLX）、[ストリーミングディクテーション](https://soniqo.audio/guides/dictate)（ライブ部分結果）。
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-CoreML経由でNeural Engine上で動作 — GPUを他のワークロードに解放します。25のヨーロッパ言語対応、~315 MB。
-
-### ASR CLI
-
-```bash
-make build  # または: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# デフォルト (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# 1.7Bモデルを使用
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# CoreMLエンコーダー (Neural Engine + MLXデコーダー)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## 強制アラインメント
-
-### 単語レベルのタイムスタンプ
+### 強制整列 — [完全ガイド →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// 初回実行時に~979 MBをダウンロード
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### 強制アラインメントCLI
-
-```bash
-swift build -c release
-
-# テキストを指定してアラインメント
-.build/release/audio align audio.wav --text "Hello world"
-
-# まず文字起こしし、その後アラインメント
-.build/release/audio align audio.wav
-```
-
-出力：
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-エンドツーエンドモデル、非自己回帰型でサンプリングループなし。アーキテクチャの詳細は[強制アラインメント](docs/inference/forced-aligner.md)を参照。
-
-## テキスト読み上げ (TTS) — Swiftで音声を生成
-
-### 基本的な音声合成
+### 音声合成 — [完全ガイド →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // WAVWriter用
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// 初回実行時に~1.7 GBをダウンロード (モデル + コーデック重み)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// 出力は24kHzモノラルfloatサンプル
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### TTS CLI
+代替TTSエンジン：[CosyVoice3](https://soniqo.audio/guides/cosyvoice)（ストリーミング + 音声クローン + 感情タグ）、[Kokoro-82M](https://soniqo.audio/guides/kokoro)（iOS対応、54ボイス）、[音声クローン](https://soniqo.audio/guides/voice-cloning)。
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### カスタムボイス / スピーカー選択
-
-**CustomVoice**モデルバリアントは、9種類の内蔵スピーカーボイスと、トーン・スタイルを制御する自然言語指示をサポートしています。CustomVoiceモデルIDを渡してロードします：
-
-```swift
-import Qwen3TTS
-
-// CustomVoiceモデルをロード (初回実行時に~1.7 GBをダウンロード)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// 特定のスピーカーで合成
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// 利用可能なスピーカーを表示
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# CustomVoiceモデルでスピーカーを指定
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# 利用可能なスピーカーを一覧表示
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### 音声クローン (Baseモデル)
-
-リファレンス音声ファイルからスピーカーの声をクローンします。2つのモードがあります：
-
-**ICLモード** (推奨) — リファレンス音声をトランスクリプト付きでコーデックトークンにエンコード。高品質で確実なEOS：
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**X-vectorモード** — 話者埋め込みのみ、トランスクリプト不要ですが品質は低め：
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### トーン / スタイル指示 (CustomVoiceのみ)
-
-CustomVoiceモデルは、話し方のスタイル、トーン、感情、ペースを制御する自然言語の`instruct`パラメーターを受け付けます。指示はChatML形式でモデル入力の先頭に付加されます。
-
-```swift
-// 明るいトーン
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// ゆっくりと真剣に
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// ささやき
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# スタイル指示付き
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# デフォルトの指示 ("Speak naturally.") はCustomVoice使用時に自動適用
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-CustomVoiceモデルで`--instruct`を指定しない場合、冗長な出力を防ぐために`"Speak naturally."`が自動適用されます。Baseモデルはinstruct非対応です。
-
-### バッチ合成
-
-単一のバッチフォワードパスで複数のテキストを合成し、高スループットを実現：
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i]はtexts[i]の24kHzモノラルfloatサンプル
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### バッチCLI
-
-```bash
-# 1行に1テキストのファイルを作成
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# output_0.wav, output_1.wav, ... が生成される
-```
-
-> バッチモードはモデル重みのロードを各アイテム間で償却します。Apple SiliconのB=4でスループットが~1.5-2.5倍向上します。テキストが似た長さの音声を生成する場合に最適です。
-
-### サンプリングオプション
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### ストリーミング合成
-
-最初のパケットの低レイテンシーのために、音声チャンクを段階的に出力：
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // 最初の音声チャンクまで~120ms
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: 最後のチャンクでtrue
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# デフォルトストリーミング (3フレーム初期チャンク、~225msレイテンシー)
-.build/release/audio speak "Hello world" --stream
-
-# 低レイテンシー (1フレーム初期チャンク、~120msレイテンシー)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## 音声間変換 — 全二重音声会話
-
-> マイク入力によるインタラクティブな音声アシスタントは **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** をご覧ください。タップして話しかけ、自動音声検出によるマルチターン会話が可能です。
-
-### 音声間変換
+### 音声間変換 — [完全ガイド →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // WAVWriter, AudioFileLoader用
 
 let model = try await PersonaPlexModel.fromPretrained()
-// 初回実行時に~5.5 GBをダウンロード (temporal 4-bit + depformer + Mimiコーデック + ボイスプリセット)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: 24kHzモノラルfloatサンプル
-// textTokens: モデルの内部独白 (SentencePieceトークンID)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// 24 kHz モノラル Float32 出力、再生可能
 ```
 
-### 内部独白 (テキスト出力)
-
-PersonaPlexは音声と並行してテキストトークンを生成します。これはモデルの内部推論です。内蔵のSentencePieceデコーダーでデコードできます：
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // 例: "Sure, I can help you with that..."
-```
-
-### ストリーミング音声間変換
-
-```swift
-// 生成されたそばから音声チャンクを受信 (チャンクあたり~2秒)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // 即座に再生、24kHzモノラル
-    // chunk.textTokensにこのチャンクのテキスト; 最終チャンクに全トークン
-    if chunk.isFinal { break }
-}
-```
-
-### ボイス選択
-
-18種類のボイスプリセットが利用可能：
-- **ナチュラル女性**: NATF0, NATF1, NATF2, NATF3
-- **ナチュラル男性**: NATM0, NATM1, NATM2, NATM3
-- **バラエティ女性**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **バラエティ男性**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### システムプロンプト
-
-システムプロンプトはモデルの会話動作を制御します。任意のカスタムプロンプトをプレーンな文字列として渡すことができます：
-
-```swift
-// カスタムシステムプロンプト（自動的にトークン化されます）
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// またはプリセットを使用
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-利用可能なプリセット: `focused` (デフォルト)、`assistant`、`customerService`、`teacher`。
-
-### PersonaPlex CLI
-
-```bash
-make build
-
-# 基本的な音声間変換
-.build/release/audio respond --input question.wav --output response.wav
-
-# トランスクリプト付き (内部独白テキストをデコード)
-.build/release/audio respond --input question.wav --transcript
-
-# JSON出力 (音声パス、トランスクリプト、レイテンシーメトリクス)
-.build/release/audio respond --input question.wav --json
-
-# カスタムシステムプロンプトテキスト
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# ボイスとシステムプロンプトプリセットを選択
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# サンプリングパラメーターの調整
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# テキストエントロピー早期停止を有効化 (テキストが崩壊した場合に停止)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# 利用可能なボイスとプロンプトを一覧表示
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — 音声クローン対応ストリーミングテキスト読み上げ
-
-### 基本的な音声合成
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // WAVWriter用
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// 初回実行時に~1.9 GBをダウンロード (LLM + DiT + HiFi-GAN重み)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// 出力は24kHzモノラルfloatサンプル
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### ストリーミング合成
-
-```swift
-// ストリーミング: 生成された音声チャンクを順次受信 (最初のチャンクまで~150ms)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // 即座に再生
-}
-```
-
-### 音声クローン (CosyVoice)
-
-CAM++話者エンコーダー (192次元、CoreML Neural Engine) を使って話者の声をクローン：
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// 初回使用時に~14 MB CAM++ CoreMLモデルをダウンロード
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: 長さ192の[Float]
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CosyVoice TTS CLI
-
-```bash
-make build
-
-# 基本的な合成
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# 音声クローン (初回使用時にCAM++話者エンコーダーをダウンロード)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# 音声クローンによるマルチスピーカー対話
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# インライン感情・スタイルタグ
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# 組み合わせ: 対話 + 感情 + 音声クローン
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# カスタムスタイル指示
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# ストリーミング合成
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — 軽量オンデバイステキスト読み上げ (iOS + macOS)
-
-### 基本的な音声合成
-
-```swift
-import KokoroTTS
-import AudioCommon  // WAVWriter用
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// 初回実行時に~170 MBをダウンロード (CoreMLモデル + ボイス埋め込み + 辞書)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// 出力は24kHzモノラルfloatサンプル
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-10言語で54種類のプリセットボイス。エンドツーエンドCoreMLモデル、非自己回帰型でサンプリングループなし。Neural Engine上で動作し、GPUを完全に解放します。
-
-### Kokoro TTS CLI
-
-```bash
-make build
-
-# 基本的な合成
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# 言語を選択
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# 利用可能なボイスを一覧表示
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-CoreML上で動作する6モデル自己回帰パイプライン。W8A16パレタイズ重み。
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (オンデバイスLLM)
+### LLMチャット — [完全ガイド →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// 初回実行時に~318 MBをダウンロード (INT4 CoreMLモデル + トークナイザー)
-
-// 単一応答
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// ストリーミングトークン
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B INT4量子化CoreML。Neural Engine上で動作し、iPhone ~2 tok/s、Mシリーズ ~15 tok/s。KVキャッシュによるマルチターン会話、思考モード (`<think>`トークン)、設定可能なサンプリング (temperature、top-k、top-p、repetition penalty) をサポート。
-
-## 音声区間検出 (VAD) — 音声中の発話を検出
-
-### ストリーミングVAD (Silero)
-
-Silero VAD v5は32msの音声チャンクをサブミリ秒レイテンシーで処理します。マイクやストリームからのリアルタイム音声検出に最適です。
+### 音声区間検出 — [完全ガイド →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// またはCoreMLを使用 (Neural Engine、低消費電力):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// ストリーミング: 512サンプルチャンク (16kHzで32ms) を処理
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // 異なる音声ストリーム間で呼び出し
-
-// または全セグメントを一括検出
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Speech: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### イベント駆動型ストリーミング
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// 任意の長さの音声を供給 — 発話が確認されるとイベントが発行
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Speech started at \(time)s")
-    case .speechEnded(let segment):
-        print("Speech: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// ストリーム終了時にフラッシュ
-let final = processor.flush()
-```
-
-### VAD CLI
-
-```bash
-make build
-
-# ストリーミングSilero VAD (32msチャンク)
-.build/release/audio vad-stream audio.wav
-
-# CoreMLバックエンド (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# カスタム閾値
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# JSON出力
-.build/release/audio vad-stream audio.wav --json
-
-# バッチpyannote VAD (10秒スライディングウィンドウ)
-.build/release/audio vad audio.wav
-```
-
-## 話者ダイアライゼーション — 誰がいつ話したか
-
-### ダイアライゼーションパイプライン
+### 話者ダイアライゼーション — [完全ガイド →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// またはCoreML埋め込みを使用 (Neural Engine、GPUを解放):
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) speakers detected")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### 話者埋め込み
+### 音声強調 — [完全ガイド →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// または: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: 長さ256、L2正規化済みの[Float]
+import SpeechEnhancement
 
-// 話者を比較
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### 話者抽出
-
-リファレンス録音を使って特定の話者のセグメントのみを抽出：
+### 音声パイプライン（ASR → LLM → TTS）— [完全ガイド →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Sortformerダイアライゼーション (エンドツーエンド、CoreML)
+`VoicePipeline` はリアルタイム音声agentのステートマシンで（[speech-core](https://github.com/soniqo/speech-core)が駆動）、VADベースのターン検出、割り込み処理、イーガーSTTを備えています。任意の `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider` を接続できます。
 
-NVIDIA Sortformerは最大4人の話者のフレーム単位話者アクティビティを直接予測します。埋め込みやクラスタリングは不要です。Neural Engine上で動作します。
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### ダイアライゼーションCLI
+### HTTP APIサーバー
 
 ```bash
-make build
-
-# Pyannoteダイアライゼーション (デフォルト)
-.build/release/audio diarize meeting.wav
-
-# Sortformerダイアライゼーション (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# CoreML埋め込み (Neural Engine、pyannoteのみ)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# JSON出力
-.build/release/audio diarize meeting.wav --json
-
-# 特定の話者を抽出 (pyannoteのみ)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# 話者埋め込み
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-アーキテクチャの詳細は[話者ダイアライゼーション](docs/inference/speaker-diarization.md)を参照。
-
-## 音声強調 — ノイズ抑制とオーディオクリーンアップ
-
-### ノイズ抑制
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // WAVWriter用
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// 初回実行時に~4.3 MBをダウンロード (Core ML FP16モデル + 補助データ)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### ノイズ除去CLI
-
-```bash
-make build
-
-# 基本的なノイズ除去
-.build/release/audio denoise noisy.wav
-
-# カスタム出力パス
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-アーキテクチャの詳細は[音声強調](docs/inference/speech-enhancement.md)を参照。
-
-## パイプライン — 複数モデルの組み合わせ
-
-すべてのモデルは共有プロトコル (`SpeechRecognitionModel`、`SpeechGenerationModel`、`SpeechEnhancementModel`など) に準拠しており、パイプラインとして組み合わせることができます：
-
-### ノイズの多い音声の認識 (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// 48kHzで強調し、16kHzで文字起こし
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### 音声リレー (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// 音声セグメントを検出し、文字起こしし、再合成
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: 24kHzモノラルfloatサンプル
-}
-```
-
-### 会議の文字起こし (ダイアライゼーション + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Speaker \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-プロトコルの完全なリファレンスは[共有プロトコル](docs/shared-protocols.md)を参照。
-
-## HTTP APIサーバー
-
-スタンドアロンのHTTPサーバーが、すべてのモデルをRESTおよびWebSocketエンドポイントで公開します。モデルは最初のリクエスト時に遅延ロードされます。
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# 音声を文字起こし
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# テキスト読み上げ
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# 音声間変換 (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# 音声強調
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# 起動時にすべてのモデルをプリロード
-.build/release/audio-server --preload --port 8080
-```
-
-### WebSocketストリーミング
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-主要WebSocketエンドポイントは[OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime)プロトコルを実装しています。すべてのメッセージは`type`フィールドを持つJSONで、音声はbase64エンコードされたPCM16 24kHzモノラルです。
-
-**クライアント → サーバーイベント:**
-
-| イベント | 説明 |
-|-------|-------------|
-| `session.update` | エンジン、言語、音声フォーマットの設定 |
-| `input_audio_buffer.append` | base64 PCM16音声チャンクの送信 |
-| `input_audio_buffer.commit` | 蓄積された音声の文字起こし (ASR) |
-| `input_audio_buffer.clear` | 音声バッファのクリア |
-| `response.create` | TTS合成のリクエスト |
-
-**サーバー → クライアントイベント:**
-
-| イベント | 説明 |
-|-------|-------------|
-| `session.created` | セッション初期化完了 |
-| `session.updated` | 設定確認 |
-| `input_audio_buffer.committed` | 文字起こしのための音声コミット完了 |
-| `conversation.item.input_audio_transcription.completed` | ASR結果 |
-| `response.audio.delta` | base64 PCM16音声チャンク (TTS) |
-| `response.audio.done` | 音声ストリーミング完了 |
-| `response.done` | メタデータ付きレスポンス完了 |
-| `error` | タイプとメッセージ付きエラー |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: 音声を送信し、文字起こしを取得
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → 受信: conversation.item.input_audio_transcription.completed
-
-// TTS: テキストを送信し、ストリーミング音声を取得
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → 受信: response.audio.delta (base64チャンク), response.audio.done, response.done
-```
-
-サンプルHTMLクライアントが`Examples/websocket-client.html`にあります。サーバー稼働中にブラウザで開いてください。
-
-サーバーは独立した`AudioServer`モジュールと`audio-server`実行ファイルです。メインの`audio` CLIにHummingbird/WebSocketを追加することはありません。
-
-## レイテンシー (M2 Max, 64 GB)
-
-### ASR
-
-| モデル | バックエンド | RTF | 10秒音声の処理時間 |
-|-------|---------|-----|------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 cold, ~0.03 warm | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### 強制アラインメント
-
-| モデル | フレームワーク | 20秒音声 | RTF |
-|-------|-----------|-----------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> 非自己回帰型の単一フォワードパス — サンプリングループなし。音声エンコーダーが支配的 (~328ms)、デコーダー単一パスは~37ms。**リアルタイムの55倍高速。**
-
-### TTS
-
-| モデル | フレームワーク | 短い (1s) | 中程度 (3s) | 長い (6s) | ストリーミング最初のパケット |
-|-------|-----------|-----------|-------------|------------|----------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1-frame) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (非自己回帰型) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTSは韻律と感情を備えた自然で表現力豊かな音声を生成し、**リアルタイムより高速** (RTF < 1.0) で動作します。ストリーミング合成は最初の音声チャンクを~120msで配信します。Kokoro-82MはNeural Engine上でエンドツーエンドモデルとして動作（RTFx約0.7）、iOS向けに最適です。Appleの内蔵TTSはより高速ですが、機械的で単調な音声を生成します。
-
-### PersonaPlex (音声間変換)
-
-| モデル | フレームワーク | ms/step | RTF | 備考 |
-|-------|-----------|---------|-----|-------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | 推奨 — 一貫した応答、4-bitより30%高速 |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | 非推奨 — 出力品質が劣化 |
-
-> **8-bitを使用してください。** INT8はより高速（112 ms/step vs. 158 ms/step）で、一貫した全二重応答を生成します。INT4量子化は生成品質を劣化させ、意味不明な音声を生成します。INT8はM2 Maxで~112ms/stepで動作します。
-
-### VAD & 話者埋め込み
-
-| モデル | バックエンド | 1回のレイテンシー | RTF | 備考 |
-|-------|---------|-----------------|-----|-------|
-| Silero-VAD-v5 | MLX | ~2.1ms / chunk | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / chunk | 0.008 | Neural Engine、**7.7倍高速** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20s音声 | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20s音声 | 0.021 | Neural Engine、GPUを解放 |
-
-> Silero VAD CoreMLはNeural Engine上でMLXの7.7倍の速度で動作し、常時オンのマイク入力に最適です。WeSpeaker MLXはGPU上でより高速ですが、CoreMLはGPUを並行ワークロード (TTS、ASR) に解放します。両バックエンドで同等の結果が得られます。
-
-### 音声強調
-
-| モデル | バックエンド | 音声長 | レイテンシー | RTF |
-|-------|---------|----------|---------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Real-Time Factor (低いほど良い、< 1.0 = リアルタイムより高速)。GRUのコストは~O(n^2)でスケールします。
-
-### MLX vs CoreML
-
-両バックエンドで同等の結果が得られます。ワークロードに応じて選択してください：
-
-| | MLX | CoreML |
-|---|---|---|
-| **ハードウェア** | GPU (Metal shaders) | Neural Engine + CPU |
-| **最適な用途** | 最大スループット、単一モデルワークロード | マルチモデルパイプライン、バックグラウンドタスク |
-| **消費電力** | GPU使用率が高い | 低消費電力、GPUを解放 |
-| **レイテンシー** | 大型モデルで高速 (WeSpeaker) | 小型モデルで高速 (Silero VAD) |
-
-**デスクトップ推論**: MLXがデフォルト — Apple Silicon上で最速の単一モデルパフォーマンス。複数モデルを同時実行する場合 (例: VAD + ASR + TTS) はGPUの競合を避けるためにCoreMLに切り替えるか、ノートPCのバッテリーに配慮したワークロードに使用してください。
-
-CoreMLモデルはQwen3-ASRエンコーダー、Silero VAD、WeSpeakerで利用可能です。Qwen3-ASRの場合は`--engine qwen3-coreml`を使用 (ハイブリッド: ANE上のCoreMLエンコーダー + GPU上のMLXテキストデコーダー)。VAD/埋め込みの場合は構築時に`engine: .coreml`を渡します。推論APIは同一です。
-
-## 精度ベンチマーク
-
-### ASR — 単語誤り率 ([詳細](docs/benchmarks/asr-wer.md))
-
-| モデル | WER% (LibriSpeech test-clean) | RTF |
-|-------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bitは同等サイズでWhisper Large v3 Turbo (2.5%) を超えます。多言語: FLEURSで10言語のベンチマーク済み。
-
-### TTS — ラウンドトリップ明瞭度 ([詳細](docs/benchmarks/tts-roundtrip.md))
-
-| エンジン | WER% | RTF |
-|--------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — 音声検出 ([詳細](docs/benchmarks/vad-detection.md))
-
-| エンジン | F1% (FLEURS) | RTF |
-|--------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+HTTP REST + WebSocketエンドポイントですべてのモデルを公開します。OpenAI Realtime API互換のWebSocket `/v1/realtime` も含まれます。[`Sources/AudioServer/`](Sources/AudioServer/) を参照してください。
 
 ## アーキテクチャ
 
-**モデル:** [ASRモデル](docs/models/asr-model.md)、[TTSモデル](docs/models/tts-model.md)、[CosyVoice TTS](docs/models/cosyvoice-tts.md)、[Kokoro TTS](docs/models/kokoro-tts.md)、[Parakeet TDT](docs/models/parakeet-asr.md)、[Parakeet Streaming](docs/models/parakeet-streaming-asr.md)、[PersonaPlex](docs/models/personaplex.md)、[FireRedVAD](docs/models/fireredvad.md)
+speech-swift はモデルごとに1つのSPMターゲットに分割されており、利用者はインポートした分だけコストを負担します。共有インフラは `AudioCommon`（プロトコル、音声I/O、HuggingFaceダウンローダー、`SentencePieceModel`）と `MLXCommon`（ウェイトローディング、`QuantizedLinear` ヘルパー、`SDPA` マルチヘッドアテンションヘルパー）にあります。
 
-**推論:** [ASR推論](docs/inference/qwen3-asr-inference.md)、[Parakeet ストリーミング](docs/inference/parakeet-streaming-asr-inference.md)、[TTS推論](docs/inference/qwen3-tts-inference.md)、[強制アラインメント](docs/inference/forced-aligner.md)、[FireRedVAD](docs/inference/fireredvad.md)、[Silero VAD](docs/inference/silero-vad.md)、[話者ダイアライゼーション](docs/inference/speaker-diarization.md)、[音声強調](docs/inference/speech-enhancement.md)、[オーディオ再生](docs/audio/playback.md)
+**[バックエンド、メモリ表、モジュールマップ付きの完全なアーキテクチャ図 → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[APIリファレンス → soniqo.audio/api](https://soniqo.audio/api)** · **[ベンチマーク → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**ベンチマーク:** [ASR WER](docs/benchmarks/asr-wer.md)、[TTSラウンドトリップ](docs/benchmarks/tts-roundtrip.md)、[VAD検出](docs/benchmarks/vad-detection.md)
-
-**リファレンス:** [共有プロトコル](docs/shared-protocols.md)
+ローカルドキュメント（リポジトリ内）：
+- **モデル：** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **推論：** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [話者ダイアライゼーション](docs/inference/speaker-diarization.md) · [音声強調](docs/inference/speech-enhancement.md)
+- **リファレンス：** [共有プロトコル](docs/shared-protocols.md)
 
 ## キャッシュ設定
 
-モデルの重みは `~/Library/Caches/qwen3-speech/` にローカルキャッシュされます。
+モデルの重みは初回使用時にHuggingFaceからダウンロードされ、`~/Library/Caches/qwen3-speech/` にキャッシュされます。`QWEN3_CACHE_DIR`（CLI）または `cacheDir:`（Swift API）で上書き可能です。すべての `fromPretrained()` エントリーポイントは `offlineMode: true` を受け付け、重みがすでにキャッシュされている場合はネットワークをスキップします。
 
-**CLI** — 環境変数でオーバーライド：
-
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
-
-**Swift API** — すべての `fromPretrained()` メソッドが `cacheDir` と `offlineMode` をサポート：
-
-```swift
-// カスタムキャッシュディレクトリ（サンドボックスアプリ、iOSコンテナ）
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// オフラインモード — 重みがキャッシュ済みの場合ネットワークをスキップ
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-詳細は [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md) を参照。
+iOSサンドボックスコンテナのパスを含む詳細は [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md) を参照してください。
 
 ## MLX Metalライブラリ
 
-実行時に`Failed to load the default metallib`が表示された場合、Metal shaderライブラリが不足しています。`make build` (または手動の`swift build`の後に`./scripts/build_mlx_metallib.sh release`) を実行してコンパイルしてください。Metal Toolchainが不足している場合は、先にインストールしてください：
+実行時に `Failed to load the default metallib` と表示された場合は、Metalシェーダーライブラリが不足しています。`make build` または手動 `swift build` の後に `./scripts/build_mlx_metallib.sh release` を実行してください。Metal Toolchainがない場合はまずインストールします：
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## テスト
 
-ユニットテスト (設定、サンプリング、テキスト前処理、タイムスタンプ補正) はモデルのダウンロードなしで実行できます：
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # 完全スイート（ユニット + モデルダウンロード付きE2E）
+swift test --skip E2E                # ユニットのみ（CIセーフ、ダウンロードなし）
+swift test --filter Qwen3ASRTests    # 指定モジュール
 ```
 
-統合テストにはモデルの重みが必要です (初回実行時に自動ダウンロード)：
-
-```bash
-# TTSラウンドトリップ: テキストを合成、WAV保存、ASRで逆文字起こし
-swift test --filter TTSASRRoundTripTests
-
-# ASRのみ: テスト音声を文字起こし
-swift test --filter Qwen3ASRIntegrationTests
-
-# 強制アラインメントE2E: 単語レベルのタイムスタンプ (~979 MBダウンロード)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E: 音声間パイプライン (~5.5 GBダウンロード)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **注意:** MLX操作を使用するテストの実行前に、MLX Metalライブラリをビルドする必要があります。
-> 手順は[MLX Metalライブラリ](#mlx-metalライブラリ)を参照してください。
-
-## 対応言語
-
-| モデル | 対応言語 |
-|-------|-----------|
-| Qwen3-ASR | 52言語 (CN, EN, 広東語, DE, FR, ES, JA, KO, RU, + 中国語方言22種, ...) |
-| Parakeet TDT | ヨーロッパ25言語 (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1,672言語**、150以上の語族をカバー。Metaの「直接サポート」セット全体（約1,100言語）と、コミュニティデータで追加された500以上の低リソース言語を含む。主な言語：EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ...（完全なリスト：[`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)）。CTCヘッドは言語非依存で、推論時に言語ヒントは不要です。 |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ CustomVoiceで北京語/四川方言) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## 他との比較
-
-### 音声認識 (ASR): speech-swift vs 他の選択肢
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **ランタイム** | オンデバイス (MLX/CoreML) | オンデバイス (CPU/GPU) | オンデバイスまたはクラウド | クラウドのみ |
-| **対応言語** | 52 | 100以上 | ~70 (オンデバイス: 限定的) | 125以上 |
-| **RTF (10秒音声, M2 Max)** | 0.06 (リアルタイムの17倍) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **ストリーミング** | なし (バッチ) | なし (バッチ) | あり | あり |
-| **カスタムモデル** | あり (HuggingFace重みを差し替え) | あり (GGMLモデル) | なし | なし |
-| **Swift API** | ネイティブasync/await | C++のSwiftブリッジ | ネイティブ | REST/gRPC |
-| **プライバシー** | 完全オンデバイス | 完全オンデバイス | 設定による | クラウドにデータ送信 |
-| **単語タイムスタンプ** | あり (強制アラインメント) | あり | 限定的 | あり |
-| **コスト** | 無料 (Apache 2.0) | 無料 (MIT) | 無料 (オンデバイス) | 分単位課金 |
-
-### テキスト読み上げ (TTS): speech-swift vs 他の選択肢
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / クラウドTTS** |
-|---|---|---|---|---|
-| **品質** | ニューラル、表現力豊か | ニューラル、自然 | 機械的、単調 | ニューラル、最高品質 |
-| **ランタイム** | オンデバイス (MLX) | オンデバイス (CoreML) | オンデバイス | クラウドのみ |
-| **ストリーミング** | あり (最初のチャンク~120ms) | なし (エンドツーエンドモデル) | なし | あり |
-| **音声クローン** | あり | なし | なし | あり |
-| **ボイス** | 9種類内蔵 + 任意のクローン | 54種類のプリセット | ~50種類のシステムボイス | 1000以上 |
-| **対応言語** | 10 | 10 | 60以上 | 30以上 |
-| **iOS対応** | macOSのみ | iOS + macOS | iOS + macOS | あり (API) |
-| **コスト** | 無料 (Apache 2.0) | 無料 (Apache 2.0) | 無料 | 文字単位課金 |
-
-### speech-swiftを使うべき場面
-
-- **プライバシー重視のアプリ** — 医療、法律、企業向けなど、音声をデバイス外に送信できない場合
-- **オフライン利用** — 初回モデルダウンロード後はインターネット接続不要
-- **コスト重視** — 分単位や文字単位のAPI課金なし
-- **Apple Silicon最適化** — Mシリーズ GPU (Metal) とNeural Engine専用設計
-- **フルパイプライン** — ASR + TTS + VAD + ダイアライゼーション + 音声強調を単一のSwiftパッケージで統合
-
-## FAQ
-
-**speech-swiftはiOSで動作しますか？**
-Kokoro TTS、Qwen3.5-Chat (CoreML)、Silero VAD、Parakeet ASR、DeepFilterNet3、WeSpeakerはすべてiOS 17以上でCoreML (Neural Engine) を使って動作します。MLXベースのモデル (Qwen3-ASR、Qwen3-TTS、Qwen3.5-Chat MLX、PersonaPlex) はmacOS 14以上のApple Siliconが必要です。
-
-**インターネット接続は必要ですか？**
-HuggingFaceからの初回モデルダウンロード時のみ必要です (自動、`~/Library/Caches/qwen3-speech/`にキャッシュ)。以降はすべての推論がネットワークアクセスなしで完全にオフラインで実行されます。
-
-**speech-swiftはWhisperと比べてどうですか？**
-Qwen3-ASR-0.6BはM2 MaxでRTF 0.06を達成 — whisper.cpp経由のWhisper-large-v3 (RTF 0.10) より40%高速で、52言語にわたり同等の精度を備えています。speech-swiftはネイティブSwift async/await APIを提供し、whisper.cppはC++ブリッジが必要です。
-
-**商用アプリに使えますか？**
-はい。speech-swiftはApache 2.0ライセンスです。基盤となるモデルの重みにはそれぞれのライセンスがあります (各モデルのHuggingFaceページをご確認ください)。
-
-**どのApple Siliconチップに対応していますか？**
-すべてのMシリーズチップ: M1、M2、M3、M4とそのPro/Max/Ultraバリアント。macOS 14以上 (Sonoma) またはiOS 17以上が必要です。
-
-**必要なメモリはどのくらいですか？**
-~3 MB (Silero VAD) から~6.5 GB (PersonaPlex 7B) まで。Kokoro TTSは~500 MB、Qwen3-ASRは~2.2 GB使用します。詳細は[メモリ要件](#メモリ要件)の表を参照してください。
-
-**複数のモデルを同時に実行できますか？**
-はい。Neural Engine上のCoreMLモデルとGPU上のMLXモデルを併用することで競合を避けられます。例: Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX)。
-
-**REST APIはありますか？**
-はい。`audio-server`バイナリが、HTTP RESTおよびWebSocketエンドポイントですべてのモデルを公開します。`/v1/realtime`にOpenAI Realtime API互換のWebSocketも備えています。
+E2Eテストクラスは `E2E` プレフィックスを使うため、CIは `--skip E2E` でそれらを除外できます。完全なテスト規約は [CLAUDE.md](CLAUDE.md#testing) を参照してください。
 
 ## コントリビューション
 
-コントリビューションを歓迎します！バグ修正、新しいモデルの統合、ドキュメントの改善など、プルリクエストをお待ちしています。
-
-**始め方：**
-1. リポジトリをフォークしてフィーチャーブランチを作成
-2. `make build`でコンパイル (Xcode + Metal Toolchainが必要)
-3. `make test`でテストスイートを実行
-4. `main`に対してPRを作成
+PR歓迎 — バグ修正、新しいモデル統合、ドキュメント改善。fork、フィーチャーブランチ作成、`make build && make test`、`main` に対してPRを開いてください。
 
 ## ライセンス
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -4,34 +4,26 @@ MLX Swift와 CoreML 기반의 Apple Silicon용 AI 음성 모델.
 
 📖 Read in: [English](README.md) · [中文](README_zh.md) · [日本語](README_ja.md) · [한국어](README_ko.md) · [Español](README_es.md) · [Deutsch](README_de.md) · [Français](README_fr.md) · [हिन्दी](README_hi.md) · [Português](README_pt.md) · [Русский](README_ru.md)
 
-Mac과 iOS를 위한 온디바이스 음성 인식, 합성 및 이해. Apple Silicon에서 완전히 로컬로 실행 — 클라우드 없이, API 키 없이, 데이터가 기기 밖으로 나가지 않습니다.
+Mac과 iOS를 위한 온디바이스 음성 인식, 합성 및 이해. Apple Silicon에서 완전히 로컬로 실행됩니다 — 클라우드 없이, API 키 없이, 데이터가 기기 밖으로 나가지 않습니다.
 
-[Homebrew로 설치](#homebrew)하거나 Swift Package 의존성으로 추가하세요.
+**[📚 전체 문서 →](https://soniqo.audio)** · **[🤗 HuggingFace 모델](https://huggingface.co/aufklarer)** · **[📝 블로그](https://blog.ivan.digital)**
 
-**[문서](https://soniqo.audio)** · **[HuggingFace 모델](https://huggingface.co/aufklarer)** · **[블로그](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — 음성-텍스트 변환 (자동 음성 인식, 52개 언어, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — CoreML을 통한 음성-텍스트 변환 (Neural Engine, NVIDIA FastConformer + TDT 디코더, 25개 언어)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — 음성-텍스트 변환 (Meta wav2vec2 + CTC, **1,672개 언어**, 32개 문자 체계, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[스트리밍 받아쓰기](https://soniqo.audio/guides/dictate)** — 부분 결과와 발화 종료 감지를 갖춘 실시간 받아쓰기 (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — 단어 수준 타임스탬프 정렬 (오디오 + 텍스트 → 타임스탬프)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — 텍스트-음성 변환 (최고 품질, 스트리밍, 커스텀 화자, 10개 언어)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — 음성 복제, 다화자 대화, 감정 태그를 지원하는 스트리밍 TTS (9개 언어)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — 온디바이스 TTS (82M, CoreML/Neural Engine, 54개 음색, iOS 지원, 10개 언어)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — 온디바이스 LLM 채팅 (0.8B, MLX INT4 + CoreML INT8, DeltaNet 하이브리드, 스트리밍 토큰)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — 전이중 음성-음성 대화 (7B, 오디오 입력 → 오디오 출력, 18개 음색 프리셋)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — 실시간 노이즈 억제 (2.1M 파라미터, 48 kHz)
+- **[VAD](https://soniqo.audio/guides/vad)** — 음성 활동 감지 (Silero 스트리밍, Pyannote 오프라인, FireRedVAD 100+ 개 언어)
+- **[화자 분리](https://soniqo.audio/guides/diarize)** — 누가 언제 말했는지 (Pyannote 파이프라인, Neural Engine 상의 엔드투엔드 Sortformer)
+- **[화자 임베딩](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256차원), CAM++ (192차원)
 
-- **Qwen3-ASR** — 음성-텍스트 변환 / 음성 인식 (자동 음성 인식, 52개 언어)
-- **Parakeet TDT** — CoreML을 통한 음성-텍스트 변환 (Neural Engine, NVIDIA FastConformer + TDT 디코더, 25개 언어)
-- **Omnilingual ASR** — CoreML을 통한 음성-텍스트 변환 (Meta wav2vec2 + CTC, **1,672개 언어**, 150개 이상 어족, 5/10초 윈도우, INT8 팔레트화, ANE)
-- **Qwen3-ForcedAligner** — 단어 수준 타임스탬프 정렬 (오디오 + 텍스트 → 타임스탬프)
-- **Qwen3-TTS** — 텍스트-음성 변환 (최고 품질, 스트리밍, 커스텀 화자, 10개 언어)
-- **CosyVoice TTS** — 스트리밍, 음성 복제, 다화자 대화, 감정 태그를 지원하는 텍스트-음성 변환 (9개 언어, DiT flow matching, CAM++ 화자 인코더)
-- **Kokoro TTS** — 온디바이스 텍스트-음성 변환 (82M 파라미터, CoreML/Neural Engine, 54개 음색, iOS 지원, 10개 언어)
-- **Qwen3-TTS CoreML** — 텍스트-음성 변환 (0.6B, CoreML 6모델 파이프라인, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** — 온디바이스 LLM 채팅 (0.8B, MLX + CoreML, INT4 + CoreML INT8, DeltaNet 하이브리드, 스트리밍 토큰)
-- **PersonaPlex** — 전이중 음성-음성 대화 (7B, 오디오 입력 → 오디오 출력, 18개 음색 프리셋)
-- **DeepFilterNet3** — 음성 향상 / 노이즈 억제 (2.1M 파라미터, 실시간 48kHz)
-- **FireRedVAD** — 오프라인 음성 활동 감지 (DFSMN, CoreML, 100개 이상 언어, 97.6% F1)
-- **Silero VAD** — 스트리밍 음성 활동 감지 (32ms 청크, 밀리초 미만 지연 시간)
-- **Pyannote VAD** — 오프라인 음성 활동 감지 (10초 윈도우, 다화자 중첩)
-- **Speaker Diarization** — 누가 언제 말했는지 (Pyannote 세그멘테이션 + 활동 기반 화자 체이닝, 또는 Neural Engine 상의 엔드투엔드 Sortformer)
-- **Speaker Embeddings** — 화자 검증 및 식별 (WeSpeaker ResNet34, 256차원 벡터)
-
-논문: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## 로드맵
-
-[로드맵 토론](https://github.com/soniqo/speech-swift/discussions/81)에서 계획된 내용을 확인하세요 — 댓글과 제안을 환영합니다!
+논문: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## 소식
 
@@ -45,17 +37,17 @@ Mac과 iOS를 위한 온디바이스 음성 인식, 합성 및 이해. Apple Sil
 `Package.swift`에 패키지를 추가하세요:
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-필요한 모듈만 임포트하세요 — 모든 모델이 각자의 SPM 라이브러리입니다:
+필요한 모듈만 임포트하세요 — 모든 모델이 독립된 SPM 라이브러리이므로 사용하지 않는 것에 비용을 지불할 필요가 없습니다:
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
 .product(name: "SpeechUI",             package: "speech-swift"),  // 선택적 SwiftUI 뷰
 ```
 
-**3줄로 오디오 버퍼 전사하기:**
+**3줄로 오디오 버퍼 전사:**
 
 ```swift
 import ParakeetStreamingASR
@@ -96,128 +88,85 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI`에는 `TranscriptionView`(파이널 + 파셜)와 `TranscriptionStore`(스트리밍 ASR 어댑터)만 포함됩니다. 오디오 시각화 및 재생은 AVFoundation을 사용하세요.
+`SpeechUI`에는 `TranscriptionView`(파이널 + 파셜)와 `TranscriptionStore`(스트리밍 ASR 어댑터)만 포함됩니다. 오디오 시각화와 재생에는 AVFoundation을 사용하세요.
 
-사용 가능한 SPM 제품: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+사용 가능한 SPM 프로덕트: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## 모델
 
-| 모델 | 태스크 | 스트리밍 | 언어 | 크기 |
-|-------|------|-----------|-----------|-------|
-| Qwen3-ASR-0.6B | 음성 → 텍스트 | 아니오 | 52개 언어 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | 음성 → 텍스트 | 아니오 | 52개 언어 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | 음성 → 텍스트 | 아니오 | 25개 유럽 언어 | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | 음성 → 텍스트 | 예 (스트리밍 + EOU) | 25개 유럽 언어 | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | 음성 → 텍스트 | 아니오 (5/10초 윈도우) | [1,672개 언어](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | 음성 → 텍스트 | 아니오 | [1,672개 언어](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | 음성 → 텍스트 | 아니오 | [1,672개 언어](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | 음성 → 텍스트 | 아니오 | [1,672개 언어](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | 오디오 + 텍스트 → 타임스탬프 | 아니오 | 다국어 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | 텍스트 → 음성 | 예 (~120ms) | 10개 언어 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | 텍스트 → 음성 | 예 (~120ms) | 10개 언어 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | 텍스트 → 음성 | 예 (~120ms) | 10개 언어 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | 텍스트 → 음성 | 예 (~150ms) | 9개 언어 | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | 텍스트 → 음성 | 아니오 | 10개 언어 | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | 음성 → 음성 | 예 (~2초 청크) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | 음성 활동 감지 | 아니오 (오프라인) | 100개 이상 언어 | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | 음성 활동 감지 | 예 (32ms 청크) | 언어 무관 | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + 화자 세그멘테이션 | 아니오 (10초 윈도우) | 언어 무관 | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | 음성 향상 | 예 (10ms 프레임) | 언어 무관 | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | 화자 임베딩 (256차원) | 아니오 | 언어 무관 | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | 화자 임베딩 (192차원) | 아니오 | 언어 무관 | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | 화자 분리 (엔드투엔드) | 예 (청크) | 언어 무관 | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+아래는 컴팩트 뷰입니다. **[크기, 양자화, 다운로드 URL, 메모리 테이블을 포함한 전체 모델 카탈로그 → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### 메모리 요구 사항
-
-가중치 메모리는 모델 파라미터가 소비하는 GPU (MLX) 또는 ANE (CoreML) 메모리입니다. 최대 추론 메모리에는 KV 캐시, 활성화 값, 중간 텐서가 포함됩니다.
-
-| 모델 | 가중치 메모리 | 최대 추론 메모리 |
-|-------|--------------|----------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### TTS 선택 가이드
-
-- **Qwen3-TTS**: 최고 품질, 스트리밍 (~120ms), 9개 내장 화자, 10개 언어, 배치 합성
-- **CosyVoice TTS**: 스트리밍 (~150ms), 9개 언어, 음성 복제 (CAM++ 화자 인코더), 다화자 대화 (`[S1] ... [S2] ...`), 인라인 감정/스타일 태그 (`(happy)`, `(whispers)`), DiT flow matching + HiFi-GAN 보코더
-- **Kokoro TTS**: iOS에 적합한 경량 TTS (82M 파라미터), CoreML/Neural Engine, 54개 음색, 10개 언어, 엔드투엔드 모델
-- **PersonaPlex**: 전이중 음성-음성 (오디오 입력 → 오디오 출력), 스트리밍 (~2초 청크), 18개 음색 프리셋, Moshi 아키텍처 기반
+| 모델 | 작업 | 백엔드 | 크기 | 언어 |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | 음성 → 텍스트 | MLX, CoreML (하이브리드) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | 음성 → 텍스트 | CoreML (ANE) | 0.6B | 25개 유럽어 |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | 음성 → 텍스트 (스트리밍) | CoreML (ANE) | 120M | 25개 유럽어 |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | 음성 → 텍스트 | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1,672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | 오디오 + 텍스트 → 타임스탬프 | MLX, CoreML | 0.6B | 다언어 |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | 텍스트 → 음성 | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | 텍스트 → 음성 | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | 텍스트 → 음성 | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | 텍스트 → 텍스트 (LLM) | MLX, CoreML | 0.8B | 다언어 |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | 음성 → 음성 | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | 음성 활동 감지 | MLX, CoreML | 309K | 언어 무관 |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + 화자 분리 | MLX | 1.5M | 언어 무관 |
+| [Sortformer](https://soniqo.audio/guides/diarize) | 화자 분리 (E2E) | CoreML (ANE) | — | 언어 무관 |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | 음성 향상 | CoreML | 2.1M | 언어 무관 |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | 화자 임베딩 | MLX, CoreML | 6.6M | 언어 무관 |
 
 ## 설치
 
 ### Homebrew
 
-네이티브 ARM Homebrew (`/opt/homebrew`)가 필요합니다. Rosetta/x86_64 Homebrew는 지원되지 않습니다.
+네이티브 ARM Homebrew(`/opt/homebrew`)가 필요합니다. Rosetta/x86_64 Homebrew는 지원되지 않습니다.
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-사용 방법:
+그런 다음:
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (뉴럴 엔진)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> 마이크 입력을 사용한 대화형 음성 대화는 **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** 를 참조하세요.
+**[전체 CLI 레퍼런스 →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-`Package.swift`에 추가하세요:
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-필요한 모듈을 가져오세요:
+필요한 것만 임포트하세요 — 모든 모델이 독립된 SPM 타겟입니다:
 
 ```swift
-import Qwen3ASR      // 음성 인식 (MLX)
-import ParakeetASR   // 음성 인식 (CoreML)
-import Qwen3TTS      // 텍스트-음성 변환 (Qwen3)
-import CosyVoiceTTS  // 텍스트-음성 변환 (스트리밍)
-import KokoroTTS     // 텍스트-음성 변환 (CoreML, iOS 지원)
-import Qwen3Chat     // 온디바이스 LLM 채팅 (CoreML)
-import PersonaPlex   // 음성-음성 (전이중)
-import SpeechVAD          // 음성 활동 감지 (pyannote + Silero)
-import SpeechEnhancement  // 노이즈 억제 (DeepFilterNet3)
-import AudioCommon        // 공용 유틸리티
+import Qwen3ASR             // 음성 인식 (MLX)
+import ParakeetASR          // 음성 인식 (CoreML, 배치)
+import ParakeetStreamingASR // 부분 결과 + EOU 포함 스트리밍 받아쓰기
+import OmnilingualASR       // 1,672개 언어 (CoreML + MLX)
+import Qwen3TTS             // 텍스트-음성 변환
+import CosyVoiceTTS         // 음성 복제 포함 텍스트-음성 변환
+import KokoroTTS            // 텍스트-음성 변환 (iOS 지원)
+import Qwen3Chat            // 온디바이스 LLM 채팅
+import PersonaPlex          // 전이중 음성-음성 변환
+import SpeechVAD            // VAD + 화자 분리 + 임베딩
+import SpeechEnhancement    // 노이즈 억제
+import SpeechUI             // 스트리밍 전사를 위한 SwiftUI 컴포넌트
+import AudioCommon          // 공유 프로토콜 및 유틸리티
 ```
 
-### 요구 사항
+### 요구사항
 
-- Swift 5.9+
-- macOS 14+ 또는 iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (Metal Toolchain 포함 — 없으면 `xcodebuild -downloadComponent MetalToolchain` 실행)
+- Swift 5.9+, Xcode 15+ (Metal Toolchain 포함)
+- macOS 14+ 또는 iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
-### 소스에서 빌드
+### 소스 빌드
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-이 명령은 Swift 패키지 **및** MLX Metal 셰이더 라이브러리를 한 번에 컴파일합니다. Metal 라이브러리(`mlx.metallib`)는 GPU 추론에 필수이며 — 없으면 런타임에 `Failed to load the default metallib` 오류가 발생합니다.
+`make build`는 Swift 패키지**와** MLX Metal 셰이더 라이브러리를 함께 컴파일합니다. Metal 라이브러리는 GPU 추론에 필요합니다 — 없으면 런타임에 `Failed to load the default metallib`이 발생합니다. 디버그 빌드는 `make debug`, 테스트 스위트는 `make test`로 실행합니다.
 
-디버그 빌드: `make debug`. 단위 테스트 실행: `make test`.
-
-## 음성 어시스턴트 사용해 보기
-
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** 는 바로 실행할 수 있는 macOS 음성 어시스턴트입니다 — 탭하여 말하면 실시간으로 음성 응답을 받을 수 있습니다. 자동 음성 감지를 위한 Silero VAD가 포함된 마이크 입력, 전사를 위한 Qwen3-ASR, 음성-음성 생성을 위한 PersonaPlex 7B를 사용합니다. 18개 음색 프리셋과 내면 독백 트랜스크립트 표시를 갖춘 멀티턴 대화를 지원합니다.
-
-```bash
-make build  # 리포 루트에서 — MLX metallib 포함 전체 빌드
-cd Examples/PersonaPlexDemo
-# .app 번들 안내는 Examples/PersonaPlexDemo/README.md를 참조하세요
-```
-
-> M2 Max에서 RTF ~0.94 (실시간보다 빠름). 모델은 첫 실행 시 자동 다운로드됩니다 (~5.5 GB PersonaPlex + ~400 MB ASR).
+**[전체 빌드 및 설치 가이드 →](https://soniqo.audio/getting-started)**
 
 ## 데모 앱
 
-- **[DictateDemo](Examples/DictateDemo/)** ([문서](https://soniqo.audio/guides/dictate/)) — macOS 메뉴 바 스트리밍 받아쓰기. 실시간 부분 결과, VAD 기반 발화 종료 감지, 원클릭 복사. 백그라운드 메뉴 바 에이전트로 실행 (Parakeet-EOU-120M + Silero VAD).
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS 에코 데모 (Parakeet ASR + Kokoro TTS, 말하고 다시 듣기). 디바이스 및 시뮬레이터 지원.
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — 대화형 음성 어시스턴트 (마이크 입력, VAD, 멀티턴). macOS.
-- **[SpeechDemo](Examples/SpeechDemo/)** — 받아쓰기 및 텍스트-음성 합성 탭 인터페이스. macOS.
+- **[DictateDemo](Examples/DictateDemo/)** ([문서](https://soniqo.audio/guides/dictate)) — macOS 메뉴 바 스트리밍 받아쓰기. 라이브 파셜, VAD 기반 발화 종료 감지, 원클릭 복사. 백그라운드 agent로 실행됩니다 (Parakeet-EOU-120M + Silero VAD).
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS 에코 데모 (Parakeet ASR + Kokoro TTS). 기기 및 시뮬레이터 지원.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — 마이크 입력, VAD, 멀티턴 컨텍스트를 지원하는 대화형 음성 어시스턴트. macOS. M2 Max에서 RTF 약 0.94 (실시간보다 빠름).
+- **[SpeechDemo](Examples/SpeechDemo/)** — 탭형 인터페이스에서 받아쓰기와 TTS 합성. macOS.
 
-빌드하고 실행하세요 — 각 데모의 README에서 안내를 확인할 수 있습니다.
+각 데모의 README에 빌드 방법이 있습니다.
 
-## 음성-텍스트 변환 (ASR) — Swift로 오디오 전사하기
+## 코드 예제
 
-### 기본 전사
+아래 스니펫은 각 도메인의 최소 사용 경로를 보여줍니다. 각 섹션은 [soniqo.audio](https://soniqo.audio)의 전체 가이드로 링크되어 있으며, 설정 옵션, 다양한 백엔드, 스트리밍 패턴 및 CLI 레시피를 다룹니다.
 
-```swift
-import Qwen3ASR
-
-// 기본값: 0.6B 모델
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// 더 높은 정확도를 위해 1.7B 모델 사용
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// 오디오는 아무 샘플레이트나 가능 — 내부적으로 16kHz로 자동 리샘플링
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### CoreML 인코더 (Neural Engine)
-
-하이브리드 모드: Neural Engine의 CoreML 인코더 + GPU의 MLX 텍스트 디코더. 저전력이며 인코더 패스에서 GPU를 확보합니다.
+### 음성-텍스트 변환 — [전체 가이드 →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-INT8 (180 MB, 기본값) 및 INT4 (90 MB) 변형을 사용할 수 있습니다. INT8 권장 (FP32 대비 코사인 유사도 > 0.999).
+대체 백엔드: [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× 실시간), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1,672개 언어, CoreML 또는 MLX), [스트리밍 받아쓰기](https://soniqo.audio/guides/dictate) (라이브 파셜).
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-CoreML을 통해 Neural Engine에서 실행됩니다 — GPU를 다른 동시 작업에 사용할 수 있습니다. 25개 유럽 언어, ~315 MB.
-
-### ASR CLI
-
-```bash
-make build  # 또는: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# 기본값 (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# 1.7B 모델 사용
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# CoreML 인코더 (Neural Engine + MLX 디코더)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## 강제 정렬
-
-### 단어 수준 타임스탬프
+### 강제 정렬 — [전체 가이드 →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// 첫 실행 시 ~979 MB 다운로드
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### 강제 정렬 CLI
-
-```bash
-swift build -c release
-
-# 제공된 텍스트로 정렬
-.build/release/audio align audio.wav --text "Hello world"
-
-# 먼저 전사한 후 정렬
-.build/release/audio align audio.wav
-```
-
-출력:
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-엔드투엔드 모델, 비자기회귀, 샘플링 루프 없음. 아키텍처 상세 내용은 [Forced Aligner](docs/inference/forced-aligner.md)를 참조하세요.
-
-## 텍스트-음성 변환 (TTS) — Swift로 음성 생성하기
-
-### 기본 합성
+### 텍스트-음성 변환 — [전체 가이드 →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // WAVWriter 사용
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// 첫 실행 시 ~1.7 GB 다운로드 (모델 + 코덱 가중치)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// 출력은 24kHz 모노 float 샘플
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### TTS CLI
+대체 TTS 엔진: [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (스트리밍 + 음성 복제 + 감정 태그), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (iOS 지원, 54개 음색), [음성 복제](https://soniqo.audio/guides/voice-cloning).
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### 커스텀 음성 / 화자 선택
-
-**CustomVoice** 모델 변형은 9개의 내장 화자 음색과 톤/스타일 제어를 위한 자연어 지시를 지원합니다. CustomVoice 모델 ID를 전달하여 로드하세요:
-
-```swift
-import Qwen3TTS
-
-// CustomVoice 모델 로드 (첫 실행 시 ~1.7 GB 다운로드)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// 특정 화자로 합성
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// 사용 가능한 화자 목록
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# 화자를 지정한 CustomVoice 모델 사용
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# 사용 가능한 화자 목록
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### 음성 복제 (Base 모델)
-
-참조 오디오 파일에서 화자의 음성을 복제합니다. 두 가지 모드:
-
-**ICL 모드** (권장) — 참조 오디오를 트랜스크립트와 함께 코덱 토큰으로 인코딩합니다. 더 높은 품질, 안정적인 EOS:
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**X-vector 모드** — 화자 임베딩만 사용, 트랜스크립트 불필요하지만 품질이 낮음:
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### 톤 / 스타일 지시 (CustomVoice 전용)
-
-CustomVoice 모델은 발화 스타일, 톤, 감정, 속도를 제어하기 위한 자연어 `instruct` 파라미터를 지원합니다. 지시는 ChatML 형식으로 모델 입력 앞에 추가됩니다.
-
-```swift
-// 밝은 톤
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// 느리고 진지하게
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// 속삭이기
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# 스타일 지시 포함
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# CustomVoice 사용 시 기본 지시 ("Speak naturally.")가 자동 적용됨
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-CustomVoice 모델에서 `--instruct`를 제공하지 않으면 `"Speak naturally."`가 자동으로 적용되어 장황한 출력을 방지합니다. Base 모델은 instruct를 지원하지 않습니다.
-
-### 배치 합성
-
-단일 배치 순전파로 여러 텍스트를 합성하여 처리량을 높입니다:
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i]는 texts[i]에 대한 24kHz 모노 float 샘플
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### 배치 CLI
-
-```bash
-# 한 줄에 하나의 텍스트가 있는 파일 생성
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# output_0.wav, output_1.wav, ... 생성
-```
-
-> 배치 모드는 항목 간에 모델 가중치 로드를 분산합니다. Apple Silicon에서 B=4 기준 ~1.5-2.5배 처리량 향상을 기대할 수 있습니다. 비슷한 길이의 오디오를 생성하는 텍스트에서 최적의 결과를 얻을 수 있습니다.
-
-### 샘플링 옵션
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### 스트리밍 합성
-
-첫 패킷 지연 시간을 줄이기 위해 오디오 청크를 점진적으로 출력합니다:
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // 첫 오디오 청크까지 ~120ms
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: 마지막 청크에서 true
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# 기본 스트리밍 (3프레임 첫 청크, ~225ms 지연)
-.build/release/audio speak "Hello world" --stream
-
-# 저지연 (1프레임 첫 청크, ~120ms 지연)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## 음성-음성 — 전이중 음성 대화
-
-> 마이크 입력이 포함된 대화형 음성 어시스턴트는 **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** 를 참조하세요 — 탭하여 말하기, 자동 음성 감지로 멀티턴 대화를 지원합니다.
-
-### 음성-음성 변환
+### 음성-음성 변환 — [전체 가이드 →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // WAVWriter, AudioFileLoader 사용
 
 let model = try await PersonaPlexModel.fromPretrained()
-// 첫 실행 시 ~5.5 GB 다운로드 (temporal 4-bit + depformer + Mimi 코덱 + 음색 프리셋)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: 24kHz 모노 float 샘플
-// textTokens: 모델의 내면 독백 (SentencePiece 토큰 ID)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// 24 kHz 모노 Float32 출력, 재생 준비 완료
 ```
 
-### 내면 독백 (텍스트 출력)
-
-PersonaPlex는 오디오와 함께 텍스트 토큰을 생성합니다 — 모델의 내부 추론입니다. 내장된 SentencePiece 디코더로 디코딩하세요:
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // 예: "Sure, I can help you with that..."
-```
-
-### 스트리밍 음성-음성
-
-```swift
-// 생성되는 대로 오디오 청크 수신 (청크당 ~2초)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // 즉시 재생, 24kHz 모노
-    // chunk.textTokens에 이 청크의 텍스트 포함; 마지막 청크에 모든 토큰 포함
-    if chunk.isFinal { break }
-}
-```
-
-### 음색 선택
-
-18개 음색 프리셋 사용 가능:
-- **자연스러운 여성**: NATF0, NATF1, NATF2, NATF3
-- **자연스러운 남성**: NATM0, NATM1, NATM2, NATM3
-- **다양한 여성**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **다양한 남성**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### 시스템 프롬프트
-
-시스템 프롬프트는 모델의 대화 동작을 조정합니다. 임의의 커스텀 프롬프트를 일반 문자열로 전달할 수 있습니다:
-
-```swift
-// 커스텀 시스템 프롬프트 (자동 토큰화)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// 또는 프리셋 사용
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-사용 가능한 프리셋: `focused` (기본값), `assistant`, `customerService`, `teacher`.
-
-### PersonaPlex CLI
-
-```bash
-make build
-
-# 기본 음성-음성
-.build/release/audio respond --input question.wav --output response.wav
-
-# 트랜스크립트 포함 (내면 독백 텍스트 디코딩)
-.build/release/audio respond --input question.wav --transcript
-
-# JSON 출력 (오디오 경로, 트랜스크립트, 지연 시간 메트릭)
-.build/release/audio respond --input question.wav --json
-
-# 커스텀 시스템 프롬프트 텍스트
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# 음색 및 시스템 프롬프트 프리셋 선택
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# 샘플링 파라미터 조정
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# 텍스트 엔트로피 조기 중단 활성화 (텍스트가 수렴하면 중단)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# 사용 가능한 음색 및 프롬프트 목록
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — 음성 복제를 지원하는 스트리밍 텍스트-음성 변환
-
-### 기본 합성
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // WAVWriter 사용
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// 첫 실행 시 ~1.9 GB 다운로드 (LLM + DiT + HiFi-GAN 가중치)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// 출력은 24kHz 모노 float 샘플
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### 스트리밍 합성
-
-```swift
-// 스트리밍: 생성되는 대로 오디오 청크 수신 (첫 청크까지 ~150ms)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // 즉시 재생
-}
-```
-
-### 음성 복제 (CosyVoice)
-
-CAM++ 화자 인코더 (192차원, CoreML Neural Engine)를 사용하여 화자의 음성을 복제합니다:
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// 첫 사용 시 ~14 MB CAM++ CoreML 모델 다운로드
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: 길이 192의 [Float]
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CosyVoice TTS CLI
-
-```bash
-make build
-
-# 기본 합성
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# 음성 복제 (첫 사용 시 CAM++ 화자 인코더 다운로드)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# 음성 복제를 포함한 다화자 대화
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# 인라인 감정/스타일 태그
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# 조합: 대화 + 감정 + 음성 복제
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# 커스텀 스타일 지시
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# 스트리밍 합성
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — 경량 온디바이스 텍스트-음성 변환 (iOS + macOS)
-
-### 기본 합성
-
-```swift
-import KokoroTTS
-import AudioCommon  // WAVWriter 사용
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// 첫 실행 시 ~170 MB 다운로드 (CoreML 모델 + 음색 임베딩 + 사전)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// 출력은 24kHz 모노 float 샘플
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-10개 언어에 걸쳐 54개 프리셋 음색을 제공합니다. 엔드투엔드 CoreML 모델, 비자기회귀, 샘플링 루프 없음. Neural Engine에서 실행되어 GPU를 완전히 확보합니다.
-
-### Kokoro TTS CLI
-
-```bash
-make build
-
-# 기본 합성
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# 언어 선택
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# 사용 가능한 음색 목록
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-CoreML에서 실행되는 6모델 자기회귀 파이프라인. W8A16 팔레타이즈 가중치.
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (온디바이스 LLM)
+### LLM 채팅 — [전체 가이드 →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// 첫 실행 시 ~318 MB 다운로드 (INT4 CoreML 모델 + 토크나이저)
-
-// 단일 응답
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// 스트리밍 토큰
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B는 CoreML용 INT4로 양자화되었습니다. Neural Engine에서 실행되며 iPhone에서 ~2 tok/s, M 시리즈에서 ~15 tok/s를 달성합니다. KV 캐시를 사용한 멀티턴 대화, 사고 모드 (`<think>` 토큰), 설정 가능한 샘플링 (temperature, top-k, top-p, repetition penalty)을 지원합니다.
-
-## 음성 활동 감지 (VAD) — 오디오에서 음성 감지
-
-### 스트리밍 VAD (Silero)
-
-Silero VAD v5는 32ms 오디오 청크를 밀리초 미만의 지연 시간으로 처리합니다 — 마이크나 스트림에서의 실시간 음성 감지에 이상적입니다.
+### 음성 활동 감지 — [전체 가이드 →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// 또는 CoreML 사용 (Neural Engine, 저전력):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// 스트리밍: 512 샘플 청크 처리 (16kHz에서 32ms)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // 다른 오디오 스트림 간에 호출
-
-// 또는 모든 세그먼트를 한 번에 감지
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("음성: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### 이벤트 기반 스트리밍
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// 임의 길이의 오디오 입력 — 음성이 확인되면 이벤트 발생
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("음성 시작: \(time)s")
-    case .speechEnded(let segment):
-        print("음성: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// 스트림 종료 시 플러시
-let final = processor.flush()
-```
-
-### VAD CLI
-
-```bash
-make build
-
-# 스트리밍 Silero VAD (32ms 청크)
-.build/release/audio vad-stream audio.wav
-
-# CoreML 백엔드 (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# 커스텀 임계값
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# JSON 출력
-.build/release/audio vad-stream audio.wav --json
-
-# 배치 pyannote VAD (10초 슬라이딩 윈도우)
-.build/release/audio vad audio.wav
-```
-
-## 화자 분리 — 누가 언제 말했는지
-
-### 분리 파이프라인
+### 화자 분리 — [전체 가이드 →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// 또는 CoreML 임베딩 사용 (Neural Engine, GPU 확보):
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("화자 \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers)명의 화자 감지")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### 화자 임베딩
+### 음성 향상 — [전체 가이드 →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// 또는: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: L2 정규화된 길이 256의 [Float]
+import SpeechEnhancement
 
-// 화자 비교
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### 화자 추출
-
-참조 녹음을 사용하여 특정 화자의 세그먼트만 추출합니다:
+### 음성 파이프라인 (ASR → LLM → TTS) — [전체 가이드 →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Sortformer 화자 분리 (엔드투엔드, CoreML)
+`VoicePipeline`은 실시간 음성 agent 상태 머신으로 ([speech-core](https://github.com/soniqo/speech-core)로 구동), VAD 기반 턴 감지, 인터럽션 처리, 이거(eager) STT를 지원합니다. 임의의 `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`를 연결할 수 있습니다.
 
-NVIDIA Sortformer는 최대 4명의 화자에 대해 프레임별 화자 활동을 직접 예측합니다 — 임베딩이나 클러스터링이 필요 없습니다. Neural Engine에서 실행됩니다.
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("화자 \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### 화자 분리 CLI
+### HTTP API 서버
 
 ```bash
-make build
-
-# Pyannote 화자 분리 (기본값)
-.build/release/audio diarize meeting.wav
-
-# Sortformer 화자 분리 (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# CoreML 임베딩 (Neural Engine, pyannote 전용)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# JSON 출력
-.build/release/audio diarize meeting.wav --json
-
-# 특정 화자 추출 (pyannote 전용)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# 화자 임베딩
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-아키텍처 상세 내용은 [Speaker Diarization](docs/inference/speaker-diarization.md)을 참조하세요.
-
-## 음성 향상 — 노이즈 억제 및 오디오 정리
-
-### 노이즈 억제
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // WAVWriter 사용
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// 첫 실행 시 ~4.3 MB 다운로드 (Core ML FP16 모델 + 보조 데이터)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### 노이즈 제거 CLI
-
-```bash
-make build
-
-# 기본 노이즈 제거
-.build/release/audio denoise noisy.wav
-
-# 커스텀 출력 경로
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-아키텍처 상세 내용은 [Speech Enhancement](docs/inference/speech-enhancement.md)를 참조하세요.
-
-## 파이프라인 — 여러 모델 조합
-
-모든 모델은 공유 프로토콜(`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel` 등)을 준수하며 파이프라인으로 조합할 수 있습니다:
-
-### 잡음 환경 음성 인식 (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// 48kHz에서 향상 후 16kHz에서 전사
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### 음성-음성 릴레이 (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// 음성 세그먼트 감지, 전사, 재합성
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: 24kHz 모노 float 샘플
-}
-```
-
-### 회의 전사 (화자 분리 + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("화자 \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-전체 프로토콜 레퍼런스는 [Shared Protocols](docs/shared-protocols.md)를 참조하세요.
-
-## HTTP API 서버
-
-독립형 HTTP 서버가 모든 모델을 REST 및 WebSocket 엔드포인트를 통해 제공합니다. 모델은 첫 번째 요청 시 지연 로드됩니다.
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# 오디오 전사
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# 텍스트-음성 변환
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# 음성-음성 (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# 음성 향상
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# 시작 시 모든 모델 사전 로드
-.build/release/audio-server --preload --port 8080
-```
-
-### WebSocket 스트리밍
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-기본 WebSocket 엔드포인트는 [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) 프로토콜을 구현합니다 — 모든 메시지는 `type` 필드가 있는 JSON이며, 오디오는 base64 인코딩된 PCM16 24kHz 모노입니다.
-
-**클라이언트 → 서버 이벤트:**
-
-| 이벤트 | 설명 |
-|-------|-------------|
-| `session.update` | 엔진, 언어, 오디오 형식 설정 |
-| `input_audio_buffer.append` | base64 PCM16 오디오 청크 전송 |
-| `input_audio_buffer.commit` | 축적된 오디오 전사 (ASR) |
-| `input_audio_buffer.clear` | 오디오 버퍼 초기화 |
-| `response.create` | TTS 합성 요청 |
-
-**서버 → 클라이언트 이벤트:**
-
-| 이벤트 | 설명 |
-|-------|-------------|
-| `session.created` | 세션 초기화됨 |
-| `session.updated` | 설정 확인됨 |
-| `input_audio_buffer.committed` | 전사를 위한 오디오 커밋됨 |
-| `conversation.item.input_audio_transcription.completed` | ASR 결과 |
-| `response.audio.delta` | Base64 PCM16 오디오 청크 (TTS) |
-| `response.audio.done` | 오디오 스트리밍 완료 |
-| `response.done` | 메타데이터 포함 응답 완료 |
-| `error` | 유형 및 메시지 포함 오류 |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: 오디오 전송, 전사 결과 수신
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → 수신: conversation.item.input_audio_transcription.completed
-
-// TTS: 텍스트 전송, 스트리밍 오디오 수신
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → 수신: response.audio.delta (base64 청크), response.audio.done, response.done
-```
-
-`Examples/websocket-client.html`에 예제 HTML 클라이언트가 있습니다 — 서버 실행 중에 브라우저에서 열어보세요.
-
-서버는 별도의 `AudioServer` 모듈이자 `audio-server` 실행 파일입니다 — 메인 `audio` CLI에 Hummingbird/WebSocket을 추가하지 않습니다.
-
-## 지연 시간 (M2 Max, 64 GB)
-
-### ASR
-
-| 모델 | 백엔드 | RTF | 10초 오디오 처리 시간 |
-|-------|---------|-----|------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 cold, ~0.03 warm | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### 강제 정렬
-
-| 모델 | 프레임워크 | 20초 오디오 | RTF |
-|-------|-----------|-----------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> 단일 비자기회귀 순전파 — 샘플링 루프 없음. 오디오 인코더가 대부분을 차지하며 (~328ms), 디코더 단일 패스는 ~37ms. **실시간보다 55배 빠름.**
-
-### TTS
-
-| 모델 | 프레임워크 | 짧은 (1초) | 중간 (3초) | 긴 (6초) | 스트리밍 첫 패킷 |
-|-------|-----------|-----------|-------------|------------|----------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1-frame) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (비자기회귀) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTS는 운율과 감정이 담긴 자연스럽고 표현력 있는 음성을 생성하며, **실시간보다 빠르게** (RTF < 1.0) 실행됩니다. 스트리밍 합성은 첫 오디오 청크를 ~120ms에 전달합니다. Kokoro-82M은 엔드투엔드 모델로 Neural Engine에서 완전히 실행됩니다 (RTFx ~0.7), iOS에 이상적입니다. Apple 내장 TTS는 더 빠르지만 기계적이고 단조로운 음성을 생성합니다.
-
-### PersonaPlex (음성-음성)
-
-| 모델 | 프레임워크 | ms/step | RTF | 비고 |
-|-------|-----------|---------|-----|-------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | 권장 — 일관된 응답, 4-bit보다 30% 빠름 |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | 비권장 — 출력 품질 저하 |
-
-> **8-bit를 사용하세요.** INT8은 더 빠르고 (112 ms/step vs. 158 ms/step) 일관된 전이중 응답을 생성합니다. INT4 양자화는 생성 품질을 저하시켜 알아들을 수 없는 음성을 생성합니다. INT8은 M2 Max에서 ~112ms/step으로 실행됩니다.
-
-### VAD 및 화자 임베딩
-
-| 모델 | 백엔드 | 호출당 지연 시간 | RTF | 비고 |
-|-------|---------|-----------------|-----|-------|
-| Silero-VAD-v5 | MLX | ~2.1ms / 청크 | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / 청크 | 0.008 | Neural Engine, **7.7배 빠름** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20초 오디오 | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20초 오디오 | 0.021 | Neural Engine, GPU 확보 |
-
-> Silero VAD CoreML은 Neural Engine에서 MLX보다 7.7배 빠르게 실행되어 상시 마이크 입력에 이상적입니다. WeSpeaker MLX는 GPU에서 더 빠르지만, CoreML은 동시 작업(TTS, ASR)을 위해 GPU를 확보합니다. 두 백엔드 모두 동일한 결과를 생성합니다.
-
-### 음성 향상
-
-| 모델 | 백엔드 | 길이 | 지연 시간 | RTF |
-|-------|---------|----------|---------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Real-Time Factor (낮을수록 좋음, < 1.0 = 실시간보다 빠름). GRU 비용은 ~O(n²)로 증가합니다.
-
-### MLX vs CoreML
-
-두 백엔드 모두 동일한 결과를 생성합니다. 작업 부하에 따라 선택하세요:
-
-| | MLX | CoreML |
-|---|---|---|
-| **하드웨어** | GPU (Metal 셰이더) | Neural Engine + CPU |
-| **적합한 용도** | 최대 처리량, 단일 모델 작업 | 다중 모델 파이프라인, 백그라운드 작업 |
-| **전력** | 높은 GPU 활용률 | 저전력, GPU 확보 |
-| **지연 시간** | 대형 모델에서 빠름 (WeSpeaker) | 소형 모델에서 빠름 (Silero VAD) |
-
-**데스크톱 추론**: MLX가 기본값입니다 — Apple Silicon에서 가장 빠른 단일 모델 성능을 제공합니다. 여러 모델을 동시에 실행할 때 (예: VAD + ASR + TTS) GPU 경합을 피하려면 CoreML로 전환하거나, 노트북에서 배터리에 민감한 작업에 사용하세요.
-
-CoreML 모델은 Qwen3-ASR 인코더, Silero VAD, WeSpeaker에 사용할 수 있습니다. Qwen3-ASR의 경우 `--engine qwen3-coreml` (하이브리드: ANE의 CoreML 인코더 + GPU의 MLX 텍스트 디코더)을 사용하세요. VAD/임베딩의 경우 생성 시 `engine: .coreml`을 전달하세요 — 추론 API는 동일합니다.
-
-## 정확도 벤치마크
-
-### ASR — 단어 오류율 ([상세](docs/benchmarks/asr-wer.md))
-
-| 모델 | WER% (LibriSpeech test-clean) | RTF |
-|-------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit는 비슷한 크기에서 Whisper Large v3 Turbo (2.5%)를 능가합니다. 다국어: FLEURS에서 10개 언어 벤치마크 완료.
-
-### TTS — 왕복 명료도 ([상세](docs/benchmarks/tts-roundtrip.md))
-
-| 엔진 | WER% | RTF |
-|--------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — 음성 감지 ([상세](docs/benchmarks/vad-detection.md))
-
-| 엔진 | F1% (FLEURS) | RTF |
-|--------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+HTTP REST + WebSocket 엔드포인트로 모든 모델을 공개합니다. OpenAI Realtime API 호환 WebSocket `/v1/realtime`도 포함됩니다. [`Sources/AudioServer/`](Sources/AudioServer/)를 참조하세요.
 
 ## 아키텍처
 
-**모델:** [ASR Model](docs/models/asr-model.md), [TTS Model](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift는 모델당 하나의 SPM 타겟으로 분리되어 있어 사용자는 임포트한 것에 대해서만 비용을 지불합니다. 공유 인프라는 `AudioCommon` (프로토콜, 오디오 I/O, HuggingFace 다운로더, `SentencePieceModel`)과 `MLXCommon` (웨이트 로딩, `QuantizedLinear` 헬퍼, `SDPA` 멀티헤드 어텐션 헬퍼)에 있습니다.
 
-**추론:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS Inference](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Speaker Diarization](docs/inference/speaker-diarization.md), [Speech Enhancement](docs/inference/speech-enhancement.md), [오디오 재생](docs/audio/playback.md)
+**[백엔드, 메모리 테이블, 모듈 맵이 포함된 전체 아키텍처 다이어그램 → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[API 레퍼런스 → soniqo.audio/api](https://soniqo.audio/api)** · **[벤치마크 → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**벤치마크:** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD Detection](docs/benchmarks/vad-detection.md)
-
-**레퍼런스:** [Shared Protocols](docs/shared-protocols.md)
+로컬 문서 (리포지토리):
+- **모델:** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **추론:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [화자 분리](docs/inference/speaker-diarization.md) · [음성 향상](docs/inference/speech-enhancement.md)
+- **레퍼런스:** [공유 프로토콜](docs/shared-protocols.md)
 
 ## 캐시 설정
 
-모델 가중치는 `~/Library/Caches/qwen3-speech/`에 로컬 캐시됩니다.
+모델 웨이트는 첫 사용 시 HuggingFace에서 다운로드되어 `~/Library/Caches/qwen3-speech/`에 캐시됩니다. `QWEN3_CACHE_DIR` (CLI) 또는 `cacheDir:` (Swift API)로 재정의할 수 있습니다. 모든 `fromPretrained()` 엔트리 포인트는 `offlineMode: true`를 지원하여 웨이트가 이미 캐시되어 있으면 네트워크를 건너뜁니다.
 
-**CLI** — 환경 변수로 오버라이드:
-
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
-
-**Swift API** — 모든 `fromPretrained()` 메서드가 `cacheDir` 및 `offlineMode` 지원:
-
-```swift
-// 커스텀 캐시 디렉터리 (샌드박스 앱, iOS 컨테이너)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// 오프라인 모드 — 가중치가 캐시된 경우 네트워크 건너뛰기
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-자세한 내용은 [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md) 참조.
+샌드박스 iOS 컨테이너 경로를 포함한 자세한 내용은 [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md)를 참조하세요.
 
 ## MLX Metal 라이브러리
 
-런타임에 `Failed to load the default metallib`이 표시되면 Metal 셰이더 라이브러리가 없는 것입니다. `make build` (또는 수동 `swift build` 후 `./scripts/build_mlx_metallib.sh release`)를 실행하여 컴파일하세요. Metal Toolchain이 없으면 먼저 설치하세요:
+런타임에 `Failed to load the default metallib`이 보이면 Metal 셰이더 라이브러리가 없습니다. 수동 `swift build` 후에 `make build` 또는 `./scripts/build_mlx_metallib.sh release`를 실행하세요. Metal Toolchain이 없다면 먼저 설치하세요:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## 테스트
 
-단위 테스트 (config, 샘플링, 텍스트 전처리, 타임스탬프 보정)는 모델 다운로드 없이 실행됩니다:
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # 전체 스위트 (단위 + 모델 다운로드 포함 E2E)
+swift test --skip E2E                # 단위만 (CI 안전, 다운로드 없음)
+swift test --filter Qwen3ASRTests    # 특정 모듈
 ```
 
-통합 테스트는 모델 가중치가 필요합니다 (첫 실행 시 자동 다운로드):
+E2E 테스트 클래스는 `E2E` 접두사를 사용하므로 CI는 `--skip E2E`로 필터링할 수 있습니다. 전체 테스트 규약은 [CLAUDE.md](CLAUDE.md#testing)를 참조하세요.
 
-```bash
-# TTS 왕복: 텍스트 합성, WAV 저장, ASR로 다시 전사
-swift test --filter TTSASRRoundTripTests
+## 기여
 
-# ASR만: 테스트 오디오 전사
-swift test --filter Qwen3ASRIntegrationTests
-
-# Forced Aligner E2E: 단어 수준 타임스탬프 (~979 MB 다운로드)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E: 음성-음성 파이프라인 (~5.5 GB 다운로드)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **참고:** MLX 연산을 사용하는 테스트를 실행하기 전에 MLX Metal 라이브러리를 빌드해야 합니다.
-> [MLX Metal 라이브러리](#mlx-metal-라이브러리) 안내를 참조하세요.
-
-## 지원 언어
-
-| 모델 | 언어 |
-|-------|-----------|
-| Qwen3-ASR | 52개 언어 (CN, EN, 광둥어, DE, FR, ES, JA, KO, RU, + 22개 중국어 방언, ...) |
-| Parakeet TDT | 25개 유럽 언어 (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1,672개 언어**, 150개 이상 어족을 포괄. Meta의 "직접 지원" 세트(약 1,100개) 전체와 커뮤니티 데이터로 추가된 500개 이상의 저자원 언어를 포함. 주요 언어: EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (전체 목록: [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)). CTC 헤드는 언어 비종속적이므로 추론 시 언어 힌트가 필요하지 않습니다. |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ CustomVoice를 통한 북경/사천 방언) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## 비교
-
-### 음성-텍스트 (ASR): speech-swift vs 대안
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **런타임** | 온디바이스 (MLX/CoreML) | 온디바이스 (CPU/GPU) | 온디바이스 또는 클라우드 | 클라우드 전용 |
-| **언어** | 52 | 100+ | ~70 (온디바이스: 제한적) | 125+ |
-| **RTF (10초 오디오, M2 Max)** | 0.06 (17배 실시간) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **스트리밍** | 아니오 (배치) | 아니오 (배치) | 예 | 예 |
-| **커스텀 모델** | 예 (HuggingFace 가중치 교체) | 예 (GGML 모델) | 아니오 | 아니오 |
-| **Swift API** | 네이티브 async/await | Swift 브릿지가 필요한 C++ | 네이티브 | REST/gRPC |
-| **프라이버시** | 완전 온디바이스 | 완전 온디바이스 | 설정에 따라 다름 | 데이터가 클라우드로 전송됨 |
-| **단어 타임스탬프** | 예 (Forced Aligner) | 예 | 제한적 | 예 |
-| **비용** | 무료 (Apache 2.0) | 무료 (MIT) | 무료 (온디바이스) | 분당 과금 |
-
-### 텍스트-음성 (TTS): speech-swift vs 대안
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / 클라우드 TTS** |
-|---|---|---|---|---|
-| **품질** | 뉴럴, 표현력 있음 | 뉴럴, 자연스러움 | 기계적, 단조로움 | 뉴럴, 최고 품질 |
-| **런타임** | 온디바이스 (MLX) | 온디바이스 (CoreML) | 온디바이스 | 클라우드 전용 |
-| **스트리밍** | 예 (첫 청크 ~120ms) | 아니오 (엔드투엔드 모델) | 아니오 | 예 |
-| **음성 복제** | 예 | 아니오 | 아니오 | 예 |
-| **음색** | 9개 내장 + 아무 음성 복제 | 54개 프리셋 음색 | ~50개 시스템 음색 | 1000+ |
-| **언어** | 10 | 10 | 60+ | 30+ |
-| **iOS 지원** | macOS 전용 | iOS + macOS | iOS + macOS | 아무 플랫폼 (API) |
-| **비용** | 무료 (Apache 2.0) | 무료 (Apache 2.0) | 무료 | 글자당 과금 |
-
-### speech-swift를 사용해야 할 때
-
-- **프라이버시가 중요한 앱** — 의료, 법률, 기업 환경에서 오디오가 기기를 떠날 수 없는 경우
-- **오프라인 사용** — 초기 모델 다운로드 후 인터넷 연결 불필요
-- **비용에 민감한 경우** — 분당 또는 글자당 API 요금 없음
-- **Apple Silicon 최적화** — M 시리즈 GPU (Metal) 및 Neural Engine에 특화되어 구축됨
-- **전체 파이프라인** — ASR + TTS + VAD + 화자 분리 + 음성 향상을 단일 Swift 패키지로 조합
-
-## FAQ
-
-**speech-swift는 iOS에서 작동하나요?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3, WeSpeaker는 모두 CoreML을 통해 Neural Engine에서 iOS 17+에서 실행됩니다. MLX 기반 모델 (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex)은 Apple Silicon의 macOS 14+ 이상이 필요합니다.
-
-**인터넷 연결이 필요한가요?**
-HuggingFace에서 초기 모델 다운로드 시에만 필요합니다 (자동, `~/Library/Caches/qwen3-speech/`에 캐시). 이후에는 네트워크 접속 없이 모든 추론이 완전히 오프라인으로 실행됩니다.
-
-**speech-swift는 Whisper와 어떻게 비교되나요?**
-Qwen3-ASR-0.6B는 M2 Max에서 RTF 0.06을 달성합니다 — whisper.cpp를 통한 Whisper-large-v3 (RTF 0.10)보다 40% 빠르며, 52개 언어에 걸쳐 비슷한 정확도를 보여줍니다. speech-swift는 네이티브 Swift async/await API를 제공하는 반면, whisper.cpp는 C++ 브릿지가 필요합니다.
-
-**상용 앱에 사용할 수 있나요?**
-예. speech-swift는 Apache 2.0 라이선스입니다. 기반 모델 가중치에는 자체 라이선스가 있습니다 (각 모델의 HuggingFace 페이지를 확인하세요).
-
-**어떤 Apple Silicon 칩이 지원되나요?**
-모든 M 시리즈 칩: M1, M2, M3, M4 및 Pro/Max/Ultra 변형. macOS 14+ (Sonoma) 또는 iOS 17+ 이상이 필요합니다.
-
-**메모리는 얼마나 필요한가요?**
-~3 MB (Silero VAD)에서 ~6.5 GB (PersonaPlex 7B)까지 다양합니다. Kokoro TTS는 ~500 MB, Qwen3-ASR는 ~2.2 GB를 사용합니다. 전체 세부 사항은 [메모리 요구 사항](#메모리-요구-사항) 표를 참조하세요.
-
-**여러 모델을 동시에 실행할 수 있나요?**
-예. GPU 경합을 피하기 위해 Neural Engine의 CoreML 모델과 GPU의 MLX 모델을 함께 사용하세요 — 예를 들어, Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX).
-
-**REST API가 있나요?**
-예. `audio-server` 바이너리가 HTTP REST 및 WebSocket 엔드포인트를 통해 모든 모델을 제공하며, `/v1/realtime`에서 OpenAI Realtime API 호환 WebSocket을 포함합니다.
-
-## 기여하기
-
-기여를 환영합니다! 버그 수정, 새 모델 통합, 문서 개선 등 — PR을 환영합니다.
-
-**시작하려면:**
-1. 리포를 포크하고 기능 브랜치를 생성하세요
-2. `make build`로 컴파일하세요 (Xcode + Metal Toolchain 필요)
-3. `make test`로 테스트 스위트를 실행하세요
-4. `main`을 대상으로 PR을 제출하세요
+PR 환영합니다 — 버그 수정, 새 모델 통합, 문서. fork, 피처 브랜치 생성, `make build && make test`, `main`에 대해 PR을 여세요.
 
 ## 라이선스
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -6,56 +6,48 @@ Modelos de IA para fala em Apple Silicon, com tecnologia MLX Swift e CoreML.
 
 Reconhecimento, sintese e compreensao de fala no dispositivo para Mac e iOS. Executa localmente no Apple Silicon — sem nuvem, sem chaves de API, nenhum dado sai do dispositivo.
 
-[Instale via Homebrew](#homebrew) ou adicione como dependencia do Swift Package.
+**[📚 Documentacao completa →](https://soniqo.audio)** · **[🤗 Modelos no HuggingFace](https://huggingface.co/aufklarer)** · **[📝 Blog](https://blog.ivan.digital)**
 
-**[Documentacao](https://soniqo.audio)** · **[Modelos no HuggingFace](https://huggingface.co/aufklarer)** · **[Blog](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Fala para texto (reconhecimento automatico de fala, 52 idiomas, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — Fala para texto via CoreML (Neural Engine, NVIDIA FastConformer + decodificador TDT, 25 idiomas)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Fala para texto (Meta wav2vec2 + CTC, **1.672 idiomas** em 32 escritas, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[Ditado em streaming](https://soniqo.audio/guides/dictate)** — Ditado em tempo real com resultados parciais e deteccao de fim de enunciado (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — Alinhamento de timestamps por palavra (audio + texto → timestamps)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — Sintese de texto para fala (mais alta qualidade, streaming, locutores personalizados, 10 idiomas)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — TTS em streaming com clonagem de voz, dialogo multi-locutor, tags de emocao (9 idiomas)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — TTS no dispositivo (82M, CoreML/Neural Engine, 54 vozes, pronto para iOS, 10 idiomas)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — Chat LLM no dispositivo (0.8B, MLX INT4 + CoreML INT8, DeltaNet hibrido, tokens em streaming)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — Fala-a-fala full-duplex (7B, audio de entrada → audio de saida, 18 presets de voz)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Supressao de ruido em tempo real (2.1M parametros, 48 kHz)
+- **[VAD](https://soniqo.audio/guides/vad)** — Deteccao de atividade de voz (Silero streaming, Pyannote offline, FireRedVAD 100+ idiomas)
+- **[Diarizacao de falantes](https://soniqo.audio/guides/diarize)** — Quem falou quando (pipeline Pyannote, Sortformer ponta-a-ponta no Neural Engine)
+- **[Embeddings de falante](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), CAM++ (192 dim)
 
-- **Qwen3-ASR** — Fala para texto / reconhecimento de fala (reconhecimento automatico de fala, 52 idiomas)
-- **Parakeet TDT** — Fala para texto via CoreML (Neural Engine, NVIDIA FastConformer + decodificador TDT, 25 idiomas)
-- **Omnilingual ASR** — Fala para texto via CoreML (Meta wav2vec2 + CTC, **1.672 idiomas** em mais de 150 famílias, janelas de 5/10 s, INT8 palletizado, ANE)
-- **Qwen3-ForcedAligner** — Alinhamento de timestamps por palavra (audio + texto → timestamps)
-- **Qwen3-TTS** — Sintese de texto para fala (mais alta qualidade, streaming, locutores personalizados, 10 idiomas)
-- **CosyVoice TTS** — Texto para fala com streaming, clonagem de voz, dialogo multi-locutor e tags de emocao (9 idiomas, DiT flow matching, codificador de locutor CAM++)
-- **Kokoro TTS** — Texto para fala no dispositivo (82M parametros, CoreML/Neural Engine, 54 vozes, pronto para iOS, 10 idiomas)
-- **Qwen3-TTS CoreML** — Texto para fala (0.6B, pipeline CoreML de 6 modelos, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** — Chat com LLM no dispositivo (0.8B, MLX + CoreML, INT4 + CoreML INT8, DeltaNet hibrido, tokens em streaming)
-- **PersonaPlex** — Conversa fala-a-fala full-duplex (7B, audio de entrada → audio de saida, 18 presets de voz)
-- **DeepFilterNet3** — Aprimoramento de fala / supressao de ruido (2.1M parametros, tempo real a 48kHz)
-- **FireRedVAD** — Deteccao offline de atividade de voz (DFSMN, CoreML, 100+ idiomas, 97.6% F1)
-- **Silero VAD** — Deteccao de atividade de voz em streaming (blocos de 32ms, latencia sub-milissegundo)
-- **Pyannote VAD** — Deteccao offline de atividade de voz (janelas de 10s, sobreposicao multi-locutor)
-- **Speaker Diarization** — Quem falou quando (segmentacao Pyannote + encadeamento de falantes por atividade, ou Sortformer ponta-a-ponta no Neural Engine)
-- **Speaker Embeddings** — Verificacao e identificacao de falantes (WeSpeaker ResNet34, vetores de 256 dimensoes)
-
-Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## Roadmap
-
-Veja a [discussao do Roadmap](https://github.com/soniqo/speech-swift/discussions/81) para o que esta planejado — comentarios e sugestoes sao bem-vindos!
+Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## Novidades
 
-- **20 Mar 2026** — [We Beat Whisper Large v3 with a 600M Model Running Entirely on Your Mac](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
-- **26 Feb 2026** — [Speaker Diarization and Voice Activity Detection on Apple Silicon — Native Swift with MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
-- **23 Feb 2026** — [NVIDIA PersonaPlex 7B on Apple Silicon — Full-Duplex Speech-to-Speech in Native Swift with MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
-- **12 Feb 2026** — [Qwen3-ASR Swift: On-Device ASR + TTS for Apple Silicon — Architecture and Benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
+- **20 Mar 2026** — [Superamos o Whisper Large v3 com um modelo de 600M rodando inteiramente no seu Mac](https://blog.ivan.digital/we-beat-whisper-large-v3-with-a-600m-model-running-entirely-on-your-mac-20e6ce191174)
+- **26 Fev 2026** — [Diarizacao de falantes e deteccao de atividade de voz em Apple Silicon — Swift nativo com MLX](https://blog.ivan.digital/speaker-diarization-and-voice-activity-detection-on-apple-silicon-native-swift-with-mlx-92ea0c9aca0f)
+- **23 Fev 2026** — [NVIDIA PersonaPlex 7B em Apple Silicon — fala-a-fala full-duplex em Swift nativo com MLX](https://blog.ivan.digital/nvidia-personaplex-7b-on-apple-silicon-full-duplex-speech-to-speech-in-native-swift-with-mlx-0aa5276f2e23)
+- **12 Fev 2026** — [Qwen3-ASR Swift: ASR + TTS no dispositivo para Apple Silicon — arquitetura e benchmarks](https://blog.ivan.digital/qwen3-asr-swift-on-device-asr-tts-for-apple-silicon-architecture-and-benchmarks-27cbf1e4463f)
 
-## Início rápido
+## Inicio rapido
 
 Adicione o pacote ao seu `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-Importe apenas os módulos que você precisa — cada modelo é sua própria biblioteca SPM:
+Importe apenas os modulos que voce precisa — cada modelo e uma biblioteca SPM independente, entao voce nao paga pelo que nao usa:
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
 .product(name: "SpeechUI",             package: "speech-swift"),  // views SwiftUI opcionais
 ```
 
-**Transcrever um buffer de áudio em 3 linhas:**
+**Transcrever um buffer de audio em 3 linhas:**
 
 ```swift
 import ParakeetStreamingASR
@@ -96,128 +88,85 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI` inclui apenas `TranscriptionView` (finais + parciais) e `TranscriptionStore` (adaptador de ASR em streaming). Use AVFoundation para visualização e reprodução de áudio.
+`SpeechUI` inclui apenas `TranscriptionView` (finais + parciais) e `TranscriptionStore` (adaptador de ASR em streaming). Use AVFoundation para visualizacao e reproducao de audio.
 
-Produtos SPM disponíveis: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Produtos SPM disponiveis: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modelos
 
-| Modelo | Tarefa | Streaming | Idiomas | Tamanhos |
-|--------|--------|-----------|---------|----------|
-| Qwen3-ASR-0.6B | Fala → Texto | Nao | 52 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | Fala → Texto | Nao | 52 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | Fala → Texto | Nao | 25 idiomas europeus | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | Fala → Texto | Sim (streaming + EOU) | 25 idiomas europeus | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | Fala → Texto | Nao (janela de 5/10 s) | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | Fala → Texto | Nao | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | Fala → Texto | Nao | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | Fala → Texto | Nao | [1.672 idiomas](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | Audio + Texto → Timestamps | Nao | Multi | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | Texto → Fala | Sim (~120ms) | 10 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | Texto → Fala | Sim (~120ms) | 10 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | Texto → Fala | Sim (~120ms) | 10 idiomas | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | Texto → Fala | Sim (~150ms) | 9 idiomas | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | Texto → Fala | Nao | 10 idiomas | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | Fala → Fala | Sim (~2s por bloco) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | Deteccao de Atividade de Voz | Nao (offline) | 100+ idiomas | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | Deteccao de Atividade de Voz | Sim (blocos de 32ms) | Independente de idioma | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + Segmentacao de Falantes | Nao (janelas de 10s) | Independente de idioma | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | Aprimoramento de Fala | Sim (quadros de 10ms) | Independente de idioma | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | Embedding de Falante (256-dim) | Nao | Independente de idioma | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | Embedding de Falante (192-dim) | Nao | Independente de idioma | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | Diarizacao de Falantes (ponta-a-ponta) | Sim (em blocos) | Independente de idioma | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoes, URLs de download e tabelas de memoria → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### Requisitos de Memoria
-
-Memoria de pesos e a memoria da GPU (MLX) ou ANE (CoreML) consumida pelos parametros do modelo. Pico de inferencia inclui caches KV, ativacoes e tensores intermediarios.
-
-| Modelo | Memoria de Pesos | Pico de Inferencia |
-|--------|-----------------|-------------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### Quando Usar Qual TTS
-
-- **Qwen3-TTS**: Melhor qualidade, streaming (~120ms), 9 locutores integrados, 10 idiomas, sintese em lote
-- **CosyVoice TTS**: Streaming (~150ms), 9 idiomas, clonagem de voz (codificador de locutor CAM++), dialogo multi-locutor (`[S1] ... [S2] ...`), tags de emocao/estilo em linha (`(happy)`, `(whispers)`), DiT flow matching + vocoder HiFi-GAN
-- **Kokoro TTS**: TTS leve pronto para iOS (82M parametros), CoreML/Neural Engine, 54 vozes, 10 idiomas, modelo de ponta a ponta
-- **PersonaPlex**: Fala-a-fala full-duplex (audio de entrada → audio de saida), streaming (~2s por bloco), 18 presets de voz, baseado na arquitetura Moshi
+| Modelo | Tarefa | Backends | Tamanhos | Idiomas |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Fala → Texto | MLX, CoreML (hibrido) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Fala → Texto | CoreML (ANE) | 0.6B | 25 europeus |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | Fala → Texto (streaming) | CoreML (ANE) | 120M | 25 europeus |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | Fala → Texto | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1.672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | Audio + Texto → Timestamps | MLX, CoreML | 0.6B | Multi |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | Texto → Fala | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | Texto → Fala | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | Texto → Fala | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Texto → Texto (LLM) | MLX, CoreML | 0.8B | Multi |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | Fala → Fala | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | Deteccao de atividade de voz | MLX, CoreML | 309K | Agnostico |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarizacao | MLX | 1.5M | Agnostico |
+| [Sortformer](https://soniqo.audio/guides/diarize) | Diarizacao (E2E) | CoreML (ANE) | — | Agnostico |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Aprimoramento de fala | CoreML | 2.1M | Agnostico |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Embedding de falante | MLX, CoreML | 6.6M | Agnostico |
 
 ## Instalacao
 
 ### Homebrew
 
-Requer Homebrew nativo ARM (`/opt/homebrew`). Homebrew via Rosetta/x86_64 nao e suportado.
+Requer Homebrew ARM nativo (`/opt/homebrew`). Homebrew Rosetta/x86_64 nao e suportado.
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-Depois use:
+Depois:
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (Motor Neural)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> Para conversa interativa por voz com entrada de microfone, veja **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**.
+**[Referencia completa do CLI →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-Adicione ao seu `Package.swift`:
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-Importe o modulo que voce precisa:
+Importe apenas o que voce precisa — cada modelo e o seu proprio target SPM:
 
 ```swift
-import Qwen3ASR      // Reconhecimento de fala (MLX)
-import ParakeetASR   // Reconhecimento de fala (CoreML)
-import Qwen3TTS      // Texto para fala (Qwen3)
-import CosyVoiceTTS  // Texto para fala (streaming)
-import KokoroTTS     // Texto para fala (CoreML, pronto para iOS)
-import Qwen3Chat     // Chat com LLM no dispositivo (CoreML)
-import PersonaPlex   // Fala-a-fala (full-duplex)
-import SpeechVAD          // Deteccao de atividade de voz (pyannote + Silero)
-import SpeechEnhancement  // Supressao de ruido (DeepFilterNet3)
-import AudioCommon        // Utilitarios compartilhados
+import Qwen3ASR             // Reconhecimento de fala (MLX)
+import ParakeetASR          // Reconhecimento de fala (CoreML, batch)
+import ParakeetStreamingASR // Ditado em streaming com parciais + EOU
+import OmnilingualASR       // 1.672 idiomas (CoreML + MLX)
+import Qwen3TTS             // Sintese de fala
+import CosyVoiceTTS         // Sintese de fala com clonagem
+import KokoroTTS            // Sintese de fala (pronto para iOS)
+import Qwen3Chat            // Chat LLM no dispositivo
+import PersonaPlex          // Fala-a-fala full-duplex
+import SpeechVAD            // VAD + diarizacao + embeddings
+import SpeechEnhancement    // Supressao de ruido
+import SpeechUI             // Componentes SwiftUI para transcricoes em streaming
+import AudioCommon          // Protocolos e utilitarios compartilhados
 ```
 
 ### Requisitos
 
-- Swift 5.9+
-- macOS 14+ ou iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (com Metal Toolchain — execute `xcodebuild -downloadComponent MetalToolchain` se estiver faltando)
+- Swift 5.9+, Xcode 15+ (com Metal Toolchain)
+- macOS 14+ ou iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
-### Compilar a Partir do Codigo-Fonte
+### Compilar a partir do codigo-fonte
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-Isso compila o pacote Swift **e** a biblioteca de shaders Metal do MLX em um unico passo. A biblioteca Metal (`mlx.metallib`) e necessaria para inferencia via GPU — sem ela voce vera `Failed to load the default metallib` em tempo de execucao.
+`make build` compila o pacote Swift **e** a biblioteca de shaders MLX Metal. A biblioteca Metal e necessaria para inferencia em GPU — sem ela voce vera `Failed to load the default metallib` em tempo de execucao. `make debug` para builds de debug, `make test` para a suite de testes.
 
-Para builds de depuracao: `make debug`. Para executar testes unitarios: `make test`.
+**[Guia completo de build e instalacao →](https://soniqo.audio/getting-started)**
 
-## Experimente o Assistente de Voz
+## Aplicativos de demonstracao
 
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** e um assistente de voz para macOS pronto para usar — toque para falar e receba respostas faladas em tempo real. Usa entrada de microfone com Silero VAD para deteccao automatica de fala, Qwen3-ASR para transcricao e PersonaPlex 7B para geracao fala-a-fala. Conversa multi-turno com 18 presets de voz e exibicao de transcricao do monologo interno.
+- **[DictateDemo](Examples/DictateDemo/)** ([docs](https://soniqo.audio/guides/dictate)) — Ditado em streaming na barra de menus do macOS com parciais ao vivo, deteccao de fim de enunciado baseada em VAD e copia com um clique. Roda como agent em segundo plano (Parakeet-EOU-120M + Silero VAD).
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — Demo de eco iOS (Parakeet ASR + Kokoro TTS). Dispositivo e simulador.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Assistente de voz conversacional com entrada de microfone, VAD e contexto multi-turno. macOS. RTF ~0.94 em M2 Max (mais rapido que tempo real).
+- **[SpeechDemo](Examples/SpeechDemo/)** — Ditado e sintese TTS em uma interface com abas. macOS.
 
-```bash
-make build  # a partir da raiz do repositorio — compila tudo incluindo o metallib do MLX
-cd Examples/PersonaPlexDemo
-# Veja Examples/PersonaPlexDemo/README.md para instrucoes do pacote .app
-```
+O README de cada demo tem instrucoes de build.
 
-> RTF ~0.94 no M2 Max (mais rapido que tempo real). Os modelos sao baixados automaticamente na primeira execucao (~5.5 GB PersonaPlex + ~400 MB ASR).
+## Exemplos de codigo
 
-## Apps de Demonstracao
+Os snippets abaixo mostram o caminho minimo para cada dominio. Cada secao tem link para um guia completo em [soniqo.audio](https://soniqo.audio) com opcoes de configuracao, multiplos backends, padroes de streaming e receitas de CLI.
 
-- **[DictateDemo](Examples/DictateDemo/)** ([docs](https://soniqo.audio/guides/dictate/)) — Ditado em streaming na barra de menus do macOS com parciais ao vivo, detecao de fim de enunciado por VAD e copia com um clique. Executa como agente de barra de menus em segundo plano (Parakeet-EOU-120M + Silero VAD).
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — Demo de eco para iOS (Parakeet ASR + Kokoro TTS, fale e ouca de volta). Dispositivo e simulador.
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Assistente de voz conversacional (entrada por microfone, VAD, multi-turno). macOS.
-- **[SpeechDemo](Examples/SpeechDemo/)** — Ditado e sintese de texto para fala em uma interface com abas. macOS.
-
-Compile e execute — veja o README de cada demo para instrucoes.
-
-## Fala para Texto (ASR) — Transcrever Audio em Swift
-
-### Transcricao Basica
+### Fala para texto — [guia completo →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-// Padrao: modelo 0.6B
 let model = try await Qwen3ASRModel.fromPretrained()
-
-// Ou use o modelo maior 1.7B para melhor precisao
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// O audio pode ter qualquer taxa de amostragem — reamostrado automaticamente para 16kHz internamente
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-### Encoder CoreML (Neural Engine)
+Backends alternativos: [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× tempo real), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1.672 idiomas, CoreML ou MLX), [Ditado em streaming](https://soniqo.audio/guides/dictate) (parciais ao vivo).
 
-Modo hibrido: encoder CoreML no Neural Engine + decodificador de texto MLX na GPU. Menor consumo de energia, libera a GPU durante a passagem do encoder.
-
-```swift
-import Qwen3ASR
-
-let encoder = try await CoreMLASREncoder.fromPretrained()
-let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
-```
-
-Variantes INT8 (180 MB, padrao) e INT4 (90 MB) disponiveis. INT8 recomendado (similaridade cosseno > 0.999 vs FP32).
-
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-Executa no Neural Engine via CoreML — libera a GPU para cargas de trabalho concorrentes. 25 idiomas europeus, ~315 MB.
-
-### CLI de ASR
-
-```bash
-make build  # ou: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# Padrao (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# Usar modelo 1.7B
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# Encoder CoreML (Neural Engine + decodificador MLX)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## Alinhamento Forcado
-
-### Timestamps por Palavra
+### Alinhamento forcado — [guia completo →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// Baixa ~979 MB na primeira execucao
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### CLI de Alinhamento Forcado
-
-```bash
-swift build -c release
-
-# Alinhar com texto fornecido
-.build/release/audio align audio.wav --text "Hello world"
-
-# Transcrever primeiro, depois alinhar
-.build/release/audio align audio.wav
-```
-
-Saida:
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-Modelo de ponta a ponta, nao-autorregressivo, sem loop de amostragem. Veja [Forced Aligner](docs/inference/forced-aligner.md) para detalhes da arquitetura.
-
-## Texto para Fala (TTS) — Gerar Fala em Swift
-
-### Sintese Basica
+### Texto para fala — [guia completo →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // para WAVWriter
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// Baixa ~1.7 GB na primeira execucao (modelo + pesos do codec)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// Saida: amostras float mono a 24kHz
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### CLI de TTS
+Engines TTS alternativas: [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (streaming + clonagem + tags de emocao), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (pronto para iOS, 54 vozes), [Clonagem de voz](https://soniqo.audio/guides/voice-cloning).
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### Voz Personalizada / Selecao de Locutor
-
-A variante **CustomVoice** do modelo suporta 9 vozes de locutores integradas e instrucoes em linguagem natural para controle de tom/estilo. Carregue-a passando o ID do modelo CustomVoice:
-
-```swift
-import Qwen3TTS
-
-// Carregar o modelo CustomVoice (baixa ~1.7 GB na primeira execucao)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// Sintetizar com um locutor especifico
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// Listar locutores disponiveis
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# Usar modelo CustomVoice com um locutor
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# Listar locutores disponiveis
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### Clonagem de Voz (modelo Base)
-
-Clone a voz de um locutor a partir de um arquivo de audio de referencia. Dois modos:
-
-**Modo ICL** (recomendado) — codifica o audio de referencia em tokens de codec com transcricao. Maior qualidade, EOS confiavel:
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**Modo X-vector** — apenas embedding do locutor, sem necessidade de transcricao, porem menor qualidade:
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### Instrucoes de Tom / Estilo (apenas CustomVoice)
-
-O modelo CustomVoice aceita um parametro `instruct` em linguagem natural para controlar estilo de fala, tom, emocao e ritmo. A instrucao e adicionada a entrada do modelo no formato ChatML.
-
-```swift
-// Tom alegre
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// Lento e serio
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// Sussurrando
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# Com instrucao de estilo
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# O instruct padrao ("Speak naturally.") e aplicado automaticamente ao usar CustomVoice
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-Quando nenhum `--instruct` e fornecido com o modelo CustomVoice, `"Speak naturally."` e aplicado automaticamente para evitar saida prolixa. O modelo Base nao suporta instruct.
-
-### Sintese em Lote
-
-Sintetize multiplos textos em uma unica passagem em lote para maior vazao:
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] sao amostras float mono a 24kHz para texts[i]
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### CLI em Lote
-
-```bash
-# Crie um arquivo com um texto por linha
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# Produz output_0.wav, output_1.wav, ...
-```
-
-> O modo em lote amortiza o carregamento dos pesos do modelo entre os itens. Espere ~1.5-2.5x de melhoria na vazao para B=4 em Apple Silicon. Melhores resultados quando os textos produzem audio de comprimento similar.
-
-### Opcoes de Amostragem
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### Sintese em Streaming
-
-Emita blocos de audio incrementalmente para baixa latencia do primeiro pacote:
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // ~120ms ate o primeiro bloco de audio
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: true no ultimo bloco
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# Streaming padrao (primeiro bloco de 3 quadros, ~225ms de latencia)
-.build/release/audio speak "Hello world" --stream
-
-# Baixa latencia (primeiro bloco de 1 quadro, ~120ms de latencia)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## Fala-a-Fala — Conversa Full-Duplex por Voz
-
-> Para um assistente de voz interativo com entrada de microfone, veja **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — toque para falar, conversa multi-turno com deteccao automatica de fala.
-
-### Fala-a-Fala
+### Fala para fala — [guia completo →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // para WAVWriter, AudioFileLoader
 
 let model = try await PersonaPlexModel.fromPretrained()
-// Baixa ~5.5 GB na primeira execucao (temporal 4-bit + depformer + codec Mimi + presets de voz)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: amostras float mono a 24kHz
-// textTokens: monologo interno do modelo (IDs de tokens SentencePiece)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// Saida mono Float32 a 24 kHz pronta para reproducao
 ```
 
-### Monologo Interno (Saida de Texto)
-
-PersonaPlex gera tokens de texto junto com o audio — o raciocinio interno do modelo. Decodifique-os com o decodificador SentencePiece integrado:
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // ex.: "Sure, I can help you with that..."
-```
-
-### Fala-a-Fala em Streaming
-
-```swift
-// Receba blocos de audio conforme sao gerados (~2s por bloco)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // reproduza imediatamente, 24kHz mono
-    // chunk.textTokens contem o texto deste bloco; o bloco final tem todos os tokens
-    if chunk.isFinal { break }
-}
-```
-
-### Selecao de Voz
-
-18 presets de voz disponiveis:
-- **Natural Feminino**: NATF0, NATF1, NATF2, NATF3
-- **Natural Masculino**: NATM0, NATM1, NATM2, NATM3
-- **Variedade Feminino**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **Variedade Masculino**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### Prompts de Sistema
-
-O prompt de sistema direciona o comportamento conversacional do modelo. Passe qualquer prompt personalizado como uma string simples:
-
-```swift
-// Prompt de sistema personalizado (tokenizado automaticamente)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// Ou usar um preset
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-Presets disponiveis: `focused` (padrao), `assistant`, `customerService`, `teacher`.
-
-### CLI PersonaPlex
-
-```bash
-make build
-
-# Fala-a-fala basico
-.build/release/audio respond --input question.wav --output response.wav
-
-# Com transcricao (decodifica texto do monologo interno)
-.build/release/audio respond --input question.wav --transcript
-
-# Saida JSON (caminho do audio, transcricao, metricas de latencia)
-.build/release/audio respond --input question.wav --json
-
-# Texto de prompt de sistema personalizado
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# Escolher uma voz e preset de prompt de sistema
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# Ajustar parametros de amostragem
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# Ativar parada antecipada por entropia de texto (para se o texto colapsar)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# Listar vozes e prompts disponiveis
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — Texto para Fala em Streaming com Clonagem de Voz
-
-### Sintese Basica
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // para WAVWriter
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// Baixa ~1.9 GB na primeira execucao (pesos LLM + DiT + HiFi-GAN)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// Saida: amostras float mono a 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### Sintese em Streaming
-
-```swift
-// Streaming: receba blocos de audio conforme sao gerados (~150ms ate o primeiro bloco)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // reproduza imediatamente
-}
-```
-
-### Clonagem de Voz (CosyVoice)
-
-Clone a voz de um locutor usando o codificador de locutor CAM++ (192-dim, CoreML Neural Engine):
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// Baixa ~14 MB do modelo CoreML CAM++ no primeiro uso
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: [Float] de comprimento 192
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CLI CosyVoice TTS
-
-```bash
-make build
-
-# Sintese basica
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# Clonagem de voz (baixa o codificador de locutor CAM++ no primeiro uso)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# Dialogo multi-locutor com clonagem de voz
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# Tags de emocao/estilo em linha
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# Combinado: dialogo + emocoes + clonagem de voz
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# Instrucao de estilo personalizada
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# Sintese em streaming
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — Texto para Fala Leve no Dispositivo (iOS + macOS)
-
-### Sintese Basica
-
-```swift
-import KokoroTTS
-import AudioCommon  // para WAVWriter
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// Baixa ~170 MB na primeira execucao (modelos CoreML + embeddings de voz + dicionarios)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// Saida: amostras float mono a 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-54 vozes predefinidas em 10 idiomas. Modelo CoreML de ponta a ponta, nao-autorregressivo, sem loop de amostragem. Executa no Neural Engine, liberando a GPU completamente.
-
-### CLI Kokoro TTS
-
-```bash
-make build
-
-# Sintese basica
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# Escolher idioma
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# Listar vozes disponiveis
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-Pipeline autorregressivo de 6 modelos executando em CoreML. Pesos paletizados W8A16.
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (LLM no Dispositivo)
+### Chat LLM — [guia completo →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// Baixa ~318 MB na primeira execucao (modelo CoreML INT4 + tokenizer)
-
-// Resposta unica
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// Tokens em streaming
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B quantizado em INT4 para CoreML. Executa no Neural Engine com ~2 tok/s no iPhone, ~15 tok/s em chips M-series. Suporta conversa multi-turno com cache KV, modo de raciocinio (tokens `<think>`), e amostragem configuravel (temperature, top-k, top-p, penalidade de repeticao).
-
-## Deteccao de Atividade de Voz (VAD) — Detectar Fala em Audio
-
-### VAD em Streaming (Silero)
-
-Silero VAD v5 processa blocos de audio de 32ms com latencia sub-milissegundo — ideal para deteccao de fala em tempo real a partir de microfones ou streams.
+### Deteccao de atividade de voz — [guia completo →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// Ou use CoreML (Neural Engine, menor consumo de energia):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// Streaming: processar blocos de 512 amostras (32ms @ 16kHz)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // chame entre diferentes streams de audio
-
-// Ou detecte todos os segmentos de uma vez
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Speech: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### Streaming Orientado a Eventos
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// Alimente audio de qualquer comprimento — eventos sao emitidos conforme a fala e confirmada
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Speech started at \(time)s")
-    case .speechEnded(let segment):
-        print("Speech: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// Finalize ao fim do stream
-let final = processor.flush()
-```
-
-### CLI de VAD
-
-```bash
-make build
-
-# Silero VAD em streaming (blocos de 32ms)
-.build/release/audio vad-stream audio.wav
-
-# Backend CoreML (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# Com limiares personalizados
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# Saida JSON
-.build/release/audio vad-stream audio.wav --json
-
-# VAD em lote com pyannote (janelas deslizantes de 10s)
-.build/release/audio vad audio.wav
-```
-
-## Diarizacao de Falantes — Quem Falou Quando
-
-### Pipeline de Diarizacao
+### Diarizacao de falantes — [guia completo →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// Ou use embeddings CoreML (Neural Engine, libera a GPU):
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) speakers detected")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### Embedding de Falante
+### Aprimoramento de fala — [guia completo →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// Ou: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: [Float] de comprimento 256, normalizado L2
+import SpeechEnhancement
 
-// Comparar falantes
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### Extracao de Falante
-
-Extraia apenas os segmentos de um falante especifico usando uma gravacao de referencia:
+### Voice Pipeline (ASR → LLM → TTS) — [guia completo →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Diarizacao Sortformer (Ponta-a-Ponta, CoreML)
+`VoicePipeline` e a maquina de estados de agent de voz em tempo real (movida por [speech-core](https://github.com/soniqo/speech-core)) com deteccao de turnos baseada em VAD, tratamento de interrupcoes e STT eager. Conecta qualquer `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`.
 
-NVIDIA Sortformer prediz atividade por quadro para ate 4 falantes diretamente — sem necessidade de embedding ou clusterizacao. Executa no Neural Engine.
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### CLI de Diarizacao
+### Servidor HTTP API
 
 ```bash
-make build
-
-# Diarizacao Pyannote (padrao)
-.build/release/audio diarize meeting.wav
-
-# Diarizacao Sortformer (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# Embeddings CoreML (Neural Engine, apenas pyannote)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# Saida JSON
-.build/release/audio diarize meeting.wav --json
-
-# Extrair um falante especifico (apenas pyannote)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# Embedding de falante
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-Veja [Speaker Diarization](docs/inference/speaker-diarization.md) para detalhes da arquitetura.
-
-## Aprimoramento de Fala — Supressao de Ruido e Limpeza de Audio
-
-### Supressao de Ruido
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // para WAVWriter
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// Baixa ~4.3 MB na primeira execucao (modelo Core ML FP16 + dados auxiliares)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### CLI de Reducao de Ruido
-
-```bash
-make build
-
-# Remocao basica de ruido
-.build/release/audio denoise noisy.wav
-
-# Caminho de saida personalizado
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-Veja [Speech Enhancement](docs/inference/speech-enhancement.md) para detalhes da arquitetura.
-
-## Pipelines — Compor Multiplos Modelos
-
-Todos os modelos seguem protocolos compartilhados (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel`, etc.) e podem ser compostos em pipelines:
-
-### Reconhecimento de Fala com Ruido (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// Aprimorar a 48kHz, depois transcrever a 16kHz
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### Retransmissao Voz-a-Voz (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// Detectar segmentos de fala, transcrever, re-sintetizar
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: amostras float mono a 24kHz
-}
-```
-
-### Transcricao de Reuniao (Diarizacao + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Speaker \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-Veja [Shared Protocols](docs/shared-protocols.md) para a referencia completa de protocolos.
-
-## Servidor de API HTTP
-
-Um servidor HTTP independente expoe todos os modelos via endpoints REST e WebSocket. Os modelos sao carregados sob demanda na primeira requisicao.
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# Transcrever audio
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# Texto para fala
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# Fala-a-fala (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# Aprimoramento de fala
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# Pre-carregar todos os modelos na inicializacao
-.build/release/audio-server --preload --port 8080
-```
-
-### Streaming via WebSocket
-
-#### API Realtime OpenAI (`/v1/realtime`)
-
-O endpoint WebSocket principal implementa o protocolo da [API Realtime da OpenAI](https://platform.openai.com/docs/api-reference/realtime) — todas as mensagens sao JSON com um campo `type`, audio e PCM16 codificado em base64 a 24kHz mono.
-
-**Eventos Cliente → Servidor:**
-
-| Evento | Descricao |
-|--------|-----------|
-| `session.update` | Configurar motor, idioma, formato de audio |
-| `input_audio_buffer.append` | Enviar bloco de audio PCM16 em base64 |
-| `input_audio_buffer.commit` | Transcrever audio acumulado (ASR) |
-| `input_audio_buffer.clear` | Limpar buffer de audio |
-| `response.create` | Solicitar sintese TTS |
-
-**Eventos Servidor → Cliente:**
-
-| Evento | Descricao |
-|--------|-----------|
-| `session.created` | Sessao inicializada |
-| `session.updated` | Configuracao confirmada |
-| `input_audio_buffer.committed` | Audio enviado para transcricao |
-| `conversation.item.input_audio_transcription.completed` | Resultado do ASR |
-| `response.audio.delta` | Bloco de audio PCM16 em base64 (TTS) |
-| `response.audio.done` | Streaming de audio concluido |
-| `response.done` | Resposta completa com metadados |
-| `error` | Erro com tipo e mensagem |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: enviar audio, receber transcricao
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → recebe: conversation.item.input_audio_transcription.completed
-
-// TTS: enviar texto, receber audio em streaming
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → recebe: response.audio.delta (blocos base64), response.audio.done, response.done
-```
-
-Um exemplo de cliente HTML esta em `Examples/websocket-client.html` — abra em um navegador enquanto o servidor estiver rodando.
-
-O servidor e um modulo `AudioServer` separado e um executavel `audio-server` — ele nao adiciona Hummingbird/WebSocket ao CLI principal `audio`.
-
-## Latencia (M2 Max, 64 GB)
-
-### ASR
-
-| Modelo | Backend | RTF | Audio de 10s processado em |
-|--------|---------|-----|---------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 frio, ~0.03 quente | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### Alinhamento Forcado
-
-| Modelo | Framework | Audio de 20s | RTF |
-|--------|-----------|-------------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> Passagem unica nao-autorregressiva — sem loop de amostragem. O encoder de audio domina (~328ms), decodificador de passagem unica e ~37ms. **55x mais rapido que tempo real.**
-
-### TTS
-
-| Modelo | Framework | Curto (1s) | Medio (3s) | Longo (6s) | Primeiro Pacote em Streaming |
-|--------|-----------|-----------|------------|-----------|---------------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1 quadro) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | N/A (nao-autorregressivo) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | N/A |
-
-> Qwen3-TTS gera fala natural e expressiva com prosodia e emocao, executando **mais rapido que tempo real** (RTF < 1.0). A sintese em streaming entrega o primeiro bloco de audio em ~120ms. Kokoro-82M executa inteiramente no Neural Engine com um modelo de ponta a ponta (RTFx ~0.7), ideal para iOS. O TTS integrado da Apple e mais rapido, mas produz fala robotica e monotona.
-
-### PersonaPlex (Fala-a-Fala)
-
-| Modelo | Framework | ms/passo | RTF | Observacoes |
-|--------|-----------|----------|-----|-------------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | Recomendado — respostas coerentes, 30% mais rapido que 4-bit |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | Nao recomendado — qualidade de saida degradada |
-
-> **Use 8-bit.** INT8 e mais rapido (112 ms/passo vs. 158 ms/passo) e produz respostas full-duplex coerentes. A quantizacao INT4 degrada a qualidade de geracao, produzindo fala incoerente. INT8 executa a ~112ms/passo no M2 Max.
-
-### VAD e Embedding de Falante
-
-| Modelo | Backend | Latencia por Chamada | RTF | Observacoes |
-|--------|---------|---------------------|-----|-------------|
-| Silero-VAD-v5 | MLX | ~2.1ms / bloco | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / bloco | 0.008 | Neural Engine, **7.7x mais rapido** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / audio de 20s | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / audio de 20s | 0.021 | Neural Engine, libera a GPU |
-
-> Silero VAD CoreML executa no Neural Engine a 7.7x a velocidade do MLX, sendo ideal para entrada continua de microfone. WeSpeaker MLX e mais rapido na GPU, mas CoreML libera a GPU para cargas de trabalho concorrentes (TTS, ASR). Ambos os backends produzem resultados equivalentes.
-
-### Aprimoramento de Fala
-
-| Modelo | Backend | Duracao | Latencia | RTF |
-|--------|---------|---------|----------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = Fator de Tempo Real (menor e melhor, < 1.0 = mais rapido que tempo real). O custo da GRU escala ~O(n^2).
-
-### MLX vs CoreML
-
-Ambos os backends produzem resultados equivalentes. Escolha de acordo com sua carga de trabalho:
-
-| | MLX | CoreML |
-|---|---|---|
-| **Hardware** | GPU (shaders Metal) | Neural Engine + CPU |
-| **Melhor para** | Vazao maxima, cargas de modelo unico | Pipelines multi-modelo, tarefas em segundo plano |
-| **Energia** | Maior utilizacao de GPU | Menor consumo, libera a GPU |
-| **Latencia** | Mais rapido para modelos grandes (WeSpeaker) | Mais rapido para modelos pequenos (Silero VAD) |
-
-**Inferencia em desktop**: MLX e o padrao — melhor desempenho de modelo unico em Apple Silicon. Mude para CoreML ao executar multiplos modelos simultaneamente (ex.: VAD + ASR + TTS) para evitar contencao de GPU, ou para cargas de trabalho sensiveis a bateria em laptops.
-
-Modelos CoreML estao disponiveis para o encoder Qwen3-ASR, Silero VAD e WeSpeaker. Para Qwen3-ASR, use `--engine qwen3-coreml` (hibrido: encoder CoreML no ANE + decodificador de texto MLX na GPU). Para VAD/embeddings, passe `engine: .coreml` no momento da construcao — a API de inferencia e identica.
-
-## Benchmarks de Precisao
-
-### ASR — Taxa de Erro de Palavras ([detalhes](docs/benchmarks/asr-wer.md))
-
-| Modelo | WER% (LibriSpeech test-clean) | RTF |
-|--------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit supera Whisper Large v3 Turbo (2.5%) com tamanho comparavel. Multilingual: 10 idiomas avaliados no FLEURS.
-
-### TTS — Inteligibilidade Round-Trip ([detalhes](docs/benchmarks/tts-roundtrip.md))
-
-| Motor | WER% | RTF |
-|-------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — Deteccao de Fala ([detalhes](docs/benchmarks/vad-detection.md))
-
-| Motor | F1% (FLEURS) | RTF |
-|-------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+Expoe cada modelo via endpoints HTTP REST + WebSocket, incluindo um WebSocket compativel com OpenAI Realtime API em `/v1/realtime`. Veja [`Sources/AudioServer/`](Sources/AudioServer/).
 
 ## Arquitetura
 
-**Modelos:** [ASR Model](docs/models/asr-model.md), [TTS Model](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift e dividido em um target SPM por modelo para que os consumidores paguem apenas pelo que importarem. A infraestrutura compartilhada fica em `AudioCommon` (protocolos, I/O de audio, downloader do HuggingFace, `SentencePieceModel`) e `MLXCommon` (carregamento de pesos, helpers `QuantizedLinear`, helper de atencao multi-head `SDPA`).
 
-**Inferencia:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS Inference](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Speaker Diarization](docs/inference/speaker-diarization.md), [Speech Enhancement](docs/inference/speech-enhancement.md), [Reprodução de Áudio](docs/audio/playback.md)
+**[Diagrama completo de arquitetura com backends, tabelas de memoria e mapa de modulos → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[Referencia de API → soniqo.audio/api](https://soniqo.audio/api)** · **[Benchmarks → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**Benchmarks:** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD Detection](docs/benchmarks/vad-detection.md)
+Docs locais (repositorio):
+- **Modelos:** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **Inferencia:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [Diarizacao](docs/inference/speaker-diarization.md) · [Aprimoramento de fala](docs/inference/speech-enhancement.md)
+- **Referencia:** [Protocolos compartilhados](docs/shared-protocols.md)
 
-**Referencia:** [Shared Protocols](docs/shared-protocols.md)
+## Configuracao de cache
 
-## Configuração de Cache
+Os pesos dos modelos sao baixados do HuggingFace no primeiro uso e armazenados em cache em `~/Library/Caches/qwen3-speech/`. Sobrescreva com `QWEN3_CACHE_DIR` (CLI) ou `cacheDir:` (API Swift). Todos os pontos de entrada `fromPretrained()` aceitam `offlineMode: true` para pular a rede quando os pesos ja estao em cache.
 
-Os pesos dos modelos são armazenados em cache em `~/Library/Caches/qwen3-speech/`.
+Veja [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md) para detalhes completos, incluindo caminhos de container iOS sandboxed.
 
-**CLI** — alterar via variável de ambiente:
+## Biblioteca MLX Metal
 
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
-
-**Swift API** — todos os métodos `fromPretrained()` aceitam `cacheDir` e `offlineMode`:
-
-```swift
-// Diretório de cache personalizado (apps sandbox, contêineres iOS)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// Modo offline — pular rede quando os pesos já estão em cache
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-Veja [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md) para mais detalhes.
-
-## Biblioteca Metal MLX
-
-Se voce vir `Failed to load the default metallib` em tempo de execucao, a biblioteca de shaders Metal esta faltando. Execute `make build` (ou `./scripts/build_mlx_metallib.sh release` apos um `swift build` manual) para compila-la. Se o Metal Toolchain estiver faltando, instale-o primeiro:
+Se voce ver `Failed to load the default metallib` em tempo de execucao, a biblioteca de shaders Metal esta faltando. Execute `make build` ou `./scripts/build_mlx_metallib.sh release` apos um `swift build` manual. Se o Metal Toolchain estiver faltando, instale-o primeiro:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## Testes
 
-Testes unitarios (configuracao, amostragem, pre-processamento de texto, correcao de timestamps) executam sem download de modelos:
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # suite completa (unidade + E2E com downloads de modelos)
+swift test --skip E2E                # somente unidade (seguro para CI, sem downloads)
+swift test --filter Qwen3ASRTests    # modulo especifico
 ```
 
-Testes de integracao requerem pesos dos modelos (baixados automaticamente na primeira execucao):
-
-```bash
-# Round-trip TTS: sintetizar texto, salvar WAV, transcrever de volta com ASR
-swift test --filter TTSASRRoundTripTests
-
-# Apenas ASR: transcrever audio de teste
-swift test --filter Qwen3ASRIntegrationTests
-
-# Alinhamento Forcado E2E: timestamps por palavra (~979 MB de download)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E: pipeline fala-a-fala (~5.5 GB de download)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **Nota:** A biblioteca Metal MLX deve ser compilada antes de executar testes que usam operacoes MLX.
-> Veja [Biblioteca Metal MLX](#biblioteca-metal-mlx) para instrucoes.
-
-## Idiomas Suportados
-
-| Modelo | Idiomas |
-|--------|---------|
-| Qwen3-ASR | 52 idiomas (CN, EN, Cantones, DE, FR, ES, JA, KO, RU, + 22 dialetos chineses, ...) |
-| Parakeet TDT | 25 idiomas europeus (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1.672 idiomas** em mais de 150 famílias. Inclui todo o conjunto "servido diretamente" da Meta (~1.100) mais 500+ idiomas de baixos recursos adicionados através de dados da comunidade. Selecionados: EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (lista completa: [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)). A cabeça CTC é agnóstica ao idioma — nenhuma dica de idioma é necessária no momento da inferência. |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ dialetos de Pequim/Sichuan via CustomVoice) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## Comparacao
-
-### Fala para Texto (ASR): speech-swift vs Alternativas
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **Execucao** | No dispositivo (MLX/CoreML) | No dispositivo (CPU/GPU) | No dispositivo ou nuvem | Somente nuvem |
-| **Idiomas** | 52 | 100+ | ~70 (no dispositivo: limitado) | 125+ |
-| **RTF (audio de 10s, M2 Max)** | 0.06 (17x tempo real) | 0.10 (Whisper-large-v3) | N/A | N/A |
-| **Streaming** | Nao (em lote) | Nao (em lote) | Sim | Sim |
-| **Modelos personalizados** | Sim (trocar pesos do HuggingFace) | Sim (modelos GGML) | Nao | Nao |
-| **API Swift** | Nativa async/await | C++ com ponte Swift | Nativa | REST/gRPC |
-| **Privacidade** | Totalmente no dispositivo | Totalmente no dispositivo | Depende da configuracao | Dados enviados a nuvem |
-| **Timestamps por palavra** | Sim (Forced Aligner) | Sim | Limitado | Sim |
-| **Custo** | Gratuito (Apache 2.0) | Gratuito (MIT) | Gratuito (no dispositivo) | Pago por minuto |
-
-### Texto para Fala (TTS): speech-swift vs Alternativas
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / TTS na Nuvem** |
-|---|---|---|---|---|
-| **Qualidade** | Neural, expressiva | Neural, natural | Robotica, monotona | Neural, mais alta qualidade |
-| **Execucao** | No dispositivo (MLX) | No dispositivo (CoreML) | No dispositivo | Somente nuvem |
-| **Streaming** | Sim (~120ms primeiro bloco) | Nao (modelo de ponta a ponta) | Nao | Sim |
-| **Clonagem de voz** | Sim | Nao | Nao | Sim |
-| **Vozes** | 9 integradas + clonar qualquer | 54 vozes predefinidas | ~50 vozes do sistema | 1000+ |
-| **Idiomas** | 10 | 10 | 60+ | 30+ |
-| **Suporte iOS** | Somente macOS | iOS + macOS | iOS + macOS | Qualquer (API) |
-| **Custo** | Gratuito (Apache 2.0) | Gratuito (Apache 2.0) | Gratuito | Pago por caractere |
-
-### Quando Usar speech-swift
-
-- **Apps com privacidade critica** — saude, juridico, empresarial onde o audio nao pode sair do dispositivo
-- **Uso offline** — nao precisa de conexao com internet apos o download inicial do modelo
-- **Sensivel a custos** — sem cobranca por minuto ou por caractere de API
-- **Otimizado para Apple Silicon** — construido especificamente para GPU M-series (Metal) e Neural Engine
-- **Pipeline completo** — combine ASR + TTS + VAD + diarizacao + aprimoramento em um unico pacote Swift
-
-## Perguntas Frequentes
-
-**O speech-swift funciona no iOS?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3 e WeSpeaker funcionam no iOS 17+ via CoreML no Neural Engine. Modelos baseados em MLX (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex) requerem macOS 14+ em Apple Silicon.
-
-**E necessaria conexao com a internet?**
-Apenas para o download inicial do modelo a partir do HuggingFace (automatico, armazenado em cache em `~/Library/Caches/qwen3-speech/`). Depois disso, toda a inferencia executa totalmente offline sem acesso a rede.
-
-**Como o speech-swift se compara ao Whisper?**
-Qwen3-ASR-0.6B alcanca RTF 0.06 no M2 Max — 40% mais rapido que Whisper-large-v3 via whisper.cpp (RTF 0.10) — com precisao comparavel em 52 idiomas. speech-swift oferece uma API Swift nativa com async/await, enquanto whisper.cpp requer uma ponte C++.
-
-**Posso usar em um app comercial?**
-Sim. speech-swift esta licenciado sob Apache 2.0. Os pesos dos modelos subjacentes possuem suas proprias licencas (verifique a pagina do HuggingFace de cada modelo).
-
-**Quais chips Apple Silicon sao suportados?**
-Todos os chips da serie M: M1, M2, M3, M4 e suas variantes Pro/Max/Ultra. Requer macOS 14+ (Sonoma) ou iOS 17+.
-
-**Quanta memoria e necessaria?**
-De ~3 MB (Silero VAD) ate ~6.5 GB (PersonaPlex 7B). Kokoro TTS usa ~500 MB, Qwen3-ASR ~2.2 GB. Veja a tabela de [Requisitos de Memoria](#requisitos-de-memoria) para detalhes completos.
-
-**Posso executar multiplos modelos simultaneamente?**
-Sim. Use modelos CoreML no Neural Engine junto com modelos MLX na GPU para evitar contencao — por exemplo, Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX).
-
-**Existe uma API REST?**
-Sim. O binario `audio-server` expoe todos os modelos via endpoints HTTP REST e WebSocket, incluindo um WebSocket compativel com a API Realtime da OpenAI em `/v1/realtime`.
+Classes de teste E2E usam o prefixo `E2E` para que a CI possa filtra-las com `--skip E2E`. Veja [CLAUDE.md](CLAUDE.md#testing) para a convencao completa de testes.
 
 ## Contribuindo
 
-Contribuicoes sao bem-vindas! Seja uma correcao de bug, integracao de um novo modelo ou melhoria na documentacao — PRs sao apreciados.
-
-**Para comecar:**
-1. Faca um fork do repositorio e crie uma branch de feature
-2. `make build` para compilar (requer Xcode + Metal Toolchain)
-3. `make test` para executar a suite de testes
-4. Abra um PR contra `main`
+PRs bem-vindos — correcoes de bugs, integracoes de novos modelos, documentacao. Fork, crie uma branch de feature, `make build && make test`, abra um PR contra `main`.
 
 ## Licenca
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -6,32 +6,24 @@
 
 Распознавание, синтез и понимание речи на устройстве для Mac и iOS. Работает полностью локально на Apple Silicon — без облака, без API-ключей, данные не покидают устройство.
 
-[Установите через Homebrew](#homebrew) или добавьте как зависимость Swift Package.
+**[📚 Полная документация →](https://soniqo.audio)** · **[🤗 Модели на HuggingFace](https://huggingface.co/aufklarer)** · **[📝 Блог](https://blog.ivan.digital)**
 
-**[Документация](https://soniqo.audio)** · **[Модели на HuggingFace](https://huggingface.co/aufklarer)** · **[Блог](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Распознавание речи (автоматическое распознавание речи, 52 языка, MLX + CoreML)
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — Распознавание речи через CoreML (Neural Engine, NVIDIA FastConformer + TDT-декодер, 25 языков)
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Распознавание речи (Meta wav2vec2 + CTC, **1 672 языка** в 32 письменностях, CoreML 300M + MLX 300M/1B/3B/7B)
+- **[Streaming Dictation](https://soniqo.audio/guides/dictate)** — Диктовка в реальном времени с частичными результатами и детекцией окончания реплики (Parakeet-EOU-120M)
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — Выравнивание временных меток на уровне слов (аудио + текст → временные метки)
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — Синтез речи (наивысшее качество, потоковый режим, пользовательские голоса, 10 языков)
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — Потоковый синтез речи с клонированием голоса, многоголосым диалогом, тегами эмоций (9 языков)
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — Синтез речи на устройстве (82M, CoreML/Neural Engine, 54 голоса, готов для iOS, 10 языков)
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — Локальный чат на базе LLM (0.8B, MLX INT4 + CoreML INT8, гибрид DeltaNet, потоковая генерация токенов)
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — Полнодуплексная генерация речи из речи (7B, аудио на входе → аудио на выходе, 18 голосовых пресетов)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Подавление шума в реальном времени (2.1M параметров, 48 кГц)
+- **[VAD](https://soniqo.audio/guides/vad)** — Обнаружение голосовой активности (Silero потоковый, Pyannote офлайн, FireRedVAD 100+ языков)
+- **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — Кто говорил и когда (Pyannote-пайплайн, сквозной Sortformer на Neural Engine)
+- **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-мерные векторы), CAM++ (192-мерные)
 
-- **Qwen3-ASR** — Распознавание речи (автоматическое распознавание речи, 52 языка)
-- **Parakeet TDT** — Распознавание речи через CoreML (Neural Engine, NVIDIA FastConformer + TDT-декодер, 25 языков)
-- **Omnilingual ASR** — Распознавание речи через CoreML (Meta wav2vec2 + CTC, **1 672 языка** из более чем 150 языковых семей, окна 5/10 с, INT8 палетизация, ANE)
-- **Qwen3-ForcedAligner** — Выравнивание временных меток на уровне слов (аудио + текст → временные метки)
-- **Qwen3-TTS** — Синтез речи из текста (наивысшее качество, потоковый режим, пользовательские голоса, 10 языков)
-- **CosyVoice TTS** — Синтез речи с потоковой генерацией, клонированием голоса, многоголосым диалогом и тегами эмоций (9 языков, DiT flow matching, CAM++ speaker encoder)
-- **Kokoro TTS** — Синтез речи на устройстве (82M параметров, CoreML/Neural Engine, 54 голоса, готов для iOS, 10 языков)
-- **Qwen3-TTS CoreML** — Синтез речи (0.6B, CoreML-пайплайн из 6 моделей, W8A16, iOS/macOS)
-- **Qwen3.5-Chat** — Локальный чат на базе LLM (0.8B, MLX + CoreML, INT4/INT8, гибридная архитектура DeltaNet, потоковая генерация токенов)
-- **PersonaPlex** — Полнодуплексная генерация речи из речи (7B, аудио на входе → аудио на выходе, 18 голосовых пресетов)
-- **DeepFilterNet3** — Улучшение речи / подавление шума (2.1M параметров, реальное время 48kHz)
-- **FireRedVAD** — Офлайн-обнаружение голосовой активности (DFSMN, CoreML, 100+ языков, 97.6% F1)
-- **Silero VAD** — Потоковое обнаружение голосовой активности (фрагменты по 32мс, субмиллисекундная задержка)
-- **Pyannote VAD** — Офлайн-обнаружение голосовой активности (окна по 10с, перекрытие нескольких спикеров)
-- **Speaker Diarization** — Кто говорил и когда (сегментация Pyannote + цепочки спикеров на основе активности, или сквозная модель Sortformer на Neural Engine)
-- **Speaker Embeddings** — Верификация и идентификация спикеров (WeSpeaker ResNet34, 256-мерные векторы)
-
-Статьи: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## Дорожная карта
-
-Смотрите [обсуждение дорожной карты](https://github.com/soniqo/speech-swift/discussions/81) — комментарии и предложения приветствуются!
+Статьи: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## Новости
 
@@ -45,14 +37,14 @@
 Добавьте пакет в `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-Импортируйте только нужные модули — каждая модель это отдельная SPM-библиотека:
+Импортируйте только те модули, которые вам нужны — каждая модель это отдельная SPM-библиотека, поэтому вы не платите за то, чем не пользуетесь:
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
-.product(name: "SpeechUI",             package: "speech-swift"),  // опциональные SwiftUI-вью
+.product(name: "SpeechUI",             package: "speech-swift"),  // опциональные SwiftUI-компоненты
 ```
 
 **Транскрибировать аудиобуфер в 3 строки:**
@@ -64,7 +56,7 @@ let model = try await ParakeetStreamingASRModel.fromPretrained()
 let text = try model.transcribeAudio(audioSamples, sampleRate: 16000)
 ```
 
-**Потоковая транскрипция с частичными результатами:**
+**Потоковый режим с частичными результатами:**
 
 ```swift
 for await partial in model.transcribeStream(audio: samples, sampleRate: 16000) {
@@ -72,7 +64,7 @@ for await partial in model.transcribeStream(audio: samples, sampleRate: 16000) {
 }
 ```
 
-**SwiftUI-вью для диктовки в ~10 строк:**
+**SwiftUI-вид для диктовки примерно в 10 строк:**
 
 ```swift
 import SwiftUI
@@ -96,128 +88,85 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI` содержит только `TranscriptionView` (финальные + частичные) и `TranscriptionStore` (адаптер streaming ASR). Для визуализации и воспроизведения аудио используйте AVFoundation.
+`SpeechUI` предоставляет только `TranscriptionView` (финальные + частичные результаты) и `TranscriptionStore` (адаптер для потокового ASR). Для визуализации и воспроизведения аудио используйте AVFoundation.
 
 Доступные SPM-продукты: `Qwen3ASR`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `OmnilingualASR`, `KokoroTTS`, `CosyVoiceTTS`, `PersonaPlex`, `SpeechVAD`, `SpeechEnhancement`, `Qwen3Chat`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Модели
 
-| Модель | Задача | Потоковый режим | Языки | Размеры |
-|--------|--------|-----------------|-------|---------|
-| Qwen3-ASR-0.6B | Речь → Текст | Нет | 52 языка | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | Речь → Текст | Нет | 52 языка | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | Речь → Текст | Нет | 25 европейских языков | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | Речь → Текст | Да (потоково + EOU) | 25 европейских языков | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | Речь → Текст | Нет (окно 5/10 с) | [1 672 языка](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | Речь → Текст | Нет | [1 672 языка](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | Речь → Текст | Нет | [1 672 языка](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | Речь → Текст | Нет | [1 672 языка](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | Аудио + Текст → Временные метки | Нет | Мульти | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | Текст → Речь | Да (~120мс) | 10 языков | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | Текст → Речь | Да (~120мс) | 10 языков | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | Текст → Речь | Да (~120мс) | 10 языков | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | Текст → Речь | Да (~150мс) | 9 языков | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | Текст → Речь | Нет | 10 языков | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | Речь → Речь | Да (~2с фрагменты) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | Обнаружение голосовой активности | Нет (офлайн) | 100+ языков | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | Обнаружение голосовой активности | Да (фрагменты по 32мс) | Языконезависимый | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + сегментация спикеров | Нет (окна по 10с) | Языконезависимый | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | Улучшение речи | Да (кадры по 10мс) | Языконезависимый | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | Голосовые эмбеддинги (256-мерные) | Нет | Языконезависимый | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | Голосовые эмбеддинги (192-мерные) | Нет | Языконезависимый | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | Диаризация спикеров (сквозная) | Да (фрагментами) | Языконезависимый | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+Краткий обзор ниже. **[Полный каталог моделей со всеми размерами, квантизациями, ссылками на скачивание и таблицами памяти → soniqo.audio/architecture](https://soniqo.audio/architecture)**.
 
-### Требования к памяти
-
-Память для весов — это память GPU (MLX) или ANE (CoreML), занятая параметрами модели. Пиковое потребление при инференсе включает KV-кеши, активации и промежуточные тензоры.
-
-| Модель | Память для весов | Пиковое потребление |
-|--------|-----------------|---------------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### Какой TTS выбрать
-
-- **Qwen3-TTS**: Лучшее качество, потоковый режим (~120мс), 9 встроенных голосов, 10 языков, пакетный синтез
-- **CosyVoice TTS**: Потоковый режим (~150мс), 9 языков, клонирование голоса (CAM++ speaker encoder), многоголосый диалог (`[S1] ... [S2] ...`), встроенные теги эмоций/стиля (`(happy)`, `(whispers)`), DiT flow matching + HiFi-GAN вокодер
-- **Kokoro TTS**: Лёгкий TTS для iOS (82M параметров), CoreML/Neural Engine, 54 голоса, 10 языков, сквозная модель
-- **PersonaPlex**: Полнодуплексная генерация речи из речи (аудио на входе → аудио на выходе), потоковый режим (~2с фрагменты), 18 голосовых пресетов, на базе архитектуры Moshi
+| Модель | Задача | Бэкенды | Размеры | Языки |
+|--------|--------|---------|---------|-------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Речь → Текст | MLX, CoreML (гибрид) | 0.6B, 1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Речь → Текст | CoreML (ANE) | 0.6B | 25 европейских |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | Речь → Текст (потоковый) | CoreML (ANE) | 120M | 25 европейских |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | Речь → Текст | CoreML (ANE), MLX | 300M / 1B / 3B / 7B | **[1 672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | Аудио + Текст → Метки | MLX, CoreML | 0.6B | Многоязычный |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | Текст → Речь | MLX, CoreML | 0.6B, 1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | Текст → Речь | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | Текст → Речь | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Текст → Текст (LLM) | MLX, CoreML | 0.8B | Многоязычный |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | Речь → Речь | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | Детектор речи | MLX, CoreML | 309K | Универсальный |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Диаризация | MLX | 1.5M | Универсальный |
+| [Sortformer](https://soniqo.audio/guides/diarize) | Диаризация (E2E) | CoreML (ANE) | — | Универсальный |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Улучшение речи | CoreML | 2.1M | Универсальный |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Эмбеддинги спикеров | MLX, CoreML | 6.6M | Универсальный |
 
 ## Установка
 
 ### Homebrew
 
-Требуется нативный ARM Homebrew (`/opt/homebrew`). Homebrew через Rosetta/x86_64 не поддерживается.
+Требуется нативный ARM Homebrew (`/opt/homebrew`). Rosetta/x86_64-версия Homebrew не поддерживается.
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-Затем используйте:
+Затем:
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML (нейронный движок)
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> Для интерактивного голосового диалога с микрофоном смотрите **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**.
+**[Полный справочник CLI →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-Добавьте в ваш `Package.swift`:
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-Импортируйте нужный модуль:
+Импортируйте только то, что вам нужно — каждая модель это отдельный SPM-таргет:
 
 ```swift
-import Qwen3ASR      // Распознавание речи (MLX)
-import ParakeetASR   // Распознавание речи (CoreML)
-import Qwen3TTS      // Синтез речи (Qwen3)
-import CosyVoiceTTS  // Синтез речи (потоковый)
-import KokoroTTS     // Синтез речи (CoreML, для iOS)
-import Qwen3Chat     // Локальный чат на базе LLM (CoreML)
-import PersonaPlex   // Генерация речи из речи (полный дуплекс)
-import SpeechVAD          // Обнаружение голосовой активности (pyannote + Silero)
-import SpeechEnhancement  // Подавление шума (DeepFilterNet3)
-import AudioCommon        // Общие утилиты
+import Qwen3ASR             // Распознавание речи (MLX)
+import ParakeetASR          // Распознавание речи (CoreML, пакетный режим)
+import ParakeetStreamingASR // Потоковая диктовка с частичными результатами + EOU
+import OmnilingualASR       // 1 672 языка (CoreML + MLX)
+import Qwen3TTS             // Синтез речи
+import CosyVoiceTTS         // Синтез речи с клонированием голоса
+import KokoroTTS            // Синтез речи (готов для iOS)
+import Qwen3Chat            // Локальный чат на базе LLM
+import PersonaPlex          // Полнодуплексная речь-в-речь
+import SpeechVAD            // VAD + диаризация спикеров + эмбеддинги
+import SpeechEnhancement    // Подавление шума
+import SpeechUI             // SwiftUI-компоненты для потоковой транскрипции
+import AudioCommon          // Общие протоколы и утилиты
 ```
 
-### Системные требования
+### Требования
 
-- Swift 5.9+
-- macOS 14+ или iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+ (с Metal Toolchain — выполните `xcodebuild -downloadComponent MetalToolchain`, если отсутствует)
+- Swift 5.9+, Xcode 15+ (с Metal Toolchain)
+- macOS 14+ или iOS 17+, Apple Silicon (M1/M2/M3/M4)
 
-### Сборка из исходного кода
+### Сборка из исходников
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-Эта команда компилирует Swift-пакет **и** библиотеку Metal-шейдеров MLX за один шаг. Библиотека Metal (`mlx.metallib`) необходима для GPU-инференса — без неё при запуске возникнет ошибка `Failed to load the default metallib`.
+`make build` компилирует Swift-пакет **и** библиотеку Metal-шейдеров MLX. Metal-библиотека необходима для GPU-инференса — без неё при запуске будет ошибка `Failed to load the default metallib`. `make debug` для отладочных сборок, `make test` для тестового набора.
 
-Отладочная сборка: `make debug`. Запуск юнит-тестов: `make test`.
-
-## Попробуйте голосового ассистента
-
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — это готовое к запуску macOS-приложение голосового ассистента: нажмите, чтобы говорить, и получайте голосовые ответы в реальном времени. Использует микрофонный ввод с Silero VAD для автоматического обнаружения речи, Qwen3-ASR для транскрипции и PersonaPlex 7B для генерации речи из речи. Многоходовый диалог с 18 голосовыми пресетами и отображением внутреннего монолога.
-
-```bash
-make build  # из корня репозитория — собирает всё, включая MLX metallib
-cd Examples/PersonaPlexDemo
-# См. Examples/PersonaPlexDemo/README.md для инструкций по сборке .app
-```
-
-> RTF ~0.94 на M2 Max (быстрее реального времени). Модели загружаются автоматически при первом запуске (~5.5 GB PersonaPlex + ~400 MB ASR).
+**[Полное руководство по сборке и установке →](https://soniqo.audio/getting-started)**
 
 ## Демо-приложения
 
-- **[DictateDemo](Examples/DictateDemo/)** ([документация](https://soniqo.audio/guides/dictate/)) — Потоковая диктовка в строке меню macOS с живыми частичными результатами, определением конца фразы через VAD и копированием одним щелчком. Работает как фоновый агент строки меню (Parakeet-EOU-120M + Silero VAD).
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS-демо эхо (Parakeet ASR + Kokoro TTS, говорите и слушайте ответ). Устройство и симулятор.
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Голосовой ассистент для диалога (микрофонный ввод, VAD, многоходовый диалог). macOS.
-- **[SpeechDemo](Examples/SpeechDemo/)** — Диктовка и синтез речи в интерфейсе с вкладками. macOS.
+- **[DictateDemo](Examples/DictateDemo/)** ([документация](https://soniqo.audio/guides/dictate)) — macOS-приложение в строке меню с потоковой диктовкой, живыми частичными результатами, детекцией окончания реплики по VAD и копированием в один клик. Работает как фоновый агент (Parakeet-EOU-120M + Silero VAD).
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS-эхо-демо (Parakeet ASR + Kokoro TTS). Устройство и симулятор.
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — Диалоговый голосовой ассистент с микрофонным вводом, VAD и многоходовым контекстом. macOS. RTF ~0.94 на M2 Max (быстрее реального времени).
+- **[SpeechDemo](Examples/SpeechDemo/)** — Диктовка и синтез TTS в интерфейсе с вкладками. macOS.
 
-Соберите и запустите — инструкции в README каждого демо.
+В README каждого демо есть инструкции по сборке.
 
-## Распознавание речи (ASR) — транскрибирование аудио на Swift
+## Примеры кода
 
-### Базовая транскрипция
+Сниппеты ниже показывают минимальный путь для каждой области. Каждый раздел ссылается на полное руководство на [soniqo.audio](https://soniqo.audio) с опциями конфигурации, множественными бэкендами, шаблонами потоковой обработки и примерами CLI.
 
-```swift
-import Qwen3ASR
-
-// По умолчанию: модель 0.6B
-let model = try await Qwen3ASRModel.fromPretrained()
-
-// Или используйте более крупную модель 1.7B для лучшей точности
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// Аудио может быть любой частоты дискретизации — автоматический ресемплинг до 16kHz
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
-```
-
-### CoreML-энкодер (Neural Engine)
-
-Гибридный режим: CoreML-энкодер на Neural Engine + MLX текстовый декодер на GPU. Меньшее энергопотребление, освобождает GPU на этапе работы энкодера.
+### Распознавание речи — [полное руководство →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-let encoder = try await CoreMLASREncoder.fromPretrained()
 let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-Доступны варианты INT8 (180 MB, по умолчанию) и INT4 (90 MB). Рекомендуется INT8 (косинусное сходство > 0.999 относительно FP32).
+Альтернативные бэкенды: [Parakeet TDT](https://soniqo.audio/guides/parakeet) (CoreML, 32× быстрее реального времени), [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) (1 672 языка, CoreML или MLX), [Потоковая диктовка](https://soniqo.audio/guides/dictate) (живые частичные результаты).
 
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-Работает на Neural Engine через CoreML — освобождает GPU для параллельных задач. 25 европейских языков, ~315 MB.
-
-### CLI для ASR
-
-```bash
-make build  # или: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# По умолчанию (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# Модель 1.7B
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# CoreML-энкодер (Neural Engine + MLX-декодер)
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, Neural Engine)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## Принудительное выравнивание
-
-### Временные метки на уровне слов
+### Выравнивание с форсированием — [полное руководство →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// Загружает ~979 MB при первом запуске
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### CLI для принудительного выравнивания
-
-```bash
-swift build -c release
-
-# Выравнивание с указанным текстом
-.build/release/audio align audio.wav --text "Hello world"
-
-# Сначала транскрипция, затем выравнивание
-.build/release/audio align audio.wav
-```
-
-Вывод:
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-Сквозная модель, неавторегрессионная, без цикла сэмплирования. Подробнее об архитектуре см. [Forced Aligner](docs/inference/forced-aligner.md).
-
-## Синтез речи (TTS) — генерация речи на Swift
-
-### Базовый синтез
+### Синтез речи — [полное руководство →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // для WAVWriter
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// Загружает ~1.7 GB при первом запуске (модель + веса кодека)
 let audio = model.synthesize(text: "Hello world", language: "english")
-// Выход: моно-сэмплы float 24kHz
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### CLI для TTS
+Альтернативные TTS-движки: [CosyVoice3](https://soniqo.audio/guides/cosyvoice) (потоковый + клонирование голоса + теги эмоций), [Kokoro-82M](https://soniqo.audio/guides/kokoro) (готов для iOS, 54 голоса), [Клонирование голоса](https://soniqo.audio/guides/voice-cloning).
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### Пользовательский голос / Выбор диктора
-
-Вариант модели **CustomVoice** поддерживает 9 встроенных голосов и инструкции на естественном языке для управления тоном и стилем. Загрузите его, указав ID модели CustomVoice:
-
-```swift
-import Qwen3TTS
-
-// Загрузка модели CustomVoice (загружает ~1.7 GB при первом запуске)
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// Синтез с конкретным диктором
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// Список доступных дикторов
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-CLI:
-
-```bash
-# Использование модели CustomVoice с диктором
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# Список доступных дикторов
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### Клонирование голоса (базовая модель)
-
-Клонирование голоса диктора из эталонного аудиофайла. Два режима:
-
-**Режим ICL** (рекомендуется) — кодирует эталонное аудио в токены кодека с транскриптом. Более высокое качество, надёжный EOS:
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**Режим X-vector** — только голосовой эмбеддинг, транскрипт не нужен, но качество ниже:
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-CLI:
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### Управление тоном и стилем (только CustomVoice)
-
-Модель CustomVoice принимает параметр `instruct` на естественном языке для управления стилем речи, тоном, эмоциями и темпом. Инструкция добавляется к входным данным модели в формате ChatML.
-
-```swift
-// Радостный тон
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// Медленно и серьёзно
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// Шёпотом
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-CLI:
-
-```bash
-# С инструкцией стиля
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# Инструкция по умолчанию ("Speak naturally.") применяется автоматически при использовании CustomVoice
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-Если `--instruct` не указан для модели CustomVoice, автоматически применяется `"Speak naturally."`, чтобы предотвратить бессвязную генерацию. Базовая модель не поддерживает instruct.
-
-### Пакетный синтез
-
-Синтез нескольких текстов за один пакетный прямой проход для более высокой пропускной способности:
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] — моно-сэмплы float 24kHz для texts[i]
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### CLI для пакетного синтеза
-
-```bash
-# Создайте файл с одним текстом на строку
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# Создаёт output_0.wav, output_1.wav, ...
-```
-
-> Пакетный режим амортизирует загрузку весов модели между элементами. Ожидайте прирост пропускной способности в ~1.5-2.5 раза при B=4 на Apple Silicon. Лучшие результаты достигаются, когда тексты генерируют аудио примерно одинаковой длины.
-
-### Параметры сэмплирования
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### Потоковый синтез
-
-Генерация аудиофрагментов по мере готовности для минимальной задержки до первого пакета:
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // ~120мс до первого аудиофрагмента
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: true для последнего фрагмента
-    playAudio(chunk.samples)
-}
-```
-
-CLI:
-
-```bash
-# Потоковый режим по умолчанию (первый фрагмент из 3 кадров, задержка ~225мс)
-.build/release/audio speak "Hello world" --stream
-
-# Минимальная задержка (первый фрагмент из 1 кадра, задержка ~120мс)
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## Генерация речи из речи — полнодуплексный голосовой диалог
-
-> Для интерактивного голосового ассистента с микрофонным вводом см. **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — нажмите, чтобы говорить, многоходовый диалог с автоматическим обнаружением речи.
-
-### Генерация речи из речи
+### Речь-в-речь — [полное руководство →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // для WAVWriter, AudioFileLoader
 
 let model = try await PersonaPlexModel.fromPretrained()
-// Загружает ~5.5 GB при первом запуске (temporal 4-bit + depformer + Mimi кодек + голосовые пресеты)
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: моно-сэмплы float 24kHz
-// textTokens: внутренний монолог модели (ID токенов SentencePiece)
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// 24 кГц моно Float32 — готово к воспроизведению
 ```
 
-### Внутренний монолог (текстовый вывод)
-
-PersonaPlex генерирует текстовые токены параллельно с аудио — это внутренние рассуждения модели. Декодируйте их встроенным декодером SentencePiece:
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // например, "Sure, I can help you with that..."
-```
-
-### Потоковая генерация речи из речи
-
-```swift
-// Получайте аудиофрагменты по мере генерации (~2с на фрагмент)
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // воспроизводите сразу, 24kHz моно
-    // chunk.textTokens содержит текст этого фрагмента; последний фрагмент содержит все токены
-    if chunk.isFinal { break }
-}
-```
-
-### Выбор голоса
-
-Доступно 18 голосовых пресетов:
-- **Естественные женские**: NATF0, NATF1, NATF2, NATF3
-- **Естественные мужские**: NATM0, NATM1, NATM2, NATM3
-- **Разнообразные женские**: VARF0, VARF1, VARF2, VARF3, VARF4
-- **Разнообразные мужские**: VARM0, VARM1, VARM2, VARM3, VARM4
-
-### Системные промпты
-
-Системный промпт определяет поведение модели в диалоге. Можно передать любой пользовательский промпт в виде обычной строки:
-
-```swift
-// Пользовательский системный промпт (токенизируется автоматически)
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// Или использование пресета
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-Доступные пресеты: `focused` (по умолчанию), `assistant`, `customerService`, `teacher`.
-
-### CLI для PersonaPlex
-
-```bash
-make build
-
-# Базовая генерация речи из речи
-.build/release/audio respond --input question.wav --output response.wav
-
-# С транскрипцией (декодирует текст внутреннего монолога)
-.build/release/audio respond --input question.wav --transcript
-
-# JSON-вывод (путь к аудио, транскрипт, метрики задержки)
-.build/release/audio respond --input question.wav --json
-
-# Пользовательский текст системного промпта
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# Выбор голоса и пресета системного промпта
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# Настройка параметров сэмплирования
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# Ранняя остановка по энтропии текста (останавливается при схлопывании текста)
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# Список доступных голосов и промптов
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS — потоковый синтез речи с клонированием голоса
-
-### Базовый синтез
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // для WAVWriter
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// Загружает ~1.9 GB при первом запуске (LLM + DiT + веса HiFi-GAN)
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// Выход: моно-сэмплы float 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### Потоковый синтез
-
-```swift
-// Потоковый режим: получайте аудиофрагменты по мере генерации (~150мс до первого фрагмента)
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // воспроизводите сразу
-}
-```
-
-### Клонирование голоса (CosyVoice)
-
-Клонирование голоса диктора с помощью CAM++ speaker encoder (192-мерный, CoreML Neural Engine):
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// Загружает ~14 MB модели CAM++ CoreML при первом использовании
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: [Float] длиной 192
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CLI для CosyVoice TTS
-
-```bash
-make build
-
-# Базовый синтез
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# Клонирование голоса (загружает CAM++ speaker encoder при первом использовании)
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# Многоголосый диалог с клонированием голоса
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# Встроенные теги эмоций/стиля
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# Комбинация: диалог + эмоции + клонирование голоса
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# Пользовательская инструкция стиля
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# Потоковый синтез
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS — лёгкий синтез речи на устройстве (iOS + macOS)
-
-### Базовый синтез
-
-```swift
-import KokoroTTS
-import AudioCommon  // для WAVWriter
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// Загружает ~170 MB при первом запуске (CoreML-модели + голосовые эмбеддинги + словари)
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// Выход: моно-сэмплы float 24kHz
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-54 предустановленных голоса на 10 языках. Сквозная модель CoreML, неавторегрессионная, без цикла сэмплирования. Работает на Neural Engine, полностью освобождая GPU.
-
-### CLI для Kokoro TTS
-
-```bash
-make build
-
-# Базовый синтез
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# Выбор языка
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# Список доступных голосов
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-Авторегрессионный пайплайн из 6 моделей, работающий на CoreML. Палетизированные веса W8A16.
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat (локальный LLM)
+### LLM-чат — [полное руководство →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// Загружает ~318 MB при первом запуске (INT4 CoreML-модель + токенизатор)
-
-// Одиночный ответ
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// Потоковая генерация токенов
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B с INT4-квантованием для CoreML. Работает на Neural Engine со скоростью ~2 ток/с на iPhone, ~15 ток/с на M-серии. Поддерживает многоходовый диалог с KV-кешем, режим размышления (токены `<think>`), настраиваемое сэмплирование (temperature, top-k, top-p, repetition penalty).
-
-## Обнаружение голосовой активности (VAD) — детекция речи в аудио
-
-### Потоковый VAD (Silero)
-
-Silero VAD v5 обрабатывает аудиофрагменты по 32мс с субмиллисекундной задержкой — идеально для обнаружения речи в реальном времени с микрофона или потока.
+### Детектор голосовой активности — [полное руководство →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// Или используйте CoreML (Neural Engine, меньше энергопотребление):
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// Потоковый режим: обработка фрагментов по 512 сэмплов (32мс @ 16kHz)
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // вызывайте между разными аудиопотоками
-
-// Или определите все сегменты сразу
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Речь: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### Событийный потоковый режим
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// Подавайте аудио любой длины — события генерируются при подтверждении речи
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Речь началась в \(time)с")
-    case .speechEnded(let segment):
-        print("Речь: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// Завершите обработку в конце потока
-let final = processor.flush()
-```
-
-### CLI для VAD
-
-```bash
-make build
-
-# Потоковый Silero VAD (фрагменты по 32мс)
-.build/release/audio vad-stream audio.wav
-
-# CoreML-бэкенд (Neural Engine)
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# С пользовательскими порогами
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# JSON-вывод
-.build/release/audio vad-stream audio.wav --json
-
-# Пакетный pyannote VAD (скользящие окна по 10с)
-.build/release/audio vad audio.wav
-```
-
-## Диаризация спикеров — кто говорил и когда
-
-### Конвейер диаризации
+### Диаризация спикеров — [полное руководство →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// Или используйте CoreML-эмбеддинги (Neural Engine, освобождает GPU):
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Спикер \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("Обнаружено \(result.numSpeakers) спикеров")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### Голосовые эмбеддинги
+### Улучшение речи — [полное руководство →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// Или: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: [Float] длиной 256, L2-нормализованный
+import SpeechEnhancement
 
-// Сравнение спикеров
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### Извлечение спикера
-
-Извлечение сегментов конкретного спикера по эталонной записи:
+### Голосовой пайплайн (ASR → LLM → TTS) — [полное руководство →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Диаризация Sortformer (сквозная, CoreML)
+`VoicePipeline` — это конечный автомат голосового агента реального времени (на базе [speech-core](https://github.com/soniqo/speech-core)) с детекцией переключения реплик по VAD, обработкой прерываний и eager STT. Он соединяет любой `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`.
 
-NVIDIA Sortformer предсказывает покадровую активность до 4 спикеров напрямую — без эмбеддингов и кластеризации. Работает на Neural Engine.
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Спикер \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### CLI для диаризации
+### HTTP API-сервер
 
 ```bash
-make build
-
-# Диаризация Pyannote (по умолчанию)
-.build/release/audio diarize meeting.wav
-
-# Диаризация Sortformer (CoreML, Neural Engine)
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# CoreML-эмбеддинги (Neural Engine, только pyannote)
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# JSON-вывод
-.build/release/audio diarize meeting.wav --json
-
-# Извлечение конкретного спикера (только pyannote)
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# Голосовой эмбеддинг
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-Подробнее об архитектуре см. [Speaker Diarization](docs/inference/speaker-diarization.md).
-
-## Улучшение речи — подавление шума и очистка аудио
-
-### Подавление шума
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // для WAVWriter
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// Загружает ~4.3 MB при первом запуске (Core ML FP16-модель + вспомогательные данные)
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### CLI для шумоподавления
-
-```bash
-make build
-
-# Базовое подавление шума
-.build/release/audio denoise noisy.wav
-
-# Пользовательский путь вывода
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-Подробнее об архитектуре см. [Speech Enhancement](docs/inference/speech-enhancement.md).
-
-## Конвейеры — композиция нескольких моделей
-
-Все модели реализуют общие протоколы (`SpeechRecognitionModel`, `SpeechGenerationModel`, `SpeechEnhancementModel` и др.) и могут объединяться в конвейеры:
-
-### Распознавание зашумлённой речи (DeepFilterNet + ASR)
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// Улучшение на 48kHz, затем распознавание на 16kHz
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### Голосовая ретрансляция (VAD + ASR + TTS)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// Обнаружение речевых сегментов, распознавание, повторный синтез
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: моно-сэмплы float 24kHz
-}
-```
-
-### Транскрипция совещаний (диаризация + ASR)
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Спикер \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-Полный справочник протоколов см. в [Shared Protocols](docs/shared-protocols.md).
-
-## HTTP API-сервер
-
-Автономный HTTP-сервер предоставляет доступ ко всем моделям через REST и WebSocket. Модели загружаются лениво при первом запросе.
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# Распознавание речи
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# Синтез речи
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# Генерация речи из речи (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# Улучшение речи
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# Предзагрузка всех моделей при запуске
-.build/release/audio-server --preload --port 8080
-```
-
-### Потоковая передача по WebSocket
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-Основной WebSocket-эндпоинт реализует протокол [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) — все сообщения в формате JSON с полем `type`, аудио в формате base64 PCM16 24kHz моно.
-
-**События от клиента к серверу:**
-
-| Событие | Описание |
-|---------|----------|
-| `session.update` | Настройка движка, языка, аудиоформата |
-| `input_audio_buffer.append` | Отправка аудиофрагмента в base64 PCM16 |
-| `input_audio_buffer.commit` | Запуск распознавания накопленного аудио (ASR) |
-| `input_audio_buffer.clear` | Очистка аудиобуфера |
-| `response.create` | Запрос синтеза речи (TTS) |
-
-**События от сервера к клиенту:**
-
-| Событие | Описание |
-|---------|----------|
-| `session.created` | Сессия инициализирована |
-| `session.updated` | Конфигурация подтверждена |
-| `input_audio_buffer.committed` | Аудио принято для распознавания |
-| `conversation.item.input_audio_transcription.completed` | Результат ASR |
-| `response.audio.delta` | Аудиофрагмент в base64 PCM16 (TTS) |
-| `response.audio.done` | Потоковая передача аудио завершена |
-| `response.done` | Ответ завершён с метаданными |
-| `error` | Ошибка с типом и сообщением |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR: отправка аудио, получение транскрипции
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → получает: conversation.item.input_audio_transcription.completed
-
-// TTS: отправка текста, получение потокового аудио
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → получает: response.audio.delta (base64-фрагменты), response.audio.done, response.done
-```
-
-Пример HTML-клиента находится в `Examples/websocket-client.html` — откройте его в браузере при запущенном сервере.
-
-Сервер является отдельным модулем `AudioServer` и исполняемым файлом `audio-server` — он не добавляет Hummingbird/WebSocket к основному CLI `audio`.
-
-## Задержка (M2 Max, 64 GB)
-
-### ASR
-
-| Модель | Бэкенд | RTF | 10с аудио обработано за |
-|--------|--------|-----|-------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6с |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9с |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1с |
-| Parakeet-TDT-0.6B (INT8) | CoreML (Neural Engine) | ~0.09 холодный, ~0.03 прогретый | ~0.9с / ~0.3с |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0с |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4с |
-
-### Принудительное выравнивание
-
-| Модель | Фреймворк | 20с аудио | RTF |
-|--------|-----------|-----------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365мс | ~0.018 |
-
-> Один неавторегрессионный прямой проход — без цикла сэмплирования. Аудио-энкодер доминирует (~328мс), один проход декодера ~37мс. **В 55 раз быстрее реального времени.**
-
-### TTS
-
-| Модель | Фреймворк | Короткий (1с) | Средний (3с) | Длинный (6с) | Потоковый первый пакет |
-|--------|-----------|---------------|--------------|--------------|----------------------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6с (RTF 1.2) | 2.3с (RTF 0.7) | 3.9с (RTF 0.7) | ~120мс (1 кадр) |
-| Kokoro-82M | CoreML (Neural Engine) | ~1.4с (RTFx 0.7) | ~4.3с (RTFx 0.7) | ~8.6с (RTFx 0.7) | Н/Д (неавторегрессионный) |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08с | 0.08с | 0.17с (RTF 0.02) | Н/Д |
-
-> Qwen3-TTS генерирует естественную, выразительную речь с просодией и эмоциями, работая **быстрее реального времени** (RTF < 1.0). Потоковый синтез выдаёт первый аудиофрагмент за ~120мс. Kokoro-82M работает полностью на Neural Engine со сквозной моделью (RTFx ~0.7), идеально для iOS. Встроенный TTS от Apple быстрее, но производит роботизированную, монотонную речь.
-
-### PersonaPlex (генерация речи из речи)
-
-| Модель | Фреймворк | мс/шаг | RTF | Примечания |
-|--------|-----------|--------|-----|------------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112мс | ~1.4 | Рекомендуется — связные ответы, на 30% быстрее 4-bit |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158мс | ~1.97 | Не рекомендуется — ухудшенное качество |
-
-> **Используйте 8-bit.** INT8 быстрее (112 мс/шаг vs. 158 мс/шаг) и генерирует связные полнодуплексные ответы. Квантование INT4 ухудшает качество генерации, создавая бессвязную речь. INT8 работает со скоростью ~112мс/шаг на M2 Max.
-
-### VAD и голосовые эмбеддинги
-
-| Модель | Бэкенд | Задержка вызова | RTF | Примечания |
-|--------|--------|----------------|-----|------------|
-| Silero-VAD-v5 | MLX | ~2.1мс / фрагмент | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27мс / фрагмент | 0.008 | Neural Engine, **в 7.7 раз быстрее** |
-| WeSpeaker ResNet34-LM | MLX | ~310мс / 20с аудио | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430мс / 20с аудио | 0.021 | Neural Engine, освобождает GPU |
-
-> Silero VAD CoreML работает на Neural Engine в 7.7 раз быстрее MLX, что делает его идеальным для постоянного мониторинга микрофонного ввода. WeSpeaker MLX быстрее на GPU, но CoreML освобождает GPU для параллельных задач (TTS, ASR). Оба бэкенда дают эквивалентные результаты.
-
-### Улучшение речи
-
-| Модель | Бэкенд | Длительность | Задержка | RTF |
-|--------|--------|-------------|---------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5с | 0.65с | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10с | 1.2с | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20с | 4.8с | 0.24 |
-
-RTF = Real-Time Factor (чем меньше, тем лучше, < 1.0 = быстрее реального времени). Стоимость GRU растёт как ~O(n^2).
-
-### MLX и CoreML
-
-Оба бэкенда дают эквивалентные результаты. Выбирайте в зависимости от вашей задачи:
-
-| | MLX | CoreML |
-|---|---|---|
-| **Аппаратура** | GPU (Metal-шейдеры) | Neural Engine + CPU |
-| **Лучше для** | Максимальная пропускная способность, работа с одной моделью | Мультимодельные конвейеры, фоновые задачи |
-| **Энергопотребление** | Высокая загрузка GPU | Меньшее потребление, освобождает GPU |
-| **Задержка** | Быстрее для крупных моделей (WeSpeaker) | Быстрее для мелких моделей (Silero VAD) |
-
-**Настольный инференс**: MLX используется по умолчанию — максимальная производительность для одной модели на Apple Silicon. Переключайтесь на CoreML при одновременном запуске нескольких моделей (например, VAD + ASR + TTS), чтобы избежать конкуренции за GPU, или для энергозависимых задач на ноутбуках.
-
-CoreML-модели доступны для энкодера Qwen3-ASR, Silero VAD и WeSpeaker. Для Qwen3-ASR используйте `--engine qwen3-coreml` (гибрид: CoreML-энкодер на ANE + MLX текстовый декодер на GPU). Для VAD/эмбеддингов передайте `engine: .coreml` при создании — API инференса идентичен.
-
-## Бенчмарки точности
-
-### ASR — Word Error Rate ([подробности](docs/benchmarks/asr-wer.md))
-
-| Модель | WER% (LibriSpeech test-clean) | RTF |
-|--------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit превосходит Whisper Large v3 Turbo (2.5%) при сопоставимом размере. Многоязычность: 10 языков протестировано на FLEURS.
-
-### TTS — оценка через обратное распознавание ([подробности](docs/benchmarks/tts-roundtrip.md))
-
-| Движок | WER% | RTF |
-|--------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD — обнаружение речи ([подробности](docs/benchmarks/vad-detection.md))
-
-| Движок | F1% (FLEURS) | RTF |
-|--------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+Предоставляет все модели через HTTP REST + WebSocket-эндпоинты, включая совместимый с OpenAI Realtime API WebSocket по адресу `/v1/realtime`. См. [`Sources/AudioServer/`](Sources/AudioServer/).
 
 ## Архитектура
 
-**Модели:** [ASR Model](docs/models/asr-model.md), [TTS Model](docs/models/tts-model.md), [CosyVoice TTS](docs/models/cosyvoice-tts.md), [Kokoro TTS](docs/models/kokoro-tts.md), [Parakeet TDT](docs/models/parakeet-asr.md), [Parakeet Streaming](docs/models/parakeet-streaming-asr.md), [PersonaPlex](docs/models/personaplex.md), [FireRedVAD](docs/models/fireredvad.md)
+speech-swift разделён на отдельные SPM-таргеты для каждой модели, чтобы потребители платили только за то, что импортируют. Общая инфраструктура находится в `AudioCommon` (протоколы, аудио ввод/вывод, загрузчик HuggingFace, `SentencePieceModel`) и `MLXCommon` (загрузка весов, хелперы `QuantizedLinear`, хелпер `SDPA` для multi-head attention).
 
-**Инференс:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md), [Parakeet TDT](docs/inference/parakeet-asr-inference.md), [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md), [TTS Inference](docs/inference/qwen3-tts-inference.md), [Forced Aligner](docs/inference/forced-aligner.md), [FireRedVAD](docs/inference/fireredvad.md), [Silero VAD](docs/inference/silero-vad.md), [Speaker Diarization](docs/inference/speaker-diarization.md), [Speech Enhancement](docs/inference/speech-enhancement.md), [Воспроизведение аудио](docs/audio/playback.md)
+**[Полная архитектурная диаграмма с бэкендами, таблицами памяти и картой модулей → soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[Справочник API → soniqo.audio/api](https://soniqo.audio/api)** · **[Бенчмарки → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**Бенчмарки:** [ASR WER](docs/benchmarks/asr-wer.md), [TTS Round-Trip](docs/benchmarks/tts-roundtrip.md), [VAD Detection](docs/benchmarks/vad-detection.md)
+Локальная документация (в репозитории):
+- **Модели:** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **Инференс:** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [Диаризация спикеров](docs/inference/speaker-diarization.md) · [Улучшение речи](docs/inference/speech-enhancement.md)
+- **Справочник:** [Общие протоколы](docs/shared-protocols.md)
 
-**Справочник:** [Shared Protocols](docs/shared-protocols.md)
+## Настройка кэша
 
-## Настройка кеша
+Веса моделей скачиваются с HuggingFace при первом использовании и кэшируются в `~/Library/Caches/qwen3-speech/`. Переопределите с помощью `QWEN3_CACHE_DIR` (CLI) или `cacheDir:` (Swift API). Все точки входа `fromPretrained()` также принимают `offlineMode: true` для пропуска сети, когда веса уже закэшированы.
 
-Веса моделей кешируются локально в `~/Library/Caches/qwen3-speech/`.
+Подробности, включая пути в песочницах iOS-контейнеров, см. в [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md).
 
-**CLI** — переопределить через переменную окружения:
+## Metal-библиотека MLX
 
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
-
-**Swift API** — все методы `fromPretrained()` поддерживают `cacheDir` и `offlineMode`:
-
-```swift
-// Пользовательский каталог кеша (sandbox-приложения, iOS-контейнеры)
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// Офлайн-режим — пропустить сеть, если веса уже в кеше
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-Подробнее в [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md).
-
-## Библиотека MLX Metal
-
-Если при запуске появляется ошибка `Failed to load the default metallib`, библиотека Metal-шейдеров отсутствует. Выполните `make build` (или `./scripts/build_mlx_metallib.sh release` после ручной `swift build`) для её компиляции. Если Metal Toolchain отсутствует, сначала установите его:
+Если при запуске вы видите `Failed to load the default metallib`, это значит что библиотека Metal-шейдеров отсутствует. Запустите `make build` или `./scripts/build_mlx_metallib.sh release` после ручного `swift build`. Если Metal Toolchain отсутствует, сначала установите его:
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## Тестирование
 
-Юнит-тесты (конфигурация, сэмплирование, предобработка текста, коррекция временных меток) выполняются без загрузки моделей:
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # полный набор (юнит + E2E с загрузкой моделей)
+swift test --skip E2E                # только юнит-тесты (безопасно для CI, без загрузок)
+swift test --filter Qwen3ASRTests    # конкретный модуль
 ```
 
-Интеграционные тесты требуют весов моделей (загружаются автоматически при первом запуске):
+Классы E2E-тестов используют префикс `E2E`, чтобы CI мог отфильтровать их с помощью `--skip E2E`. Полное соглашение о тестировании см. в [CLAUDE.md](CLAUDE.md#testing).
 
-```bash
-# Круговая проверка TTS: синтез текста, сохранение WAV, обратное распознавание через ASR
-swift test --filter TTSASRRoundTripTests
+## Участие в разработке
 
-# Только ASR: распознавание тестового аудио
-swift test --filter Qwen3ASRIntegrationTests
-
-# E2E принудительного выравнивания: временные метки на уровне слов (~979 MB загрузка)
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# E2E PersonaPlex: конвейер генерации речи из речи (~5.5 GB загрузка)
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **Примечание:** Библиотека MLX Metal должна быть скомпилирована перед запуском тестов, использующих MLX-операции.
-> Инструкции см. в [MLX Metal Library](#библиотека-mlx-metal).
-
-## Поддерживаемые языки
-
-| Модель | Языки |
-|--------|-------|
-| Qwen3-ASR | 52 языка (CN, EN, кантонский, DE, FR, ES, JA, KO, RU, + 22 китайских диалекта, ...) |
-| Parakeet TDT | 25 европейских языков (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1 672 языка** из более чем 150 языковых семей. Включает весь набор Meta «поддерживаемых напрямую» (~1 100) плюс 500+ малоресурсных языков, добавленных через данные сообщества. Избранные: EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ... (полный список: [`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)). CTC-голова не зависит от языка — при инференсе языковая подсказка не требуется. |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT (+ пекинский/сычуаньский диалекты через CustomVoice) |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## Сравнение
-
-### Распознавание речи (ASR): speech-swift и альтернативы
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **Среда выполнения** | На устройстве (MLX/CoreML) | На устройстве (CPU/GPU) | На устройстве или облако | Только облако |
-| **Языки** | 52 | 100+ | ~70 (на устройстве: ограничено) | 125+ |
-| **RTF (10с аудио, M2 Max)** | 0.06 (в 17 раз быстрее реального) | 0.10 (Whisper-large-v3) | Н/Д | Н/Д |
-| **Потоковый режим** | Нет (пакетный) | Нет (пакетный) | Да | Да |
-| **Свои модели** | Да (замена весов HuggingFace) | Да (GGML-модели) | Нет | Нет |
-| **Swift API** | Нативный async/await | C++ с мостом в Swift | Нативный | REST/gRPC |
-| **Приватность** | Полностью на устройстве | Полностью на устройстве | Зависит от настроек | Данные отправляются в облако |
-| **Пословные метки** | Да (Forced Aligner) | Да | Ограничено | Да |
-| **Стоимость** | Бесплатно (Apache 2.0) | Бесплатно (MIT) | Бесплатно (на устройстве) | Оплата за минуту |
-
-### Синтез речи (TTS): speech-swift и альтернативы
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / Cloud TTS** |
-|---|---|---|---|---|
-| **Качество** | Нейросетевое, выразительное | Нейросетевое, естественное | Роботизированное, монотонное | Нейросетевое, наивысшее качество |
-| **Среда выполнения** | На устройстве (MLX) | На устройстве (CoreML) | На устройстве | Только облако |
-| **Потоковый режим** | Да (~120мс первый фрагмент) | Нет (сквозная модель) | Нет | Да |
-| **Клонирование голоса** | Да | Нет | Нет | Да |
-| **Голоса** | 9 встроенных + клонирование | 54 предустановленных | ~50 системных | 1000+ |
-| **Языки** | 10 | 10 | 60+ | 30+ |
-| **Поддержка iOS** | Только macOS | iOS + macOS | iOS + macOS | Любая платформа (API) |
-| **Стоимость** | Бесплатно (Apache 2.0) | Бесплатно (Apache 2.0) | Бесплатно | Оплата за символ |
-
-### Когда использовать speech-swift
-
-- **Критичная приватность** — медицина, юриспруденция, корпоративные задачи, где аудио не должно покидать устройство
-- **Офлайн-использование** — интернет не нужен после первоначальной загрузки модели
-- **Экономия** — без поминутной или посимвольной оплаты API
-- **Оптимизация для Apple Silicon** — разработан специально для GPU M-серии (Metal) и Neural Engine
-- **Полный конвейер** — ASR + TTS + VAD + диаризация + улучшение речи в одном Swift-пакете
-
-## Частые вопросы
-
-**Работает ли speech-swift на iOS?**
-Kokoro TTS, Qwen3.5-Chat (CoreML), Silero VAD, Parakeet ASR, DeepFilterNet3 и WeSpeaker работают на iOS 17+ через CoreML на Neural Engine. Модели на базе MLX (Qwen3-ASR, Qwen3-TTS, Qwen3.5-Chat MLX, PersonaPlex) требуют macOS 14+ на Apple Silicon.
-
-**Нужен ли интернет?**
-Только для первоначальной загрузки модели с HuggingFace (автоматически, кешируется в `~/Library/Caches/qwen3-speech/`). После этого весь инференс работает полностью офлайн без сетевого доступа.
-
-**Как speech-swift соотносится с Whisper?**
-Qwen3-ASR-0.6B достигает RTF 0.06 на M2 Max — на 40% быстрее, чем Whisper-large-v3 через whisper.cpp (RTF 0.10) — с сопоставимой точностью на 52 языках. speech-swift предоставляет нативный Swift API с async/await, тогда как whisper.cpp требует моста C++.
-
-**Можно ли использовать в коммерческом приложении?**
-Да. speech-swift распространяется под лицензией Apache 2.0. У весов моделей свои лицензии (проверяйте на странице HuggingFace каждой модели).
-
-**Какие чипы Apple Silicon поддерживаются?**
-Все чипы M-серии: M1, M2, M3, M4 и их варианты Pro/Max/Ultra. Требуется macOS 14+ (Sonoma) или iOS 17+.
-
-**Сколько памяти нужно?**
-От ~3 MB (Silero VAD) до ~6.5 GB (PersonaPlex 7B). Kokoro TTS использует ~500 MB, Qwen3-ASR ~2.2 GB. Полные данные см. в таблице [Требования к памяти](#требования-к-памяти).
-
-**Можно ли запускать несколько моделей одновременно?**
-Да. Используйте CoreML-модели на Neural Engine вместе с MLX-моделями на GPU, чтобы избежать конкуренции — например, Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX).
-
-**Есть ли REST API?**
-Да. Исполняемый файл `audio-server` предоставляет доступ ко всем моделям через HTTP REST и WebSocket, включая WebSocket-эндпоинт, совместимый с OpenAI Realtime API, по адресу `/v1/realtime`.
-
-## Участие в проекте
-
-Мы приветствуем вклад в проект! Будь то исправление ошибки, интеграция новой модели или улучшение документации — пулл-реквесты приветствуются.
-
-**Как начать:**
-1. Сделайте форк репозитория и создайте ветку для новой функциональности
-2. `make build` для компиляции (требуется Xcode + Metal Toolchain)
-3. `make test` для запуска тестов
-4. Откройте пулл-реквест в ветку `main`
+Приветствуются PR — исправления багов, интеграции новых моделей, документация. Сделайте форк, создайте feature-ветку, `make build && make test`, откройте PR в `main`.
 
 ## Лицензия
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,37 +1,29 @@
 # Speech Swift
 
-面向 Apple Silicon 的 AI 语音模型，基于 MLX Swift 和 CoreML 构建。
+面向 Apple Silicon 的 AI 语音模型，基于 MLX Swift 和 CoreML。
 
 📖 Read in: [English](README.md) · [中文](README_zh.md) · [日本語](README_ja.md) · [한국어](README_ko.md) · [Español](README_es.md) · [Deutsch](README_de.md) · [Français](README_fr.md) · [हिन्दी](README_hi.md) · [Português](README_pt.md) · [Русский](README_ru.md)
 
-端侧语音识别、合成与理解，适用于 Mac 和 iOS。完全在 Apple Silicon 上本地运行——无需云端、无需 API 密钥、数据不出设备。
+端侧语音识别、合成与理解，适用于 Mac 与 iOS。完全在 Apple Silicon 上本地运行——无需云端、无需 API 密钥、数据不出设备。
 
-通过 [Homebrew 安装](#homebrew)或作为 Swift Package 依赖引入。
+**[📚 完整文档 →](https://soniqo.audio)** · **[🤗 HuggingFace 模型](https://huggingface.co/aufklarer)** · **[📝 博客](https://blog.ivan.digital)**
 
-**[文档](https://soniqo.audio)** · **[HuggingFace 模型](https://huggingface.co/aufklarer)** · **[博客](https://blog.ivan.digital)**
+- **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — 语音转文字（自动语音识别，52 种语言，MLX + CoreML）
+- **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — 通过 CoreML 进行语音转文字（神经引擎，NVIDIA FastConformer + TDT 解码器，25 种语言）
+- **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — 语音转文字（Meta wav2vec2 + CTC，**1,672 种语言**，覆盖 32 种文字系统，CoreML 300M + MLX 300M/1B/3B/7B）
+- **[流式听写](https://soniqo.audio/guides/dictate)** — 带部分结果和句末检测的实时听写（Parakeet-EOU-120M）
+- **[Qwen3-ForcedAligner](https://soniqo.audio/guides/align)** — 词级时间戳对齐（音频 + 文本 → 时间戳）
+- **[Qwen3-TTS](https://soniqo.audio/guides/speak)** — 文本转语音（最高质量、流式输出、自定义说话人，10 种语言）
+- **[CosyVoice TTS](https://soniqo.audio/guides/cosyvoice)** — 流式 TTS，支持声音克隆、多说话人对话、情感标签（9 种语言）
+- **[Kokoro TTS](https://soniqo.audio/guides/kokoro)** — 端侧 TTS（82M，CoreML/神经引擎，54 种音色，iOS 就绪，10 种语言）
+- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — 端侧 LLM 对话（0.8B，MLX INT4 + CoreML INT8，DeltaNet 混合架构，流式 token）
+- **[PersonaPlex](https://soniqo.audio/guides/respond)** — 全双工语音到语音（7B，音频输入 → 音频输出，18 种预设音色）
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — 实时噪声抑制（2.1M 参数，48 kHz）
+- **[VAD](https://soniqo.audio/guides/vad)** — 语音活动检测（Silero 流式、Pyannote 离线、FireRedVAD 100+ 种语言）
+- **[说话人分离](https://soniqo.audio/guides/diarize)** — 谁在什么时间说话（Pyannote 流水线，神经引擎上的端到端 Sortformer）
+- **[说话人嵌入向量](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34（256 维）、CAM++（192 维）
 
-- **Qwen3-ASR** — 语音转文字 / 语音识别（自动语音识别，支持 52 种语言）
-- **Parakeet TDT** — 通过 CoreML 进行语音转文字（神经引擎，NVIDIA FastConformer + TDT 解码器，25 种语言）
-- **Omnilingual ASR** — 通过 CoreML 进行语音转文字（Meta wav2vec2 + CTC，**1,672 种语言**，覆盖 150+ 个语系，5/10 秒窗口，INT8 调色板量化，ANE）
-- **Qwen3-ForcedAligner** — 词级时间戳对齐（音频 + 文本 → 时间戳）
-- **Qwen3-TTS** — 文本转语音合成（最高质量，流式输出，自定义说话人，10 种语言）
-- **CosyVoice TTS** — 支持流式合成、声音克隆、多说话人对话和情感标签的文本转语音（9 种语言，DiT flow matching，CAM++ 说话人编码器）
-- **Kokoro TTS** — 端侧文本转语音（82M 参数，CoreML/神经引擎，54 种音色，iOS 就绪，10 种语言）
-- **Qwen3-TTS CoreML** — 文本转语音（0.6B，CoreML 6 模型流水线，W8A16，iOS/macOS）
-- **Qwen3.5-Chat** — 端侧 LLM 对话（0.8B，MLX + CoreML，INT4/INT8，DeltaNet 混合架构，流式 token）
-- **PersonaPlex** — 全双工语音到语音对话（7B，音频输入 → 音频输出，18 种预设音色）
-- **DeepFilterNet3** — 语音增强 / 噪声抑制（2.1M 参数，实时 48kHz）
-- **FireRedVAD** — 离线语音活动检测（DFSMN，CoreML，100+ 种语言，97.6% F1）
-- **Silero VAD** — 流式语音活动检测（32ms 分块，亚毫秒延迟）
-- **Pyannote VAD** — 离线语音活动检测（10 秒窗口，多说话人重叠）
-- **说话人分离** — 谁在什么时间说话（Pyannote 分割 + 基于活动的说话人链接，或基于神经引擎的端到端 Sortformer）
-- **说话人嵌入向量** — 说话人验证与识别（WeSpeaker ResNet34，256 维向量）
-
-论文：[Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba), [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba), [Qwen3](https://arxiv.org/abs/2505.09388) (Alibaba), [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA), [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba), [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2), [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA), [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai), [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
-
-## 路线图
-
-请查看[路线图讨论](https://github.com/soniqo/speech-swift/discussions/81)了解未来计划——欢迎评论和建议！
+论文：[Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
 ## 动态
 
@@ -45,10 +37,10 @@
 将依赖添加到你的 `Package.swift`：
 
 ```swift
-.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.8")
+.package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ```
 
-只引入你需要的模块——每个模型都是独立的 SPM 库：
+只引入你需要的模块——每个模型都是独立的 SPM 库，不用为你不使用的东西买单：
 
 ```swift
 .product(name: "ParakeetStreamingASR", package: "speech-swift"),
@@ -64,7 +56,7 @@ let model = try await ParakeetStreamingASRModel.fromPretrained()
 let text = try model.transcribeAudio(audioSamples, sampleRate: 16000)
 ```
 
-**带部分结果的实时流式转写：**
+**带部分结果的实时流式：**
 
 ```swift
 for await partial in model.transcribeStream(audio: samples, sampleRate: 16000) {
@@ -96,128 +88,85 @@ struct DictateView: View {
 }
 ```
 
-`SpeechUI` 只包含 `TranscriptionView`（最终结果 + 部分结果）和 `TranscriptionStore`（流式 ASR 适配器）。音频可视化和播放请使用 AVFoundation。
+`SpeechUI` 只提供 `TranscriptionView`（最终结果 + 部分结果）与 `TranscriptionStore`（流式 ASR 适配器）。音频可视化和播放请使用 AVFoundation。
 
-可用的 SPM 产品：`Qwen3ASR`、`Qwen3TTS`、`Qwen3TTSCoreML`、`ParakeetASR`、`ParakeetStreamingASR`、`OmnilingualASR`、`KokoroTTS`、`CosyVoiceTTS`、`PersonaPlex`、`SpeechVAD`、`SpeechEnhancement`、`Qwen3Chat`、`SpeechCore`、`SpeechUI`、`AudioCommon`。
+可用的 SPM products：`Qwen3ASR`、`Qwen3TTS`、`Qwen3TTSCoreML`、`ParakeetASR`、`ParakeetStreamingASR`、`OmnilingualASR`、`KokoroTTS`、`CosyVoiceTTS`、`PersonaPlex`、`SpeechVAD`、`SpeechEnhancement`、`Qwen3Chat`、`SpeechCore`、`SpeechUI`、`AudioCommon`。
 
 ## 模型
 
-| 模型 | 任务 | 流式 | 语言 | 规格 |
-|------|------|------|------|------|
-| Qwen3-ASR-0.6B | 语音 → 文本 | 否 | 52 种语言 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-4bit) 680 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-0.6B-MLX-8bit) 1.0 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML) 180 MB |
-| Qwen3-ASR-1.7B | 语音 → 文本 | 否 | 52 种语言 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-4bit) 2.1 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ASR-1.7B-MLX-8bit) 3.2 GB |
-| Parakeet-TDT-0.6B | 语音 → 文本 | 否 | 25 种欧洲语言 | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) 500 MB |
-| Parakeet-EOU-120M | 语音 → 文本 | 是 (流式 + EOU) | 25 种欧洲语言 | [CoreML INT8](https://huggingface.co/aufklarer/Parakeet-EOU-120M-CoreML-INT8) ~120 MB |
-| Omnilingual-ASR-CTC-300M | 语音 → 文本 | 否 (5/10 秒窗口) | [1,672 种语言](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [CoreML INT8 (10s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) 312 MB · [CoreML INT8 (5s)](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8) 312 MB · [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-4bit) 193 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-300M-MLX-8bit) 342 MB |
-| Omnilingual-ASR-CTC-1B | 语音 → 文本 | 否 | [1,672 种语言](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-4bit) 549 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-1B-MLX-8bit) 1006 MB |
-| Omnilingual-ASR-CTC-3B | 语音 → 文本 | 否 | [1,672 种语言](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-4bit) 1709 MB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-3B-MLX-8bit) 3159 MB |
-| Omnilingual-ASR-CTC-7B | 语音 → 文本 | 否 | [1,672 种语言](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py) | [MLX 4-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-4bit) 3.55 GB · [MLX 8-bit](https://huggingface.co/aufklarer/Omnilingual-ASR-CTC-7B-MLX-8bit) 6.63 GB |
-| Qwen3-ForcedAligner-0.6B | 音频 + 文本 → 时间戳 | 否 | 多语言 | [4-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-4bit) 979 MB · [8-bit](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-8bit) 1.4 GB · [CoreML INT4](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4) 630 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8) 1.0 GB |
-| Qwen3-TTS-0.6B Base | 文本 → 语音 | 是 (~120ms) | 10 种语言 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit) 1.7 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit) 2.4 GB · [CoreML](https://huggingface.co/aufklarer/Qwen3-TTS-CoreML) 1.0 GB |
-| Qwen3-TTS-0.6B CustomVoice | 文本 → 语音 | 是 (~120ms) | 10 种语言 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit) 1.7 GB |
-| Qwen3-TTS-1.7B Base | 文本 → 语音 | 是 (~120ms) | 10 种语言 | [4-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit) 3.2 GB · [8-bit](https://huggingface.co/aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit) 4.8 GB |
-| CosyVoice3-0.5B | 文本 → 语音 | 是 (~150ms) | 9 种语言 | [4-bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) 1.2 GB |
-| Kokoro-82M | 文本 → 语音 | 否 | 10 种语言 | [CoreML](https://huggingface.co/aufklarer/Kokoro-82M-CoreML) ~170 MB |
-| Qwen3.5-0.8B Chat | Text → Text (LLM) | Yes (streaming) | Multi | [MLX INT4](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-MLX) 418 MB · [CoreML INT8](https://huggingface.co/aufklarer/Qwen3.5-0.8B-Chat-CoreML) 981 MB |
-| PersonaPlex-7B | 语音 → 语音 | 是 (~2s 分块) | EN | [4-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-4bit) 4.9 GB · [8-bit](https://huggingface.co/aufklarer/PersonaPlex-7B-MLX-8bit) 9.1 GB |
-| FireRedVAD | 语音活动检测 | 否（离线） | 100+ 种语言 | [CoreML](https://huggingface.co/aufklarer/FireRedVAD-CoreML) ~1.2 MB |
-| Silero-VAD-v5 | 语音活动检测 | 是 (32ms 分块) | 语言无关 | [MLX](https://huggingface.co/aufklarer/Silero-VAD-v5-MLX) · [CoreML](https://huggingface.co/aufklarer/Silero-VAD-v5-CoreML) ~1.2 MB |
-| Pyannote-Segmentation-3.0 | VAD + 说话人分割 | 否 (10s 窗口) | 语言无关 | [MLX](https://huggingface.co/aufklarer/Pyannote-Segmentation-MLX) ~5.7 MB |
-| DeepFilterNet3 | 语音增强 | 是 (10ms 帧) | 语言无关 | [CoreML FP16](https://huggingface.co/aufklarer/DeepFilterNet3-CoreML) ~4.2 MB |
-| WeSpeaker-ResNet34-LM | 说话人嵌入向量 (256 维) | 否 | 语言无关 | [MLX](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-MLX) · [CoreML](https://huggingface.co/aufklarer/WeSpeaker-ResNet34-LM-CoreML) ~25 MB |
-| CAM++ | 说话人嵌入向量 (192 维) | 否 | 语言无关 | [CoreML](https://huggingface.co/aufklarer/CamPlusPlus-Speaker-CoreML) ~14 MB |
-| Sortformer | 说话人分离（端到端） | 是（分块） | 语言无关 | [CoreML](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) ~240 MB |
+下方是精简视图。**[完整模型目录（含大小、量化方式、下载地址、内存表）→ soniqo.audio/architecture](https://soniqo.audio/architecture)**。
 
-### 内存需求
-
-权重内存指模型参数占用的 GPU (MLX) 或 ANE (CoreML) 内存。峰值推理内存包括 KV 缓存、激活值和中间张量。
-
-| 模型 | 权重内存 | 峰值推理内存 |
-|------|---------|-------------|
-| Qwen3-ASR-0.6B (4-bit, MLX) | 675 MB | ~2.2 GB |
-| Qwen3-ASR-0.6B (INT8, CoreML) | 180 MB | ~400 MB |
-| Qwen3-ASR-1.7B (8-bit, MLX) | 2,349 MB | ~4 GB |
-| Parakeet-TDT-0.6B (CoreML) | 315 MB | ~400 MB |
-| Parakeet-EOU-120M (CoreML) | ~120 MB | ~200 MB |
-| Omnilingual-ASR-CTC-300M (CoreML INT8) | 312 MB | ~600 MB |
-| Qwen3-ForcedAligner-0.6B (4-bit, MLX) | 933 MB | ~1.5 GB |
-| Qwen3-TTS-1.7B (4-bit, MLX) | 2,300 MB | ~4–6 GB |
-| Qwen3-TTS-0.6B (4-bit, MLX) | 977 MB | ~2 GB |
-| CosyVoice3-0.5B (4-bit, MLX) | 732 MB | ~2.5 GB |
-| Kokoro-82M (CoreML) | 170 MB | ~200 MB |
-| Qwen3.5-Chat-0.8B (INT4, MLX) | 418 MB | ~700 MB |
-| Qwen3.5-Chat-0.8B (INT8, CoreML) | 981 MB | ~1.2 GB |
-| PersonaPlex-7B (8-bit, MLX) | 9,100 MB | ~11 GB |
-| PersonaPlex-7B (4-bit, MLX) | 4,900 MB | ~6.5 GB |
-| Silero-VAD-v5 (MLX) | 1.2 MB | ~5 MB |
-| Silero-VAD-v5 (CoreML) | 0.7 MB | ~3 MB |
-| Pyannote-Segmentation-3.0 (MLX) | 6 MB | ~20 MB |
-| DeepFilterNet3 (CoreML FP16) | 4.2 MB | ~10 MB |
-| WeSpeaker-ResNet34-LM (MLX) | 25 MB | ~50 MB |
-
-### TTS 引擎选择指南
-
-- **Qwen3-TTS**：最佳质量，流式合成 (~120ms)，9 种内置说话人，10 种语言，批量合成
-- **CosyVoice TTS**：流式合成 (~150ms)，9 种语言，声音克隆（CAM++ 说话人编码器），多说话人对话（`[S1] ... [S2] ...`），行内情感/风格标签（`(happy)`、`(whispers)`），DiT flow matching + HiFi-GAN 声码器
-- **Kokoro TTS**：轻量级 iOS 就绪 TTS（82M 参数），CoreML/神经引擎，54 种音色，10 种语言，端到端模型
-- **PersonaPlex**：全双工语音到语音（音频输入 → 音频输出），流式 (~2s 分块)，18 种预设音色，基于 Moshi 架构
+| 模型 | 任务 | 后端 | 大小 | 语言 |
+|-------|------|----------|-------|-----------|
+| [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | 语音 → 文字 | MLX、CoreML（混合） | 0.6B、1.7B | 52 |
+| [Parakeet TDT](https://soniqo.audio/guides/parakeet) | 语音 → 文字 | CoreML (ANE) | 0.6B | 25 种欧洲语言 |
+| [Parakeet EOU](https://soniqo.audio/guides/dictate) | 语音 → 文字（流式） | CoreML (ANE) | 120M | 25 种欧洲语言 |
+| [Omnilingual ASR](https://soniqo.audio/guides/omnilingual) | 语音 → 文字 | CoreML (ANE)、MLX | 300M / 1B / 3B / 7B | **[1,672](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)** |
+| [Qwen3-ForcedAligner](https://soniqo.audio/guides/align) | 音频 + 文本 → 时间戳 | MLX、CoreML | 0.6B | 多语言 |
+| [Qwen3-TTS](https://soniqo.audio/guides/speak) | 文本 → 语音 | MLX、CoreML | 0.6B、1.7B | 10 |
+| [CosyVoice3](https://soniqo.audio/guides/cosyvoice) | 文本 → 语音 | MLX | 0.5B | 9 |
+| [Kokoro-82M](https://soniqo.audio/guides/kokoro) | 文本 → 语音 | CoreML (ANE) | 82M | 10 |
+| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | 文本 → 文本（LLM） | MLX、CoreML | 0.8B | 多语言 |
+| [PersonaPlex](https://soniqo.audio/guides/respond) | 语音 → 语音 | MLX | 7B | EN |
+| [Silero VAD](https://soniqo.audio/guides/vad) | 语音活动检测 | MLX、CoreML | 309K | 语言无关 |
+| [Pyannote](https://soniqo.audio/guides/diarize) | VAD + 说话人分离 | MLX | 1.5M | 语言无关 |
+| [Sortformer](https://soniqo.audio/guides/diarize) | 说话人分离（端到端） | CoreML (ANE) | — | 语言无关 |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | 语音增强 | CoreML | 2.1M | 语言无关 |
+| [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | 说话人嵌入向量 | MLX、CoreML | 6.6M | 语言无关 |
 
 ## 安装
 
 ### Homebrew
 
-需要原生 ARM Homebrew (`/opt/homebrew`)。不支持 Rosetta/x86_64 Homebrew。
+需要原生 ARM Homebrew（`/opt/homebrew`），不支持 Rosetta/x86_64 Homebrew。
 
 ```bash
 brew tap soniqo/speech https://github.com/soniqo/speech-swift
 brew install speech
 ```
 
-使用方式：
+然后：
 
 ```bash
 audio transcribe recording.wav
 audio speak "Hello world"
-audio speak "Hello world" --engine coreml                      # CoreML（神经引擎）
-audio speak "Hallo Welt" --engine cosyvoice --language german
 audio respond --input question.wav --transcript
 ```
 
-> 如需使用麦克风进行交互式语音对话，请参见 **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**。
+**[完整 CLI 参考 →](https://soniqo.audio/cli)**
 
 ### Swift Package Manager
 
-在 `Package.swift` 中添加：
-
 ```swift
 dependencies: [
-    .package(url: "https://github.com/soniqo/speech-swift", branch: "main")
+    .package(url: "https://github.com/soniqo/speech-swift", from: "0.0.9")
 ]
 ```
 
-导入所需模块：
+只引入你需要的模块——每个模型都是独立的 SPM target：
 
 ```swift
-import Qwen3ASR      // 语音识别 (MLX)
-import ParakeetASR   // 语音识别 (CoreML)
-import Qwen3TTS      // 文本转语音 (Qwen3)
-import CosyVoiceTTS  // 文本转语音（流式）
-import KokoroTTS     // 文本转语音 (CoreML, iOS 就绪)
-import Qwen3Chat     // 端侧 LLM 对话 (CoreML)
-import PersonaPlex   // 语音到语音（全双工）
-import SpeechVAD          // 语音活动检测 (pyannote + Silero)
-import SpeechEnhancement  // 噪声抑制 (DeepFilterNet3)
-import AudioCommon        // 共享工具库
+import Qwen3ASR             // 语音识别 (MLX)
+import ParakeetASR          // 语音识别 (CoreML，批量)
+import ParakeetStreamingASR // 带部分结果和 EOU 的流式听写
+import OmnilingualASR       // 1,672 种语言 (CoreML + MLX)
+import Qwen3TTS             // 文本转语音
+import CosyVoiceTTS         // 带声音克隆的文本转语音
+import KokoroTTS            // 文本转语音 (iOS 就绪)
+import Qwen3Chat            // 端侧 LLM 对话
+import PersonaPlex          // 全双工语音到语音
+import SpeechVAD            // VAD + 说话人分离 + 嵌入向量
+import SpeechEnhancement    // 噪声抑制
+import SpeechUI             // 流式转写的 SwiftUI 组件
+import AudioCommon          // 共享协议与工具
 ```
 
-### 系统要求
+### 环境要求
 
-- Swift 5.9+
-- macOS 14+ 或 iOS 17+
-- Apple Silicon (M1/M2/M3/M4)
-- Xcode 15+（需安装 Metal Toolchain——如缺失请运行 `xcodebuild -downloadComponent MetalToolchain`）
+- Swift 5.9+、Xcode 15+（含 Metal Toolchain）
+- macOS 14+ 或 iOS 17+、Apple Silicon（M1/M2/M3/M4）
 
-### 从源码构建
+### 从源代码构建
 
 ```bash
 git clone https://github.com/soniqo/speech-swift
@@ -225,1021 +174,159 @@ cd speech-swift
 make build
 ```
 
-此命令一步完成 Swift 包编译**和** MLX Metal 着色器库构建。Metal 库 (`mlx.metallib`) 是 GPU 推理所必需的——缺少它运行时会报 `Failed to load the default metallib` 错误。
+`make build` 会同时编译 Swift 包**和** MLX Metal 着色器库。Metal 库是 GPU 推理所必需的——若缺失，运行时会出现 `Failed to load the default metallib`。`make debug` 用于调试构建，`make test` 运行测试套件。
 
-调试构建：`make debug`。运行单元测试：`make test`。
+**[完整构建与安装指南 →](https://soniqo.audio/getting-started)**
 
-## 体验语音助手
+## 演示应用
 
-**[PersonaPlexDemo](Examples/PersonaPlexDemo/)** 是一个即开即用的 macOS 语音助手——点击说话，实时获取语音回复。使用麦克风输入配合 Silero VAD 自动检测语音，Qwen3-ASR 进行转录，PersonaPlex 7B 生成语音到语音的回复。支持多轮对话，18 种预设音色，并可显示内心独白转录。
+- **[DictateDemo](Examples/DictateDemo/)**（[文档](https://soniqo.audio/guides/dictate)）— macOS 菜单栏流式听写，带实时部分结果、VAD 驱动的句末检测、一键复制。以后台 agent 方式运行（Parakeet-EOU-120M + Silero VAD）。
+- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS 回声 demo（Parakeet ASR + Kokoro TTS）。支持设备和模拟器。
+- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — 带麦克风输入、VAD 和多轮上下文的对话式语音助手。macOS。M2 Max 上 RTF 约 0.94（快于实时）。
+- **[SpeechDemo](Examples/SpeechDemo/)** — 标签式界面中的听写与 TTS 合成。macOS。
 
-```bash
-make build  # 在仓库根目录运行——构建所有内容包括 MLX metallib
-cd Examples/PersonaPlexDemo
-# 参见 Examples/PersonaPlexDemo/README.md 了解 .app 打包说明
-```
+每个 demo 的 README 都包含构建说明。
 
-> M2 Max 上 RTF ~0.94（快于实时）。首次运行时模型自动下载（PersonaPlex ~5.5 GB + ASR ~400 MB）。
+## 代码示例
 
-## 示例应用
+下方代码片段展示每个领域的最小使用路径。每一节都链接到 [soniqo.audio](https://soniqo.audio) 上的完整指南，涵盖配置选项、多种后端、流式模式和 CLI 示例。
 
-- **[DictateDemo](Examples/DictateDemo/)** ([文档](https://soniqo.audio/guides/dictate/)) — macOS 菜单栏流式听写，带实时部分结果、VAD 驱动的语句结束检测和一键复制。作为后台菜单栏代理运行（Parakeet-EOU-120M + Silero VAD）。
-- **[iOSEchoDemo](Examples/iOSEchoDemo/)** — iOS 回声演示（Parakeet ASR + Kokoro TTS，说话后听到回放）。支持设备和模拟器。
-- **[PersonaPlexDemo](Examples/PersonaPlexDemo/)** — 对话式语音助手（麦克风输入、VAD、多轮对话）。macOS。
-- **[SpeechDemo](Examples/SpeechDemo/)** — 听写与文本转语音合成，标签式界面。macOS。
-
-构建并运行——各示例应用的 README 中有详细说明。
-
-## 语音转文字 (ASR)——Swift 音频转录
-
-### 基础转录
+### 语音转文字 — [完整指南 →](https://soniqo.audio/guides/transcribe)
 
 ```swift
 import Qwen3ASR
 
-// 默认：0.6B 模型
 let model = try await Qwen3ASRModel.fromPretrained()
-
-// 或使用更大的 1.7B 模型以获得更高精度
-let model = try await Qwen3ASRModel.fromPretrained(
-    modelId: "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
-)
-
-// 音频可以是任意采样率——内部自动重采样至 16kHz
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-print(transcription)
+let text = model.transcribe(audio: audioSamples, sampleRate: 16000)
 ```
 
-### CoreML 编码器（神经引擎）
+其他后端：[Parakeet TDT](https://soniqo.audio/guides/parakeet)（CoreML，32× 实时）、[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)（1,672 种语言，CoreML 或 MLX）、[流式听写](https://soniqo.audio/guides/dictate)（实时部分结果）。
 
-混合模式：CoreML 编码器运行在神经引擎上 + MLX 文本解码器运行在 GPU 上。更低功耗，编码器推理时释放 GPU。
-
-```swift
-import Qwen3ASR
-
-let encoder = try await CoreMLASREncoder.fromPretrained()
-let model = try await Qwen3ASRModel.fromPretrained()
-let text = try model.transcribe(audio: audioSamples, sampleRate: 16000, coremlEncoder: encoder)
-```
-
-提供 INT8（180 MB，默认）和 INT4（90 MB）两种量化版本。推荐使用 INT8（与 FP32 的余弦相似度 > 0.999）。
-
-### Parakeet TDT (CoreML)
-
-```swift
-import ParakeetASR
-
-let model = try await ParakeetASRModel.fromPretrained()
-let transcription = model.transcribe(audio: audioSamples, sampleRate: 16000)
-```
-
-通过 CoreML 在神经引擎上运行——释放 GPU 用于并行任务。支持 25 种欧洲语言，约 315 MB。
-
-### ASR 命令行
-
-```bash
-make build  # 或: swift build -c release && ./scripts/build_mlx_metallib.sh release
-
-# 默认 (Qwen3-ASR 0.6B, MLX)
-.build/release/audio transcribe audio.wav
-
-# 使用 1.7B 模型
-.build/release/audio transcribe audio.wav --model 1.7B
-
-# CoreML 编码器（神经引擎 + MLX 解码器）
-.build/release/audio transcribe --engine qwen3-coreml audio.wav
-
-# Parakeet TDT (CoreML, 神经引擎)
-.build/release/audio transcribe --engine parakeet audio.wav
-```
-
-## 强制对齐
-
-### 词级时间戳
+### 强制对齐 — [完整指南 →](https://soniqo.audio/guides/align)
 
 ```swift
 import Qwen3ASR
 
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
-// 首次运行下载约 979 MB
-
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
-
 for word in aligned {
-    print("[\(String(format: "%.2f", word.startTime))s - \(String(format: "%.2f", word.endTime))s] \(word.text)")
+    print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```
 
-### 强制对齐命令行
-
-```bash
-swift build -c release
-
-# 使用提供的文本进行对齐
-.build/release/audio align audio.wav --text "Hello world"
-
-# 先转录，再对齐
-.build/release/audio align audio.wav
-```
-
-输出：
-```
-[0.12s - 0.45s] Can
-[0.45s - 0.72s] you
-[0.72s - 1.20s] guarantee
-...
-```
-
-端到端模型，非自回归，无采样循环。架构详情请参阅[强制对齐器](docs/inference/forced-aligner.md)。
-
-## 文本转语音 (TTS)——Swift 语音合成
-
-### 基础合成
+### 文本转语音 — [完整指南 →](https://soniqo.audio/guides/speak)
 
 ```swift
 import Qwen3TTS
-import AudioCommon  // for WAVWriter
+import AudioCommon
 
 let model = try await Qwen3TTSModel.fromPretrained()
-// 首次运行下载约 1.7 GB（模型 + 编解码器权重）
 let audio = model.synthesize(text: "Hello world", language: "english")
-// 输出为 24kHz 单声道浮点采样
 try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
 ```
 
-### TTS 命令行
+其他 TTS 引擎：[CosyVoice3](https://soniqo.audio/guides/cosyvoice)（流式 + 声音克隆 + 情感标签）、[Kokoro-82M](https://soniqo.audio/guides/kokoro)（iOS 就绪，54 种音色）、[声音克隆](https://soniqo.audio/guides/voice-cloning)。
 
-```bash
-make build
-.build/release/audio speak "Hello world" --output output.wav --language english
-```
-
-### 自定义音色 / 说话人选择
-
-**CustomVoice** 模型变体支持 9 种内置说话人音色和自然语言指令控制语调/风格。通过传入 CustomVoice 模型 ID 加载：
-
-```swift
-import Qwen3TTS
-
-// 加载 CustomVoice 模型（首次运行下载约 1.7 GB）
-let model = try await Qwen3TTSModel.fromPretrained(
-    modelId: TTSModelVariant.customVoice.rawValue
-)
-
-// 使用指定说话人合成
-let audio = model.synthesize(text: "Hello world", language: "english", speaker: "vivian")
-
-// 列出可用说话人
-print(model.availableSpeakers)  // ["aiden", "dylan", "eric", ...]
-```
-
-命令行：
-
-```bash
-# 使用 CustomVoice 模型并指定说话人
-.build/release/audio speak "Hello world" --model customVoice --speaker vivian --output vivian.wav
-
-# 列出可用说话人
-.build/release/audio speak --model customVoice --list-speakers
-```
-
-### 声音克隆（Base 模型）
-
-从参考音频克隆说话人的声音。两种模式：
-
-**ICL 模式**（推荐）——使用转录文本将参考音频编码为编解码器 token。质量更高，EOS 可靠：
-
-```swift
-let (model, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 24000)
-let audio = model.synthesizeWithVoiceCloneICL(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    referenceText: "Exact transcript of reference audio.",
-    language: "english",
-    codecEncoder: encoder
-)
-```
-
-**X-vector 模式**——仅使用说话人嵌入向量，无需转录文本但质量较低：
-
-```swift
-let audio = model.synthesizeWithVoiceClone(
-    text: "Hello world",
-    referenceAudio: refAudio,
-    referenceSampleRate: 24000,
-    language: "english"
-)
-```
-
-命令行：
-
-```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
-```
-
-### 语调 / 风格指令（仅 CustomVoice）
-
-CustomVoice 模型支持自然语言 `instruct` 参数来控制说话风格、语调、情感和语速。指令以 ChatML 格式添加到模型输入的前面。
-
-```swift
-// 欢快语调
-let audio = model.synthesize(
-    text: "Welcome to our store!",
-    language: "english",
-    speaker: "ryan",
-    instruct: "Speak in a cheerful, upbeat tone"
-)
-
-// 缓慢而严肃
-let audio = model.synthesize(
-    text: "We regret to inform you...",
-    language: "english",
-    speaker: "aiden",
-    instruct: "Read this slowly and solemnly"
-)
-
-// 耳语
-let audio = model.synthesize(
-    text: "Can you keep a secret?",
-    language: "english",
-    speaker: "vivian",
-    instruct: "Whisper this softly"
-)
-```
-
-命令行：
-
-```bash
-# 带风格指令
-.build/release/audio speak "Good morning!" --model customVoice --speaker ryan \
-    --instruct "Speak in a cheerful, upbeat tone" --output cheerful.wav
-
-# 使用 CustomVoice 时默认自动应用 instruct ("Speak naturally.")
-.build/release/audio speak "Hello world" --model customVoice --speaker ryan --output natural.wav
-```
-
-使用 CustomVoice 模型时若未提供 `--instruct`，会自动应用 `"Speak naturally."` 以防止输出过长。Base 模型不支持 instruct。
-
-### 批量合成
-
-在单次批量前向推理中合成多段文本，提高吞吐量：
-
-```swift
-let texts = ["Good morning everyone.", "The weather is nice today.", "Please open the window."]
-let audioList = model.synthesizeBatch(texts: texts, language: "english", maxBatchSize: 4)
-// audioList[i] 是 texts[i] 对应的 24kHz 单声道浮点采样
-for (i, audio) in audioList.enumerated() {
-    try WAVWriter.write(samples: audio, sampleRate: 24000, to: URL(fileURLWithPath: "output_\(i).wav"))
-}
-```
-
-#### 批量命令行
-
-```bash
-# 创建一个每行一段文本的文件
-echo "Hello world.\nGoodbye world." > texts.txt
-.build/release/audio speak --batch-file texts.txt --output output.wav --batch-size 4
-# 生成 output_0.wav, output_1.wav, ...
-```
-
-> 批量模式将模型权重加载成本分摊到多个项目上。在 Apple Silicon 上 B=4 时预计可获得约 1.5-2.5 倍的吞吐量提升。文本生成长度相近时效果最佳。
-
-### 采样选项
-
-```swift
-let config = SamplingConfig(temperature: 0.9, topK: 50, repetitionPenalty: 1.05)
-let audio = model.synthesize(text: "Hello", language: "english", sampling: config)
-```
-
-### 流式合成
-
-增量输出音频分块，降低首包延迟：
-
-```swift
-let stream = model.synthesizeStream(
-    text: "Hello, this is streaming synthesis.",
-    language: "english",
-    streaming: .lowLatency  // 首个音频分块约 120ms
-)
-
-for try await chunk in stream {
-    // chunk.samples: [Float] PCM @ 24kHz
-    // chunk.isFinal: 最后一个分块时为 true
-    playAudio(chunk.samples)
-}
-```
-
-命令行：
-
-```bash
-# 默认流式（3 帧首块，约 225ms 延迟）
-.build/release/audio speak "Hello world" --stream
-
-# 低延迟（1 帧首块，约 120ms 延迟）
-.build/release/audio speak "Hello world" --stream --first-chunk-frames 1
-```
-
-## 语音到语音——全双工语音对话
-
-> 如需使用麦克风进行交互式语音助手体验，请参见 **[PersonaPlexDemo](Examples/PersonaPlexDemo/)**——点击说话，支持多轮对话和自动语音检测。
-
-### 语音到语音
+### 语音到语音 — [完整指南 →](https://soniqo.audio/guides/respond)
 
 ```swift
 import PersonaPlex
-import AudioCommon  // for WAVWriter, AudioFileLoader
 
 let model = try await PersonaPlexModel.fromPretrained()
-// 首次运行下载约 5.5 GB（temporal 4-bit + depformer + Mimi 编解码器 + 音色预设）
-
-let audio = try AudioFileLoader.load(url: inputURL, targetSampleRate: 24000)
-let (response, textTokens) = model.respond(userAudio: audio, voice: .NATM0)
-// response: 24kHz 单声道浮点采样
-// textTokens: 模型的内心独白（SentencePiece token ID）
-try WAVWriter.write(samples: response.audio, sampleRate: 24000, to: outputURL)
+let responseAudio = model.respond(userAudio: userSamples)
+// 24 kHz 单声道 Float32 输出，可直接播放
 ```
 
-### 内心独白（文本输出）
-
-PersonaPlex 在生成音频的同时也生成文本 token——这是模型的内部推理过程。使用内置的 SentencePiece 解码器进行解码：
-
-```swift
-let decoder = try SentencePieceDecoder(modelPath: "tokenizer_spm_32k_3.model")
-let transcript = decoder.decode(textTokens)
-print(transcript)  // 例如 "Sure, I can help you with that..."
-```
-
-### 流式语音到语音
-
-```swift
-// 在生成过程中接收音频分块（每块约 2 秒）
-let stream = model.respondStream(userAudio: audio, voice: .NATM0)
-for try await chunk in stream {
-    playAudio(chunk.samples)  // 即时播放，24kHz 单声道
-    // chunk.textTokens 包含此分块的文本；最后一个分块包含所有 token
-    if chunk.isFinal { break }
-}
-```
-
-### 音色选择
-
-提供 18 种预设音色：
-- **自然女声**：NATF0, NATF1, NATF2, NATF3
-- **自然男声**：NATM0, NATM1, NATM2, NATM3
-- **多样女声**：VARF0, VARF1, VARF2, VARF3, VARF4
-- **多样男声**：VARM0, VARM1, VARM2, VARM3, VARM4
-
-### 系统提示词
-
-系统提示词引导模型的对话行为。可以将任意自定义提示词作为纯字符串传入：
-
-```swift
-// 自定义系统提示词（自动分词）
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPrompt: "You enjoy having a good conversation."
-)
-
-// 或使用预设
-let response = model.respond(
-    userAudio: audio,
-    voice: .NATM0,
-    systemPromptTokens: SystemPromptPreset.customerService.tokens
-)
-```
-
-可用预设：`focused`（默认）、`assistant`、`customerService`、`teacher`。
-
-### PersonaPlex 命令行
-
-```bash
-make build
-
-# 基础语音到语音
-.build/release/audio respond --input question.wav --output response.wav
-
-# 带转录（解码内心独白文本）
-.build/release/audio respond --input question.wav --transcript
-
-# JSON 输出（音频路径、转录、延迟指标）
-.build/release/audio respond --input question.wav --json
-
-# 自定义系统提示词文本
-.build/release/audio respond --input question.wav --system-prompt-text "You enjoy having a good conversation."
-
-# 选择音色和系统提示词预设
-.build/release/audio respond --input question.wav --voice NATF1 --system-prompt focused
-
-# 调整采样参数
-.build/release/audio respond --input question.wav --audio-temp 0.6 --repetition-penalty 1.5
-
-# 启用文本熵早停（文本熵过低时停止生成）
-.build/release/audio respond --input question.wav --entropy-threshold 1.0 --entropy-window 5
-
-# 列出可用音色和提示词
-.build/release/audio respond --list-voices
-.build/release/audio respond --list-prompts
-```
-
-## CosyVoice TTS——支持声音克隆的流式文本转语音
-
-### 基础合成
-
-```swift
-import CosyVoiceTTS
-import AudioCommon  // for WAVWriter
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-// 首次运行下载约 1.9 GB（LLM + DiT + HiFi-GAN 权重）
-
-let audio = model.synthesize(text: "Hello, how are you today?", language: "english")
-// 输出为 24kHz 单声道浮点采样
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-### 流式合成
-
-```swift
-// 流式：在生成过程中接收音频分块（首块约 150ms）
-for try await chunk in model.synthesizeStream(text: "Hello, how are you today?", language: "english") {
-    // chunk.audio: [Float], chunk.sampleRate: Int
-    playAudio(chunk.audio)  // 即时播放
-}
-```
-
-### 声音克隆 (CosyVoice)
-
-使用 CAM++ 说话人编码器（192 维，CoreML 神经引擎）克隆说话人声音：
-
-```swift
-import CosyVoiceTTS
-import AudioCommon
-
-let model = try await CosyVoiceTTSModel.fromPretrained()
-let speaker = try await CamPlusPlusSpeaker.fromPretrained()
-// 首次使用时下载约 14 MB CAM++ CoreML 模型
-
-let refAudio = try AudioFileLoader.load(url: referenceURL, targetSampleRate: 16000)
-let embedding = try speaker.embed(audio: refAudio, sampleRate: 16000)
-// embedding: 长度为 192 的 [Float]
-
-let audio = model.synthesize(
-    text: "Hello in a cloned voice!",
-    language: "english",
-    speakerEmbedding: embedding
-)
-```
-
-### CosyVoice TTS 命令行
-
-```bash
-make build
-
-# 基础合成
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --output output.wav
-
-# 声音克隆（首次使用时下载 CAM++ 说话人编码器）
-.build/release/audio speak "Hello world" --engine cosyvoice --voice-sample reference.wav --output cloned.wav
-
-# 多说话人对话配合声音克隆
-.build/release/audio speak "[S1] Hello there! [S2] Hey, how are you?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o dialogue.wav
-
-# 行内情感/风格标签
-.build/release/audio speak "(excited) Wow, amazing! (sad) But I have to go..." \
-    --engine cosyvoice -o emotion.wav
-
-# 组合：对话 + 情感 + 声音克隆
-.build/release/audio speak "[S1] (happy) Great news! [S2] (surprised) Really?" \
-    --engine cosyvoice --speakers s1=alice.wav,s2=bob.wav -o combined.wav
-
-# 自定义风格指令
-.build/release/audio speak "Hello world" --engine cosyvoice --cosy-instruct "Speak cheerfully" -o cheerful.wav
-
-# 流式合成
-.build/release/audio speak "Hello world" --engine cosyvoice --language english --stream --output output.wav
-```
-
-## Kokoro TTS——轻量级端侧文本转语音 (iOS + macOS)
-
-### 基础合成
-
-```swift
-import KokoroTTS
-import AudioCommon  // for WAVWriter
-
-let tts = try await KokoroTTSModel.fromPretrained()
-// 首次运行下载约 170 MB（CoreML 模型 + 音色嵌入向量 + 字典）
-
-let audio = try tts.synthesize(text: "Hello world", voice: "af_heart")
-// 输出为 24kHz 单声道浮点采样
-try WAVWriter.write(samples: audio, sampleRate: 24000, to: outputURL)
-```
-
-54 种预设音色覆盖 10 种语言。端到端 CoreML 模型，非自回归，无采样循环。完全在神经引擎上运行，不占用 GPU。
-
-### Kokoro TTS 命令行
-
-```bash
-make build
-
-# 基础合成
-.build/release/audio kokoro "Hello world" --voice af_heart --output hello.wav
-
-# 选择语言
-.build/release/audio kokoro "Bonjour le monde" --voice ff_siwis --language fr --output bonjour.wav
-
-# 列出可用音色
-.build/release/audio kokoro --list-voices
-```
-
-### Qwen3-TTS CoreML
-
-CoreML 上运行的 6 模型自回归流水线。W8A16 调色板量化权重。
-
-```bash
-.build/release/audio qwen3-tts-coreml "Hello, how are you?" --output hello.wav
-.build/release/audio qwen3-tts-coreml "Guten Tag" --language german --output guten.wav
-```
-
-## Qwen3 Chat（端侧 LLM）
+### LLM 对话 — [完整指南 →](https://soniqo.audio/guides/chat)
 
 ```swift
 import Qwen3Chat
 
-let chat = try await Qwen3ChatModel.fromPretrained()
-// 首次运行下载约 318 MB（INT4 CoreML 模型 + 分词器）
-
-// 单次回复
-let response = try chat.generate("What is Swift?", systemPrompt: "Answer briefly.")
-print(response)
-
-// 流式 token
-let stream = chat.chatStream("Tell me a joke", systemPrompt: "Be funny.")
-for try await token in stream {
+let chat = try await Qwen35MLXChat.fromPretrained()
+chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
 ```
 
-Qwen3-0.6B 经 INT4 量化后部署于 CoreML。在神经引擎上运行，iPhone 上约 2 tok/s，M 系列芯片上约 15 tok/s。支持多轮对话（KV 缓存）、思考模式（`<think>` token）以及可配置的采样参数（temperature、top-k、top-p、重复惩罚）。
-
-## 语音活动检测 (VAD)——检测音频中的语音
-
-### 流式 VAD (Silero)
-
-Silero VAD v5 以 32ms 音频分块为单位处理，亚毫秒延迟——非常适合麦克风或音频流的实时语音检测。
+### 语音活动检测 — [完整指南 →](https://soniqo.audio/guides/vad)
 
 ```swift
 import SpeechVAD
 
 let vad = try await SileroVADModel.fromPretrained()
-// 或使用 CoreML（神经引擎，更低功耗）：
-// let vad = try await SileroVADModel.fromPretrained(engine: .coreml)
-
-// 流式：处理 512 采样点的分块（16kHz 下 32ms）
-let prob = vad.processChunk(samples)  // → 0.0...1.0
-vad.resetState()  // 在不同音频流之间调用
-
-// 或一次性检测所有片段
-let segments = vad.detectSpeech(audio: audioSamples, sampleRate: 16000)
-for seg in segments {
-    print("Speech: \(seg.startTime)s - \(seg.endTime)s")
-}
+let segments = vad.detectSpeech(audio: samples, sampleRate: 16000)
+for s in segments { print("\(s.startTime)s → \(s.endTime)s") }
 ```
 
-### 事件驱动流式处理
-
-```swift
-let processor = StreamingVADProcessor(model: vad)
-
-// 输入任意长度音频——语音确认后触发事件
-let events = processor.process(samples: audioBuffer)
-for event in events {
-    switch event {
-    case .speechStarted(let time):
-        print("Speech started at \(time)s")
-    case .speechEnded(let segment):
-        print("Speech: \(segment.startTime)s - \(segment.endTime)s")
-    }
-}
-
-// 在流结束时刷新
-let final = processor.flush()
-```
-
-### VAD 命令行
-
-```bash
-make build
-
-# 流式 Silero VAD（32ms 分块）
-.build/release/audio vad-stream audio.wav
-
-# CoreML 后端（神经引擎）
-.build/release/audio vad-stream audio.wav --engine coreml
-
-# 自定义阈值
-.build/release/audio vad-stream audio.wav --onset 0.6 --offset 0.4
-
-# JSON 输出
-.build/release/audio vad-stream audio.wav --json
-
-# 批量 pyannote VAD（10 秒滑动窗口）
-.build/release/audio vad audio.wav
-```
-
-## 说话人分离——谁在什么时间说话
-
-### 分离管线
+### 说话人分离 — [完整指南 →](https://soniqo.audio/guides/diarize)
 
 ```swift
 import SpeechVAD
 
-let pipeline = try await DiarizationPipeline.fromPretrained()
-// 或使用 CoreML 嵌入（神经引擎，释放 GPU）：
-// let pipeline = try await DiarizationPipeline.fromPretrained(embeddingEngine: .coreml)
-
-let result = pipeline.diarize(audio: samples, sampleRate: 16000)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-print("\(result.numSpeakers) speakers detected")
+let diarizer = try await DiarizationPipeline.fromPretrained()
+let segments = diarizer.diarize(audio: samples, sampleRate: 16000)
+for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime)s") }
 ```
 
-### 说话人嵌入向量
+### 语音增强 — [完整指南 →](https://soniqo.audio/guides/denoise)
 
 ```swift
-let model = try await WeSpeakerModel.fromPretrained()
-// 或: let model = try await WeSpeakerModel.fromPretrained(engine: .coreml)
-let embedding = model.embed(audio: samples, sampleRate: 16000)
-// embedding: 长度为 256 的 [Float]，L2 归一化
+import SpeechEnhancement
 
-// 比较说话人
-let similarity = WeSpeakerModel.cosineSimilarity(embeddingA, embeddingB)
+let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 
-### 说话人提取
-
-使用参考录音提取特定说话人的片段：
+### 语音流水线（ASR → LLM → TTS） — [完整指南 →](https://soniqo.audio/api)
 
 ```swift
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let targetEmb = pipeline.embeddingModel.embed(audio: enrollmentAudio, sampleRate: 16000)
-let segments = pipeline.extractSpeaker(
-    audio: meetingAudio, sampleRate: 16000,
-    targetEmbedding: targetEmb
+import SpeechCore
+
+let pipeline = VoicePipeline(
+    stt: parakeetASR,
+    tts: qwen3TTS,
+    vad: sileroVAD,
+    config: .init(mode: .voicePipeline),
+    onEvent: { event in print(event) }
 )
+pipeline.start()
+pipeline.pushAudio(micSamples)
 ```
 
-### Sortformer 分离（端到端，CoreML）
+`VoicePipeline` 是实时语音 agent 的状态机（由 [speech-core](https://github.com/soniqo/speech-core) 提供），支持 VAD 驱动的轮次检测、打断处理和积极式 STT。它可以连接任意 `SpeechRecognitionModel` + `SpeechGenerationModel` + `StreamingVADProvider`。
 
-NVIDIA Sortformer 直接预测最多 4 位说话人的逐帧语音活动——无需嵌入或聚类。在神经引擎上运行。
-
-```swift
-let diarizer = try await SortformerDiarizer.fromPretrained()
-let result = diarizer.diarize(audio: samples, sampleRate: 16000, config: .default)
-for seg in result.segments {
-    print("Speaker \(seg.speakerId): [\(seg.startTime)s - \(seg.endTime)s]")
-}
-```
-
-### 分离命令行
+### HTTP API 服务器
 
 ```bash
-make build
-
-# Pyannote 分离（默认）
-.build/release/audio diarize meeting.wav
-
-# Sortformer 分离（CoreML，神经引擎）
-.build/release/audio diarize meeting.wav --engine sortformer
-
-# CoreML 嵌入（神经引擎，仅 pyannote）
-.build/release/audio diarize meeting.wav --embedding-engine coreml
-
-# JSON 输出
-.build/release/audio diarize meeting.wav --json
-
-# 提取特定说话人（仅 pyannote）
-.build/release/audio diarize meeting.wav --target-speaker enrollment.wav
-
-# 说话人嵌入向量
-.build/release/audio embed-speaker enrollment.wav --json
-.build/release/audio embed-speaker enrollment.wav --engine coreml
+audio-server --port 8080
 ```
 
-架构详情请参阅[说话人分离](docs/inference/speaker-diarization.md)。
-
-## 语音增强——噪声抑制与音频清理
-
-### 噪声抑制
-
-```swift
-import SpeechEnhancement
-import AudioCommon  // for WAVWriter
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-// 首次运行下载约 4.3 MB（Core ML FP16 模型 + 辅助数据）
-
-let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-try WAVWriter.write(samples: cleanAudio, sampleRate: 48000, to: outputURL)
-```
-
-### 降噪命令行
-
-```bash
-make build
-
-# 基础降噪
-.build/release/audio denoise noisy.wav
-
-# 自定义输出路径
-.build/release/audio denoise noisy.wav --output clean.wav
-```
-
-架构详情请参阅[语音增强](docs/inference/speech-enhancement.md)。
-
-## 管线——组合多个模型
-
-所有模型遵循共享协议（`SpeechRecognitionModel`、`SpeechGenerationModel`、`SpeechEnhancementModel` 等），可以组合为管线：
-
-### 嘈杂语音识别（DeepFilterNet + ASR）
-
-```swift
-import SpeechEnhancement
-import Qwen3ASR
-
-let enhancer = try await SpeechEnhancer.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-// 以 48kHz 增强，再以 16kHz 转录
-let clean = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
-let clean16k = AudioResampler.resample(clean, from: 48000, to: 16000)
-let text = asr.transcribe(audio: clean16k, sampleRate: 16000)
-```
-
-### 语音中转（VAD + ASR + TTS）
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-import Qwen3TTS
-
-let vad = try await SileroVADModel.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-let tts = try await Qwen3TTSModel.fromPretrained()
-
-// 检测语音片段，转录，重新合成
-let segments = vad.detectSpeech(audio: audio, sampleRate: 16000)
-for seg in segments {
-    let chunk = Array(audio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    let speech = tts.synthesize(text: text, language: "english")
-    // speech: 24kHz 单声道浮点采样
-}
-```
-
-### 会议转录（分离 + ASR）
-
-```swift
-import SpeechVAD
-import Qwen3ASR
-
-let pipeline = try await DiarizationPipeline.fromPretrained()
-let asr = try await Qwen3ASRModel.fromPretrained()
-
-let result = pipeline.diarize(audio: meetingAudio, sampleRate: 16000)
-for seg in result.segments {
-    let chunk = Array(meetingAudio[Int(seg.startTime * 16000)..<Int(seg.endTime * 16000)])
-    let text = asr.transcribe(audio: chunk, sampleRate: 16000)
-    print("Speaker \(seg.speakerId) [\(seg.startTime)s-\(seg.endTime)s]: \(text)")
-}
-```
-
-完整协议参考请参阅[共享协议](docs/shared-protocols.md)。
-
-## HTTP API 服务器
-
-一个独立的 HTTP 服务器通过 REST 和 WebSocket 端点暴露所有模型。模型在首次请求时懒加载。
-
-```bash
-swift build -c release
-.build/release/audio-server --port 8080
-
-# 音频转录
-curl -X POST http://localhost:8080/transcribe --data-binary @audio.wav -H "Content-Type: audio/wav"
-
-# 文本转语音
-curl -X POST http://localhost:8080/speak -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "engine": "cosyvoice"}' -o output.wav
-
-# 语音到语音 (PersonaPlex)
-curl -X POST http://localhost:8080/respond --data-binary @question.wav -o response.wav
-
-# 语音增强
-curl -X POST http://localhost:8080/enhance --data-binary @noisy.wav -o clean.wav
-
-# 启动时预加载所有模型
-.build/release/audio-server --preload --port 8080
-```
-
-### WebSocket 流式接口
-
-#### OpenAI Realtime API (`/v1/realtime`)
-
-主要 WebSocket 端点实现了 [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime) 协议——所有消息为 JSON 格式，带 `type` 字段，音频为 base64 编码的 PCM16 24kHz 单声道。
-
-**客户端 → 服务端事件：**
-
-| 事件 | 描述 |
-|------|------|
-| `session.update` | 配置引擎、语言、音频格式 |
-| `input_audio_buffer.append` | 发送 base64 PCM16 音频分块 |
-| `input_audio_buffer.commit` | 转录累积的音频 (ASR) |
-| `input_audio_buffer.clear` | 清空音频缓冲区 |
-| `response.create` | 请求 TTS 合成 |
-
-**服务端 → 客户端事件：**
-
-| 事件 | 描述 |
-|------|------|
-| `session.created` | 会话已初始化 |
-| `session.updated` | 配置已确认 |
-| `input_audio_buffer.committed` | 音频已提交进行转录 |
-| `conversation.item.input_audio_transcription.completed` | ASR 结果 |
-| `response.audio.delta` | Base64 PCM16 音频分块 (TTS) |
-| `response.audio.done` | 音频流完成 |
-| `response.done` | 回复完成，附带元数据 |
-| `error` | 错误类型和消息 |
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/v1/realtime');
-
-// ASR：发送音频，获取转录
-ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64PCM16 }));
-ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
-// → 接收: conversation.item.input_audio_transcription.completed
-
-// TTS：发送文本，获取流式音频
-ws.send(JSON.stringify({
-  type: 'response.create',
-  response: { modalities: ['audio', 'text'], instructions: 'Hello world' }
-}));
-// → 接收: response.audio.delta (base64 分块), response.audio.done, response.done
-```
-
-示例 HTML 客户端位于 `Examples/websocket-client.html`——在服务器运行时用浏览器打开即可。
-
-服务器是独立的 `AudioServer` 模块和 `audio-server` 可执行文件——不会将 Hummingbird/WebSocket 添加到主 `audio` CLI 中。
-
-## 延迟 (M2 Max, 64 GB)
-
-### ASR
-
-| 模型 | 后端 | RTF | 10 秒音频处理耗时 |
-|------|------|-----|-------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX | ~0.06 | ~0.6s |
-| Qwen3-ASR-0.6B (INT8) | CoreML + MLX | ~0.09 | ~0.9s |
-| Qwen3-ASR-1.7B (8-bit) | MLX | ~0.11 | ~1.1s |
-| Parakeet-TDT-0.6B (INT8) | CoreML (神经引擎) | ~0.09 冷启动, ~0.03 热启动 | ~0.9s / ~0.3s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
-
-### 强制对齐
-
-| 模型 | 框架 | 20 秒音频 | RTF |
-|------|------|----------|-----|
-| Qwen3-ForcedAligner-0.6B (4-bit) | MLX Swift (debug) | ~365ms | ~0.018 |
-
-> 单次非自回归前向推理——无采样循环。音频编码器耗时占主导（约 328ms），解码器单次推理约 37ms。**比实时快 55 倍。**
-
-### TTS
-
-| 模型 | 框架 | 短文本 (1s) | 中等 (3s) | 长文本 (6s) | 流式首包 |
-|------|------|-----------|----------|-----------|---------|
-| Qwen3-TTS-0.6B (4-bit) | MLX Swift (release) | 1.6s (RTF 1.2) | 2.3s (RTF 0.7) | 3.9s (RTF 0.7) | ~120ms (1 帧) |
-| Kokoro-82M | CoreML (神经引擎) | ~1.4s (RTFx 0.7) | ~4.3s (RTFx 0.7) | ~8.6s (RTFx 0.7) | 不适用（非自回归） |
-| Apple `AVSpeechSynthesizer` | AVFoundation | 0.08s | 0.08s | 0.17s (RTF 0.02) | 不适用 |
-
-> Qwen3-TTS 生成自然、富有表现力的语音，具备韵律和情感，运行**快于实时**（RTF < 1.0）。流式合成在约 120ms 内输出首个音频分块。Kokoro-82M 完全在神经引擎上通过端到端模型运行（RTFx 约 0.7），非常适合 iOS。Apple 内置 TTS 速度更快但语音生硬单调。
-
-### PersonaPlex（语音到语音）
-
-| 模型 | 框架 | ms/步 | RTF | 说明 |
-|------|------|-------|-----|------|
-| PersonaPlex-7B (8-bit) | MLX Swift (release) | ~112ms | ~1.4 | 推荐——连贯的响应，比 4-bit 快 30% |
-| PersonaPlex-7B (4-bit) | MLX Swift (release) | ~158ms | ~1.97 | 不推荐——输出质量下降 |
-
-> **请使用 8-bit。** INT8 更快（112 ms/步 vs. 158 ms/步）且能生成连贯的全双工响应。INT4 量化会降低生成质量，产生不连贯的语音。INT8 在 M2 Max 上以约 112ms/步运行。
-
-### VAD 与说话人嵌入
-
-| 模型 | 后端 | 单次调用延迟 | RTF | 说明 |
-|------|------|-------------|-----|------|
-| Silero-VAD-v5 | MLX | ~2.1ms / 分块 | 0.065 | GPU (Metal) |
-| Silero-VAD-v5 | CoreML | ~0.27ms / 分块 | 0.008 | 神经引擎，**快 7.7 倍** |
-| WeSpeaker ResNet34-LM | MLX | ~310ms / 20s 音频 | 0.016 | GPU (Metal) |
-| WeSpeaker ResNet34-LM | CoreML | ~430ms / 20s 音频 | 0.021 | 神经引擎，释放 GPU |
-
-> Silero VAD CoreML 在神经引擎上运行，速度是 MLX 的 7.7 倍，非常适合常开麦克风输入场景。WeSpeaker MLX 在 GPU 上更快，但 CoreML 可释放 GPU 用于并发任务（TTS、ASR）。两种后端产生等效结果。
-
-### 语音增强
-
-| 模型 | 后端 | 时长 | 延迟 | RTF |
-|------|------|------|------|-----|
-| DeepFilterNet3 (FP16) | CoreML | 5s | 0.65s | 0.13 |
-| DeepFilterNet3 (FP16) | CoreML | 10s | 1.2s | 0.12 |
-| DeepFilterNet3 (FP16) | CoreML | 20s | 4.8s | 0.24 |
-
-RTF = 实时因子（越低越好，< 1.0 = 快于实时）。GRU 计算成本约为 O(n²)。
-
-### MLX 与 CoreML 对比
-
-两种后端产生等效结果。根据您的工作负载选择：
-
-| | MLX | CoreML |
-|---|---|---|
-| **硬件** | GPU (Metal 着色器) | 神经引擎 + CPU |
-| **最适合** | 最大吞吐量，单模型场景 | 多模型管线，后台任务 |
-| **功耗** | GPU 利用率较高 | 功耗更低，释放 GPU |
-| **延迟** | 大模型更快 (WeSpeaker) | 小模型更快 (Silero VAD) |
-
-**桌面推理**：MLX 为默认选择——在 Apple Silicon 上提供最快的单模型性能。在同时运行多个模型时（如 VAD + ASR + TTS）切换至 CoreML 以避免 GPU 争用，或在笔记本电脑上用于对电池敏感的场景。
-
-CoreML 模型可用于 Qwen3-ASR 编码器、Silero VAD 和 WeSpeaker。对于 Qwen3-ASR，使用 `--engine qwen3-coreml`（混合模式：CoreML 编码器在 ANE 上 + MLX 文本解码器在 GPU 上）。对于 VAD/嵌入，在构造时传入 `engine: .coreml`——推理 API 完全相同。
-
-## 精度基准
-
-### ASR——词错误率（[详情](docs/benchmarks/asr-wer.md)）
-
-| 模型 | WER% (LibriSpeech test-clean) | RTF |
-|------|-------------------------------|-----|
-| Qwen3-ASR 1.7B 8-bit | **2.35** | 0.090 |
-| Qwen3-ASR 1.7B 4-bit | 2.57 | 0.045 |
-| Parakeet TDT INT8 | 2.74 | 0.089 |
-| Qwen3-ASR 0.6B 8-bit | 2.80 | 0.025 |
-
-Qwen3-ASR 1.7B 8-bit 在同等规模下超越 Whisper Large v3 Turbo (2.5%)。多语言：在 FLEURS 上对 10 种语言进行了基准测试。
-
-### TTS——往返可理解性（[详情](docs/benchmarks/tts-roundtrip.md)）
-
-| 引擎 | WER% | RTF |
-|------|------|-----|
-| CosyVoice3 | **3.25** | 0.59 |
-| Qwen3-TTS 1.7B | 3.47 | 0.79 |
-| Kokoro-82M | 3.90 | 0.17 |
-
-### VAD——语音检测（[详情](docs/benchmarks/vad-detection.md)）
-
-| 引擎 | F1% (FLEURS) | RTF |
-|------|-------------|-----|
-| FireRedVAD | **99.12** | 0.007 |
-| Silero CoreML | 95.13 | 0.022 |
-| Pyannote MLX | 94.86 | 0.358 |
+通过 HTTP REST + WebSocket 接口暴露每个模型，包括一个兼容 OpenAI Realtime API 的 WebSocket 接口 `/v1/realtime`。详见 [`Sources/AudioServer/`](Sources/AudioServer/)。
 
 ## 架构
 
-**模型：** [ASR 模型](docs/models/asr-model.md)、[TTS 模型](docs/models/tts-model.md)、[CosyVoice TTS](docs/models/cosyvoice-tts.md)、[Kokoro TTS](docs/models/kokoro-tts.md)、[Parakeet TDT](docs/models/parakeet-asr.md)、[Parakeet Streaming](docs/models/parakeet-streaming-asr.md)、[PersonaPlex](docs/models/personaplex.md)、[FireRedVAD](docs/models/fireredvad.md)
+speech-swift 把每个模型拆成独立的 SPM target，因此使用者只为 import 的模块付费。共享基础设施在 `AudioCommon`（协议、音频 I/O、HuggingFace 下载器、`SentencePieceModel`）和 `MLXCommon`（权重加载、`QuantizedLinear` 辅助工具、`SDPA` 多头注意力辅助工具）。
 
-**推理：** [ASR 推理](docs/inference/qwen3-asr-inference.md)、[Parakeet 流式](docs/inference/parakeet-streaming-asr-inference.md)、[TTS 推理](docs/inference/qwen3-tts-inference.md)、[强制对齐器](docs/inference/forced-aligner.md)、[FireRedVAD](docs/inference/fireredvad.md)、[Silero VAD](docs/inference/silero-vad.md)、[说话人分离](docs/inference/speaker-diarization.md)、[语音增强](docs/inference/speech-enhancement.md)、[音频播放](docs/audio/playback.md)
+**[完整架构图（含后端、内存表、模块映射）→ soniqo.audio/architecture](https://soniqo.audio/architecture)** · **[API 参考 → soniqo.audio/api](https://soniqo.audio/api)** · **[基准测试 → soniqo.audio/benchmarks](https://soniqo.audio/benchmarks)**
 
-**基准测试：** [ASR WER](docs/benchmarks/asr-wer.md)、[TTS 往返测试](docs/benchmarks/tts-roundtrip.md)、[VAD 检测](docs/benchmarks/vad-detection.md)
-
-**参考：** [共享协议](docs/shared-protocols.md)
+本地文档（仓库内）：
+- **模型：** [Qwen3-ASR](docs/models/asr-model.md) · [Qwen3-TTS](docs/models/tts-model.md) · [CosyVoice](docs/models/cosyvoice-tts.md) · [Kokoro](docs/models/kokoro-tts.md) · [Parakeet TDT](docs/models/parakeet-asr.md) · [Parakeet Streaming](docs/models/parakeet-streaming-asr.md) · [Omnilingual ASR](docs/models/omnilingual-asr.md) · [PersonaPlex](docs/models/personaplex.md) · [FireRedVAD](docs/models/fireredvad.md)
+- **推理：** [Qwen3-ASR](docs/inference/qwen3-asr-inference.md) · [Parakeet TDT](docs/inference/parakeet-asr-inference.md) · [Parakeet Streaming](docs/inference/parakeet-streaming-asr-inference.md) · [Omnilingual ASR](docs/inference/omnilingual-asr-inference.md) · [TTS](docs/inference/qwen3-tts-inference.md) · [Forced Aligner](docs/inference/forced-aligner.md) · [Silero VAD](docs/inference/silero-vad.md) · [说话人分离](docs/inference/speaker-diarization.md) · [语音增强](docs/inference/speech-enhancement.md)
+- **参考：** [共享协议](docs/shared-protocols.md)
 
 ## 缓存配置
 
-模型权重本地缓存在 `~/Library/Caches/qwen3-speech/`。
+模型权重在首次使用时从 HuggingFace 下载并缓存到 `~/Library/Caches/qwen3-speech/`。可通过 `QWEN3_CACHE_DIR`（CLI）或 `cacheDir:`（Swift API）覆盖。所有 `fromPretrained()` 入口都接受 `offlineMode: true`，在权重已缓存时跳过网络。
 
-**命令行** — 通过环境变量覆盖：
-
-```bash
-export QWEN3_CACHE_DIR=/path/to/cache
-```
-
-**Swift API** — 所有 `fromPretrained()` 方法支持 `cacheDir` 和 `offlineMode`：
-
-```swift
-// 自定义缓存目录（沙盒应用、iOS 容器）
-let model = try await ParakeetASRModel.fromPretrained(
-    cacheDir: myAppModelsDir)
-
-// 离线模式 — 权重已缓存时跳过网络请求
-let model = try await KokoroTTSModel.fromPretrained(offlineMode: true)
-```
-
-详见 [docs/inference/cache-and-offline.md](docs/inference/cache-and-offline.md)。
+详见 [`docs/inference/cache-and-offline.md`](docs/inference/cache-and-offline.md)，包含 iOS 沙盒容器路径等完整说明。
 
 ## MLX Metal 库
 
-如果运行时出现 `Failed to load the default metallib` 错误，说明 Metal 着色器库缺失。运行 `make build`（或在手动 `swift build` 后运行 `./scripts/build_mlx_metallib.sh release`）来编译它。如果缺少 Metal Toolchain，请先安装：
+如果运行时出现 `Failed to load the default metallib`，说明缺少 Metal 着色器库。在 `swift build` 之后运行 `make build` 或 `./scripts/build_mlx_metallib.sh release`。如果缺少 Metal Toolchain，先安装：
 
 ```bash
 xcodebuild -downloadComponent MetalToolchain
@@ -1247,115 +334,17 @@ xcodebuild -downloadComponent MetalToolchain
 
 ## 测试
 
-单元测试（配置、采样、文本预处理、时间戳校正）无需下载模型即可运行：
-
 ```bash
-swift test --filter "Qwen3TTSConfigTests|SamplingTests|CosyVoiceTTSConfigTests|CamPlusPlusMelExtractorTests|PersonaPlexTests|ForcedAlignerTests/testText|ForcedAlignerTests/testTimestamp|ForcedAlignerTests/testLIS|SileroVADTests/testSilero|SileroVADTests/testReflection|SileroVADTests/testProcess|SileroVADTests/testReset|SileroVADTests/testDetect|SileroVADTests/testStreaming|SileroVADTests/testVADEvent|KokoroTTSTests"
+make test                            # 完整套件（单元 + 需要下载模型的 E2E）
+swift test --skip E2E                # 仅单元测试（CI 安全，无下载）
+swift test --filter Qwen3ASRTests    # 指定模块
 ```
 
-集成测试需要模型权重（首次运行时自动下载）：
-
-```bash
-# TTS 往返测试：合成文本，保存 WAV，再用 ASR 转录回来
-swift test --filter TTSASRRoundTripTests
-
-# 仅 ASR：转录测试音频
-swift test --filter Qwen3ASRIntegrationTests
-
-# 强制对齐器 E2E：词级时间戳（下载约 979 MB）
-swift test --filter ForcedAlignerTests/testForcedAlignerE2E
-
-# PersonaPlex E2E：语音到语音管线（下载约 5.5 GB）
-PERSONAPLEX_E2E=1 swift test --filter PersonaPlexE2ETests
-```
-
-> **注意：** 运行使用 MLX 操作的测试前必须先构建 MLX Metal 库。
-> 请参阅 [MLX Metal 库](#mlx-metal-库)了解说明。
-
-## 支持的语言
-
-| 模型 | 语言 |
-|------|------|
-| Qwen3-ASR | 52 种语言（中文、英文、粤语、德语、法语、西班牙语、日语、韩语、俄语 + 22 种中国方言，...） |
-| Parakeet TDT | 25 种欧洲语言 (BG, CS, DA, DE, EL, EN, ES, ET, FI, FR, HR, HU, IT, LT, LV, MT, NL, PL, PT, RO, RU, SK, SL, SV, UK) |
-| Omnilingual ASR | **1,672 种语言**，覆盖 150+ 个语系。包含 Meta"直接支持"集合的全部语言（约 1,100 种）以及通过社区数据新增的 500+ 种低资源语言。精选示例：EN, ES, FR, DE, ZH, JA, KO, AR, HI, BN, UR, FA, HE, TR, RU, UK, PL, NL, IT, PT, SW, YO, IG, HA, AM, ZU, XH, VI, TH, ID, MS, TL, MY, KM, LO, NE, SI, GU, MR, PA, TA, TE, KN, ML, OR, AS, KA, HY, AZ, KK, UZ, MN, BO, DZ, ...（完整列表：[`lang_ids.py`](https://github.com/facebookresearch/omnilingual-asr/blob/main/src/omnilingual_asr/models/wav2vec2_llama/lang_ids.py)）。CTC 头与语言无关——推理时无需语言提示。 |
-| Qwen3-TTS | EN, CN, DE, JA, ES, FR, KO, RU, IT, PT（CustomVoice 还支持北京/四川方言） |
-| CosyVoice TTS | CN, EN, JA, KO, DE, ES, FR, IT, RU |
-| Kokoro TTS | EN (US/UK), ES, FR, HI, IT, JA, PT, CN, KO, DE |
-| PersonaPlex | EN |
-
-## 与其他方案对比
-
-### 语音转文字 (ASR)：speech-swift 与替代方案
-
-| | **speech-swift (Qwen3-ASR)** | **whisper.cpp** | **Apple SFSpeechRecognizer** | **Google Cloud Speech** |
-|---|---|---|---|---|
-| **运行方式** | 端侧 (MLX/CoreML) | 端侧 (CPU/GPU) | 端侧或云端 | 仅云端 |
-| **语言** | 52 | 100+ | ~70（端侧：有限） | 125+ |
-| **RTF（10s 音频，M2 Max）** | 0.06 (17x 实时) | 0.10 (Whisper-large-v3) | 不适用 | 不适用 |
-| **流式** | 否（批处理） | 否（批处理） | 是 | 是 |
-| **自定义模型** | 是（替换 HuggingFace 权重） | 是（GGML 模型） | 否 | 否 |
-| **Swift API** | 原生 async/await | C++ Swift 桥接 | 原生 | REST/gRPC |
-| **隐私** | 完全端侧 | 完全端侧 | 取决于配置 | 数据发送至云端 |
-| **词级时间戳** | 是（强制对齐器） | 是 | 有限 | 是 |
-| **费用** | 免费 (Apache 2.0) | 免费 (MIT) | 免费（端侧） | 按分钟计费 |
-
-### 文本转语音 (TTS)：speech-swift 与替代方案
-
-| | **speech-swift (Qwen3-TTS)** | **speech-swift (Kokoro)** | **Apple AVSpeechSynthesizer** | **ElevenLabs / 云端 TTS** |
-|---|---|---|---|---|
-| **质量** | 神经网络，富有表现力 | 神经网络，自然 | 机械，单调 | 神经网络，最高质量 |
-| **运行方式** | 端侧 (MLX) | 端侧 (CoreML) | 端侧 | 仅云端 |
-| **流式** | 是（首块约 120ms） | 否（端到端模型） | 否 | 是 |
-| **声音克隆** | 是 | 否 | 否 | 是 |
-| **音色** | 9 种内置 + 克隆任意 | 54 种预设 | ~50 种系统音色 | 1000+ |
-| **语言** | 10 | 10 | 60+ | 30+ |
-| **iOS 支持** | 仅 macOS | iOS + macOS | iOS + macOS | 任意（API） |
-| **费用** | 免费 (Apache 2.0) | 免费 (Apache 2.0) | 免费 | 按字符计费 |
-
-### 何时使用 speech-swift
-
-- **隐私关键应用** — 医疗、法律、企业等音频不能离开设备的场景
-- **离线使用** — 首次模型下载后无需网络连接
-- **成本敏感** — 无按分钟或按字符的 API 费用
-- **Apple Silicon 优化** — 专为 M 系列 GPU (Metal) 和神经引擎打造
-- **完整管线** — 在单个 Swift 包中组合 ASR + TTS + VAD + 分离 + 增强
-
-## 常见问题
-
-**speech-swift 能在 iOS 上运行吗？**
-Kokoro TTS、Qwen3.5-Chat（CoreML）、Silero VAD、Parakeet ASR、DeepFilterNet3 和 WeSpeaker 均可通过 CoreML 在 iOS 17+ 的神经引擎上运行。基于 MLX 的模型（Qwen3-ASR、Qwen3-TTS、Qwen3.5-Chat MLX、PersonaPlex）需要在 Apple Silicon 上运行 macOS 14+。
-
-**需要网络连接吗？**
-仅在首次从 HuggingFace 下载模型时需要（自动下载，缓存在 `~/Library/Caches/qwen3-speech/`）。之后所有推理完全离线运行，不进行任何网络访问。
-
-**speech-swift 与 Whisper 相比如何？**
-Qwen3-ASR-0.6B 在 M2 Max 上达到 RTF 0.06——比通过 whisper.cpp 运行的 Whisper-large-v3 (RTF 0.10) 快 40%——在 52 种语言上精度相当。speech-swift 提供原生 Swift async/await API，而 whisper.cpp 需要 C++ 桥接。
-
-**可以用于商业应用吗？**
-可以。speech-swift 采用 Apache 2.0 许可证。底层模型权重有各自的许可证（请查看各模型的 HuggingFace 页面）。
-
-**支持哪些 Apple Silicon 芯片？**
-所有 M 系列芯片：M1、M2、M3、M4 及其 Pro/Max/Ultra 变体。需要 macOS 14+ (Sonoma) 或 iOS 17+。
-
-**需要多少内存？**
-从约 3 MB（Silero VAD）到约 6.5 GB（PersonaPlex 7B）不等。Kokoro TTS 约 500 MB，Qwen3-ASR 约 2.2 GB。完整详情请参阅[内存需求](#内存需求)表。
-
-**可以同时运行多个模型吗？**
-可以。在神经引擎上使用 CoreML 模型，同时在 GPU 上使用 MLX 模型以避免争用——例如 Silero VAD (CoreML) + Qwen3-ASR (MLX) + Qwen3-TTS (MLX)。
-
-**有 REST API 吗？**
-有。`audio-server` 二进制文件通过 HTTP REST 和 WebSocket 端点暴露所有模型，包括 `/v1/realtime` 上兼容 OpenAI Realtime API 的 WebSocket。
+E2E 测试类使用 `E2E` 前缀，这样 CI 就可以用 `--skip E2E` 过滤掉它们。完整测试规范见 [CLAUDE.md](CLAUDE.md#testing)。
 
 ## 贡献
 
-欢迎贡献！无论是 bug 修复、新模型集成还是文档改进——PR 都受到欢迎。
-
-**开始贡献：**
-1. Fork 仓库并创建功能分支
-2. `make build` 编译（需要 Xcode + Metal Toolchain）
-3. `make test` 运行测试套件
-4. 向 `main` 提交 PR
+欢迎 PR——bug 修复、新模型集成、文档改进。fork、创建功能分支、`make build && make test`，然后向 `main` 提交 PR。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

- **OmnilingualASR** — new module wrapping Meta's wav2vec2 + CTC model with support for 1,672 languages across 32 scripts. Ships CoreML 300M (Neural Engine, INT8 palettized, 5/10 s windows) and MLX variants at 300M / 1B / 3B / 7B.
- **Shared infra** — extracted \`AudioCommon.SentencePieceModel\` protobuf reader and \`MLXCommon.SDPA\` multi-head attention helper so new ports stop reimplementing tokenizer + attention boilerplate.
- **Forced aligner E2E** — new bf16 regression test covering \`FloatTextAttention\`.
- **Cleanup** — remove orphaned Qwen3.5 CoreML conversion test.
- **README** — trim the top-level README (and all 9 translations) from a full manual to a compact landing page; every section now links to the matching guide on [soniqo.audio](https://soniqo.audio). SPM version bumped to 0.0.9.

## Test plan
- [ ] \`make build\` — release build with metallib
- [ ] \`make test\` — full suite including the new OmnilingualASR unit + E2E tests
- [ ] \`audio transcribe audio.wav --engine omnilingual\` on a sample from a low-resource language
- [ ] Spot-check the new compact README renders on GitHub, and confirm every soniqo.audio link resolves (the companion soniqo-web deploy is already on \`main\`).