### PR TITLE
docs: Kokoro computeUnits override; Qwen3-TTS reference audio caching

### DIFF
--- a/docs/inference/qwen3-tts-inference.md
+++ b/docs/inference/qwen3-tts-inference.md
@@ -253,6 +253,28 @@ let audio = model.synthesizeWithVoiceCloneICL(
 
 ICL fixes EOS failure on short texts and non-English languages (e.g. German) that occur with x-vector-only mode.
 
+### Reference Audio Caching
+
+Both `synthesizeWithVoiceClone` (x-vector) and `synthesizeWithVoiceCloneICL` (ICL) cache their per-reference preprocessing across calls on the same model instance:
+
+- **x-vector mode** caches the ECAPA-TDNN speaker embedding `[1, 1024]`.
+- **ICL mode** additionally caches the Mimi codec encoder output `[1, 16, T_ref]`.
+
+The cache is content-addressed — keyed by a hash of the raw sample buffer and its sample rate. Repeated synthesis against the same reference waveform skips the mel + speaker encoder pass (and the codec encoder pass for ICL). Capacity is a bounded LRU (default 4 entries) to keep memory predictable when cycling through multiple reference voices.
+
+```swift
+let tts = try await Qwen3TTSModel.fromPretrained()
+
+// First call: runs ECAPA-TDNN, caches the embedding
+_ = tts.synthesizeWithVoiceClone(text: "Hello", referenceAudio: ref, ...)
+
+// Subsequent calls with the same reference: cache hit (logs "Speaker embedding: cache hit")
+_ = tts.synthesizeWithVoiceClone(text: "How are you?", referenceAudio: ref, ...)
+
+// Explicit eviction (rarely needed — LRU handles capacity)
+tts.clearReferenceAudioCache()
+```
+
 
 ## CoreML Backend (Neural Engine)
 

--- a/docs/models/kokoro-tts.md
+++ b/docs/models/kokoro-tts.md
@@ -157,6 +157,21 @@ Weights: [aufklarer/Kokoro-82M-CoreML](https://huggingface.co/aufklarer/Kokoro-8
 
 Non-autoregressive — no sampling loop, latency scales linearly with output length but remains faster than real-time.
 
+## Compute Unit Override
+
+`fromPretrained(computeUnits:)` selects which hardware the main CoreML model runs on:
+
+```swift
+// Default: Neural Engine preferred (recommended)
+let tts = try await KokoroTTSModel.fromPretrained()
+
+// Fallback: bypass ANE (use on platforms where the ANE compiler
+// produces incorrect output for this model — e.g., some iOS 26 builds)
+let tts = try await KokoroTTSModel.fromPretrained(computeUnits: .cpuAndGPU)
+```
+
+The G2P encoder/decoder always run on CPU regardless of this setting; they are small enough that CPU is the fastest path.
+
 ## Conversion
 
 ```bash


### PR DESCRIPTION
Follow-up docs for #214 (merged before docs landed).

## Summary
- \`docs/models/kokoro-tts.md\` — new "Compute Unit Override" section documenting the \`fromPretrained(computeUnits:)\` parameter and the \`.cpuAndGPU\` Neural Engine fallback.
- \`docs/inference/qwen3-tts-inference.md\` — new "Reference Audio Caching" subsection describing x-vector + ICL caching, LRU bounding, and \`clearReferenceAudioCache()\`.