### PR TITLE
KokoroTTS: download full voice catalog; ship resource bundle in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,11 @@ jobs:
           mkdir -p dist
           cp .build/release/audio .build/release/audio-server dist/
           cp .build/release/mlx.metallib dist/
+          # KokoroTTS loads fr/pt/hi pronunciation dicts via Bundle.module,
+          # which hard-crashes if the resource bundle isn't beside the binary (#212).
+          cp -R .build/release/Qwen3Speech_KokoroTTS.bundle dist/
           cd dist
-          tar czf audio-macos-arm64.tar.gz audio audio-server mlx.metallib
+          tar czf audio-macos-arm64.tar.gz audio audio-server mlx.metallib Qwen3Speech_KokoroTTS.bundle
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2

--- a/Formula/speech.rb
+++ b/Formula/speech.rb
@@ -10,6 +10,7 @@ class Speech < Formula
 
   def install
     libexec.install "audio", "audio-server", "mlx.metallib"
+    libexec.install "Qwen3Speech_KokoroTTS.bundle"
     bin.write_exec_script libexec/"audio"
     bin.write_exec_script libexec/"audio-server"
   end

--- a/Sources/KokoroTTS/KokoroTTS.swift
+++ b/Sources/KokoroTTS/KokoroTTS.swift
@@ -146,7 +146,7 @@ public final class KokoroTTSModel {
                 "g2p_vocab.json",
                 "us_gold.json",
                 "us_silver.json",
-                "voices/\(voice).json",
+                "voices/*.json",
             ],
             offlineMode: offlineMode
         ) { fraction in

--- a/Tests/KokoroTTSTests/KokoroE2ETests.swift
+++ b/Tests/KokoroTTSTests/KokoroE2ETests.swift
@@ -29,6 +29,12 @@ final class E2EKokoroTests: XCTestCase {
     func testModelLoadsAndHasE2E() async throws {
         let m = try await model()
         XCTAssertTrue(m.availableVoices.contains("af_heart"))
+        // Regression (#212): `fromPretrained` used to download only one voice JSON,
+        // so `availableVoices` reported a single entry and non-default voices failed.
+        XCTAssertGreaterThan(m.availableVoices.count, 1,
+            "fromPretrained must download the full voice catalog, not just the default voice")
+        XCTAssertTrue(m.availableVoices.contains("jf_alpha"),
+            "Japanese voice preset must be available without re-downloading")
     }
 
     func testSynthesizeEnglish() async throws {


### PR DESCRIPTION
Fixes #212.

## Summary

On `audio` v0.0.10 installed via Homebrew, Kokoro TTS was broken in three ways:

1. `--list-voices` reported only `af_heart`.
2. `--voice jf_alpha --language ja` failed with `voiceNotFound`.
3. `--voice ff_siwis --language fr` crashed with a `Bundle.module` fatal error before synthesis.

### Root cause A — only the default voice is downloaded

`KokoroTTSModel.fromPretrained` was globbing `voices/\(voice).json`, where `voice` defaults to `af_heart` and is never passed through from the CLI. One file lands in the cache, `availableVoices` returns one entry, and every non-default voice raises `voiceNotFound`.

Fix: switch the glob to `voices/*.json` so the full catalog (~54 presets, <2 MB) comes down on first load. The `voice` parameter on `fromPretrained` is kept to avoid an API break but no longer affects the download set.

### Root cause B — resource bundle not shipped to Homebrew

`PronunciationDicts.{fr,pt,hi}` load via `Bundle.module`. The SwiftPM-generated accessor calls `fatalError()` when the bundle isn't beside the binary, and that crash is uncatchable by the `nil`-guard in `loadJSON`. The release workflow and Homebrew formula only packaged `audio`, `audio-server`, `mlx.metallib` — the `.bundle` directory never made it into the tarball.

Fix: copy `Qwen3Speech_KokoroTTS.bundle` into `dist/`, include it in the tarball, and `libexec.install` it from the formula. Takes effect on the next release cut (v0.0.11+).

## Changes

- `Sources/KokoroTTS/KokoroTTS.swift` — glob `voices/*.json` instead of a single file
- `.github/workflows/release.yml` — package the KokoroTTS resource bundle
- `Formula/speech.rb` — install the bundle alongside the binaries
- `Tests/KokoroTTSTests/KokoroE2ETests.swift` — regression assertions on `availableVoices`

## Test plan

- [ ] `make test` locally (E2E Kokoro tests pass, `availableVoices.count > 1`, `jf_alpha` present)
- [ ] Cut a pre-release from this branch, install the tarball via a scratch formula, and verify:
  - [ ] `audio kokoro --list-voices` lists ~54 voices
  - [ ] `audio kokoro "こんにちは" --voice jf_alpha --language ja --output /tmp/ja.wav` succeeds
  - [ ] `audio kokoro "Bonjour" --voice ff_siwis --language fr --output /tmp/fr.wav` succeeds (no bundle crash)