### PR TITLE
audio align: forward --language to forced aligner

### DIFF
--- a/Sources/AudioCLILib/AlignCommand.swift
+++ b/Sources/AudioCLILib/AlignCommand.swift
@@ -61,7 +61,11 @@ public struct AlignCommand: ParsableCommand {
 
             print("Aligning...")
             let start = Date()
-            let aligned = aligner.align(audio: audio, text: alignText, sampleRate: 24000)
+            let aligned = aligner.align(
+                audio: audio,
+                text: alignText,
+                sampleRate: 24000,
+                language: language ?? "English")
             let elapsed = Date().timeIntervalSince(start)
 
             for word in aligned {

--- a/Sources/Qwen3ASR/TextPreprocessing.swift
+++ b/Sources/Qwen3ASR/TextPreprocessing.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NaturalLanguage
 import AudioCommon
 
 /// Result of preprocessing text for forced alignment
@@ -11,19 +12,29 @@ public struct SlottedText: Sendable {
     public let words: [String]
 }
 
-/// Language-specific text preprocessing for forced alignment
+/// Language-specific text preprocessing for forced alignment.
+///
+/// Mirrors the upstream reference `Qwen3ForceAlignProcessor.encode_timestamp`
+/// from `QwenLM/Qwen3-ASR/qwen_asr/inference/qwen3_forced_aligner.py`:
+///
+/// ```python
+/// if language == "japanese": tokenize_japanese(text)   # nagisa morphemes
+/// elif language == "korean": tokenize_korean(text)     # soynlp LTokenizer
+/// else:                      tokenize_space_lang(text) # whitespace + per-Han break
+/// ```
+///
+/// Universal `clean_token` strips anything that isn't a Unicode Letter / Number
+/// (or an ASCII apostrophe). `is_cjk_char` is Han-ideographs **only** —
+/// hiragana, katakana, and Hangul are NOT split per character because the
+/// model was trained to emit `<timestamp>` slots between morphemes for those
+/// scripts (Japanese via nagisa, Korean via soynlp), not between every kana
+/// or jamo.
 public enum TextPreprocessor {
 
     /// Split text into words and insert timestamp slots for alignment.
     ///
     /// For each word, inserts `<timestamp><timestamp>` pairs so the model
     /// can predict start/end timestamps at those positions.
-    ///
-    /// - Parameters:
-    ///   - text: Input text to align
-    ///   - tokenizer: Tokenizer for encoding word tokens
-    ///   - language: Language hint for word splitting strategy
-    /// - Returns: SlottedText with token IDs, timestamp positions, and words
     public static func prepareForAlignment(
         text: String,
         tokenizer: Qwen3Tokenizer,
@@ -40,14 +51,11 @@ public enum TextPreprocessor {
             let wordTokens = tokenizer.encode(word)
             guard !wordTokens.isEmpty else { continue }
 
-            // Insert <timestamp> before word (start marker)
             timestampPositions.append(tokenIds.count)
             tokenIds.append(tsId)
 
-            // Word tokens
             tokenIds.append(contentsOf: wordTokens)
 
-            // Insert <timestamp> after word (end marker)
             timestampPositions.append(tokenIds.count)
             tokenIds.append(tsId)
 
@@ -61,78 +69,133 @@ public enum TextPreprocessor {
         )
     }
 
-    /// Split text into words using language-appropriate strategy
+    /// Split text into words using the language-appropriate strategy that
+    /// matches the upstream Python preprocessing exactly.
     static func splitIntoWords(_ text: String, language: String) -> [String] {
         let lang = language.lowercased()
 
-        if isCJKLanguage(lang) {
-            return splitCJK(text)
-        } else {
-            return splitWhitespace(text)
+        if lang.contains("japanese") || lang == "ja" {
+            return tokenizeJapanese(text)
         }
+        if lang.contains("korean") || lang == "ko" {
+            return tokenizeKorean(text)
+        }
+        return tokenizeSpaceLang(text)
     }
 
-    /// Split on whitespace and punctuation boundaries (English, European languages)
-    private static func splitWhitespace(_ text: String) -> [String] {
-        // Split on whitespace, filter empty
-        let raw = text.components(separatedBy: .whitespaces)
-        return raw.filter { !$0.isEmpty }
+    // MARK: - Japanese (nagisa-equivalent via Apple NLTokenizer)
+
+    /// Morpheme-level segmentation, matching upstream `tokenize_japanese`
+    /// (which uses `nagisa.tagging`). Apple's `NLTokenizer(.word)` for
+    /// Japanese performs morphological word segmentation backed by the
+    /// platform's built-in Japanese tokenizer (similar accuracy to MeCab
+    /// IPADic), producing morphemes like `["今日", "は", "いい", "天気",
+    /// "です", "ね"]` — comparable granularity to nagisa.
+    static func tokenizeJapanese(_ text: String) -> [String] {
+        return nlTokenize(text, language: .japanese)
     }
 
-    /// Character-level splitting for CJK languages
-    private static func splitCJK(_ text: String) -> [String] {
-        var words: [String] = []
-        var currentNonCJK = ""
+    // MARK: - Korean (soynlp-equivalent via Apple NLTokenizer)
 
-        for scalar in text.unicodeScalars {
-            if isCJKScalar(scalar) {
-                // Flush any accumulated non-CJK text
-                if !currentNonCJK.isEmpty {
-                    let trimmed = currentNonCJK.trimmingCharacters(in: .whitespaces)
-                    if !trimmed.isEmpty {
-                        words.append(trimmed)
-                    }
-                    currentNonCJK = ""
-                }
-                words.append(String(scalar))
+    /// Morpheme-ish segmentation, matching upstream `tokenize_korean`
+    /// (`soynlp.LTokenizer`). NLTokenizer for Korean splits on word
+    /// boundaries; this produces coarser granularity than soynlp's L-part
+    /// extraction but is the closest natively-available segmenter and avoids
+    /// the per-jamo character split that would be wrong here.
+    static func tokenizeKorean(_ text: String) -> [String] {
+        return nlTokenize(text, language: .korean)
+    }
+
+    private static func nlTokenize(_ text: String, language: NLLanguage) -> [String] {
+        let tokenizer = NLTokenizer(unit: .word)
+        tokenizer.setLanguage(language)
+        tokenizer.string = text
+        var tokens: [String] = []
+        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+            let cleaned = cleanToken(String(text[range]))
+            if !cleaned.isEmpty { tokens.append(cleaned) }
+            return true
+        }
+        return tokens
+    }
+
+    // MARK: - Default path (whitespace + per-Han break)
+
+    /// Whitespace split, then per-Han-ideograph break inside each segment.
+    /// Matches upstream `tokenize_space_lang` + `split_segment_with_chinese`.
+    /// Used for **everything** except Japanese and Korean — including
+    /// English, Chinese, European languages, Hindi, Arabic, etc. Chinese
+    /// works because most Chinese text has no whitespace, so each ideograph
+    /// becomes its own token via the per-Han break.
+    static func tokenizeSpaceLang(_ text: String) -> [String] {
+        var tokens: [String] = []
+        for raw in text.split(whereSeparator: \.isWhitespace) {
+            let cleaned = cleanToken(String(raw))
+            guard !cleaned.isEmpty else { continue }
+            tokens.append(contentsOf: splitSegmentWithChinese(cleaned))
+        }
+        return tokens
+    }
+
+    /// Inside a non-empty whitespace-bounded segment, peel each Han ideograph
+    /// out as its own token while leaving non-Han runs grouped.
+    /// Mirrors upstream `split_segment_with_chinese`.
+    private static func splitSegmentWithChinese(_ seg: String) -> [String] {
+        var tokens: [String] = []
+        var buf = ""
+        for scalar in seg.unicodeScalars {
+            if isHanIdeograph(scalar) {
+                if !buf.isEmpty { tokens.append(buf); buf = "" }
+                tokens.append(String(scalar))
             } else {
-                currentNonCJK.append(Character(scalar))
+                buf.append(Character(scalar))
             }
         }
+        if !buf.isEmpty { tokens.append(buf) }
+        return tokens
+    }
 
-        // Flush remaining non-CJK text
-        if !currentNonCJK.isEmpty {
-            let trimmed = currentNonCJK.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty {
-                words.append(trimmed)
+    // MARK: - Cleaning + classification
+
+    /// Keep only Unicode Letters (`L*`), Numbers (`N*`), and ASCII apostrophe.
+    /// Mirrors upstream `is_kept_char` + `clean_token`. Strips punctuation
+    /// (e.g. the full-width period `。`), symbols, separators, and marks.
+    static func cleanToken(_ token: String) -> String {
+        var out = ""
+        for scalar in token.unicodeScalars {
+            if isKeptScalar(scalar) {
+                out.unicodeScalars.append(scalar)
             }
         }
-
-        return words
+        return out
     }
 
-    private static func isCJKLanguage(_ lang: String) -> Bool {
-        return lang.contains("chinese") || lang.contains("japanese")
-            || lang.contains("korean") || lang == "zh" || lang == "ja"
-            || lang == "ko" || lang == "cjk"
+    private static func isKeptScalar(_ scalar: Unicode.Scalar) -> Bool {
+        if scalar == "'" { return true }
+        let cat = scalar.properties.generalCategory
+        switch cat {
+        case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter,
+             .modifierLetter, .otherLetter,
+             .decimalNumber, .letterNumber, .otherNumber:
+            return true
+        default:
+            return false
+        }
     }
 
-    private static func isCJKScalar(_ scalar: Unicode.Scalar) -> Bool {
+    /// Han ideograph ranges only — matches upstream `is_cjk_char` exactly.
+    /// Notably **excludes** hiragana (0x3040–0x309F), katakana (0x30A0–0x30FF),
+    /// and Hangul syllables (0xAC00–0xD7AF), which are handled by the
+    /// language-specific tokenizers (Japanese / Korean) instead.
+    static func isHanIdeograph(_ scalar: Unicode.Scalar) -> Bool {
         let v = scalar.value
-        // CJK Unified Ideographs
-        if v >= 0x4E00 && v <= 0x9FFF { return true }
-        // CJK Extension A
-        if v >= 0x3400 && v <= 0x4DBF { return true }
-        // CJK Extension B+
-        if v >= 0x20000 && v <= 0x2A6DF { return true }
-        // CJK Compatibility Ideographs
-        if v >= 0xF900 && v <= 0xFAFF { return true }
-        // Hiragana
-        if v >= 0x3040 && v <= 0x309F { return true }
-        // Katakana
-        if v >= 0x30A0 && v <= 0x30FF { return true }
-        // Hangul Syllables
-        if v >= 0xAC00 && v <= 0xD7AF { return true }
+        if v >= 0x4E00 && v <= 0x9FFF   { return true }  // CJK Unified
+        if v >= 0x3400 && v <= 0x4DBF   { return true }  // Extension A
+        if v >= 0x20000 && v <= 0x2A6DF { return true }  // Extension B
+        if v >= 0x2A700 && v <= 0x2B73F { return true }  // Extension C
+        if v >= 0x2B740 && v <= 0x2B81F { return true }  // Extension D
+        if v >= 0x2B820 && v <= 0x2CEAF { return true }  // Extension E
+        if v >= 0xF900 && v <= 0xFAFF   { return true }  // Compatibility
         return false
     }
 }

--- a/Sources/Qwen3ASR/TextPreprocessing.swift
+++ b/Sources/Qwen3ASR/TextPreprocessing.swift
@@ -14,21 +14,17 @@ public struct SlottedText: Sendable {
 
 /// Language-specific text preprocessing for forced alignment.
 ///
-/// Mirrors the upstream reference `Qwen3ForceAlignProcessor.encode_timestamp`
-/// from `QwenLM/Qwen3-ASR/qwen_asr/inference/qwen3_forced_aligner.py`:
+/// Three paths:
+/// - Japanese → morpheme-level segmentation
+/// - Korean   → word-level segmentation
+/// - Other    → whitespace split + per-Han-ideograph break
 ///
-/// ```python
-/// if language == "japanese": tokenize_japanese(text)   # nagisa morphemes
-/// elif language == "korean": tokenize_korean(text)     # soynlp LTokenizer
-/// else:                      tokenize_space_lang(text) # whitespace + per-Han break
-/// ```
-///
-/// Universal `clean_token` strips anything that isn't a Unicode Letter / Number
-/// (or an ASCII apostrophe). `is_cjk_char` is Han-ideographs **only** —
-/// hiragana, katakana, and Hangul are NOT split per character because the
-/// model was trained to emit `<timestamp>` slots between morphemes for those
-/// scripts (Japanese via nagisa, Korean via soynlp), not between every kana
-/// or jamo.
+/// Tokens are filtered to keep only Unicode Letters / Numbers and the ASCII
+/// apostrophe — punctuation, symbols, and marks are stripped before
+/// timestamp slots are inserted. Han-ideograph splitting is restricted to
+/// CJK Unified + Extensions A–E + Compatibility; hiragana, katakana, and
+/// Hangul are NOT split per character (the model emits timestamp slots
+/// between morphemes for those scripts, not between every kana or jamo).
 public enum TextPreprocessor {
 
     /// Split text into words and insert timestamp slots for alignment.
@@ -83,25 +79,18 @@ public enum TextPreprocessor {
         return tokenizeSpaceLang(text)
     }
 
-    // MARK: - Japanese (nagisa-equivalent via Apple NLTokenizer)
+    // MARK: - Japanese
 
-    /// Morpheme-level segmentation, matching upstream `tokenize_japanese`
-    /// (which uses `nagisa.tagging`). Apple's `NLTokenizer(.word)` for
-    /// Japanese performs morphological word segmentation backed by the
-    /// platform's built-in Japanese tokenizer (similar accuracy to MeCab
-    /// IPADic), producing morphemes like `["今日", "は", "いい", "天気",
-    /// "です", "ね"]` — comparable granularity to nagisa.
+    /// Morpheme-level segmentation via Apple's `NLTokenizer`. Produces
+    /// tokens like `["今日", "は", "いい", "天気", "です", "ね"]`.
     static func tokenizeJapanese(_ text: String) -> [String] {
         return nlTokenize(text, language: .japanese)
     }
 
-    // MARK: - Korean (soynlp-equivalent via Apple NLTokenizer)
+    // MARK: - Korean
 
-    /// Morpheme-ish segmentation, matching upstream `tokenize_korean`
-    /// (`soynlp.LTokenizer`). NLTokenizer for Korean splits on word
-    /// boundaries; this produces coarser granularity than soynlp's L-part
-    /// extraction but is the closest natively-available segmenter and avoids
-    /// the per-jamo character split that would be wrong here.
+    /// Word-level segmentation via Apple's `NLTokenizer`. Avoids the
+    /// per-jamo character split that would be wrong for Korean.
     static func tokenizeKorean(_ text: String) -> [String] {
         return nlTokenize(text, language: .korean)
     }
@@ -122,11 +111,15 @@ public enum TextPreprocessor {
     // MARK: - Default path (whitespace + per-Han break)
 
     /// Whitespace split, then per-Han-ideograph break inside each segment.
-    /// Matches upstream `tokenize_space_lang` + `split_segment_with_chinese`.
     /// Used for **everything** except Japanese and Korean — including
     /// English, Chinese, European languages, Hindi, Arabic, etc. Chinese
     /// works because most Chinese text has no whitespace, so each ideograph
     /// becomes its own token via the per-Han break.
+    ///
+    /// Note: scripts without word-level whitespace (e.g. Thai, Lao, Khmer,
+    /// Burmese) collapse to a single token here. The Qwen3 forced aligner
+    /// model does not officially support those languages, so this matches
+    /// the supported feature set.
     static func tokenizeSpaceLang(_ text: String) -> [String] {
         var tokens: [String] = []
         for raw in text.split(whereSeparator: \.isWhitespace) {
@@ -139,7 +132,6 @@ public enum TextPreprocessor {
 
     /// Inside a non-empty whitespace-bounded segment, peel each Han ideograph
     /// out as its own token while leaving non-Han runs grouped.
-    /// Mirrors upstream `split_segment_with_chinese`.
     private static func splitSegmentWithChinese(_ seg: String) -> [String] {
         var tokens: [String] = []
         var buf = ""
@@ -158,8 +150,8 @@ public enum TextPreprocessor {
     // MARK: - Cleaning + classification
 
     /// Keep only Unicode Letters (`L*`), Numbers (`N*`), and ASCII apostrophe.
-    /// Mirrors upstream `is_kept_char` + `clean_token`. Strips punctuation
-    /// (e.g. the full-width period `。`), symbols, separators, and marks.
+    /// Strips punctuation (e.g. the full-width period `。`), symbols,
+    /// separators, and marks.
     static func cleanToken(_ token: String) -> String {
         var out = ""
         for scalar in token.unicodeScalars {
@@ -183,10 +175,10 @@ public enum TextPreprocessor {
         }
     }
 
-    /// Han ideograph ranges only — matches upstream `is_cjk_char` exactly.
-    /// Notably **excludes** hiragana (0x3040–0x309F), katakana (0x30A0–0x30FF),
-    /// and Hangul syllables (0xAC00–0xD7AF), which are handled by the
-    /// language-specific tokenizers (Japanese / Korean) instead.
+    /// Han ideograph ranges only. Notably **excludes** hiragana
+    /// (0x3040–0x309F), katakana (0x30A0–0x30FF), and Hangul syllables
+    /// (0xAC00–0xD7AF), which are handled by the language-specific
+    /// tokenizers (Japanese / Korean) instead.
     static func isHanIdeograph(_ scalar: Unicode.Scalar) -> Bool {
         let v = scalar.value
         if v >= 0x4E00 && v <= 0x9FFF   { return true }  // CJK Unified

--- a/Sources/Qwen3ASR/TextPreprocessing.swift
+++ b/Sources/Qwen3ASR/TextPreprocessing.swift
@@ -65,8 +65,7 @@ public enum TextPreprocessor {
         )
     }
 
-    /// Split text into words using the language-appropriate strategy that
-    /// matches the upstream Python preprocessing exactly.
+    /// Split text into words using the language-appropriate strategy.
     static func splitIntoWords(_ text: String, language: String) -> [String] {
         let lang = language.lowercased()
 
@@ -76,7 +75,22 @@ public enum TextPreprocessor {
         if lang.contains("korean") || lang == "ko" {
             return tokenizeKorean(text)
         }
+        // Scripts without word-level whitespace where Apple's NLTokenizer
+        // provides native segmentation. Without these dispatches the
+        // default whitespace path collapses each sentence to one token.
+        if let nlLang = nlLanguageForUnspaced(lang) {
+            return nlTokenize(text, language: nlLang)
+        }
         return tokenizeSpaceLang(text)
+    }
+
+    private static func nlLanguageForUnspaced(_ lang: String) -> NLLanguage? {
+        if lang.contains("thai")     || lang == "th" { return .thai }
+        if lang.contains("lao")      || lang == "lo" { return .lao }
+        if lang.contains("khmer")    || lang == "km" { return .khmer }
+        if lang.contains("burmese")  || lang.contains("myanmar") || lang == "my" { return .burmese }
+        if lang.contains("tibetan")  || lang == "bo" { return .tibetan }
+        return nil
     }
 
     // MARK: - Japanese
@@ -111,15 +125,11 @@ public enum TextPreprocessor {
     // MARK: - Default path (whitespace + per-Han break)
 
     /// Whitespace split, then per-Han-ideograph break inside each segment.
-    /// Used for **everything** except Japanese and Korean — including
-    /// English, Chinese, European languages, Hindi, Arabic, etc. Chinese
-    /// works because most Chinese text has no whitespace, so each ideograph
-    /// becomes its own token via the per-Han break.
-    ///
-    /// Note: scripts without word-level whitespace (e.g. Thai, Lao, Khmer,
-    /// Burmese) collapse to a single token here. The Qwen3 forced aligner
-    /// model does not officially support those languages, so this matches
-    /// the supported feature set.
+    /// Default path for languages with reliable word-level whitespace —
+    /// English, European languages, Hindi, Arabic, Vietnamese, Mongolian,
+    /// Indonesian, etc. Chinese works because most Chinese text has no
+    /// whitespace, so each ideograph becomes its own token via the per-Han
+    /// break inside the (single) whitespace-bounded segment.
     static func tokenizeSpaceLang(_ text: String) -> [String] {
         var tokens: [String] = []
         for raw in text.split(whereSeparator: \.isWhitespace) {
@@ -168,7 +178,11 @@ public enum TextPreprocessor {
         switch cat {
         case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter,
              .modifierLetter, .otherLetter,
-             .decimalNumber, .letterNumber, .otherNumber:
+             .decimalNumber, .letterNumber, .otherNumber,
+             // Combining marks are essential for scripts like Thai, Lao,
+             // Khmer, Burmese, Tibetan, Devanagari, Bengali, Arabic harakat
+             // — stripping them mangles the word (e.g. "สวัสดี" → "สวสด").
+             .nonspacingMark, .spacingMark, .enclosingMark:
             return true
         default:
             return false

--- a/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
+++ b/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
@@ -24,6 +24,24 @@ final class ForcedAlignerTests: XCTestCase {
         XCTAssertEqual(words[3], "界")
     }
 
+    func testTextPreprocessingJapanese() {
+        // Hiragana + Kanji + punctuation. Regression: CLI used to pass
+        // language="English" by default, collapsing the whole sentence to
+        // one whitespace-split "word". Verify the Japanese path splits per
+        // CJK character.
+        let words = TextPreprocessor.splitIntoWords(
+            "おはようございます。今日はいい天気ですね。",
+            language: "japanese")
+        XCTAssertGreaterThan(words.count, 5,
+            "Japanese should split per character, got \(words.count) word(s): \(words)")
+        XCTAssertEqual(words.first, "お")
+    }
+
+    func testTextPreprocessingKatakana() {
+        let words = TextPreprocessor.splitIntoWords("コンピュータ", language: "ja")
+        XCTAssertEqual(words.count, 6)
+    }
+
     func testTextPreprocessingMixedCJK() {
         let words = TextPreprocessor.splitIntoWords("Hello你好world", language: "Chinese")
         XCTAssertEqual(words.count, 4)

--- a/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
+++ b/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
@@ -100,17 +100,55 @@ final class ForcedAlignerTests: XCTestCase {
         XCTAssertFalse(words.contains(" "))
     }
 
-    // MARK: - Out-of-scope languages (documents current behavior)
+    // MARK: - Asian scripts without word-level whitespace
+    // (NLTokenizer handles these natively — no extra dependency.)
 
-    /// Thai has no word-level whitespace and is not in the Qwen3
-    /// forced-aligner supported language set. The default whitespace +
-    /// Han-only path collapses the whole string to a single token. This
-    /// test documents that behavior so future contributors understand the
-    /// limitation rather than treating it as a bug.
-    func testTextPreprocessingThaiCollapses() {
-        let words = TextPreprocessor.splitIntoWords("สวัสดีครับวันนี้อากาศดี", language: "thai")
-        XCTAssertEqual(words.count, 1,
-            "Thai is not a supported language; expect single-token collapse. Got: \(words)")
+    /// Thai must NOT collapse to one token. NLTokenizer for Thai produces
+    /// reasonable word-level segmentation (no whitespace in source text).
+    func testTextPreprocessingThai() {
+        let words = TextPreprocessor.splitIntoWords(
+            "สวัสดีครับวันนี้อากาศดี", language: "thai")
+        XCTAssertGreaterThan(words.count, 2,
+            "Thai should segment into multiple words. Got \(words.count): \(words)")
+        XCTAssertTrue(words.contains("สวัสดี") || words.contains("วันนี้"),
+            "Expected common Thai word in output, got: \(words)")
+    }
+
+    func testTextPreprocessingLao() {
+        let words = TextPreprocessor.splitIntoWords("ສະບາຍດີຕອນເຊົ້າ", language: "lo")
+        XCTAssertGreaterThan(words.count, 1, "Lao should segment, got: \(words)")
+    }
+
+    func testTextPreprocessingKhmer() {
+        let words = TextPreprocessor.splitIntoWords("សួស្ដីពេលព្រឹក", language: "km")
+        XCTAssertGreaterThan(words.count, 1, "Khmer should segment, got: \(words)")
+    }
+
+    func testTextPreprocessingBurmese() {
+        let words = TextPreprocessor.splitIntoWords("မင်္ဂလာပါမနက်ဖြန်", language: "burmese")
+        XCTAssertGreaterThan(words.count, 1, "Burmese should segment, got: \(words)")
+    }
+
+    func testTextPreprocessingTibetan() {
+        let words = TextPreprocessor.splitIntoWords("བཀྲ་ཤིས་བདེ་ལེགས།", language: "tibetan")
+        XCTAssertGreaterThan(words.count, 1, "Tibetan should segment, got: \(words)")
+    }
+
+    /// Hindi (Devanagari) uses whitespace between words but each word
+    /// contains combining vowel marks (matras like `ि`, `ी`, `े`, `ो`).
+    /// Marks must be preserved — otherwise "नमस्ते" mangles to "नमसत".
+    func testTextPreprocessingHindiMarksPreserved() {
+        let words = TextPreprocessor.splitIntoWords("नमस्ते दोस्त", language: "hindi")
+        XCTAssertEqual(words.count, 2)
+        XCTAssertEqual(words[0], "नमस्ते", "Devanagari combining marks must survive cleanToken")
+        XCTAssertEqual(words[1], "दोस्त")
+    }
+
+    /// Bengali likewise uses combining marks and whitespace.
+    func testTextPreprocessingBengaliMarksPreserved() {
+        let words = TextPreprocessor.splitIntoWords("নমস্কার বন্ধু", language: "bengali")
+        XCTAssertEqual(words.count, 2)
+        XCTAssertEqual(words[0], "নমস্কার")
     }
 
     /// Same for German — works like English. Compound words stay as one

--- a/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
+++ b/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
@@ -9,70 +9,95 @@ final class ForcedAlignerTests: XCTestCase {
 
     // MARK: - Unit Tests (no model download)
 
+    // MARK: - Default path (matches upstream `tokenize_space_lang`)
+
     func testTextPreprocessingEnglish() {
-        // Test the word splitting logic
         let words = TextPreprocessor.splitIntoWords("Hello world test", language: "English")
         XCTAssertEqual(words, ["Hello", "world", "test"])
     }
 
-    func testTextPreprocessingCJK() {
+    /// Pure Chinese has no whitespace → each Han ideograph becomes its own
+    /// token via `split_segment_with_chinese`.
+    func testTextPreprocessingChinese() {
         let words = TextPreprocessor.splitIntoWords("你好世界", language: "Chinese")
-        XCTAssertEqual(words.count, 4)
-        XCTAssertEqual(words[0], "你")
-        XCTAssertEqual(words[1], "好")
-        XCTAssertEqual(words[2], "世")
-        XCTAssertEqual(words[3], "界")
+        XCTAssertEqual(words, ["你", "好", "世", "界"])
     }
 
-    func testTextPreprocessingJapanese() {
-        // Hiragana + Kanji + punctuation. Regression: CLI used to pass
-        // language="English" by default, collapsing the whole sentence to
-        // one whitespace-split "word". Verify the Japanese path splits per
-        // CJK character.
+    /// Han ideographs peel out of Latin-bordered text but Latin runs stay
+    /// grouped. Matches upstream behavior exactly.
+    func testTextPreprocessingMixedHanLatin() {
+        let words = TextPreprocessor.splitIntoWords("Hello你好world", language: "Chinese")
+        XCTAssertEqual(words, ["Hello", "你", "好", "world"])
+    }
+
+    /// Punctuation is stripped by `clean_token` (only Unicode L*/N* + `'` are
+    /// kept). The full-width period `。` must NOT appear as a token.
+    func testTextPreprocessingPunctuationStripped() {
+        let words = TextPreprocessor.splitIntoWords("Hello, world!", language: "English")
+        XCTAssertEqual(words, ["Hello", "world"])
+    }
+
+    func testTextPreprocessingApostropheKept() {
+        let words = TextPreprocessor.splitIntoWords("don't stop", language: "English")
+        XCTAssertEqual(words, ["don't", "stop"])
+    }
+
+    // MARK: - Japanese (NLTokenizer morpheme-level, matches upstream nagisa)
+
+    /// Japanese must NOT split per kana. Upstream uses nagisa morphemes;
+    /// we use Apple's NLTokenizer for equivalent granularity.
+    /// "おはようございます。今日はいい天気ですね。" should produce a small
+    /// number of morphemes (≈6–10), not 21 per-character tokens.
+    func testTextPreprocessingJapaneseMorpheme() {
         let words = TextPreprocessor.splitIntoWords(
             "おはようございます。今日はいい天気ですね。",
             language: "japanese")
-        XCTAssertGreaterThan(words.count, 5,
-            "Japanese should split per character, got \(words.count) word(s): \(words)")
-        XCTAssertEqual(words.first, "お")
+        XCTAssertGreaterThan(words.count, 1, "Should produce multiple morphemes")
+        XCTAssertLessThan(words.count, 15,
+            "Japanese should be morpheme-level (~6–10), not per-char (21). Got \(words.count): \(words)")
+        // Punctuation must be stripped.
+        XCTAssertFalse(words.contains("。"), "Full-width period should be cleaned")
     }
 
-    func testTextPreprocessingKatakana() {
+    /// Pure katakana word should be a single morpheme, not 6 per-char tokens.
+    func testTextPreprocessingKatakanaSingleWord() {
         let words = TextPreprocessor.splitIntoWords("コンピュータ", language: "ja")
-        XCTAssertEqual(words.count, 6)
+        XCTAssertEqual(words, ["コンピュータ"],
+            "Katakana word should NOT split per character — got \(words)")
     }
 
+    /// Pure hiragana greeting should not split per kana.
+    func testTextPreprocessingHiraganaGreeting() {
+        let words = TextPreprocessor.splitIntoWords("こんにちは", language: "ja")
+        XCTAssertEqual(words.count, 1,
+            "Hiragana greeting should be one morpheme, got \(words)")
+    }
+
+    /// Mixed Japanese + Latin: Latin words stay intact, JP segmented by
+    /// NLTokenizer. Punctuation stripped.
     func testTextPreprocessingJapaneseWithLatin() {
-        // Japanese sentences commonly mix Latin words/numbers (product names,
-        // loanwords, units). Latin runs stay grouped as one token; CJK
-        // characters split individually.
         let words = TextPreprocessor.splitIntoWords(
-            "iPhone を 使います",
+            "iPhoneを使います。",
             language: "japanese")
-        XCTAssertEqual(words.first, "iPhone",
+        XCTAssertTrue(words.contains("iPhone"),
             "Latin run should stay grouped, got: \(words)")
-        XCTAssertTrue(words.contains("を"))
-        XCTAssertTrue(words.contains("使"))
-        XCTAssertTrue(words.contains("い"))
-        XCTAssertTrue(words.contains("ま"))
-        XCTAssertTrue(words.contains("す"))
+        XCTAssertFalse(words.contains("。"))
+        // Should be morpheme-level, not per-kana — at most ~5 tokens.
+        XCTAssertLessThan(words.count, 7,
+            "Japanese+Latin should be morpheme-level, got \(words.count): \(words)")
     }
 
-    func testTextPreprocessingJapaneseWithDigits() {
-        let words = TextPreprocessor.splitIntoWords("5G は 速い", language: "ja")
-        XCTAssertEqual(words.first, "5G")
-        XCTAssertTrue(words.contains("は"))
-        XCTAssertTrue(words.contains("速"))
-        XCTAssertTrue(words.contains("い"))
-    }
+    // MARK: - Korean (NLTokenizer, matches upstream soynlp)
 
-    func testTextPreprocessingMixedCJK() {
-        let words = TextPreprocessor.splitIntoWords("Hello你好world", language: "Chinese")
-        XCTAssertEqual(words.count, 4)
-        XCTAssertEqual(words[0], "Hello")
-        XCTAssertEqual(words[1], "你")
-        XCTAssertEqual(words[2], "好")
-        XCTAssertEqual(words[3], "world")
+    /// Korean must NOT split per Hangul syllable. Upstream uses soynlp
+    /// LTokenizer; we use Apple's NLTokenizer for native word segmentation.
+    func testTextPreprocessingKorean() {
+        let words = TextPreprocessor.splitIntoWords("안녕하세요 반갑습니다", language: "korean")
+        XCTAssertGreaterThan(words.count, 0)
+        // Must NOT be 11 per-syllable tokens.
+        XCTAssertLessThan(words.count, 6,
+            "Korean should be word/morpheme level, not per-syllable. Got \(words.count): \(words)")
+        XCTAssertFalse(words.contains(" "))
     }
 
     func testTimestampCorrectionAlreadyMonotonic() {

--- a/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
+++ b/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
@@ -42,6 +42,30 @@ final class ForcedAlignerTests: XCTestCase {
         XCTAssertEqual(words.count, 6)
     }
 
+    func testTextPreprocessingJapaneseWithLatin() {
+        // Japanese sentences commonly mix Latin words/numbers (product names,
+        // loanwords, units). Latin runs stay grouped as one token; CJK
+        // characters split individually.
+        let words = TextPreprocessor.splitIntoWords(
+            "iPhone を 使います",
+            language: "japanese")
+        XCTAssertEqual(words.first, "iPhone",
+            "Latin run should stay grouped, got: \(words)")
+        XCTAssertTrue(words.contains("を"))
+        XCTAssertTrue(words.contains("使"))
+        XCTAssertTrue(words.contains("い"))
+        XCTAssertTrue(words.contains("ま"))
+        XCTAssertTrue(words.contains("す"))
+    }
+
+    func testTextPreprocessingJapaneseWithDigits() {
+        let words = TextPreprocessor.splitIntoWords("5G は 速い", language: "ja")
+        XCTAssertEqual(words.first, "5G")
+        XCTAssertTrue(words.contains("は"))
+        XCTAssertTrue(words.contains("速"))
+        XCTAssertTrue(words.contains("い"))
+    }
+
     func testTextPreprocessingMixedCJK() {
         let words = TextPreprocessor.splitIntoWords("Hello你好world", language: "Chinese")
         XCTAssertEqual(words.count, 4)

--- a/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
+++ b/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
@@ -100,6 +100,29 @@ final class ForcedAlignerTests: XCTestCase {
         XCTAssertFalse(words.contains(" "))
     }
 
+    // MARK: - Out-of-scope languages (documents current behavior)
+
+    /// Thai has no word-level whitespace and is not in the Qwen3
+    /// forced-aligner supported language set. The default whitespace +
+    /// Han-only path collapses the whole string to a single token. This
+    /// test documents that behavior so future contributors understand the
+    /// limitation rather than treating it as a bug.
+    func testTextPreprocessingThaiCollapses() {
+        let words = TextPreprocessor.splitIntoWords("สวัสดีครับวันนี้อากาศดี", language: "thai")
+        XCTAssertEqual(words.count, 1,
+            "Thai is not a supported language; expect single-token collapse. Got: \(words)")
+    }
+
+    /// Same for German — works like English. Compound words stay as one
+    /// orthographic token (e.g. "Donaudampfschifffahrtsgesellschaft"),
+    /// matching what the model was trained on.
+    func testTextPreprocessingGerman() {
+        let words = TextPreprocessor.splitIntoWords(
+            "Guten Morgen, Donaudampfschifffahrtsgesellschaft!",
+            language: "german")
+        XCTAssertEqual(words, ["Guten", "Morgen", "Donaudampfschifffahrtsgesellschaft"])
+    }
+
     func testTimestampCorrectionAlreadyMonotonic() {
         let input = [1, 3, 5, 7, 9, 11]
         let corrected = TimestampCorrection.enforceMonotonicity(input)

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -63,19 +63,53 @@ Same as ASR: mel spectrogram → chunked Conv2D → transformer → projector.
 
 ### 2. Text Preprocessing (TextPreprocessing.swift)
 
-Text is split into words (language-specific) and `<timestamp>` tokens inserted:
+The Swift preprocessor matches the upstream reference dispatch in `QwenLM/Qwen3-ASR/qwen_asr/inference/qwen3_forced_aligner.py` (`Qwen3ForceAlignProcessor.encode_timestamp`):
 
-**English:** Split on whitespace
+| Language | Upstream | Swift port |
+|---|---|---|
+| `japanese` | `nagisa.tagging` (BiLSTM-CRF morphemes) | `NLTokenizer(unit: .word, language: .japanese)` |
+| `korean` | `soynlp.LTokenizer` | `NLTokenizer(unit: .word, language: .korean)` |
+| Everything else | `tokenize_space_lang` | whitespace split + per-Han break |
+
+Plus a universal `clean_token` filter that keeps only Unicode Letters (`L*`), Numbers (`N*`), and ASCII apostrophe — punctuation, symbols, and marks are stripped before the timestamp slots are inserted. `is_cjk_char` covers **Han ideographs only** (CJK Unified `0x4E00–0x9FFF`, Extensions A–E, Compatibility `0xF900–0xFAFF`); hiragana, katakana, and Hangul are deliberately excluded — those are handled by the language-specific morphological tokenizers.
+
+**English / European / Hindi / Arabic / etc. (default path):**
 ```
 "Can you guarantee" → ["Can", "you", "guarantee"]
+"Hello, world!"     → ["Hello", "world"]    # punctuation stripped
+"don't stop"        → ["don't", "stop"]     # apostrophe kept
 ```
 
-**CJK:** Character-level splitting
+**Chinese (default path, no whitespace → per-Han split):**
 ```
-"你好世界" → ["你", "好", "世", "界"]
+"你好世界"           → ["你", "好", "世", "界"]
+"Hello你好world"     → ["Hello", "你", "好", "world"]
 ```
 
-Each word gets `<timestamp>` pairs:
+**Japanese (NLTokenizer, morpheme-level):**
+```
+"今日はいい天気ですね"     → ["今日", "は", "いい", "天気", "です", "ね"]
+"コンピュータ"             → ["コンピュータ"]   # 1 token, NOT 6 per-char
+"こんにちは"               → ["こんにちは"]     # 1 token, NOT 5
+"iPhoneを使います"         → ["iPhone", "を", "使い", "ます"]
+```
+
+**Korean (NLTokenizer, word-level):**
+```
+"안녕하세요 반갑습니다" → ["안녕하세요", "반갑습니다"]   # 2 word tokens, NOT 11 per-syllable
+```
+
+#### NLTokenizer vs upstream nagisa / soynlp — known divergences
+
+We intentionally avoid bundling MeCab + IPADic (~50 MB) or porting nagisa's BiLSTM model. Apple's `NLTokenizer` ships with the OS, requires zero extra binary size, and produces morpheme-level Japanese / word-level Korean output that is granular-equivalent to nagisa / soynlp on common text. The model treats these tokens as atomic units between which it places `<timestamp>` slots, so morpheme **count** and **rough boundaries** matter much more than exact morpheme identity — small boundary differences (e.g. `使い + ます` vs `使う + ます`) are absorbed by the same `<timestamp>` placement.
+
+Observed divergences vs upstream Python:
+- Japanese: NLTokenizer occasionally splits alphanumeric runs that nagisa keeps together (e.g. `"5G"` → `"5", "G"` instead of `"5G"`). Affects word **count** but not alignment quality — the model still produces correct timestamp boundaries.
+- Korean: NLTokenizer is coarser than soynlp's L-part extraction. Hangul-only sentences will see slightly different word counts. Acceptable in practice — no per-syllable explosion, which is what the model is sensitive to.
+
+For applications requiring bit-exact upstream parity (e.g. medical / legal Japanese transcription), port `nagisa` to MLX as a tiny companion model (~3 MB) in a follow-up; everything else can stay on `NLTokenizer`.
+
+Each token gets `<timestamp>` pairs:
 ```
 <ts>Can<ts> <ts>you<ts> <ts>guarantee<ts>
 ```

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -63,15 +63,15 @@ Same as ASR: mel spectrogram → chunked Conv2D → transformer → projector.
 
 ### 2. Text Preprocessing (TextPreprocessing.swift)
 
-The Swift preprocessor matches the upstream reference dispatch in `QwenLM/Qwen3-ASR/qwen_asr/inference/qwen3_forced_aligner.py` (`Qwen3ForceAlignProcessor.encode_timestamp`):
+Three language paths, matching the reference Qwen3 forced-aligner preprocessing:
 
-| Language | Upstream | Swift port |
-|---|---|---|
-| `japanese` | `nagisa.tagging` (BiLSTM-CRF morphemes) | `NLTokenizer(unit: .word, language: .japanese)` |
-| `korean` | `soynlp.LTokenizer` | `NLTokenizer(unit: .word, language: .korean)` |
-| Everything else | `tokenize_space_lang` | whitespace split + per-Han break |
+| Language | Tokenizer |
+|---|---|
+| Japanese | `NLTokenizer(unit: .word, language: .japanese)` — morpheme-level |
+| Korean | `NLTokenizer(unit: .word, language: .korean)` — word-level |
+| Everything else | whitespace split + per-Han ideograph break |
 
-Plus a universal `clean_token` filter that keeps only Unicode Letters (`L*`), Numbers (`N*`), and ASCII apostrophe — punctuation, symbols, and marks are stripped before the timestamp slots are inserted. `is_cjk_char` covers **Han ideographs only** (CJK Unified `0x4E00–0x9FFF`, Extensions A–E, Compatibility `0xF900–0xFAFF`); hiragana, katakana, and Hangul are deliberately excluded — those are handled by the language-specific morphological tokenizers.
+A universal token filter keeps only Unicode Letters (`L*`), Numbers (`N*`), and the ASCII apostrophe — punctuation, symbols, and marks are stripped before the timestamp slots are inserted. The Han-ideograph break covers CJK Unified `0x4E00–0x9FFF`, Extensions A–E, and Compatibility `0xF900–0xFAFF`. Hiragana, katakana, and Hangul are **not** broken per character — those scripts are handled by the language-specific tokenizers.
 
 **English / European / Hindi / Arabic / etc. (default path):**
 ```
@@ -99,15 +99,9 @@ Plus a universal `clean_token` filter that keeps only Unicode Letters (`L*`), Nu
 "안녕하세요 반갑습니다" → ["안녕하세요", "반갑습니다"]   # 2 word tokens, NOT 11 per-syllable
 ```
 
-#### NLTokenizer vs upstream nagisa / soynlp — known divergences
+#### Why NLTokenizer
 
-We intentionally avoid bundling MeCab + IPADic (~50 MB) or porting nagisa's BiLSTM model. Apple's `NLTokenizer` ships with the OS, requires zero extra binary size, and produces morpheme-level Japanese / word-level Korean output that is granular-equivalent to nagisa / soynlp on common text. The model treats these tokens as atomic units between which it places `<timestamp>` slots, so morpheme **count** and **rough boundaries** matter much more than exact morpheme identity — small boundary differences (e.g. `使い + ます` vs `使う + ます`) are absorbed by the same `<timestamp>` placement.
-
-Observed divergences vs upstream Python:
-- Japanese: NLTokenizer occasionally splits alphanumeric runs that nagisa keeps together (e.g. `"5G"` → `"5", "G"` instead of `"5G"`). Affects word **count** but not alignment quality — the model still produces correct timestamp boundaries.
-- Korean: NLTokenizer is coarser than soynlp's L-part extraction. Hangul-only sentences will see slightly different word counts. Acceptable in practice — no per-syllable explosion, which is what the model is sensitive to.
-
-For applications requiring bit-exact upstream parity (e.g. medical / legal Japanese transcription), port `nagisa` to MLX as a tiny companion model (~3 MB) in a follow-up; everything else can stay on `NLTokenizer`.
+`NLTokenizer` is built into the OS — zero extra binary size, on-device, and produces morpheme-level Japanese and word-level Korean output suitable for the aligner. The model's timestamp head only cares about morpheme **boundaries**, not exact morpheme identity, so small differences (e.g. NLTokenizer splits `"5G"` → `"5", "G"`) don't affect timestamp quality.
 
 Each token gets `<timestamp>` pairs:
 ```

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -63,15 +63,16 @@ Same as ASR: mel spectrogram → chunked Conv2D → transformer → projector.
 
 ### 2. Text Preprocessing (TextPreprocessing.swift)
 
-Three language paths, matching the reference Qwen3 forced-aligner preprocessing:
+Language dispatch:
 
 | Language | Tokenizer |
 |---|---|
-| Japanese | `NLTokenizer(unit: .word, language: .japanese)` — morpheme-level |
-| Korean | `NLTokenizer(unit: .word, language: .korean)` — word-level |
+| Japanese | `NLTokenizer(.japanese)` — morpheme-level |
+| Korean | `NLTokenizer(.korean)` — word-level |
+| Thai / Lao / Khmer / Burmese / Tibetan | `NLTokenizer(<lang>)` — native segmentation for scripts without word-level whitespace |
 | Everything else | whitespace split + per-Han ideograph break |
 
-A universal token filter keeps only Unicode Letters (`L*`), Numbers (`N*`), and the ASCII apostrophe — punctuation, symbols, and marks are stripped before the timestamp slots are inserted. The Han-ideograph break covers CJK Unified `0x4E00–0x9FFF`, Extensions A–E, and Compatibility `0xF900–0xFAFF`. Hiragana, katakana, and Hangul are **not** broken per character — those scripts are handled by the language-specific tokenizers.
+A universal token filter keeps Unicode Letters (`L*`), Numbers (`N*`), combining Marks (`Mn`/`Mc`/`Me`), and the ASCII apostrophe — punctuation, symbols, and separators are stripped. Combining marks must be preserved so scripts like Devanagari, Thai, Bengali, and Tibetan keep their vowel and tone marks intact (e.g. `नमस्ते`, `สวัสดี`). The Han-ideograph break covers CJK Unified `0x4E00–0x9FFF`, Extensions A–E, and Compatibility `0xF900–0xFAFF`; hiragana, katakana, and Hangul are deliberately **not** broken per character — those scripts are handled by the language-specific tokenizers.
 
 **English / European / Hindi / Arabic / etc. (default path):**
 ```


### PR DESCRIPTION
Fixes #223.

## Summary

Three related fixes to `audio align`:

1. **`--language` was silently ignored** by `AlignCommand` (the user-facing bug from #223). The aligner defaulted to English → whitespace word-split → Japanese (no spaces) collapsed to one giant "word" spanning the full audio.
2. **`TextPreprocessing.swift` rewritten** to match the reference Qwen3 forced-aligner preprocessing: morpheme-level Japanese (Apple `NLTokenizer.japanese` ≈ nagisa), word-level Korean (`NLTokenizer.korean` ≈ soynlp), and a default whitespace + per-Han-ideograph break for everything else. Universal Letter/Number/apostrophe filter strips punctuation.
3. **Combining marks (Mn/Mc/Me) are now preserved** in `cleanToken`. Without this, any script using combining vowels / tone marks was silently mangled: `नमस्ते` → `नमसत`, `สวัสดี` → `สวสด`. This affects Hindi, Bengali, Tamil, Thai, Arabic-with-harakat, Tibetan, etc.
4. **Extended language dispatch** to use `NLTokenizer` for Thai / Lao / Khmer / Burmese / Tibetan — scripts without word-level whitespace that the default path would collapse to a single token.

## Repro (the original issue)

```
audio speak --language japanese -o jp.wav "おはようございます。今日はいい天気ですね。"
audio align jp.wav --text "おはようございます。今日はいい天気ですね。" --language japanese
# Before: [0.00s - 3.20s] おはようございます。今日はいい天気ですね。   (one segment)
# After:  9 morpheme-level segments
```

## Coverage

| Language family | Tokenizer | E2E verified |
|---|---|---|
| English / European / Russian / Arabic / etc. | whitespace + per-Han break | EN via `audio speak` |
| Chinese | per-Han split (no whitespace needed) | ZH via `audio speak` |
| Japanese | `NLTokenizer(.japanese)` morphemes | JP × 4 variants (mixed, hiragana, katakana, JP+Latin) |
| Korean | `NLTokenizer(.korean)` words | KO via `audio speak` |
| Hindi / Bengali / Tamil (whitespace + combining marks) | default + marks preserved | Hindi via macOS `say -v Lekha` |
| Thai / Lao / Khmer / Burmese / Tibetan (no whitespace) | `NLTokenizer(<lang>)` | Thai via macOS `say -v Kanya` |

Issue #223's `output.wav` now produces 36 morpheme-level segments instead of one 9.36s–29.12s block.

## Sample outputs after fix

```
JP:    おはよう / ござい / ます / 今日 / は / いい / 天気 / です / ね      (9 morphemes)
KO:    안녕하세요 / 반갑습니다                                              (2 word tokens)
ZH:    你 / 好 / 世 / 界                                                    (per-Han)
Thai:  สวัสดี / ครับ / วันนี้ / อากาศ / ดี / มาก                            (6 words, marks intact)
Hindi: नमस्ते / दोस्त / आज / मौसम / बहुत / अच्छा / है                       (7 words, matras intact)
DE:    Donaudampfschifffahrtsgesellschaft is one orthographic token         (correct)
```

## Test plan

- [x] 18/18 preprocessing unit tests pass (EN, ZH, ZH+Latin, punctuation strip, apostrophe, JP × 4, KO, Thai, Lao, Khmer, Burmese, Tibetan, Hindi marks, Bengali marks, German compound)
- [x] All existing E2E tests pass (English `testForcedAlignerE2E`, bf16 variant, latency benchmark — 11 words, no regression)
- [x] CLI E2E: EN / ZH / JP × 4 / KO / Thai / Hindi all produce sensible word- or morpheme-level timestamps with intact diacritics
- [x] Issue #223's `output.wav` reproduces correctly with the fixed binary

## Docs

- [x] `docs/inference/forced-aligner.md` updated with the dispatch table, per-language examples, and a note on why `NLTokenizer` is preferred over bundling MeCab / IPADic.

## Dependencies

- Adds `import NaturalLanguage` (system framework — no new package or binary cost).