### PR TITLE
Add config.json + CLI overrides for CosyVoice3 model id and per-component quantization bits

### DIFF
--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -23,6 +23,19 @@ public struct AudioServer {
         self.port = port
     }
 
+    /// momoclaw fork extension: lets the CLI pin a non-default CosyVoice3
+    /// model id (e.g. our locally re-quantized 8-bit bundle). Nil keeps
+    /// upstream behaviour (loads aufklarer/CosyVoice3-0.5B-MLX-4bit on first
+    /// /speak request). See momoclaw doc Commit B for the contract.
+    public init(host: String = "127.0.0.1",
+                port: Int = 8080,
+                preload: Bool = false,
+                cosyvoiceModelId: String?) {
+        self.state = ModelState(cosyvoiceModelId: cosyvoiceModelId)
+        self.host = host
+        self.port = port
+    }
+
     public func run() async throws {
         let router = buildRouter()
         let state = self.state
@@ -187,6 +200,16 @@ final class ModelState: @unchecked Sendable {
     private var enhancer: SpeechEnhancer?
     var spmDecoder: SentencePieceDecoder?
 
+    /// momoclaw fork: optional override for the CosyVoice3 HF model id used
+    /// by `loadCosyVoice()`. nil = upstream behaviour
+    /// (aufklarer/CosyVoice3-0.5B-MLX-4bit). Threaded in from
+    /// `audio-server --cosyvoice-model-id` (Commit B).
+    let cosyvoiceModelId: String?
+
+    init(cosyvoiceModelId: String? = nil) {
+        self.cosyvoiceModelId = cosyvoiceModelId
+    }
+
     func loadASR() async throws -> Qwen3ASRModel {
         if let m = asr { return m }
         print("[server] Loading Qwen3-ASR...")
@@ -205,6 +228,13 @@ final class ModelState: @unchecked Sendable {
 
     func loadCosyVoice() async throws -> CosyVoiceTTSModel {
         if let m = cosyvoice { return m }
+        if let id = cosyvoiceModelId {
+            print("[server] Loading CosyVoice from \(id)...")
+            let m = try await CosyVoiceTTSModel.fromPretrained(
+                modelId: id, progressHandler: logProgress)
+            cosyvoice = m
+            return m
+        }
         print("[server] Loading CosyVoice...")
         let m = try await CosyVoiceTTSModel.fromPretrained(progressHandler: logProgress)
         cosyvoice = m

--- a/Sources/AudioServerCLI/AudioServerCommand.swift
+++ b/Sources/AudioServerCLI/AudioServerCommand.swift
@@ -18,8 +18,19 @@ struct AudioServerCommand: AsyncParsableCommand {
     @Flag(name: .long, help: "Load all models on startup (slower start, faster first request)")
     var preload: Bool = false
 
+    /// momoclaw fork extension (Commit B): pin a non-default CosyVoice3 HF
+    /// model id (or local cache directory under ~/Library/Caches/qwen3-speech/models/).
+    /// Default keeps upstream behaviour (aufklarer/CosyVoice3-0.5B-MLX-4bit on
+    /// first /speak request).
+    @Option(name: .long,
+            help: "CosyVoice3 model id (e.g. momoclaw/CosyVoice3-0.5B-MLX-8bit-full)")
+    var cosyvoiceModelId: String?
+
     func run() async throws {
-        let server = AudioServer(host: host, port: port)
+        let server = AudioServer(host: host,
+                                 port: port,
+                                 preload: preload,
+                                 cosyvoiceModelId: cosyvoiceModelId)
 
         if preload {
             print("Preloading models...")

--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -59,11 +59,21 @@ public final class CosyVoiceTTSModel {
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> CosyVoiceTTSModel {
-        let config = CosyVoiceConfig.default
-        let model = CosyVoiceTTSModel(config: config)
+        var config = CosyVoiceConfig.default
 
         // Get cache directory
         let cacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+
+        // momoclaw patch: aufklarer-style config.json carries `quantization.bits`
+        // (and optional `quantization.llm_bits` / `flow_bits`) so a higher-precision
+        // local re-quant (e.g. an 8-bit LLM) loads with matching unpacking.
+        // Falling back to default 4 if unreadable preserves the original behaviour
+        // for the stock aufklarer model on first download.
+        if let cfg = readQuantizationOverrides(from: cacheDir.appendingPathComponent("config.json")) {
+            if let llmBits = cfg.llmBits { config.llm.bits = llmBits }
+            if let flowBits = cfg.flowBits { config.flow.dit.bits = flowBits }
+        }
+        let model = CosyVoiceTTSModel(config: config)
 
         // Download if needed (check both weights and tokenizer)
         let needsWeights = !HuggingFaceDownloader.weightsExist(in: cacheDir)
@@ -287,4 +297,31 @@ public final class CosyVoiceTTSModel {
         // Concatenate: [instruction_tokens, <|endofprompt|>, text_tokens]
         return instructionTokens + [Self.endOfPromptToken] + textTokens
     }
+}
+
+// momoclaw patch: lightweight reader for the quantization block in
+// `config.json`. We only care about the bit-widths because everything
+// else in the on-disk config matches `CosyVoiceConfig.default`. Returning
+// nil silently keeps the original (4-bit) default loading path working.
+struct CosyVoiceQuantOverrides {
+    let bits: Int?
+    let llmBits: Int?
+    let flowBits: Int?
+}
+
+func readQuantizationOverrides(from url: URL) -> CosyVoiceQuantOverrides? {
+    guard let data = try? Data(contentsOf: url),
+          let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let q = root["quantization"] as? [String: Any] else {
+        return nil
+    }
+    func intOrNil(_ key: String) -> Int? {
+        if let v = q[key] as? Int { return v }
+        if let v = q[key] as? NSNumber { return v.intValue }
+        return nil
+    }
+    let bits = intOrNil("bits")
+    let llm = intOrNil("llm_bits") ?? bits
+    let flow = intOrNil("flow_bits") ?? bits
+    return CosyVoiceQuantOverrides(bits: bits, llmBits: llm, flowBits: flow)
 }


### PR DESCRIPTION
## Summary

Two small, additive patches that let `audio-server` load a non-default CosyVoice3 MLX bundle (e.g. a higher-precision local re-quantization) without forking the binary or hot-swapping at runtime. Both are backwards-compatible — when the new config keys / CLI flag are absent, behavior is byte-identical to current `main`.

- **Commit 1** — `CosyVoiceTTSModel.fromPretrained` reads `quantization.{llm_bits,flow_bits}` from the local `config.json`, threading per-component bit widths into `CosyVoiceLLMConfig.bits` / `CosyVoiceDiTConfig.bits` so a non-4-bit safetensors blob loads with the right `QuantizedLinear` unpacking factor. Without this, the loader hard-codes `bits=4` from `CosyVoiceConfig.default` and any 8-bit (or any non-4-bit) bundle fails with shape mismatches in `QuantizedLinear`.
- **Commit 2** — `audio-server` accepts `--cosyvoice-model-id <id>`, plumbed through `AudioServer` → `ModelState.loadCosyVoice()`. `nil` keeps the upstream default (`aufklarer/CosyVoice3-0.5B-MLX-4bit`), so existing deployments are unaffected.

## Motivation

Built while integrating CosyVoice3 into a desktop voice agent on Apple Silicon. The 4-bit MLX bundle produced audible "AI artefact" noise on Chinese, especially short utterances. Re-quantizing the LLM and flow components from PyTorch fp32 to MLX 8-bit (HiFi-GAN stays fp32, byte-identical) closes most of the audible gap to the fp32 oracle without giving up real-time RTF — but the stock `audio-server` wouldn't load the new bundle, hence these two knobs.

The published 8-bit-full bundle that exercises these patches is at https://huggingface.co/aimason/CosyVoice3-0.5B-MLX-8bit-full/tree/v1 (Apache-2.0, 1.07 GB).

## Test plan

- [x] `xcodebuild -scheme audio-server -configuration Release` succeeds.
- [x] `audio-server --help` lists `--cosyvoice-model-id`.
- [x] `audio-server --cosyvoice-model-id aimason/CosyVoice3-0.5B-MLX-8bit-full` + `POST /speak` returns 24 kHz mono PCM WAV (verified for both ZH and EN prompts).
- [x] `audio-server --cosyvoice-model-id <bad-id>` returns clean 500 from HF 404 (no crash, no hang).
- [x] No flag and no `quantization` key in config.json → identical behavior to current `main` (loads default 4-bit aufklarer bundle).
- [x] Snapshot-download of an 8-bit bundle from a clean cache → loaded successfully → `/speak` works end-to-end.