### PR TITLE
Fix DictateDemo build by adding MLXFast to MLXCommon

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,6 +97,7 @@ let package = Package(
                 "AudioCommon",
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
             ]
         ),
         .target(


### PR DESCRIPTION
Fixes #203.

This updates `MLXCommon` to declare `MLXFast` in `Package.swift`, matching the existing `import MLXFast` usage in `Sources/MLXCommon/SDPA.swift`.

### Verification
- Built `Examples/DictateDemo` successfully with `swift build`
- Confirmed the demo executable is produced
- Ran `swift test --skip E2E` successfully

### Why
Without this dependency, following the documented DictateDemo setup on `main` fails with `no such module 'MLXFast'`.