### PR TITLE
Require pre-compiled .mlmodelc for all CoreML loaders

### DIFF
--- a/Sources/AudioCLILib/Utilities.swift
+++ b/Sources/AudioCLILib/Utilities.swift
@@ -23,7 +23,12 @@ public func runAsync(_ block: @escaping () async throws -> Void) throws {
 }
 
 /// Git commit hash baked in at build time, or read from .git at runtime.
+///
+/// ``Process`` is only available on macOS / Linux; iOS / tvOS / watchOS /
+/// visionOS get a placeholder so shared CLI-helper types (e.g. ``runAsync``,
+/// ``reportProgress``) can still be reached from iOS-buildable targets.
 public let buildVersion: String = {
+    #if os(macOS) || os(Linux)
     let pipe = Pipe()
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
@@ -43,6 +48,9 @@ public let buildVersion: String = {
         }
     } catch {}
     return "unknown"
+    #else
+    return "unknown"
+    #endif
 }()
 
 /// Print model loading progress in a consistent format.

--- a/Sources/AudioCLILib/Utilities.swift
+++ b/Sources/AudioCLILib/Utilities.swift
@@ -24,11 +24,12 @@ public func runAsync(_ block: @escaping () async throws -> Void) throws {
 
 /// Git commit hash baked in at build time, or read from .git at runtime.
 ///
-/// ``Process`` is only available on macOS / Linux; iOS / tvOS / watchOS /
-/// visionOS get a placeholder so shared CLI-helper types (e.g. ``runAsync``,
-/// ``reportProgress``) can still be reached from iOS-buildable targets.
+/// ``Process`` isn't available on iOS and the rest of Apple's embedded
+/// platforms, so the CLI-only git probe is gated on macOS. iOS-bound targets
+/// (libraries sharing this module via ``runAsync`` / ``reportProgress``)
+/// still compile cleanly and just see ``"unknown"``.
 public let buildVersion: String = {
-    #if os(macOS) || os(Linux)
+    #if os(macOS)
     let pipe = Pipe()
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/git")

--- a/Sources/OmnilingualASR/OmnilingualASR.swift
+++ b/Sources/OmnilingualASR/OmnilingualASR.swift
@@ -84,7 +84,9 @@ public class OmnilingualASRModel {
                 additionalFiles: [
                     "config.json",
                     "tokenizer.model",
-                    "omnilingual-ctc-300m-int8.mlpackage/**",
+                    // Pre-compiled CoreML — on-device compileModel() drifts per
+                    // runtime, so we ship .mlmodelc and skip that code path.
+                    "omnilingual-ctc-300m-int8.mlmodelc/**",
                 ],
                 offlineMode: offlineMode
             ) { fraction in
@@ -130,14 +132,16 @@ public class OmnilingualASRModel {
     }
 
     private static func loadCoreMLModel(from directory: URL) throws -> MLModel {
-        // The published repos use the .mlpackage layout. Prefer the compiled
-        // .mlmodelc if it exists (first-run cached), otherwise compile on the fly.
-        let packageURL = directory.appendingPathComponent(
-            "omnilingual-ctc-300m-int8.mlpackage", isDirectory: true)
-        guard FileManager.default.fileExists(atPath: packageURL.path) else {
+        // The aufklarer repo ships pre-compiled ``.mlmodelc``; the legacy
+        // ``.mlpackage`` is gone from the download glob (see ``fromPretrained``)
+        // so on-device ``MLModel.compileModel`` never runs — it drifts per
+        // runtime and was the cause of iOS-simulator regressions.
+        let compiledURL = directory.appendingPathComponent(
+            "omnilingual-ctc-300m-int8.mlmodelc", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: compiledURL.path) else {
             throw AudioModelError.modelLoadFailed(
                 modelId: "omnilingual-ctc-300m",
-                reason: "mlpackage not found at \(packageURL.path)",
+                reason: "mlmodelc not found at \(compiledURL.path)",
                 underlying: nil)
         }
 
@@ -147,7 +151,6 @@ public class OmnilingualASRModel {
         configuration.computeUnits = .cpuAndGPU
 
         do {
-            let compiledURL = try MLModel.compileModel(at: packageURL)
             return try MLModel(contentsOf: compiledURL, configuration: configuration)
         } catch {
             throw AudioModelError.modelLoadFailed(

--- a/Sources/Qwen3ASR/CoreMLTextDecoder.swift
+++ b/Sources/Qwen3ASR/CoreMLTextDecoder.swift
@@ -63,7 +63,7 @@ public class CoreMLTextDecoder {
             hiddenSize = json["hidden_size"] as? Int ?? 1024
         }
 
-        // Try compiled first, then mlpackage
+        // Only pre-compiled ``.mlmodelc`` is supported (see ``findModel``).
         let embURL = findModel(named: "embedding", in: directory)
         let decURL = findModel(named: "decoder", in: directory)
 
@@ -294,13 +294,12 @@ public class CoreMLTextDecoder {
     // MARK: - Helpers
 
     private static func findModel(named name: String, in directory: URL) -> URL? {
+        // Only pre-compiled ``.mlmodelc`` is supported — on-device
+        // ``MLModel.compileModel`` drifts per runtime, and the published
+        // ``aufklarer/Qwen3-ASR-CoreML`` repo ships compiled bundles only.
         let compiled = directory.appendingPathComponent("\(name).mlmodelc", isDirectory: true)
         if FileManager.default.fileExists(atPath: compiled.path) {
             return compiled
-        }
-        let pkg = directory.appendingPathComponent("\(name).mlpackage", isDirectory: true)
-        if FileManager.default.fileExists(atPath: pkg.path) {
-            return pkg
         }
         return nil
     }

--- a/Sources/Qwen3Chat/Qwen35CoreMLChat.swift
+++ b/Sources/Qwen3Chat/Qwen35CoreMLChat.swift
@@ -89,7 +89,8 @@ public final class Qwen35CoreMLChat: @unchecked Sendable {
             to: cacheDir,
             additionalFiles: [
                 "\(variant)/*.json",
-                "\(variant)/**/*.mlmodelc/**",
+                "\(variant)/embedding.mlmodelc/**",
+                "\(variant)/decoder.mlmodelc/**",
             ],
             offlineMode: offlineMode,
             progressHandler: { p in progressHandler?(p * 0.5, "Downloading...") }

--- a/Sources/Qwen3Chat/Qwen35CoreMLChat.swift
+++ b/Sources/Qwen3Chat/Qwen35CoreMLChat.swift
@@ -79,14 +79,17 @@ public final class Qwen35CoreMLChat: @unchecked Sendable {
         let variant = quantization.rawValue
 
         progressHandler?(0.05, "Downloading \(variant) model...")
+        // Fetch the pre-compiled ``.mlmodelc`` bundle only. On-device
+        // ``MLModel.compileModel`` drifts per runtime, and the legacy
+        // ``.mlpackage`` internals (``*.mlmodel`` / ``Manifest.json``) would
+        // force that code path. Users with a stale ``.mlpackage`` cache
+        // transparently re-download because ``.mlmodelc`` is missing.
         try await HuggingFaceDownloader.downloadWeights(
             modelId: modelId,
             to: cacheDir,
             additionalFiles: [
                 "\(variant)/*.json",
-                "\(variant)/**/*.mlmodel",
-                "\(variant)/**/*.bin",
-                "\(variant)/**/Manifest.json",
+                "\(variant)/**/*.mlmodelc/**",
             ],
             offlineMode: offlineMode,
             progressHandler: { p in progressHandler?(p * 0.5, "Downloading...") }
@@ -164,25 +167,16 @@ public final class Qwen35CoreMLChat: @unchecked Sendable {
         named name: String, from dir: URL, computeUnits: MLComputeUnits
     ) async throws -> MLModel {
         let compiledURL = dir.appendingPathComponent("\(name).mlmodelc")
-        let packageURL = dir.appendingPathComponent("\(name).mlpackage")
-
-        let modelURL: URL
-        if FileManager.default.fileExists(atPath: compiledURL.path) {
-            modelURL = compiledURL
-        } else if FileManager.default.fileExists(atPath: packageURL.path) {
-            // Resolve symlinks before compiling — MLModel.compileModel
-            // can fail on Hub-style symlinked .mlpackage directories
-            let resolved = packageURL.resolvingSymlinksInPath()
-            os_log(.info, log: log, "Compiling %{public}@.mlpackage from %{public}@", name, resolved.path)
-            modelURL = try await MLModel.compileModel(at: resolved)
-        } else {
-            os_log(.error, log: log, "Model not found: %{public}@.mlpackage in %{public}@", name, dir.path)
+        guard FileManager.default.fileExists(atPath: compiledURL.path) else {
+            os_log(.error, log: log,
+                   "Model not found: %{public}@.mlmodelc in %{public}@",
+                   name, dir.path)
             throw ChatModelError.modelNotFound(dir)
         }
 
         let mlConfig = MLModelConfiguration()
         mlConfig.computeUnits = computeUnits
-        return try await MLModel.load(contentsOf: modelURL, configuration: mlConfig)
+        return try await MLModel.load(contentsOf: compiledURL, configuration: mlConfig)
     }
 
     // MARK: - Generation

--- a/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
+++ b/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
@@ -69,17 +69,12 @@ public final class Qwen3TTSCoreMLModel {
 
         progressHandler?(0.7, "Loading models...")
 
-        // Load 6 models
+        // Load 6 models. The HuggingFace repo ships only ``.mlmodelc`` — on-device
+        // ``MLModel.compileModel`` is known to drift per runtime (Mac vs
+        // simulator vs iPhone) so we never run it here.
         func loadML(_ name: String, _ cfg: MLModelConfiguration = defaultConfig) throws -> MLModel {
-            // Try pre-compiled .mlmodelc first
             let compiledURL = resolvedCacheDir.appendingPathComponent("\(name).mlmodelc", isDirectory: true)
-            if FileManager.default.fileExists(atPath: compiledURL.path) {
-                return try MLModel(contentsOf: compiledURL, configuration: cfg)
-            }
-            // Compile from .mlpackage at runtime
-            let pkgURL = resolvedCacheDir.appendingPathComponent("\(name).mlpackage", isDirectory: true)
-            let compiled = try MLModel.compileModel(at: pkgURL)
-            return try MLModel(contentsOf: compiled, configuration: cfg)
+            return try MLModel(contentsOf: compiledURL, configuration: cfg)
         }
 
         model.textProjector = TextProjectorModel(model: try loadML("TextProjector", cpuConfig))

--- a/Sources/SpeechEnhancement/DeepFilterNet3Model.swift
+++ b/Sources/SpeechEnhancement/DeepFilterNet3Model.swift
@@ -10,20 +10,16 @@ class DeepFilterNet3Network {
 
     private let model: MLModel
 
-    /// Load a compiled Core ML model from a .mlpackage or .mlmodelc directory.
+    /// Load a pre-compiled Core ML model from a ``.mlmodelc`` directory.
+    ///
+    /// On-device ``MLModel.compileModel`` drifts per runtime (Mac vs
+    /// simulator vs iPhone), so we require a pre-compiled bundle. The
+    /// publishing pipeline (``speech-models/models/deepfilternet``) ships
+    /// only ``.mlmodelc`` for this reason.
     init(modelURL: URL, computeUnits: MLComputeUnits = .all) throws {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnits
-
-        // Check for .mlmodelc (compiled) first, then compile from .mlpackage
-        let compiledURL: URL
-        if modelURL.pathExtension == "mlmodelc" {
-            compiledURL = modelURL
-        } else {
-            compiledURL = try MLModel.compileModel(at: modelURL)
-        }
-
-        self.model = try MLModel(contentsOf: compiledURL, configuration: config)
+        self.model = try MLModel(contentsOf: modelURL, configuration: config)
     }
 
     /// Run inference.

--- a/Sources/SpeechEnhancement/SpeechEnhancement.swift
+++ b/Sources/SpeechEnhancement/SpeechEnhancement.swift
@@ -239,7 +239,11 @@ public final class SpeechEnhancer {
             to: cacheDir,
             additionalFiles: [
                 "no_weights.safetensors",  // suppress default *.safetensors glob
-                "DeepFilterNet3.mlpackage/**",
+                // Pre-compiled CoreML — shipped by aufklarer/DeepFilterNet3-CoreML
+                // alongside the legacy .mlpackage. On-device compileModel() is
+                // known to drift per runtime (Mac vs simulator vs iPhone), so
+                // the goal is to never reach that code path for new installs.
+                "DeepFilterNet3.mlmodelc/**",
                 "auxiliary.npz",
             ],
             offlineMode: offlineMode,

--- a/Sources/SpeechEnhancement/WeightLoading.swift
+++ b/Sources/SpeechEnhancement/WeightLoading.swift
@@ -4,17 +4,25 @@ import AudioCommon
 
 /// Weight loading for DeepFilterNet3 Core ML model.
 ///
-/// Loads the .mlpackage model and auxiliary signal processing data (ERB filterbank,
-/// Vorbis window, normalization states) from an npz file.
+/// Loads the pre-compiled ``.mlmodelc`` model and auxiliary signal processing
+/// data (ERB filterbank, Vorbis window, normalization states) from an npz file.
 enum DeepFilterNet3WeightLoader {
 
     /// Load Core ML model and auxiliary data.
     ///
+    /// Only the pre-compiled ``DeepFilterNet3.mlmodelc`` is supported — on-device
+    /// ``MLModel.compileModel`` from ``.mlpackage`` is known to drift per
+    /// runtime (Mac vs simulator vs iPhone). Users upgrading with a stale
+    /// ``.mlpackage``-only cache trigger a transparent re-download of the
+    /// compiled bundle because ``.mlmodelc`` is missing and the Hub fetch
+    /// glob targets it.
+    ///
     /// - Parameters:
-    ///   - directory: Directory containing DeepFilterNet3.mlpackage and auxiliary.npz
+    ///   - directory: Directory containing DeepFilterNet3.mlmodelc and
+    ///     auxiliary.npz
     /// - Returns: `(network, auxiliaryData)`
     static func load(from directory: URL) throws -> (DeepFilterNet3Network, AuxiliaryData) {
-        let modelURL = directory.appendingPathComponent("DeepFilterNet3.mlpackage")
+        let modelURL = directory.appendingPathComponent("DeepFilterNet3.mlmodelc")
         let auxURL = directory.appendingPathComponent("auxiliary.npz")
 
         guard FileManager.default.fileExists(atPath: modelURL.path) else {

--- a/Tests/Qwen3ASRTests/SecurityHardeningTests.swift
+++ b/Tests/Qwen3ASRTests/SecurityHardeningTests.swift
@@ -340,6 +340,11 @@ final class DownloadSecurityTests: XCTestCase {
 
 // MARK: - Metallib Build Script Tests
 
+// ``MetallibScriptTests`` drives a bash script via ``Process``. ``Process``
+// is not available on iOS / iOS Simulator (it lives in Foundation's
+// macOS/Linux branch), so gate the suite on macOS to keep iOS sim builds
+// green.
+#if os(macOS)
 final class MetallibScriptTests: XCTestCase {
 
     func testScriptExists() {
@@ -393,3 +398,4 @@ final class MetallibScriptTests: XCTestCase {
         XCTAssertTrue(content.contains("set -euo pipefail"), "Script should use strict mode")
     }
 }
+#endif

--- a/Tests/Qwen3ChatTests/Qwen35CoreMLChatE2ETests.swift
+++ b/Tests/Qwen3ChatTests/Qwen35CoreMLChatE2ETests.swift
@@ -7,8 +7,10 @@ final class E2EQwen35CoreMLChatTests: XCTestCase {
 
     func testLocalModelGeneration() async throws {
         let localDir = URL(fileURLWithPath: "/tmp/Qwen3.5-CoreML-INT8")
-        guard FileManager.default.fileExists(atPath: localDir.appendingPathComponent("decoder.mlpackage").path) else {
-            print("No CoreML model at \(localDir.path), skipping")
+        // After the .mlpackage -> .mlmodelc migration, runtime loading only
+        // accepts the compiled bundle. Skip if the local cache predates that.
+        guard FileManager.default.fileExists(atPath: localDir.appendingPathComponent("decoder.mlmodelc").path) else {
+            print("No compiled CoreML model at \(localDir.path)/decoder.mlmodelc, skipping")
             return
         }
 
@@ -29,8 +31,8 @@ final class E2EQwen35CoreMLChatTests: XCTestCase {
 
     func testNoMetaCommentary() async throws {
         let localDir = URL(fileURLWithPath: "/tmp/Qwen3.5-CoreML-INT8")
-        guard FileManager.default.fileExists(atPath: localDir.appendingPathComponent("decoder.mlpackage").path) else {
-            print("No CoreML model, skipping")
+        guard FileManager.default.fileExists(atPath: localDir.appendingPathComponent("decoder.mlmodelc").path) else {
+            print("No compiled CoreML model, skipping")
             return
         }
 
@@ -48,5 +50,27 @@ final class E2EQwen35CoreMLChatTests: XCTestCase {
         print("CoreML response: '\(response.trimmingCharacters(in: .whitespacesAndNewlines))'")
         XCTAssertFalse(lower.contains("the user"), "No meta-commentary")
         XCTAssertTrue(lower.contains("paris"), "Should mention Paris")
+    }
+
+    /// Downloads the pre-compiled `.mlmodelc` bundle from HuggingFace and
+    /// runs one generation. Verifies the post-migration download glob
+    /// (`*.mlmodelc/**` only) actually resolves at runtime on the default
+    /// modelId. Gated on env to avoid multi-GB downloads on every test run.
+    func testHubFromPretrained() async throws {
+        guard ProcessInfo.processInfo.environment["RUN_HUB_E2E"] == "1" else {
+            throw XCTSkip("Set RUN_HUB_E2E=1 to exercise the HuggingFace download path")
+        }
+
+        let model = try await Qwen35CoreMLChat.fromPretrained(
+            computeUnits: .cpuAndGPU
+        )
+
+        let response = try model.generate(
+            messages: [ChatMessage(role: .user, content: "Reply with just the digit 7.")],
+            sampling: ChatSamplingConfig(temperature: 0.1, topK: 5, maxTokens: 10)
+        )
+        let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
+        print("Hub fromPretrained response: '\(trimmed)'")
+        XCTAssertFalse(trimmed.isEmpty, "Should produce non-empty response")
     }
 }

--- a/Tests/SpeechCoreTests/MemoryTierTests.swift
+++ b/Tests/SpeechCoreTests/MemoryTierTests.swift
@@ -12,7 +12,7 @@ final class MemoryTierTests: XCTestCase {
         XCTAssertTrue(allTiers.contains(tier), "detect() should return a known tier")
     }
 
-    func testDetectOnMacOS() {
+    func testDetectOnMacOS() throws {
         #if os(macOS)
         let totalGB = Double(ProcessInfo.processInfo.physicalMemory) / (1024 * 1024 * 1024)
         let tier = MemoryTier.detect()

--- a/Tests/SpeechEnhancementTests/DeepFilterNet3E2ETests.swift
+++ b/Tests/SpeechEnhancementTests/DeepFilterNet3E2ETests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import SpeechEnhancement
+
+/// E2E tests for DeepFilterNet3 speech enhancement.
+///
+/// Runs on macOS (CoreML). The default model resolves to
+/// ``SpeechEnhancer.defaultModelId`` and downloads only the pre-compiled
+/// ``.mlmodelc`` bundle — ``MLModel.compileModel`` must never be reached at
+/// runtime (the CoreML compile path drifts per runtime and caused garbage
+/// audio on the iOS simulator, see the speech-models issue #4 history).
+final class DeepFilterNet3E2ETests: XCTestCase {
+
+    /// Verify the migration to `.mlmodelc/**` globs actually resolves at
+    /// runtime against the published HuggingFace repo. Gated on env to avoid
+    /// multi-MB downloads on every unit-test run.
+    func testHubFromPretrained() async throws {
+        guard ProcessInfo.processInfo.environment["RUN_HUB_E2E"] == "1" else {
+            throw XCTSkip("Set RUN_HUB_E2E=1 to exercise the HuggingFace download path")
+        }
+
+        let enhancer = try await SpeechEnhancer.fromPretrained()
+
+        // One-second 48 kHz silence -> enhance should return the same length.
+        // We don't care about the output content here — this asserts that the
+        // full pipeline (download, .mlmodelc load, ERB/DF signal processing,
+        // auxiliary.npz parsing) works end-to-end.
+        let sampleRate = 48000
+        let samples = [Float](repeating: 0, count: sampleRate)
+        let enhanced = try enhancer.enhance(audio: samples, sampleRate: sampleRate)
+
+        XCTAssertEqual(enhanced.count, samples.count,
+                       "Enhanced signal should match input length")
+
+        // Silence in -> silence out (within FP16 conversion floor).
+        let peak = enhanced.map(abs).max() ?? 0
+        XCTAssertLessThan(peak, 0.01, "Enhanced silence should stay near 0")
+    }
+}

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -192,4 +192,4 @@ python scripts/convert_forced_aligner.py --coreml --coreml-bits 8 --upload --rep
 
 MLX: quantizes text decoder (attention + MLP + embeddings) to N-bit. Audio encoder and classify head kept as float16. `--bits 0` keeps everything as float16.
 
-CoreML: traces audio encoder, text decoder + classify head, and embedding as separate `.mlpackage` models with INT4/INT8 palettization.
+CoreML: traces audio encoder, text decoder + classify head, and embedding as separate models with INT4/INT8 palettization. Published as pre-compiled `.mlmodelc` bundles.

--- a/docs/inference/speech-enhancement.md
+++ b/docs/inference/speech-enhancement.md
@@ -48,8 +48,10 @@ swift run audio denoise noisy.wav --output clean.wav
 python scripts/convert_deepfilternet3.py [--output OUTPUT_DIR]
 ```
 
-Outputs:
-- `DeepFilterNet3.mlpackage` (~4.2 MB) — Core ML FP16 model
+Outputs (the publish flow compiles the `.mlpackage` to `.mlmodelc` and ships
+both for backward compatibility; speech-swift only loads the compiled bundle):
+- `DeepFilterNet3.mlmodelc` (~4.2 MB) — Core ML FP16 model, pre-compiled
+- `DeepFilterNet3.mlpackage` (~4.2 MB) — source `.mlpackage`, kept for legacy clients
 - `auxiliary.npz` (~126 KB) — ERB filterbank, Vorbis window, normalization states
 
 ## References

--- a/docs/models/qwen35-chat.md
+++ b/docs/models/qwen35-chat.md
@@ -96,9 +96,10 @@ Key naming:
 
 Repo: `aufklarer/Qwen3.5-0.8B-Chat-CoreML` with `int4/` and `int8/` subdirectories.
 
-Split into two models:
-- `embedding.mlpackage` — token embedding lookup
-- `decoder.mlpackage` — full transformer with stateful DeltaNet (MLState) and KV cache
+Split into two pre-compiled models (shipped as `.mlmodelc`; the legacy
+`.mlpackage` still lives in the repo for older builds):
+- `embedding.mlmodelc` — token embedding lookup
+- `decoder.mlmodelc` — full transformer with stateful DeltaNet (MLState) and KV cache
 
 ## Swift API
 


### PR DESCRIPTION
## Summary

- All five CoreML loaders (DeepFilterNet3, Qwen3-Chat, Qwen3-TTS, Omnilingual-ASR, Qwen3-ASR) now load from pre-compiled `.mlmodelc` only. On-device `MLModel.compileModel()` is removed.
- Download globs switched from `*.mlpackage/**` to `*.mlmodelc/**`. Users upgrading with a stale cache transparently re-download the compiled bundle.
- Two new Hub-level e2e tests (`RUN_HUB_E2E=1`) verify the glob migration against the published HuggingFace repos.

## Why

On-device `MLModel.compileModel()` produces different numerical results per runtime — Mac GPU, iOS simulator (CPU-only), and iPhone Neural Engine all disagree. This has caused garbage audio on the simulator for Kokoro TTS. The reliable fix is to ship the `.mlmodelc` compiled once, on the publishing machine, and only load it on-device.

All affected HuggingFace repos now carry pre-compiled `.mlmodelc` alongside the legacy `.mlpackage`:

- `aufklarer/DeepFilterNet3-CoreML`
- `aufklarer/Qwen3.5-0.8B-Chat-CoreML` *(default for `Qwen35CoreMLChat.fromPretrained()`)*
- `aufklarer/Qwen3-TTS-CoreML` *(already `.mlmodelc`-only)*
- `aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s` *(default for `OmnilingualASRModel.fromPretrained()`)*
- `aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8` *(shortWindow fallback)*
- `aufklarer/Qwen3-ASR-CoreML`

Old speech-swift builds keep loading `.mlpackage` and runtime-compiling it (repos still carry both artifacts). New builds on this PR download only `.mlmodelc` and never hit the compile path.

## Changes

| file | change |
|---|---|
| `Sources/SpeechEnhancement/SpeechEnhancement.swift` | glob `DeepFilterNet3.mlpackage/**` → `DeepFilterNet3.mlmodelc/**` |
| `Sources/SpeechEnhancement/WeightLoading.swift` | require `DeepFilterNet3.mlmodelc` |
| `Sources/SpeechEnhancement/DeepFilterNet3Model.swift` | drop `compileModel` branch; init from compiled URL only |
| `Sources/Qwen3Chat/Qwen35CoreMLChat.swift` | flat per-sub-model globs (`int8/embedding.mlmodelc/**`, `int8/decoder.mlmodelc/**`); `loadModel` requires `name.mlmodelc` |
| `Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift` | `loadML` requires `name.mlmodelc` |
| `Sources/OmnilingualASR/OmnilingualASR.swift` | glob + `loadCoreMLModel` require `.mlmodelc` |
| `Sources/Qwen3ASR/CoreMLTextDecoder.swift` | `findModel` no longer falls back to `.mlpackage` |
| `Tests/SpeechEnhancementTests/DeepFilterNet3E2ETests.swift` | **new** — Hub download + silence smoke |
| `Tests/Qwen3ChatTests/Qwen35CoreMLChatE2ETests.swift` | gate existing tests on `.mlmodelc`; new `testHubFromPretrained` |

Also unblocks iOS-simulator test builds (three pre-existing `Process`-using sites gated on `os(macOS)`), so the package test suite can run on iOS sim.

## Test plan

- [x] `swift build` clean
- [x] **DeepFilterNet3**: 24/24 SpeechEnhancementTests pass (includes an existing end-to-end test that downloads from Hub and runs real enhancement; `testHubFromPretrained` green with `RUN_HUB_E2E=1`, 1.66s)
- [x] **Qwen3-Chat**: `E2EQwen35CoreMLChatTests.testHubFromPretrained` green with `RUN_HUB_E2E=1`, 11.5s (generates token stream from Hub-downloaded `.mlmodelc`)
- [x] **Qwen3-TTS**: `E2EQwen3TTSCoreMLTests.testSynthesizeProducesAudio` green, 20s
- [x] **Omnilingual-ASR**: `E2EOmnilingualASRTests.testTranscribeRealAudio` green, 47.4s (loads `-10s` default, runs real transcription)
- [x] **Qwen3-ASR**: 9/9 `E2EQwen3ASRIntegrationTests` green
- [x] **iOS Simulator** (iPhone 17 Pro, 26.2): `DeepFilterNet3E2ETests.testHubFromPretrained` green on sim, 1.5s — validates `MLModel(contentsOf: .mlmodelc)` code path works on simulator
- [x] **iOS Simulator**: `iOSEchoDemo` builds and launches clean

### Gaps caught by running e2e

1. The `int8/**/*.mlmodelc/**` glob didn't match the flat Hub layout on `aufklarer/Qwen3.5-0.8B-Chat-CoreML` → switched to two explicit `int8/<name>.mlmodelc/**` globs.
2. `aufklarer/Qwen3.5-0.8B-Chat-CoreML` (the Swift default; distinct from the earlier-republished `Qwen3-0.6B-Chat-CoreML`) needed compiled mlmodelc — uploaded.
3. `aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s` (the Swift default; distinct from the earlier-republished short-window variant) needed compiled mlmodelc — uploaded.