### PR TITLE
audio align: lift implicit 2-min ASR cap

### DIFF
--- a/Sources/AudioCLILib/AlignCommand.swift
+++ b/Sources/AudioCLILib/AlignCommand.swift
@@ -24,6 +24,9 @@ public struct AlignCommand: ParsableCommand {
     @Option(name: .long, help: "Language hint (optional)")
     public var language: String?
 
+    @Option(name: .long, help: "Max ASR decoder tokens when transcribing (≈ 250 tokens/min)")
+    public var maxTokens: Int = 4096
+
     public init() {}
 
     public func run() throws {
@@ -46,7 +49,11 @@ public struct AlignCommand: ParsableCommand {
                     modelId: modelId, progressHandler: reportProgress)
 
                 print("Transcribing...")
-                textToAlign = asrModel.transcribe(audio: audio, sampleRate: 24000, language: language)
+                textToAlign = asrModel.transcribe(
+                    audio: audio,
+                    sampleRate: 24000,
+                    language: language,
+                    maxTokens: maxTokens)
                 print("Transcription: \(textToAlign!)")
             }
 


### PR DESCRIPTION
## Summary

- \`audio align <file>\` (no \`--text\`) was silently truncating transcription at ~2 minutes because \`AlignCommand\` called \`Qwen3ASRModel.transcribe\` with the default \`maxTokens: 448\`
- Bump the align-path default to 4096 tokens (~15 min of speech) and expose \`--max-tokens\` for longer files
- Verified locally on a 4.5-min English clip (\`ted-test.wav\`): alignment now reaches 271s; previously stopped near 120s

## Test plan

- [x] \`swift build -c release\` clean
- [x] \`audio align --help\` shows new flag with default 4096
- [x] Manual run on 4.5-min clip — alignment covers full duration