### PR TITLE
Add DictateDemo to check_demos.sh

### DIFF
--- a/scripts/check_demos.sh
+++ b/scripts/check_demos.sh
@@ -30,6 +30,7 @@ check_demo() {
 echo "=== Demo Build Check ==="
 check_demo SpeechDemo
 check_demo PersonaPlexDemo
+check_demo DictateDemo
 echo "========================"
 
 if [ $ERRORS -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Adds `DictateDemo` to `scripts/check_demos.sh` so it builds alongside `SpeechDemo` and `PersonaPlexDemo` whenever the demo build check runs.
- Guards against package-manifest regressions like #203 (missing `MLXFast` on `MLXCommon`, fixed in #204), which only surfaced when building from a sub-package whose dependency graph happened to exclude the targets that redeclared `MLXFast`.

## Why this catches the class of bug

The root `swift build` succeeded on `main` because targets like `Qwen3ASR` redundantly declare `MLXFast`, pulling it into the build graph and letting `MLXCommon`'s `import MLXFast` resolve by coincidence. `DictateDemo`'s `Package.swift` only depends on `ParakeetStreamingASR`, `SpeechVAD`, and `AudioCommon` — none of which declared `MLXFast` — so building from the sub-package was the only path that exercised `MLXCommon` in isolation and exposed the missing wiring. Running `check_demos.sh` from CI/locally would have caught #203 before merge.

## Notes

- `iOSEchoDemo` is intentionally not added — it is iOS-only and will not build via `swift build` on macOS.

## Test plan

- [x] Ran `scripts/check_demos.sh` locally with the addition: all three demos (`SpeechDemo`, `PersonaPlexDemo`, `DictateDemo`) build cleanly against `main` (which now includes #204).