### PR TITLE
Qwen3ASR: double-buffer asyncEval greedy decode

### DIFF
--- a/Sources/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/Qwen3ASR/Qwen3ASR.swift
@@ -246,47 +246,37 @@ public class Qwen3ASRModel {
         // Initialize KV cache
         var cache: [(MLXArray, MLXArray)]? = nil
 
-        // Generate tokens
-        var generatedTokens: [Int32] = []
-
         // First pass: process the full input embeddings
-        var (hiddenStates, newCache) = textDecoder(inputsEmbeds: inputEmbeds, cache: cache)
+        let (hiddenStates, newCache) = textDecoder(inputsEmbeds: inputEmbeds, cache: cache)
         cache = newCache
 
         // Get logits from the last position using embedding as LM head (tied weights)
         let seqLen = hiddenStates.dim(1)
         let lastHidden = hiddenStates[0..., (seqLen-1)..<seqLen, 0...]
-        var logits = textDecoder.embedTokens.asLinear(lastHidden)
-        var nextToken = Self.pickNextToken(
-            logits: logits,
-            generatedSoFar: generatedTokens,
-            options: decodingOptions
-        )
-        generatedTokens.append(nextToken)
+        let logits = textDecoder.embedTokens.asLinear(lastHidden)
 
-        // Continue generating
-        for _ in 1..<maxTokens {
-            // Check for EOS
-            if nextToken == Int32(Qwen3ASRTokens.eosTokenId) {
-                break
-            }
-
-            // Get embedding for the new token
-            let tokenEmbeds = textDecoder.embedTokens(MLXArray([nextToken]).expandedDimensions(axis: 0))
-
-            // Forward pass with cache
-            (hiddenStates, newCache) = textDecoder(inputsEmbeds: tokenEmbeds, cache: cache)
-            cache = newCache
-
-            // Get next token
-            let lastHiddenNext = hiddenStates[0..., (-1)..., .ellipsis]
-            logits = textDecoder.embedTokens.asLinear(lastHiddenNext)
-            nextToken = Self.pickNextToken(
-                logits: logits,
-                generatedSoFar: generatedTokens,
+        // Greedy fast path uses a double-buffered asyncEval decode loop that
+        // overlaps the GPU forward pass for token N+1 with the host-side
+        // bookkeeping (EOS check + Swift array append) for token N. The
+        // legacy slow path stays on the per-token CPU sync because it pulls
+        // the full logits tensor to CPU for repetition / n-gram / temperature
+        // manipulation, which would defeat the overlap.
+        let generatedTokens: [Int32]
+        if Self.isGreedyFastPath(decodingOptions) {
+            generatedTokens = Self.generateGreedyAsyncEval(
+                textDecoder: textDecoder,
+                initialLogits: logits,
+                cache: cache!,
+                maxTokens: maxTokens
+            )
+        } else {
+            generatedTokens = Self.generateSlow(
+                textDecoder: textDecoder,
+                initialLogits: logits,
+                cache: cache!,
+                maxTokens: maxTokens,
                 options: decodingOptions
             )
-            generatedTokens.append(nextToken)
         }
 
         // Decode tokens to text
@@ -301,6 +291,145 @@ public class Qwen3ASRModel {
             // Fallback: return token IDs
             return generatedTokens.map { String($0) }.joined(separator: " ")
         }
+    }
+
+    /// Greedy with default options: temperature 0, no repetition penalty,
+    /// no n-gram blocking. The double-buffered asyncEval loop only kicks
+    /// in for this configuration so we can guarantee bit-identical token
+    /// sequences vs. the legacy `argMax(...).item()` decoder.
+    static func isGreedyFastPath(_ options: Qwen3DecodingOptions) -> Bool {
+        return options.repetitionPenalty == 1.0
+            && options.noRepeatNgramSize == 0
+            && options.temperature == 0.0
+    }
+
+    /// Double-buffered greedy decode loop. The key trick is to keep the
+    /// "next token" as a lazy 0-D `MLXArray` (the result of `argMax`),
+    /// build the *next* step's forward pass on top of it (still lazy),
+    /// then call `MLX.asyncEval` so the GPU starts computing step N+1
+    /// before we sync step N's int32 to CPU. The host-side EOS check
+    /// and `generatedTokens.append` then overlap with the in-flight GPU
+    /// work for step N+1 instead of stalling between every token.
+    ///
+    /// Greedy correctness invariant: argMax is deterministic, so this
+    /// produces the exact same token sequence as the legacy loop on
+    /// matching inputs.
+    static func generateGreedyAsyncEval(
+        textDecoder: QuantizedTextModel,
+        initialLogits: MLXArray,
+        cache initialCache: [(MLXArray, MLXArray)],
+        maxTokens: Int
+    ) -> [Int32] {
+        var generatedTokens: [Int32] = []
+        guard maxTokens > 0 else { return generatedTokens }
+
+        // Stage 0: argmax of the prefill's last logits. Stays lazy until
+        // the first `.item()` below.
+        //
+        // Cast to int32 explicitly: MLX's `argmax` returns uint32, but the
+        // legacy loop fed `embedTokens` an int32 tensor (built from a Swift
+        // `Int32`). Quantized embedding lookup observably dispatches
+        // differently on uint32 vs. int32, producing tokens that diverge
+        // from the legacy path on a small fraction of inputs. Casting here
+        // restores exact dtype parity, so greedy stays token-for-token
+        // identical to the pre-optimisation decoder.
+        var nextTokenArr = argMax(initialLogits, axis: -1).squeezed().asType(.int32)
+        var cache = initialCache
+        // Kick off the GPU on the first token (and the prefill cache that
+        // step 1's graph will read from).
+        asyncEval(nextTokenArr, cache)
+
+        let eosToken = Int32(Qwen3ASRTokens.eosTokenId)
+
+        for step in 0..<maxTokens {
+            // Stage N+1's graph BEFORE syncing N. embedTokens expects a
+            // [batch, seq] int32 tensor; nextTokenArr is 0-D so we expand
+            // twice to [1, 1].
+            //
+            // Skip the speculative graph build on the LAST iteration —
+            // we'd never consume it, and on tiny `maxTokens` the saved
+            // GPU/host work matters.
+            var nextTokenArrN1: MLXArray? = nil
+            var cacheN1: [(MLXArray, MLXArray)]? = nil
+            if step + 1 < maxTokens {
+                let nextEmbed = textDecoder.embedTokens(
+                    nextTokenArr.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+                )
+                let (hiddenN1, newCacheN1) = textDecoder(inputsEmbeds: nextEmbed, cache: cache)
+                let lastHiddenN1 = hiddenN1[0..., (-1)..., .ellipsis]
+                let logitsN1 = textDecoder.embedTokens.asLinear(lastHiddenN1)
+                let argN1 = argMax(logitsN1, axis: -1).squeezed().asType(.int32)
+                // Kick GPU on N+1 (chains after the asyncEval that is
+                // still computing N).
+                asyncEval(argN1, newCacheN1)
+                nextTokenArrN1 = argN1
+                cacheN1 = newCacheN1
+            }
+
+            // Now sync N. By the time we reach `.item()` the GPU has
+            // very likely finished N already, and the cost of this call
+            // shrinks to a host-side memcpy of one int32 — which itself
+            // overlaps with the in-flight N+1 forward pass.
+            let nextToken = nextTokenArr.item(Int32.self)
+            // Match the legacy loop semantics exactly: append the token
+            // first, *then* break on EOS. The legacy loop emitted EOS
+            // into `generatedTokens` whenever EOS was the most recent
+            // pick, so greedy stays bit-identical.
+            generatedTokens.append(nextToken)
+            if nextToken == eosToken { break }
+
+            guard let advancedCache = cacheN1, let advancedToken = nextTokenArrN1 else {
+                // Final iteration without speculative work — nothing to
+                // advance to; the loop will exit naturally next.
+                break
+            }
+            cache = advancedCache
+            nextTokenArr = advancedToken
+        }
+        return generatedTokens
+    }
+
+    /// Legacy decode loop kept verbatim for the non-greedy slow path.
+    /// `pickNextToken` here pulls logits to CPU for repetition penalty,
+    /// n-gram masking, and temperature sampling, so there's no benefit
+    /// from `asyncEval` overlap.
+    static func generateSlow(
+        textDecoder: QuantizedTextModel,
+        initialLogits: MLXArray,
+        cache initialCache: [(MLXArray, MLXArray)],
+        maxTokens: Int,
+        options: Qwen3DecodingOptions
+    ) -> [Int32] {
+        var generatedTokens: [Int32] = []
+        guard maxTokens > 0 else { return generatedTokens }
+        var cache: [(MLXArray, MLXArray)]? = initialCache
+
+        var nextToken = Self.pickNextToken(
+            logits: initialLogits,
+            generatedSoFar: generatedTokens,
+            options: options
+        )
+        generatedTokens.append(nextToken)
+
+        for _ in 1..<maxTokens {
+            if nextToken == Int32(Qwen3ASRTokens.eosTokenId) { break }
+
+            let tokenEmbeds = textDecoder.embedTokens(
+                MLXArray([nextToken]).expandedDimensions(axis: 0)
+            )
+            let (hiddenStates, newCache) = textDecoder(inputsEmbeds: tokenEmbeds, cache: cache)
+            cache = newCache
+
+            let lastHiddenNext = hiddenStates[0..., (-1)..., .ellipsis]
+            let logits = textDecoder.embedTokens.asLinear(lastHiddenNext)
+            nextToken = Self.pickNextToken(
+                logits: logits,
+                generatedSoFar: generatedTokens,
+                options: options
+            )
+            generatedTokens.append(nextToken)
+        }
+        return generatedTokens
     }
 
     // MARK: - Decoder knobs


### PR DESCRIPTION
### Problem

Qwen3-ASR greedy decoding currently synchronizes every generated token back to the CPU before the next decoder step can be staged:

```swift
argMax(logits, axis: -1).squeezed().item(Int32.self)
```

On a downstream macOS transcription app, this showed up as hot ASR runs leaving visible GPU headroom during decode (roughly 50-60% GPU utilization), with a profile consistent with a small host/GPU synchronization bubble per token.

### Background / motivation

My background is mostly around LLMs and inference/runtime behavior, and I have been particularly interested in making local Mac inference more efficient. This patch borrows the high-level intuition from systems like vLLM and SGLang: keep device work queued and avoid synchronizing to the host earlier than necessary.

This PR is intentionally much smaller than batching/speculative decoding. It only targets the default greedy Qwen3-ASR path and tries to remove one avoidable synchronization bubble without changing public API.

### Cause

The default greedy path only needs the scalar token id on CPU for EOS checking and appending to the returned token list. The next decoder step itself can be staged from an on-device `MLXArray` token result first, then the current token can be synchronized afterward.

### Fix

This PR adds a greedy-only double-buffered decode loop for `Qwen3ASRModel.generateText`:

- routes only the default greedy options through the new path (`repetitionPenalty == 1`, `noRepeatNgramSize == 0`, `temperature == 0`)
- stages the next token embedding / decoder forward from the lazy argmax result before synchronizing the current token id
- calls `asyncEval(nextTokenArr, newCache)` to kick GPU work before CPU bookkeeping
- keeps `argMax` dtype aligned with the legacy `Int32` token input path
- preserves the legacy append-then-EOS-break behavior
- leaves repetition penalty, no-repeat n-gram, and temperature sampling on the existing CPU-side path

### Local testing

Validated in a downstream Xcode app test bundle where MLX's `default.metallib` is available:

- model: `aufklarer/Qwen3-ASR-1.7B-MLX-8bit`
- audio: local lecture `.m4a`
- chunks: 4 x 15s = 60s audio per iteration
- iterations: 5, hot mean over iter 2-5

| run | branch | hot wall | RTF | relative speed |
| --- | --- | ---: | ---: | ---: |
| baseline | `main` | 7.406s | 0.1234 | 1.000x |
| optimized | this branch | 6.838s | 0.1140 | **1.083x** |
| delta | — | **-0.568s** | **-0.0094** | **+8.3%** |

Per-chunk speedups were 1.075x-1.087x.

Correctness check: the four benchmark chunks produced matching text signatures between baseline and this branch in the same process lineage, and were deterministic across 5 hot iterations.

### Repo-local validation caveat

I also tried `swift test` directly in this repo. Compilation succeeds, but MLX-backed tests fail locally with:

```text
MLX error: Failed to load the default metallib. library not found
```

That appears to be a local SwiftPM/MLX metallib availability issue, not specific to this PR. I am happy to add or adjust a repo-local regression/benchmark if there is a preferred way to run MLX inference tests here.

Fixes #229

Love to discuss further with the code owner. The win is modest rather than dramatic, but the local testing suggests it is repeatable and comes from a small, API-neutral change to the default greedy Qwen3-ASR path.

Made with [Cursor](https://cursor.com)