### PR TITLE
brew: include audio-server binary in Homebrew formula (closes #206)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Package
         run: |
           mkdir -p dist
-          cp .build/release/audio dist/
+          cp .build/release/audio .build/release/audio-server dist/
           cp .build/release/mlx.metallib dist/
           cd dist
-          tar czf audio-macos-arm64.tar.gz audio mlx.metallib
+          tar czf audio-macos-arm64.tar.gz audio audio-server mlx.metallib
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2

--- a/Formula/speech.rb
+++ b/Formula/speech.rb
@@ -9,11 +9,13 @@ class Speech < Formula
   depends_on :macos
 
   def install
-    libexec.install "audio", "mlx.metallib"
+    libexec.install "audio", "audio-server", "mlx.metallib"
     bin.write_exec_script libexec/"audio"
+    bin.write_exec_script libexec/"audio-server"
   end
 
   test do
     assert_match "AI speech models", shell_output("#{bin}/audio --help")
+    assert_match "HTTP API server", shell_output("#{bin}/audio-server --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Then:
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # local HTTP / WebSocket server (OpenAI-compatible /v1/realtime)
 ```
 
 **[Full CLI reference →](https://soniqo.audio/cli)**

--- a/README_de.md
+++ b/README_de.md
@@ -132,6 +132,7 @@ Dann:
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # lokaler HTTP/WebSocket-Server (OpenAI-kompatibles /v1/realtime)
 ```
 
 **[Vollständige CLI-Referenz →](https://soniqo.audio/de/cli)**

--- a/README_es.md
+++ b/README_es.md
@@ -132,6 +132,7 @@ Luego:
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # servidor HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
 ```
 
 **[Referencia completa de la CLI →](https://soniqo.audio/es/cli)**

--- a/README_fr.md
+++ b/README_fr.md
@@ -132,6 +132,7 @@ Ensuite :
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # serveur HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
 ```
 
 **[Reference CLI complete →](https://soniqo.audio/fr/cli)**

--- a/README_hi.md
+++ b/README_hi.md
@@ -132,6 +132,7 @@ brew install speech
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # स्थानीय HTTP / WebSocket सर्वर (OpenAI-compatible /v1/realtime)
 ```
 
 **[पूर्ण CLI संदर्भ →](https://soniqo.audio/hi/cli)**

--- a/README_ja.md
+++ b/README_ja.md
@@ -132,6 +132,7 @@ brew install speech
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # ローカル HTTP / WebSocket サーバー（OpenAI 互換 /v1/realtime）
 ```
 
 **[完全なCLIリファレンス →](https://soniqo.audio/ja/cli)**

--- a/README_ko.md
+++ b/README_ko.md
@@ -132,6 +132,7 @@ brew install speech
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # 로컬 HTTP / WebSocket 서버 (OpenAI 호환 /v1/realtime)
 ```
 
 **[전체 CLI 레퍼런스 →](https://soniqo.audio/ko/cli)**

--- a/README_pt.md
+++ b/README_pt.md
@@ -132,6 +132,7 @@ Depois:
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # servidor HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
 ```
 
 **[Referencia completa do CLI →](https://soniqo.audio/pt/cli)**

--- a/README_ru.md
+++ b/README_ru.md
@@ -132,6 +132,7 @@ brew install speech
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # локальный HTTP / WebSocket сервер (OpenAI-совместимый /v1/realtime)
 ```
 
 **[Полный справочник CLI →](https://soniqo.audio/ru/cli)**

--- a/README_zh.md
+++ b/README_zh.md
@@ -132,6 +132,7 @@ brew install speech
 audio transcribe recording.wav
 audio speak "Hello world"
 audio respond --input question.wav --transcript
+audio-server --port 8080            # 本地 HTTP / WebSocket 服务器（OpenAI 兼容 /v1/realtime）
 ```
 
 **[完整 CLI 参考 →](https://soniqo.audio/zh/cli)**


### PR DESCRIPTION
## Summary

Ship `audio-server` alongside `audio` via `brew install speech`, resolving #206.

- `release.yml` tarball now includes `audio-server` (previously only `audio` + `mlx.metallib`).
- `Formula/speech.rb` installs both binaries into `libexec`, wraps both with `bin.write_exec_script`, and `brew test speech` now smoke-checks `audio-server --help` as well.
- README (English + 9 translations) mentions `audio-server --port 8080` in the post-install snippet.

## Test plan

- [x] Local release build produces both binaries; each responds to `--help`.
- [x] Tarball built locally matches CI's recipe (`tar czf audio-macos-arm64.tar.gz audio audio-server mlx.metallib`).
- [x] End-to-end `brew install` via a scratch local tap — clean install, both shims work (`audio --help` + `audio-server --help` via the brewed path).
- [x] `brew test` passes both assertions.
- [x] `brew style Formula/speech.rb` reports no offenses.
- [ ] Full `brew install speech` from the public tap — will run on the first release cut after merge (CI handles this on macOS-15).

## Release sequencing

Strategy A from the issue discussion: merge this PR, then immediately cut a patch release (v0.0.10). The release workflow rebuilds the tarball with `audio-server` included and the existing sed step auto-bumps the formula's `url` + `sha256`. Brief window between merge and release where the formula install block references `audio-server` but the v0.0.9 tarball lacks it — resolved by cutting the release right after merge.