### PR TITLE
Trim Kokoro trailing artifacts; pin iOSEchoDemo speaker route

### DIFF
--- a/Examples/iOSEchoDemo/iOSEchoDemo/CompanionChatViewModel.swift
+++ b/Examples/iOSEchoDemo/iOSEchoDemo/CompanionChatViewModel.swift
@@ -400,6 +400,10 @@ final class CompanionChatViewModel {
             lastResponseAudioDuration += Double(samples.count) / 24000.0
             pipelineState = "speaking..."
             dbg("audioDelta: \(samples.count) samples (\(String(format: "%.2f", Double(samples.count)/24000))s)")
+            // Capture for tts_debug.wav so we can inspect what's being
+            // sent to the speaker (helps diagnose audio artifacts like
+            // the end-of-synthesis click).
+            ttsRecordBuffer.append(contentsOf: samples)
             do { try player.play(samples: samples, sampleRate: 24000) }
             catch { dbg("playback error: \(error)") }
 
@@ -471,6 +475,11 @@ final class CompanionChatViewModel {
             try session.setCategory(.playAndRecord, mode: .default,
                                     options: [.defaultToSpeaker, .allowBluetoothHFP])
             try session.setActive(true)
+            // `.defaultToSpeaker` is honoured at category-set time but iOS
+            // can quietly route .playAndRecord audio to the earpiece at
+            // runtime (especially after the mic is hot). Force the route
+            // to the bottom speaker so TTS playback is audible.
+            try session.overrideOutputAudioPort(.speaker)
         } catch {
             errorMessage = "Mic access failed: \(error.localizedDescription)"
             return

--- a/Sources/KokoroTTS/KokoroTTS.swift
+++ b/Sources/KokoroTTS/KokoroTTS.swift
@@ -85,6 +85,21 @@ public final class KokoroTTSModel {
             for i in 0..<validSamples { audio[i] = ptr[i] }
         }
 
+        // Linear fade-out on the final ~15 ms. Kokoro is non-autoregressive
+        // and the last sample is generally non-zero — when the playback ring
+        // buffer drains to silence (0.0), the sample-level discontinuity
+        // produces an audible click on speakers. Ramping the tail to zero
+        // eliminates it without perceptibly truncating the audio.
+        let fadeSamples = min(validSamples, Int(0.015 * Double(config.sampleRate)))
+        if fadeSamples >= 2 {
+            let start = validSamples - fadeSamples
+            let denom = Float(fadeSamples - 1)
+            for i in 0..<fadeSamples {
+                let gain = Float(fadeSamples - 1 - i) / denom
+                audio[start + i] *= gain
+            }
+        }
+
         let duration = Double(validSamples) / Double(config.sampleRate)
         let elapsedMs = elapsed * 1000
         AudioLog.inference.info("Kokoro E2E: \(tokenCount) tokens → \(validSamples) samples (\(String(format: "%.1f", duration))s) in \(String(format: "%.0f", elapsedMs))ms")

--- a/Sources/KokoroTTS/KokoroTTS.swift
+++ b/Sources/KokoroTTS/KokoroTTS.swift
@@ -85,18 +85,43 @@ public final class KokoroTTSModel {
             for i in 0..<validSamples { audio[i] = ptr[i] }
         }
 
-        // Linear fade-out on the final ~15 ms. Kokoro is non-autoregressive
-        // and the last sample is generally non-zero — when the playback ring
-        // buffer drains to silence (0.0), the sample-level discontinuity
-        // produces an audible click on speakers. Ramping the tail to zero
-        // eliminates it without perceptibly truncating the audio.
-        let fadeSamples = min(validSamples, Int(0.015 * Double(config.sampleRate)))
+        // Kokoro's E2E model often emits 100–300 ms of trailing artifacts
+        // past the real speech (random low-energy noise + an occasional
+        // loud-spike click, observed on iPhone playback). Find where real
+        // speech actually ended by walking backwards through 10 ms windows
+        // and locating the last window above a silence-energy threshold —
+        // then zero everything past that, plus a short ramp-down on the
+        // last few ms of real speech to avoid a click at the new boundary.
+        // Use a 50 ms window with a higher silence floor and require the
+        // window to be SUSTAINED above threshold — Kokoro's trailing
+        // artifacts are often a single 10–20 ms spike with low surrounding
+        // energy, so a tight short window otherwise mistakes them for
+        // speech. Real speech tails consistently above ~0.03 RMS over a
+        // 50 ms span; isolated artifact spikes don't.
+        let win = max(1, Int(0.050 * Double(config.sampleRate)))
+        let silenceRMS: Float = 0.030
+        var speechEnd = validSamples
+        var i = validSamples - win
+        while i > 0 {
+            var sumSq: Float = 0
+            for j in 0..<win { let v = audio[i + j]; sumSq += v * v }
+            let rms = sqrt(sumSq / Float(win))
+            if rms > silenceRMS { speechEnd = i + win; break }
+            i -= win / 2  // 50 % overlap so we don't miss a window boundary
+        }
+        // Zero the trailing artifact region.
+        if speechEnd < validSamples {
+            for k in speechEnd..<validSamples { audio[k] = 0 }
+        }
+        // Linear fade-out on the last ~10 ms of the kept signal so the
+        // boundary between speech and the silenced region is also smooth.
+        let fadeSamples = min(speechEnd, Int(0.010 * Double(config.sampleRate)))
         if fadeSamples >= 2 {
-            let start = validSamples - fadeSamples
+            let start = speechEnd - fadeSamples
             let denom = Float(fadeSamples - 1)
-            for i in 0..<fadeSamples {
-                let gain = Float(fadeSamples - 1 - i) / denom
-                audio[start + i] *= gain
+            for k in 0..<fadeSamples {
+                let gain = Float(fadeSamples - 1 - k) / denom
+                audio[start + k] *= gain
             }
         }
 


### PR DESCRIPTION
## Summary
- **KokoroTTS**: replace the 15 ms tail-fade-only logic with a trailing-artifact trim. The CoreML E2E model emits 100-300 ms of low-energy noise plus the occasional spike past where speech actually ends, which the fade alone couldn't hide on real-device playback. Walk the tail backwards in 50 ms windows with 50% overlap and locate the last window with sustained RMS > 0.030; zero everything past it, then ramp the last 10 ms of kept signal so the new boundary is also smooth.
- **iOSEchoDemo**: call `overrideOutputAudioPort(.speaker)` right after `setActive(true)` because iOS can quietly route `.playAndRecord` audio to the earpiece at runtime even with `.defaultToSpeaker` on the category, leaving TTS playback nearly inaudible from the bottom speaker.
- **iOSEchoDemo**: append response audio deltas to `ttsRecordBuffer` so `tts_debug.wav` captures what the player actually sees. This is what surfaced the trailing-artifact pattern that motivated the KokoroTTS change.

## Test plan
- [x] Unit suite green (`swift test`)
- [ ] Manual device check: synthesize a sentence on iPhone (ares02), confirm no click at the end and TTS audible from the bottom speaker
- [ ] Confirm `tts_debug.wav` pulled via `xcrun devicectl device copy from` reflects the trimmed tail