### PR TITLE
TTS: cache voice-clone reference artifacts; expose Kokoro computeUnits

### DIFF
--- a/Sources/KokoroTTS/KokoroTTS.swift
+++ b/Sources/KokoroTTS/KokoroTTS.swift
@@ -122,11 +122,17 @@ public final class KokoroTTSModel {
     // MARK: - Model Loading
 
     /// Load a pretrained Kokoro model from HuggingFace.
+    ///
+    /// - Parameter computeUnits: Which hardware the main CoreML model runs on.
+    ///   Defaults to `.all` (Neural Engine preferred). Pass `.cpuAndGPU` to bypass
+    ///   the Neural Engine — useful as a fallback on platforms where the ANE
+    ///   compiler produces incorrect output for this model.
     public static func fromPretrained(
         modelId: String = defaultModelId,
         voice: String = defaultVoice,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
+        computeUnits: MLComputeUnits = .all,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> KokoroTTSModel {
         AudioLog.modelLoading.info("Loading Kokoro model: \(modelId)")
@@ -191,7 +197,7 @@ public final class KokoroTTSModel {
 
         // Load E2E CoreML model
         progressHandler?(0.85, "Loading CoreML model...")
-        let network = try KokoroNetwork(directory: cacheDir)
+        let network = try KokoroNetwork(directory: cacheDir, computeUnits: computeUnits)
         AudioLog.modelLoading.debug("Loaded Kokoro E2E model")
 
         progressHandler?(1.0, "Model loaded")

--- a/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
@@ -69,21 +69,33 @@ extension Qwen3TTSModel {
 
         let t0 = CFAbsoluteTimeGetCurrent()
 
-        // Step 1: Resample reference audio to 24kHz
-        let audio24k = referenceSampleRate == 24000
-            ? referenceAudio
-            : AudioFileLoader.resample(referenceAudio, from: referenceSampleRate, to: 24000)
+        // Step 1+2: Encode reference audio → codec tokens [1, 16, T_ref] (cached per reference)
+        let refCodes: MLXArray
+        if let cached = referenceAudioCache.codecRefCodes(for: referenceAudio, sampleRate: referenceSampleRate) {
+            refCodes = cached
+            print("  ICL: codec tokens cache hit (\(cached.dim(2)) frames)")
+        } else {
+            let audio24k = referenceSampleRate == 24000
+                ? referenceAudio
+                : AudioFileLoader.resample(referenceAudio, from: referenceSampleRate, to: 24000)
+            let codes = codecEncoder.encode(samples: audio24k)
+            eval(codes)
+            referenceAudioCache.storeCodecRefCodes(codes, audio: referenceAudio, sampleRate: referenceSampleRate)
+            refCodes = codes
+            print("  ICL: encoded \(audio24k.count) samples → \(codes.dim(2)) codec frames")
+        }
 
-        // Step 2: Encode reference audio → codec tokens [1, 16, T_ref]
-        let refCodes = codecEncoder.encode(samples: audio24k)
-        eval(refCodes)
-        let refTime = refCodes.dim(2)
-        print("  ICL: encoded \(audio24k.count) samples → \(refTime) codec frames")
-
-        // Step 3: Extract speaker embedding (ICL still uses x-vector for speaker conditioning)
-        let mels = SpeakerMel.compute(audio: referenceAudio, sampleRate: referenceSampleRate)
-        let speakerEmbed = speakerEncoder(mels)  // [1, 1024]
-        eval(speakerEmbed)
+        // Step 3: Extract speaker embedding (ICL still uses x-vector for speaker conditioning; cached)
+        let speakerEmbed: MLXArray
+        if let cached = referenceAudioCache.speakerEmbed(for: referenceAudio, sampleRate: referenceSampleRate) {
+            speakerEmbed = cached
+        } else {
+            let mels = SpeakerMel.compute(audio: referenceAudio, sampleRate: referenceSampleRate)
+            let embed = speakerEncoder(mels)  // [1, 1024]
+            eval(embed)
+            referenceAudioCache.storeSpeakerEmbed(embed, audio: referenceAudio, sampleRate: referenceSampleRate)
+            speakerEmbed = embed
+        }
 
         // Step 4: Build ICL prefill embeddings
         let (prefillEmbeds, trailingTextHidden, ttsPadEmbed) = buildICLPrefillEmbeddings(

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -74,6 +74,15 @@ public class Qwen3TTSModel {
     /// growing KV cache handled by shapeless mode, batch dim uses -1 reshapes.
     private var compiledCPTransformer: (([MLXArray]) -> [MLXArray])?
 
+    /// Cache for voice-cloning reference audio artifacts (speaker embedding, ICL codec tokens).
+    /// Bounded LRU; survives across synthesize calls on the same model instance.
+    let referenceAudioCache = ReferenceAudioCache()
+
+    /// Clear cached voice-cloning reference artifacts.
+    public func clearReferenceAudioCache() {
+        referenceAudioCache.clear()
+    }
+
     init(config: Qwen3TTSConfig = .base06B) {
         self.config = config
         self.talker = TalkerModel(config: config.talker)
@@ -204,11 +213,19 @@ public class Qwen3TTSModel {
 
         let t0 = CFAbsoluteTimeGetCurrent()
 
-        // Extract speaker embedding from reference audio
-        let mels = SpeakerMel.compute(audio: referenceAudio, sampleRate: referenceSampleRate)
-        let speakerEmbed = speakerEncoder(mels)  // [1, 1024]
-        eval(speakerEmbed)
-        print("  Speaker embedding extracted: \(speakerEmbed.shape)")
+        // Extract speaker embedding from reference audio (cached per reference)
+        let speakerEmbed: MLXArray
+        if let cached = referenceAudioCache.speakerEmbed(for: referenceAudio, sampleRate: referenceSampleRate) {
+            speakerEmbed = cached
+            print("  Speaker embedding: cache hit \(cached.shape)")
+        } else {
+            let mels = SpeakerMel.compute(audio: referenceAudio, sampleRate: referenceSampleRate)
+            let embed = speakerEncoder(mels)  // [1, 1024]
+            eval(embed)
+            referenceAudioCache.storeSpeakerEmbed(embed, audio: referenceAudio, sampleRate: referenceSampleRate)
+            speakerEmbed = embed
+            print("  Speaker embedding extracted: \(speakerEmbed.shape)")
+        }
 
         // Stage 1: Prepare text tokens and codec prefix (no speaker token ID — using embedding)
         let textTokens = prepareTextTokens(text: text, tokenizer: tokenizer)

--- a/Sources/Qwen3TTS/ReferenceAudioCache.swift
+++ b/Sources/Qwen3TTS/ReferenceAudioCache.swift
@@ -1,0 +1,90 @@
+import Foundation
+import MLX
+
+/// Content-addressed cache for voice-cloning reference audio artifacts.
+///
+/// Stores the ECAPA-TDNN speaker embedding and (optionally) the ICL codec-encoder
+/// tokens produced from a reference waveform, keyed by the content hash of the
+/// raw samples and the associated sample rate. Subsequent synthesize calls using
+/// the same reference audio reuse the cached artifacts instead of re-running
+/// mel extraction, the speaker encoder, or the codec encoder.
+///
+/// The cache is bounded (LRU) to keep memory predictable when many distinct
+/// references are used in sequence.
+final class ReferenceAudioCache {
+
+    private struct Entry {
+        let key: UInt64
+        let sampleRate: Int
+        var speakerEmbed: MLXArray?
+        var codecRefCodes: MLXArray?
+    }
+
+    private var entries: [Entry] = []
+    private let capacity: Int
+
+    init(capacity: Int = 4) {
+        precondition(capacity > 0, "capacity must be positive")
+        self.capacity = capacity
+    }
+
+    // MARK: - Lookup
+
+    func speakerEmbed(for audio: [Float], sampleRate: Int) -> MLXArray? {
+        entry(for: audio, sampleRate: sampleRate)?.speakerEmbed
+    }
+
+    func codecRefCodes(for audio: [Float], sampleRate: Int) -> MLXArray? {
+        entry(for: audio, sampleRate: sampleRate)?.codecRefCodes
+    }
+
+    // MARK: - Store
+
+    func storeSpeakerEmbed(_ embed: MLXArray, audio: [Float], sampleRate: Int) {
+        upsert(audio: audio, sampleRate: sampleRate) { $0.speakerEmbed = embed }
+    }
+
+    func storeCodecRefCodes(_ codes: MLXArray, audio: [Float], sampleRate: Int) {
+        upsert(audio: audio, sampleRate: sampleRate) { $0.codecRefCodes = codes }
+    }
+
+    // MARK: - Management
+
+    func clear() {
+        entries.removeAll()
+    }
+
+    var count: Int { entries.count }
+
+    // MARK: - Internals
+
+    private func entry(for audio: [Float], sampleRate: Int) -> Entry? {
+        let k = Self.hash(audio)
+        guard let idx = entries.firstIndex(where: { $0.key == k && $0.sampleRate == sampleRate })
+        else { return nil }
+        let e = entries.remove(at: idx)
+        entries.append(e)
+        return e
+    }
+
+    private func upsert(audio: [Float], sampleRate: Int, update: (inout Entry) -> Void) {
+        let k = Self.hash(audio)
+        if let idx = entries.firstIndex(where: { $0.key == k && $0.sampleRate == sampleRate }) {
+            var e = entries.remove(at: idx)
+            update(&e)
+            entries.append(e)
+            return
+        }
+        var e = Entry(key: k, sampleRate: sampleRate, speakerEmbed: nil, codecRefCodes: nil)
+        update(&e)
+        if entries.count >= capacity { entries.removeFirst() }
+        entries.append(e)
+    }
+
+    static func hash(_ audio: [Float]) -> UInt64 {
+        var hasher = Hasher()
+        hasher.combine(audio.count)
+        for v in audio { hasher.combine(v.bitPattern) }
+        return UInt64(bitPattern: Int64(hasher.finalize()))
+    }
+}

--- a/Tests/Qwen3TTSTests/ReferenceAudioCacheTests.swift
+++ b/Tests/Qwen3TTSTests/ReferenceAudioCacheTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import MLX
+@testable import Qwen3TTS
+
+final class ReferenceAudioCacheTests: XCTestCase {
+
+    // MARK: - Hashing
+
+    func testHashIsStableForSameAudio() {
+        let audio: [Float] = [0.1, -0.2, 0.3, -0.4, 0.5]
+        XCTAssertEqual(ReferenceAudioCache.hash(audio), ReferenceAudioCache.hash(audio))
+    }
+
+    func testHashDiffersOnContentChange() {
+        let a: [Float] = [0.1, 0.2, 0.3]
+        let b: [Float] = [0.1, 0.2, 0.4]
+        XCTAssertNotEqual(ReferenceAudioCache.hash(a), ReferenceAudioCache.hash(b))
+    }
+
+    func testHashDiffersOnLengthChange() {
+        let a: [Float] = [0.1, 0.2, 0.3]
+        let b: [Float] = [0.1, 0.2, 0.3, 0.0]
+        XCTAssertNotEqual(ReferenceAudioCache.hash(a), ReferenceAudioCache.hash(b))
+    }
+
+    // MARK: - Round-trip
+
+    func testStoreAndRetrieveSpeakerEmbedding() {
+        let cache = ReferenceAudioCache()
+        let audio: [Float] = [0.1, 0.2, 0.3]
+        let embed = MLXArray.zeros([1, 1024])
+
+        XCTAssertNil(cache.speakerEmbed(for: audio, sampleRate: 16000))
+
+        cache.storeSpeakerEmbed(embed, audio: audio, sampleRate: 16000)
+
+        let cached = cache.speakerEmbed(for: audio, sampleRate: 16000)
+        XCTAssertNotNil(cached)
+        XCTAssertEqual(cached?.shape, [1, 1024])
+    }
+
+    func testStoreAndRetrieveCodecRefCodes() {
+        let cache = ReferenceAudioCache()
+        let audio: [Float] = [0.1, 0.2, 0.3]
+        let codes = MLXArray.zeros([1, 16, 32])
+
+        cache.storeCodecRefCodes(codes, audio: audio, sampleRate: 24000)
+
+        let cached = cache.codecRefCodes(for: audio, sampleRate: 24000)
+        XCTAssertNotNil(cached)
+        XCTAssertEqual(cached?.shape, [1, 16, 32])
+    }
+
+    func testSpeakerAndCodecShareSameEntry() {
+        let cache = ReferenceAudioCache()
+        let audio: [Float] = [0.1, 0.2, 0.3]
+        let embed = MLXArray.zeros([1, 1024])
+        let codes = MLXArray.zeros([1, 16, 32])
+
+        cache.storeSpeakerEmbed(embed, audio: audio, sampleRate: 24000)
+        cache.storeCodecRefCodes(codes, audio: audio, sampleRate: 24000)
+
+        XCTAssertEqual(cache.count, 1, "Same audio + sample rate should collapse into one entry")
+        XCTAssertNotNil(cache.speakerEmbed(for: audio, sampleRate: 24000))
+        XCTAssertNotNil(cache.codecRefCodes(for: audio, sampleRate: 24000))
+    }
+
+    // MARK: - Keying
+
+    func testDifferentSampleRateMissesCache() {
+        let cache = ReferenceAudioCache()
+        let audio: [Float] = [0.1, 0.2, 0.3]
+        let embed = MLXArray.zeros([1, 1024])
+
+        cache.storeSpeakerEmbed(embed, audio: audio, sampleRate: 16000)
+        XCTAssertNotNil(cache.speakerEmbed(for: audio, sampleRate: 16000))
+        XCTAssertNil(cache.speakerEmbed(for: audio, sampleRate: 24000))
+    }
+
+    func testDifferentAudioMissesCache() {
+        let cache = ReferenceAudioCache()
+        let embed = MLXArray.zeros([1, 1024])
+
+        cache.storeSpeakerEmbed(embed, audio: [0.1, 0.2, 0.3], sampleRate: 24000)
+        XCTAssertNil(cache.speakerEmbed(for: [0.1, 0.2, 0.4], sampleRate: 24000))
+    }
+
+    // MARK: - LRU eviction
+
+    func testLRUEvictionAtCapacity() {
+        let cache = ReferenceAudioCache(capacity: 2)
+        let embed = MLXArray.zeros([1, 4])
+
+        cache.storeSpeakerEmbed(embed, audio: [1.0], sampleRate: 24000)
+        cache.storeSpeakerEmbed(embed, audio: [2.0], sampleRate: 24000)
+        XCTAssertEqual(cache.count, 2)
+
+        cache.storeSpeakerEmbed(embed, audio: [3.0], sampleRate: 24000)
+        XCTAssertEqual(cache.count, 2)
+        XCTAssertNil(cache.speakerEmbed(for: [1.0], sampleRate: 24000), "Oldest entry should evict")
+        XCTAssertNotNil(cache.speakerEmbed(for: [2.0], sampleRate: 24000))
+        XCTAssertNotNil(cache.speakerEmbed(for: [3.0], sampleRate: 24000))
+    }
+
+    func testLRUTouchOnLookupPreservesRecentEntry() {
+        let cache = ReferenceAudioCache(capacity: 2)
+        let embed = MLXArray.zeros([1, 4])
+
+        cache.storeSpeakerEmbed(embed, audio: [1.0], sampleRate: 24000)
+        cache.storeSpeakerEmbed(embed, audio: [2.0], sampleRate: 24000)
+
+        // Touch [1.0] via lookup — it should now be the most recent
+        _ = cache.speakerEmbed(for: [1.0], sampleRate: 24000)
+
+        cache.storeSpeakerEmbed(embed, audio: [3.0], sampleRate: 24000)
+        XCTAssertNotNil(cache.speakerEmbed(for: [1.0], sampleRate: 24000), "Touched entry should survive")
+        XCTAssertNil(cache.speakerEmbed(for: [2.0], sampleRate: 24000), "Untouched entry should evict")
+    }
+
+    // MARK: - Clear
+
+    func testClearRemovesAllEntries() {
+        let cache = ReferenceAudioCache()
+        let embed = MLXArray.zeros([1, 4])
+
+        cache.storeSpeakerEmbed(embed, audio: [1.0], sampleRate: 24000)
+        cache.storeSpeakerEmbed(embed, audio: [2.0], sampleRate: 24000)
+        XCTAssertEqual(cache.count, 2)
+
+        cache.clear()
+        XCTAssertEqual(cache.count, 0)
+        XCTAssertNil(cache.speakerEmbed(for: [1.0], sampleRate: 24000))
+    }
+}


### PR DESCRIPTION
## Summary
- **Qwen3-TTS**: cache speaker embedding and ICL codec tokens per reference audio. Repeated voice-cloning generations against the same waveform now skip the mel + ECAPA pass and the codec encoder pass. Content-addressed, LRU-bounded (default capacity 4), keyed by hash of raw samples + sample rate. `clearReferenceAudioCache()` exposed for explicit eviction.
- **KokoroTTS**: `fromPretrained(computeUnits:)` threads through to `KokoroNetwork` so callers can select \`.cpuAndGPU\` as a Neural Engine fallback when the ANE compiler produces incorrect output.

## Test plan
- [x] Unit tests for \`ReferenceAudioCache\` (hash stability, keying by sample rate + content, LRU eviction, LRU touch-on-lookup, clear) — 11 tests, 0.08s
- [x] E2E \`E2EVoiceCloningTests\` (5 tests) — pass; cache hits visible in log
- [x] E2E \`E2EICLVoiceCloningTests\` (4 tests) — pass
- [x] E2E \`E2EKokoroTests\` (6 tests) — pass
- [x] Full package builds clean

Cache confirmed firing during E2E: first call logs \`Speaker embedding extracted: [1, 1024]\`, subsequent calls with the same reference log \`Speaker embedding: cache hit [1, 1024]\`.