### PR TITLE
audio-server: per-model --preload-{asr,tts,personaplex,enhancer} flags

### DIFF
--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -48,6 +48,26 @@ public struct AudioServer {
         _ = try await state.loadEnhancer()
     }
 
+    // Individual preload entry points so callers can warm only the
+    // models they actually use. Loading every model at boot (the old
+    // --preload behaviour) can saturate the Metal wired pool on smaller
+    // devices and deadlock the allocator on the first real request.
+    public func preloadASR() async throws {
+        _ = try await state.loadASR()
+    }
+
+    public func preloadTTS() async throws {
+        _ = try await state.loadTTS()
+    }
+
+    public func preloadPersonaPlex() async throws {
+        _ = try await state.loadPersonaPlex()
+    }
+
+    public func preloadEnhancer() async throws {
+        _ = try await state.loadEnhancer()
+    }
+
     // MARK: - HTTP Routes
 
     func buildRouter() -> Router<BasicRequestContext> {

--- a/Sources/AudioServerCLI/AudioServerCommand.swift
+++ b/Sources/AudioServerCLI/AudioServerCommand.swift
@@ -15,16 +15,40 @@ struct AudioServerCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Port to bind (default: 8080)")
     var port: Int = 8080
 
-    @Flag(name: .long, help: "Load all models on startup (slower start, faster first request)")
+    @Flag(name: .long, help: "Preload every model (ASR + TTS + PersonaPlex + Enhancer). Can saturate the Metal wired pool on smaller devices — prefer the per-model flags below unless you really need all four resident.")
     var preload: Bool = false
+
+    @Flag(name: [.customLong("preload-asr")], help: "Preload Qwen3-ASR on startup (for /transcribe-only workloads).")
+    var preloadAsr: Bool = false
+
+    @Flag(name: [.customLong("preload-tts")], help: "Preload Qwen3-TTS on startup (for /speak workloads).")
+    var preloadTts: Bool = false
+
+    @Flag(name: [.customLong("preload-personaplex")], help: "Preload PersonaPlex 7B on startup (for /respond workloads).")
+    var preloadPersonaPlex: Bool = false
+
+    @Flag(name: [.customLong("preload-enhancer")], help: "Preload SpeechEnhancement on startup (for /enhance workloads).")
+    var preloadEnhancer: Bool = false
 
     func run() async throws {
         let server = AudioServer(host: host, port: port)
 
-        if preload {
-            print("Preloading models...")
-            try await server.preloadModels()
-            print("All models loaded.")
+        let loadAll = preload
+        if loadAll || preloadAsr {
+            print("Preloading Qwen3-ASR...")
+            try await server.preloadASR()
+        }
+        if loadAll || preloadTts {
+            print("Preloading Qwen3-TTS...")
+            try await server.preloadTTS()
+        }
+        if loadAll || preloadPersonaPlex {
+            print("Preloading PersonaPlex...")
+            try await server.preloadPersonaPlex()
+        }
+        if loadAll || preloadEnhancer {
+            print("Preloading SpeechEnhancement...")
+            try await server.preloadEnhancer()
         }
 
         print("Starting server on http://\(host):\(port)")


### PR DESCRIPTION
## Summary

`--preload` eagerly loads ASR + TTS + PersonaPlex + Enhancer. On our M-series machines this reliably deadlocks the Metal allocator on the first real `/transcribe`:

```
mlx::core::scheduler::StreamThread::thread_fn
  mlx::core::array::eval
    mlx::core::gpu::eval
      mlx::core::concatenate_gpu
        mlx::core::metal::MetalAllocator::malloc  ← blocked in kernel wait (state U)
```

Each model's `fromPretrained` finishes with `MetalBudget.pinMemory(fraction: 0.9)` (`Qwen3ASR.swift:535`, `Qwen3TTS.swift:1658`, `PersonaPlex.swift:1649`). By the end of `preloadModels()` the wired pool is saturated with TTS's warmup forward + PersonaPlex's in-load `eval()` calls — there's no headroom left for the first real inference's activation concat.

For ASR-only consumers (transcription orchestrators, lecture-recording apps), loading TTS + PersonaPlex + Enhancer is unnecessary *and* triggers the deadlock. This PR exposes per-model preload flags so callers can warm only what they'll actually use.

## Changes

- `AudioServer`: add `preloadASR()` / `preloadTTS()` / `preloadPersonaPlex()` / `preloadEnhancer()` wrappers around the existing `state.loadX()` entry points.
- `AudioServerCommand`: add `--preload-asr` / `--preload-tts` / `--preload-personaplex` / `--preload-enhancer` flags. `--preload` behaviour unchanged (still loads everything) for backwards compat; help text gained a warning about the allocator saturation risk.

## Test plan

- [x] `swift build -c release --disable-sandbox --product audio-server` builds clean
- [x] `audio-server --help` surfaces all five flags with correct naming
- [x] `audio-server --port 8091 --preload-asr` starts in ~2s, health returns `{"status":"ok"}`, POSTing a real 30s lecture WAV chunk to `/transcribe` completes in 2.3s with correct transcription (vs. the same chunk hanging forever under `--preload`)
- [x] No behavioural change when `--preload` is used (still loads all four; still deadlocks if your workload hits the saturation pattern — but that's separate from this PR)

## Follow-up (not in this PR)

The `MetalBudget.pinMemory(fraction: 0.9)` call is made per-model but `mlx_set_wired_limit` takes a single global value, so the aggregate semantics when multiple models co-load are surprising. Worth a separate PR to either (a) call `pinMemory` once from `preloadModels` at the end, or (b) reduce the fraction proportionally with model count. Happy to follow up if this one lands.