### PR TITLE
KokoroTTS: use .process for Resources so iOS bundle layout is flat

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -251,7 +251,7 @@ let package = Package(
                 "AudioCommon",
             ],
             resources: [
-                .copy("Resources"),
+                .process("Resources"),
             ]
         ),
         .target(


### PR DESCRIPTION
### Problem

Building any iOS app that depends on `KokoroTTS` fails at codesign with:

> Qwen3Speech_KokoroTTS.bundle: bundle format unrecognized, invalid, or unsuitable

Inspecting the bundle in `BUILT_PRODUCTS_DIR`:

```
Qwen3Speech_KokoroTTS.bundle/
├── Info.plist
└── Resources/
    ├── dict_fr.json
    ├── dict_hi.json
    └── dict_pt.json
```

That's macOS bundle layout. iOS expects flat: files at the bundle root, no `Resources/` subdir.

### Cause

`Sources/KokoroTTS/Resources` is declared with `.copy("Resources")`, which preserves the directory verbatim regardless of platform.

### Fix

Switch to `.process("Resources")`. SwiftPM then handles platform-correct placement (flat on iOS, `Contents/Resources/` on macOS) and applies any per-file processing along the way. The `dict_*.json` files pass through unchanged.

### Testing

Verified `KokoroTTSModel.fromPretrained` still loads the `dict_*.json` files via `Bundle.module` after the change on iOS Simulator (iPhone 17 Pro, iOS 26.5). macOS build unaffected.

### Repro

Add the `KokoroTTS` SPM product to any iOS app target on Xcode 26 → build for simulator → see the codesign error above.