### PR TITLE
Chunk long audio in audio align so trailing words don't pile up

### DIFF
--- a/Sources/AudioCLILib/AlignCommand.swift
+++ b/Sources/AudioCLILib/AlignCommand.swift
@@ -68,11 +68,12 @@ public struct AlignCommand: ParsableCommand {
 
             print("Aligning...")
             let start = Date()
-            let aligned = aligner.align(
+            let aligned = aligner.alignLong(
                 audio: audio,
                 text: alignText,
                 sampleRate: 24000,
-                language: language ?? "English")
+                language: language ?? "English",
+                progressHandler: { msg in print("  \(msg)") })
             let elapsed = Date().timeIntervalSince(start)
 
             for word in aligned {

--- a/Sources/Qwen3ASR/ForcedAligner.swift
+++ b/Sources/Qwen3ASR/ForcedAligner.swift
@@ -80,6 +80,141 @@ public class Qwen3ForcedAligner {
         self.config = cfg
     }
 
+    /// Align text to audio with automatic chunking for long inputs.
+    ///
+    /// The underlying classifier head emits a fixed-resolution timestamp
+    /// index (default `classifyNum=5000` × `0.08s` per slot = 400s
+    /// addressable range) but in practice the model's reliable range is
+    /// shorter (~270s on Qwen3-ForcedAligner-0.6B-4bit observed on TED-Ed
+    /// material). Past that, it produces low/non-monotonic indices that
+    /// LIS correction collapses into a flat plateau — every trailing word
+    /// shares the same timestamp.
+    ///
+    /// `alignLong` runs `align` on the full audio, detects the trailing
+    /// plateau, keeps the reliable prefix, then re-aligns the remaining
+    /// audio + remaining words and offsets timestamps. Iterates until no
+    /// plateau remains or the remaining work is below a minimum chunk size.
+    ///
+    /// For audio shorter than the threshold this is a one-pass call into
+    /// `align`. For longer audio it pays one extra align pass per chunk.
+    public func alignLong(
+        audio: [Float],
+        text: String,
+        sampleRate: Int = 16000,
+        language: String = "English",
+        progressHandler: ((String) -> Void)? = nil
+    ) -> [AlignedWord] {
+        // The model is reliable up to ~270s on the bundles we ship; we
+        // don't try to be too aggressive with the threshold so the
+        // single-pass case stays the common path. The plateau detector
+        // does the actual work — this is just a fast bypass when there's
+        // no risk of saturation.
+        let bypassThresholdSeconds: Float = 240
+        let minChunkSeconds: Float = 5
+        let plateauTolerance: Float = 0.1     // seconds; "same start time" if diff < this
+        let plateauMinWords = 5               // need ≥ N stuck words to call it a plateau
+
+        var allAligned: [AlignedWord] = []
+        var remainingAudio = audio
+        var remainingText = text
+        var offsetSec: Float = 0
+        var pass = 1
+
+        while !remainingAudio.isEmpty && !remainingText.isEmpty {
+            let durationSec = Float(remainingAudio.count) / Float(sampleRate)
+            let aligned = align(
+                audio: remainingAudio,
+                text: remainingText,
+                sampleRate: sampleRate,
+                language: language
+            )
+            if aligned.isEmpty { break }
+
+            // Skip plateau detection on small chunks — the model is reliable
+            // there, and detecting plateau on tiny outputs creates spurious
+            // splits.
+            if durationSec <= bypassThresholdSeconds || aligned.count < plateauMinWords * 2 {
+                allAligned.append(contentsOf: Self.offsetWords(aligned, by: offsetSec))
+                break
+            }
+
+            let plateauStart = Self.findTrailingPlateauStart(
+                aligned, tolerance: plateauTolerance, minSize: plateauMinWords
+            )
+            if plateauStart == aligned.count {
+                // No plateau — alignment looks healthy.
+                allAligned.append(contentsOf: Self.offsetWords(aligned, by: offsetSec))
+                break
+            }
+
+            // Take the reliable prefix; recurse on the remainder.
+            let reliable = aligned.prefix(plateauStart)
+            let splitTime = reliable.last!.endTime
+            allAligned.append(contentsOf: Self.offsetWords(Array(reliable), by: offsetSec))
+
+            let splitSample = Int(splitTime * Float(sampleRate))
+            guard splitSample < remainingAudio.count else { break }
+            let nextAudio = Array(remainingAudio[splitSample...])
+            let remainingDuration = Float(nextAudio.count) / Float(sampleRate)
+            if remainingDuration < minChunkSeconds { break }
+
+            // Pull the words from the remainder by name. We split on the
+            // same boundary `align` used (whitespace) so words line up.
+            let wordsAll = remainingText.split(separator: " ", omittingEmptySubsequences: true)
+            guard plateauStart < wordsAll.count else { break }
+            let nextText = wordsAll[plateauStart...].joined(separator: " ")
+
+            progressHandler?(
+                "Audio \(String(format: "%.1f", durationSec))s saturated after word \(plateauStart) "
+                + "(\(String(format: "%.1f", splitTime))s); chunking remaining \(String(format: "%.1f", remainingDuration))s "
+                + "(pass \(pass + 1))"
+            )
+
+            remainingAudio = nextAudio
+            remainingText = nextText
+            offsetSec += splitTime
+            pass += 1
+            if pass > 10 { break }  // belt-and-braces against pathological loops
+        }
+
+        return allAligned
+    }
+
+    static func offsetWords(_ words: [AlignedWord], by seconds: Float) -> [AlignedWord] {
+        guard seconds != 0 else { return words }
+        return words.map {
+            AlignedWord(text: $0.text, startTime: $0.startTime + seconds, endTime: $0.endTime + seconds)
+        }
+    }
+
+    /// Index of the first word in the trailing "stuck" plateau, or
+    /// `aligned.count` if no plateau is detected.
+    ///
+    /// A plateau is `≥ minSize` consecutive trailing words whose start
+    /// times differ by less than `tolerance`. This is the LIS-clamp
+    /// signature: the model produced low/garbage indices for those
+    /// positions and the monotonicity pass collapsed them onto the last
+    /// reliable anchor.
+    static func findTrailingPlateauStart(
+        _ aligned: [AlignedWord], tolerance: Float, minSize: Int
+    ) -> Int {
+        let n = aligned.count
+        guard n > minSize else { return n }
+        // Walk backward: when `aligned[i].startTime ≈ aligned[i-1].startTime`,
+        // both are in the plateau, so the plateau extends *to* index `i-1`.
+        // Stop at the first big jump.
+        var plateauStart = n
+        for i in (1..<n).reversed() {
+            let dt = abs(aligned[i].startTime - aligned[i - 1].startTime)
+            if dt < tolerance {
+                plateauStart = i - 1
+            } else {
+                break
+            }
+        }
+        return (n - plateauStart) >= minSize ? plateauStart : n
+    }
+
     /// Align text to audio, producing word-level timestamps.
     ///
     /// - Parameters:
@@ -162,6 +297,15 @@ public class Qwen3ForcedAligner {
 
         // 8. Apply LIS monotonicity correction
         let correctedIndices = TimestampCorrection.enforceMonotonicity(rawIndices)
+
+        // Optional raw/corrected dump for bug-triage of misaligned timestamps.
+        if ProcessInfo.processInfo.environment["ALIGN_DEBUG"] == "1" {
+            print("[align-debug] indices=\(rawIndices.count) numAudioTokens=\(numAudioTokens)")
+            print("[align-debug] first 10 raw:       \(Array(rawIndices.prefix(10)))")
+            print("[align-debug] first 10 corrected: \(Array(correctedIndices.prefix(10)))")
+            print("[align-debug] last 60 raw:       \(Array(rawIndices.suffix(60)))")
+            print("[align-debug] last 60 corrected: \(Array(correctedIndices.suffix(60)))")
+        }
 
         // 9. Convert to seconds and pair as (start, end)
         let segmentTime = config.timestampSegmentTime

--- a/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
+++ b/Tests/Qwen3ASRTests/ForcedAlignerTests.swift
@@ -431,4 +431,82 @@ final class ForcedAlignerTests: XCTestCase {
         print("  Audio duration: \(String(format: "%.1f", audioDuration))s")
         print("  RTF: \(String(format: "%.3f", bestMs / 1000.0 / audioDuration))")
     }
+
+    // MARK: - Trailing-plateau detection (alignLong chunking trigger)
+
+    private func makeWord(start: Float, end: Float) -> AlignedWord {
+        AlignedWord(text: "_", startTime: start, endTime: end)
+    }
+
+    func testNoPlateauOnHealthyAlignment() {
+        let aligned = (0..<20).map { i in
+            makeWord(start: Float(i) * 0.5, end: Float(i) * 0.5 + 0.4)
+        }
+        let p = Qwen3ForcedAligner.findTrailingPlateauStart(
+            aligned, tolerance: 0.1, minSize: 5
+        )
+        XCTAssertEqual(p, aligned.count, "Strictly increasing timestamps should not look like a plateau")
+    }
+
+    func testTrailingPlateauDetected() {
+        // 15 healthy + 10 stuck at 12.0 — exactly the LIS-clamp pattern.
+        var aligned = (0..<15).map { i in
+            makeWord(start: Float(i) * 0.5, end: Float(i) * 0.5 + 0.4)
+        }
+        for _ in 0..<10 {
+            aligned.append(makeWord(start: 12.0, end: 12.0))
+        }
+        let p = Qwen3ForcedAligner.findTrailingPlateauStart(
+            aligned, tolerance: 0.1, minSize: 5
+        )
+        XCTAssertEqual(p, 15, "Plateau should start at the first stuck word")
+    }
+
+    func testPlateauBelowMinSizeIgnored() {
+        // Only 3 stuck words at the tail — below the minSize threshold.
+        var aligned = (0..<10).map { i in
+            makeWord(start: Float(i) * 0.5, end: Float(i) * 0.5 + 0.4)
+        }
+        for _ in 0..<3 {
+            aligned.append(makeWord(start: 6.0, end: 6.0))
+        }
+        let p = Qwen3ForcedAligner.findTrailingPlateauStart(
+            aligned, tolerance: 0.1, minSize: 5
+        )
+        XCTAssertEqual(p, aligned.count, "A 3-word plateau should be ignored when minSize=5")
+    }
+
+    func testToleranceAcceptsTinyDrift() {
+        // Trailing words drift by 0.05s — below tolerance, should still
+        // count as a plateau.
+        var aligned = (0..<10).map { i in
+            makeWord(start: Float(i) * 0.5, end: Float(i) * 0.5 + 0.4)
+        }
+        for i in 0..<8 {
+            aligned.append(makeWord(start: 6.0 + 0.05 * Float(i), end: 6.0 + 0.05 * Float(i)))
+        }
+        let p = Qwen3ForcedAligner.findTrailingPlateauStart(
+            aligned, tolerance: 0.1, minSize: 5
+        )
+        XCTAssertEqual(p, 10, "Sub-tolerance drift should still register as plateau")
+    }
+
+    func testOffsetWordsByZeroNoOp() {
+        let aligned = [makeWord(start: 1.0, end: 1.5), makeWord(start: 2.0, end: 2.5)]
+        let offset = Qwen3ForcedAligner.offsetWords(aligned, by: 0)
+        XCTAssertEqual(offset.count, aligned.count)
+        for (a, b) in zip(aligned, offset) {
+            XCTAssertEqual(a.startTime, b.startTime)
+            XCTAssertEqual(a.endTime, b.endTime)
+        }
+    }
+
+    func testOffsetWordsAddsConstant() {
+        let aligned = [makeWord(start: 1.0, end: 1.5), makeWord(start: 2.0, end: 2.5)]
+        let offset = Qwen3ForcedAligner.offsetWords(aligned, by: 10)
+        XCTAssertEqual(offset[0].startTime, 11.0)
+        XCTAssertEqual(offset[0].endTime, 11.5)
+        XCTAssertEqual(offset[1].startTime, 12.0)
+        XCTAssertEqual(offset[1].endTime, 12.5)
+    }
 }

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -44,7 +44,7 @@ Audio (16kHz) + Text
 | Audio encoder | 24 layers, d_model=1024, 16 heads, FFN=4096, output→1024 |
 | Text decoder | 28 layers, hidden=1024, 16Q/8KV heads, headDim=128 (4-bit, 8-bit, or bf16) |
 | Classify head | Linear(1024, 5000), float16 (NOT tied to embeddings) |
-| Timestamp resolution | 80ms per class (5000 classes = 400s max) |
+| Timestamp resolution | 80ms per class (5000 classes = 400s addressable, ~270s reliable in practice — see *Long-audio handling* below) |
 
 ## Key Difference from ASR
 
@@ -136,6 +136,32 @@ Raw timestamps may not be monotonic. Fix via:
 3. Larger gaps: linear interpolation between LIS anchors
 4. Final pass: enforce non-decreasing order
 
+## Long-audio handling
+
+The classify head addresses 400 s in principle (5000 classes × 80 ms), but the trained reliable range on `Qwen3-ForcedAligner-0.6B` is **~270 s**. Past that, the model emits low / non-monotonic indices for the remaining words, and the LIS pass collapses them onto the last anchor — every trailing word ends up with the same timestamp.
+
+`Qwen3ForcedAligner.alignLong(...)` wraps `align()` to handle this:
+
+1. Run `align()` on the full audio.
+2. Detect a trailing **plateau** (≥ 5 consecutive words whose start times differ by < 0.1 s) — the LIS-clamp signature.
+3. If found: keep the reliable prefix, slice the remaining audio, re-align the remaining words with a time offset.
+4. Iterate until no plateau remains or the remainder is below 5 s.
+
+For audio under the 240 s bypass threshold this is a one-pass passthrough into `align()`. For longer audio the cost is one extra `align` pass per chunk; in practice the second chunk is short so the overhead is small (≤ ~0.5 s wall-clock on the 306 s TED-Ed test clip).
+
+The CLI (`audio align`) calls `alignLong` automatically and prints a one-line message when chunking kicks in:
+
+```
+Audio 306.2s saturated after word 690 (272.6s); chunking remaining 33.6s (pass 2)
+```
+
+Set `ALIGN_DEBUG=1` to dump raw vs corrected timestamp indices when investigating misaligned outputs.
+
+### Known limitations
+
+- **Audio with leading non-speech** (music intro, long silence): the model often stamps the first word at `~0 s` because the classifier head has no notion of "speech hasn't started yet". Workaround: trim leading non-speech before alignment, or pre-pass with a VAD.
+- **Single-language audio assumed**: the language hint applies to the whole alignment; no per-segment language switching.
+
 ## Performance (M2 Max, 64 GB)
 
 | Stage | Time | Notes |
@@ -195,13 +221,24 @@ Output format:
 ```swift
 let aligner = try await Qwen3ForcedAligner.fromPretrained()
 
+// Short-form audio (≤240s): single forward pass.
 let aligned = aligner.align(
     audio: audioSamples,
     text: "Can you guarantee that the replacement part will be shipped tomorrow?",
     sampleRate: 24000
 )
 
-for word in aligned {
+// Long-form audio: auto-chunks past the model's reliable range so trailing
+// words don't all collapse onto the last anchor's timestamp. Behaves identically
+// to `align()` for short audio.
+let alignedLong = aligner.alignLong(
+    audio: longAudioSamples,
+    text: longText,
+    sampleRate: 24000,
+    progressHandler: { print($0) }   // optional: notified when a chunk hand-off happens
+)
+
+for word in alignedLong {
     print("[\(word.startTime)s - \(word.endTime)s] \(word.text)")
 }
 ```


### PR DESCRIPTION
## Summary

`audio align` collapses every trailing word onto the same timestamp on long inputs. On the user-reported `ted-ed-pain.wav` (306 s) the last 30 words all came back as `[272.64s - 272.64s]`.

## Root cause

The forced-aligner classifier head has a fixed timestamp range (`classifyNum = 5000` slots × `0.08 s` per slot = 400 s addressable), but the trained reliable range on `Qwen3-ForcedAligner-0.6B-4bit` tops out around 270 s. Past that, the model produces low / non-monotonic indices for the remaining words, and the LIS monotonicity pass in `TimestampCorrection.enforceMonotonicity` then clamps every "after-last-anchor" position to the last anchor's value — so they all stack on `272.64 s`.

Diagnostic dump on the original repro (`ALIGN_DEBUG=1`):

```
indices=1450 numAudioTokens=3981
last 60 raw:       [1758, 1136, 1759, 1759, 1764, ..., 1874, 1874]   ← model collapses
last 60 corrected: [3408, 3408, 3408, ..., 3408, 3408]               ← LIS clamps
```

## Fix

Add `Qwen3ForcedAligner.alignLong(...)` that runs `align()`, detects a trailing plateau (≥ 5 consecutive words with identical start times within 0.1 s), keeps the reliable prefix, and re-aligns the remaining audio + remaining words with a time offset. Iterates until no plateau remains or the remainder is below a minimum chunk size (5 s). Costs at most one extra `align` pass per chunk; for audio under the 240 s bypass threshold, the call is a one-pass passthrough into `align()`.

Wire `alignLong` into `audio align` and emit a one-line message when chunking kicks in. Also add an env-gated `ALIGN_DEBUG=1` dump of raw vs corrected indices for future bug triage.

## Verification on the repro

Before:
```
[270.48s - 270.64s] stimulus.
[272.40s - 272.64s] some
[272.64s - 272.64s] memory
[272.64s - 272.64s] of
[272.64s - 272.64s] physical
... (28 more words all at 272.64s)
[272.64s - 272.64s] needlessly.
```

After:
```
  Audio 306.2s saturated after word 690 (272.6s); chunking remaining 33.6s (pass 2)
[272.40s - 272.64s] some
[272.64s - 273.12s] memory
[273.20s - 274.00s] of
[274.00s - 274.48s] physical
... (clean increasing timestamps)
[284.56s - 284.72s] needlessly.
```

Total runtime: 1.96 s (was 2.29 s before — chunked path is actually slightly faster because the second chunk is short).

## Not addressed by this PR

The leading-music miscalibration (`"Humans"` stamped at `[0.00s - 1.44s]` when actual speech starts ~7 s into the audio) is a separate model-level issue — when audio starts with non-speech, the model assigns first-word `≈ 0`. Needs a VAD pre-pass to detect speech start and offset everything. Filed for a follow-up PR.

## Test plan

- [x] 6 new unit tests for `findTrailingPlateauStart` / `offsetWords` (no model download, all pass)
- [x] Full `Qwen3ASR` regression suite (`--skip E2E`): 128/128 pass
- [x] End-to-end manual run on the original `ted-ed-pain.wav` repro: trailing words now have proper increasing timestamps