### PR TITLE
fix(vibevoice): CLI routes 1.5B model id correctly + downloader honors offlineMode

### DIFF
--- a/Sources/AudioCLILib/VibeVoiceCommand.swift
+++ b/Sources/AudioCLILib/VibeVoiceCommand.swift
@@ -25,11 +25,11 @@ public struct VibeVoiceCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Output WAV file path")
     public var output: String = "vibevoice.wav"
 
-    @Option(name: .long, help: "HuggingFace model ID")
-    public var model: String = "microsoft/VibeVoice-Realtime-0.5B"
+    @Option(name: .long, help: "HuggingFace model ID (defaults: VibeVoice-Realtime-0.5B normally, VibeVoice-1.5B with --long-form)")
+    public var model: String?
 
-    @Option(name: .long, help: "Qwen2.5 tokenizer model ID")
-    public var tokenizer: String = "Qwen/Qwen2.5-0.5B"
+    @Option(name: .long, help: "Qwen2.5 tokenizer model ID (defaults: Qwen2.5-0.5B normally, Qwen2.5-1.5B with --long-form)")
+    public var tokenizer: String?
 
     @Option(name: .long, help: "DPM-Solver inference steps (higher = better quality, slower)")
     public var steps: Int = 20
@@ -74,11 +74,10 @@ public struct VibeVoiceCommand: ParsableCommand {
             var config: VibeVoiceTTSModel.Configuration = longForm
                 ? .longForm1_5B
                 : VibeVoiceTTSModel.Configuration()
-            // Allow CLI overrides.
-            if !longForm {
-                config.modelId = model
-                config.tokenizerModelId = tokenizer
-            }
+            // Allow CLI overrides — only when user explicitly passed them, so
+            // each preset's correct defaults survive otherwise.
+            if let m = model { config.modelId = m }
+            if let t = tokenizer { config.tokenizerModelId = t }
             config.numInferenceSteps = steps
             config.cfgScale = cfg
             config.maxSpeechTokens = maxTokens
@@ -96,14 +95,17 @@ public struct VibeVoiceCommand: ParsableCommand {
                 print("Loading reference audio: \(refPath)")
                 let refURL = URL(fileURLWithPath: refPath)
                 let refSamples = try AudioFileLoader.load(url: refURL, targetSampleRate: 24000)
-                // Re-load via the proper unified-LM 1.5B model class.
-                print("Loading 1.5B unified-LM model (\(model))...")
+                // Re-load via the proper unified-LM 1.5B model class. Defaults
+                // (aufklarer/VibeVoice-1.5B-MLX-INT4 + Qwen2.5-1.5B tokenizer)
+                // come from VibeVoice15BTTSModel.Configuration — only override
+                // when the caller passed --model / --tokenizer explicitly.
                 var cfg15 = VibeVoice15BTTSModel.Configuration()
-                cfg15.modelId = model
-                cfg15.tokenizerModelId = tokenizer
+                if let m = model { cfg15.modelId = m }
+                if let t = tokenizer { cfg15.tokenizerModelId = t }
                 cfg15.numInferenceSteps = steps
                 cfg15.cfgScale = cfg
                 cfg15.maxSpeechTokens = maxTokens
+                print("Loading 1.5B unified-LM model (\(cfg15.modelId))...")
                 let tts15 = try await VibeVoice15BTTSModel.fromPretrained(
                     configuration: cfg15,
                     progressHandler: reportProgress

--- a/Sources/AudioCLILib/VibeVoiceEncodeCommand.swift
+++ b/Sources/AudioCLILib/VibeVoiceEncodeCommand.swift
@@ -28,11 +28,11 @@ public struct VibeVoiceEncodeCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Output voice cache (.safetensors)")
     public var output: String = "voice.safetensors"
 
-    @Option(name: .long, help: "HuggingFace model ID")
-    public var model: String = "microsoft/VibeVoice-Realtime-0.5B"
+    @Option(name: .long, help: "HuggingFace model ID (defaults: VibeVoice-Realtime-0.5B normally, VibeVoice-1.5B with --long-form)")
+    public var model: String?
 
-    @Option(name: .long, help: "Qwen2.5 tokenizer model ID")
-    public var tokenizer: String = "Qwen/Qwen2.5-0.5B"
+    @Option(name: .long, help: "Qwen2.5 tokenizer model ID (defaults: Qwen2.5-0.5B normally, Qwen2.5-1.5B with --long-form)")
+    public var tokenizer: String?
 
     @Flag(name: .long, help: "Use the long-form 1.5B variant preset")
     public var longForm: Bool = false
@@ -50,10 +50,10 @@ public struct VibeVoiceEncodeCommand: ParsableCommand {
             var config: VibeVoiceTTSModel.Configuration = longForm
                 ? .longForm1_5B
                 : VibeVoiceTTSModel.Configuration()
-            if !longForm {
-                config.modelId = model
-                config.tokenizerModelId = tokenizer
-            }
+            // Only override the preset's defaults when the caller passed
+            // --model / --tokenizer explicitly.
+            if let m = model { config.modelId = m }
+            if let t = tokenizer { config.tokenizerModelId = t }
 
             print("Loading VibeVoice model (\(config.modelId))...")
             let tts = try await VibeVoiceTTSModel.fromPretrained(

--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -103,7 +103,13 @@ public enum HuggingFaceDownloader {
         //   old: base/cacheKey         (flat, already has weights — won't reach here)
         //   new: base/models/org/model  (Hub-style)
         // For Hub API we need `base` as downloadBase.
-        let hub = makeHubApi(for: modelId, repoDir: directory)
+        //
+        // Forward `offlineMode` explicitly so HubApi doesn't fall through to
+        // its internal NWPathMonitor auto-detect, which on macOS can briefly
+        // report `.unsatisfied` and then refuse to download (manifesting as
+        // "Offline mode error: No files available locally for this repository"
+        // for a freshly-requested model).
+        let hub = makeHubApi(for: modelId, repoDir: directory, offlineMode: offlineMode)
         let repo = Hub.Repo(id: modelId)
 
         // Retry with exponential backoff — HuggingFace can timeout on
@@ -198,7 +204,11 @@ public enum HuggingFaceDownloader {
 
     /// Create a `HubApi` whose `downloadBase` is derived from the repo directory that
     /// `getCacheDirectory` returned (strips the `models/<org>/<model>` suffix).
-    private static func makeHubApi(for modelId: String, repoDir: URL) -> HubApi {
+    ///
+    /// `offlineMode` is forwarded as `useOfflineMode` so callers get the mode
+    /// they asked for instead of relying on `NWPathMonitor` auto-detection,
+    /// which can spuriously report `.unsatisfied` on macOS.
+    private static func makeHubApi(for modelId: String, repoDir: URL, offlineMode: Bool) -> HubApi {
         // repoDir is  base/models/org/model
         // We need     base
         let repo = Hub.Repo(id: modelId)
@@ -213,6 +223,6 @@ public enum HuggingFaceDownloader {
             // Hub won't match this path, so we derive base from env/defaults.
             downloadBase = resolveBaseCacheDir(cacheDirName: repoDir.deletingLastPathComponent().lastPathComponent)
         }
-        return HubApi(downloadBase: downloadBase)
+        return HubApi(downloadBase: downloadBase, useOfflineMode: offlineMode)
     }
 }


### PR DESCRIPTION
Two bugs that together made \`audio vibevoice ... --long-form --reference-audio ... --reference-transcript ...\` unusable.

## 1. CLI routed wrong model id into the 1.5B unified-LM stage

\`audio vibevoice ... --long-form --reference-audio ... --reference-transcript ...\` crashed with:

\`\`\`
Error: modelNotInitialized(component: "1.5B requires semantic_tokenizer_config + semantic_vae_dim")
\`\`\`

Cause: in long-form mode the CLI runs a second-stage load via \`VibeVoice15BTTSModel\`. The default for that class is \`aufklarer/VibeVoice-1.5B-MLX-INT4\` (which has the semantic configs). But the CLI was unconditionally overwriting that with \`--model\` / \`--tokenizer\`, which default to \`microsoft/VibeVoice-Realtime-0.5B\` / \`Qwen/Qwen2.5-0.5B\` — a config that legitimately has no \`semantic_tokenizer_config\`.

\`vibevoice-encode-voice\` had the same hidden assignment.

Fix: make \`--model\` / \`--tokenizer\` \`Optional<String>\`. Each load stage now keeps its preset default unless the caller explicitly passed an override. Updated the "Loading 1.5B unified-LM model (...)" log line to read from \`cfg15.modelId\` so what's printed matches what's actually loaded.

## 2. Downloader didn't forward \`offlineMode\` to \`HubApi\`

After fix #1, the downloader called \`hub.snapshot(...)\` and got:

\`\`\`
Error: failedToDownload("aufklarer/VibeVoice-1.5B-MLX-INT4: Offline mode error: No files available locally for this repository")
\`\`\`

— even though we passed \`offlineMode: false\` and the model exists on HuggingFace.

Cause: \`HuggingFaceDownloader.makeHubApi(...)\` constructed \`HubApi(downloadBase: ...)\` without forwarding \`useOfflineMode\`. \`Hub\` then fell through to its internal \`NWPathMonitor\`-based auto-detect (\`shouldUseOfflineMode = !isConnected\`). On macOS that monitor can briefly report \`.unsatisfied\`, at which point Hub flips into offline mode and refuses to fetch a fresh model.

Fix: forward \`offlineMode\` into \`HubApi(useOfflineMode:)\`. When the caller asks for online (the common case) Hub stays online regardless of NWPathMonitor's transient state. \`offlineMode: true\` behavior is unchanged.

## Verification

End-to-end against the live HF repo with both fixes applied:

\`\`\`
Loading VibeVoice model (microsoft/VibeVoice-1.5B)... [100%] Ready
Loading reference audio: /Users/ivan/voice-sample.wav
Loading 1.5B unified-LM model (aufklarer/VibeVoice-1.5B-MLX-INT4)...
  [70%] Downloading model... [100%] Ready
Synthesizing (1.5B unified LM): "That's a 7-billion-parameter speech model running on my MacBook. No cloud. No API. Let me show you."
Duration: 7.60s, Time: 1355.2s
Saved to /tmp/vibe-hook-final.wav
\`\`\`

Round-tripping the produced WAV through Parakeet-TDT v3 yields:

> "That's a seven billion p[a]rameter speech model running on my MacBook. No cloud, no API. Let me show ya."

— substantively the requested text, in the cloned reference voice. (Generation latency on this run is brutal — RTFx ~0.006 — but that's an unrelated perf issue with the 1.5B INT4 + diffusion-head path; tracking separately.)