### PR TITLE
perf(vibevoice 1.5b): shapeless-compile the autoregressive LM step (~270x cold-start speedup)

### DIFF
--- a/Sources/VibeVoiceTTS/Inference/KVCache.swift
+++ b/Sources/VibeVoiceTTS/Inference/KVCache.swift
@@ -88,6 +88,17 @@ public class KVCacheSimple: KVCache {
     public var sequenceLength: Int {
         keys?.dim(2) ?? 0
     }
+
+    /// Extract the valid `[B, H, offset, D]` slice of cached K/V as a fresh
+    /// tuple — the format consumed by the shapeless compiled autoregressive
+    /// step. Returns nil before the first `update(...)`.
+    public func snapshot() -> (MLXArray, MLXArray)? {
+        guard let k = keys, let v = values, offset > 0 else { return nil }
+        return (
+            k[.ellipsis, ..<offset, 0...],
+            v[.ellipsis, ..<offset, 0...]
+        )
+    }
 }
 
 public func createCausalMask(n: Int, offset: Int) -> MLXArray {

--- a/Sources/VibeVoiceTTS/Models/Qwen2Attention.swift
+++ b/Sources/VibeVoiceTTS/Models/Qwen2Attention.swift
@@ -81,4 +81,64 @@ public class Qwen2Attention: Module {
 
         return wo(output)
     }
+
+    /// Pure-functional single-step variant suitable for `MLX.compile(shapeless: true)`.
+    ///
+    /// Cache is passed/returned as explicit `(K, V)` MLXArray tuples instead of via
+    /// `inout KVCacheSimple`, and `offset` is an `MLXArray` so `compile` treats it as
+    /// a runtime input rather than baking the value as a constant. With shapeless
+    /// compile, the same compiled graph handles every cache length — no per-shape
+    /// recompile during the autoregressive loop.
+    ///
+    /// `attentionMask == nil` is the autoregressive-decode path (single new query
+    /// attends to all cached keys; SDPA implicitly handles it). Multi-token prefill
+    /// callers must supply an explicit causal mask.
+    public func forwardStep(
+        _ x: MLXArray,
+        offset: MLXArray,
+        attentionMask: MLXArray? = nil,
+        cache: (MLXArray, MLXArray)? = nil
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let L = x.dim(1)
+
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        // Use -1 in batch dim so the compiled graph works for any batch size.
+        // Only one -1 is allowed per reshape — head_dim is given explicitly.
+        queries = queries.reshaped(-1, L, config.attentionHeads, config.headDim).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(-1, L, config.kvHeads, config.headDim).transposed(0, 2, 1, 3)
+        values = values.reshaped(-1, L, config.kvHeads, config.headDim).transposed(0, 2, 1, 3)
+
+        queries = rope(queries, offset: offset)
+        keys = rope(keys, offset: offset)
+
+        let allKeys: MLXArray
+        let allValues: MLXArray
+        if let (prevK, prevV) = cache {
+            allKeys = concatenated([prevK, keys], axis: 2)
+            allValues = concatenated([prevV, values], axis: 2)
+        } else {
+            allKeys = keys
+            allValues = values
+        }
+
+        let mask: MLXFast.ScaledDotProductAttentionMaskMode = {
+            if let m = attentionMask { return .array(m) }
+            return .none
+        }()
+
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: allKeys,
+            values: allValues,
+            scale: scale,
+            mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(-1, L, config.attentionHeads * config.headDim)
+
+        return (wo(attended), (allKeys, allValues))
+    }
 }

--- a/Sources/VibeVoiceTTS/Models/Qwen2Model.swift
+++ b/Sources/VibeVoiceTTS/Models/Qwen2Model.swift
@@ -105,6 +105,90 @@ public class Qwen2Model: Module {
     public func newCache() -> [KVCacheSimple] {
         (0..<config.hiddenLayers).map { _ in KVCacheSimple() }
     }
+
+    // MARK: - Compiled autoregressive step
+
+    /// Compiled single-token forward step. Set up by `setupCompilation()`. When
+    /// non-nil, `executeStep(...)` uses it instead of the eager path.
+    private var compiledStep: (([MLXArray]) -> [MLXArray])?
+
+    /// Pure-functional single-step transformer pass. Cache is passed/returned
+    /// as flat `[(K, V)]` tuples and `offset` is an `MLXArray` so `MLX.compile`
+    /// treats it as a runtime input. With shapeless compile, the same graph
+    /// services every cache length — no per-shape recompile per token.
+    ///
+    /// `attentionMask == nil` is the autoregressive single-token case (one new
+    /// query, no future positions to mask). Multi-token prefill callers must
+    /// supply an explicit causal mask.
+    public func forwardStep(
+        embeddings: MLXArray,
+        offset: MLXArray,
+        cache: [(MLXArray, MLXArray)]? = nil,
+        attentionMask: MLXArray? = nil,
+        applyFinalNorm: Bool = true
+    ) -> (MLXArray, [(MLXArray, MLXArray)]) {
+        var h = embeddings
+        var newCache: [(MLXArray, MLXArray)] = []
+        newCache.reserveCapacity(layers.count)
+        for (i, layer) in layers.enumerated() {
+            let layerCache = cache?[i]
+            let (out, updated) = layer.forwardStep(
+                h, offset: offset, attentionMask: attentionMask, cache: layerCache
+            )
+            h = out
+            newCache.append(updated)
+        }
+        if applyFinalNorm { h = norm(h) }
+        return (h, newCache)
+    }
+
+    /// Install a `MLX.compile(shapeless: true)` wrapper around `forwardStep`.
+    /// Subsequent `executeStep(...)` calls fuse all layer kernels into a single
+    /// compiled graph. Call once after model load.
+    public func setupCompilation() {
+        let selfRef = self
+        let numLayers = config.hiddenLayers
+
+        compiledStep = compile(
+            inputs: [selfRef], outputs: [selfRef], shapeless: true
+        ) { inputs in
+            let embeds = inputs[0]
+            let offset = inputs[1]
+            var cache: [(MLXArray, MLXArray)] = []
+            cache.reserveCapacity(numLayers)
+            for i in 0..<numLayers {
+                cache.append((inputs[2 + i * 2], inputs[3 + i * 2]))
+            }
+            let (hidden, newCache) = selfRef.forwardStep(
+                embeddings: embeds, offset: offset, cache: cache, attentionMask: nil
+            )
+            var result: [MLXArray] = [hidden]
+            for (k, v) in newCache { result.append(k); result.append(v) }
+            return result
+        }
+    }
+
+    /// Run one autoregressive step using the compiled graph when available,
+    /// falling back to the eager path otherwise.
+    public func executeStep(
+        embeddings: MLXArray,
+        offset: MLXArray,
+        cache: [(MLXArray, MLXArray)]
+    ) -> (MLXArray, [(MLXArray, MLXArray)]) {
+        guard let compiled = compiledStep else {
+            return forwardStep(embeddings: embeddings, offset: offset, cache: cache)
+        }
+        var flat: [MLXArray] = [embeddings, offset]
+        flat.reserveCapacity(2 + cache.count * 2)
+        for (k, v) in cache { flat.append(k); flat.append(v) }
+        let out = compiled(flat)
+        var newCache: [(MLXArray, MLXArray)] = []
+        newCache.reserveCapacity(cache.count)
+        for i in 0..<cache.count {
+            newCache.append((out[1 + i * 2], out[2 + i * 2]))
+        }
+        return (out[0], newCache)
+    }
 }
 
 public class Qwen2ForCausalLM: Module {

--- a/Sources/VibeVoiceTTS/Models/Qwen2TransformerBlock.swift
+++ b/Sources/VibeVoiceTTS/Models/Qwen2TransformerBlock.swift
@@ -30,4 +30,21 @@ public class Qwen2TransformerBlock: Module {
         let mlpOut = mlp(postAttentionLayerNorm(h))
         return h + mlpOut
     }
+
+    /// Pure-functional companion to `callAsFunction` for shapeless compile.
+    /// See `Qwen2Attention.forwardStep` for the contract.
+    public func forwardStep(
+        _ x: MLXArray,
+        offset: MLXArray,
+        attentionMask: MLXArray? = nil,
+        cache: (MLXArray, MLXArray)? = nil
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let normedInput = inputLayerNorm(x)
+        let (attnOut, newCache) = attention.forwardStep(
+            normedInput, offset: offset, attentionMask: attentionMask, cache: cache
+        )
+        let h = x + attnOut
+        let mlpOut = mlp(postAttentionLayerNorm(h))
+        return (h + mlpOut, newCache)
+    }
 }

--- a/Sources/VibeVoiceTTS/VibeVoice15BTTSModel.swift
+++ b/Sources/VibeVoiceTTS/VibeVoice15BTTSModel.swift
@@ -103,6 +103,14 @@ public final class VibeVoice15BTTSModel {
         progressHandler?(0.95, "Loading tokenizer...")
         let tokenizer = try await AutoTokenizer.from(modelFolder: tokenizerCacheDir)
 
+        // Install the shapeless-compile wrapper around the autoregressive LM
+        // step. Cheap (registers the compile closure; first invocation traces
+        // and caches the graph). Without this, every cache length seen during
+        // generation triggers a fresh kernel compile — ~22 min on a cold M-series
+        // for the 1.5B INT4 path.
+        progressHandler?(0.98, "Setting up compiled step...")
+        model.languageModel.setupCompilation()
+
         progressHandler?(1.0, "Ready")
         return VibeVoice15BTTSModel(
             configuration: configuration,
@@ -189,9 +197,18 @@ public final class VibeVoice15BTTSModel {
         )
 
         // 6) Generation loop: LM token sampling + branched on <speech_diffusion> / <speech_end> / text.
+        //
+        // Per-token forwards go through `Qwen2Model.executeStep`, which is wrapped
+        // by `MLX.compile(shapeless: true)` after `setupCompilation()`. The cache
+        // is materialised once here as `[(K, V)]` tuples (extracted from the
+        // prefill state); each step then concats new K/V onto the running tensors.
+        // Shapeless compile means the same compiled graph services every cache
+        // length, eliminating the per-shape recompile that drives the cold-start
+        // cost on this 1.5B unified-LM path.
         let speechEnd = Int32(TokenConstants.speechEndId)
         let speechDiff = Int32(TokenConstants.speechDiffusionId)
-        let embedTokens = inference.model.languageModel.embedTokens
+        let lm = inference.model.languageModel
+        let embedTokens = lm.embedTokens
         let acousticCache = StreamingConvCache()
 
         var audioChunks: [MLXArray] = []
@@ -199,6 +216,25 @@ public final class VibeVoice15BTTSModel {
         var currentHidden = prefillHidden[0..., lastIdx...(lastIdx), 0...]
         let negLastIdx = negPrefillHidden.dim(1) - 1
         var negCurrentHidden = negPrefillHidden[0..., negLastIdx...(negLastIdx), 0...]
+
+        // Snapshot the prefilled K/V into compiled-step format. Both caches must
+        // already have data — prefill ran above with an explicit prompt.
+        guard
+            let posSnapshot0 = inference.lmCache.first?.snapshot(),
+            let negSnapshot0 = inference.negLmCache.first?.snapshot()
+        else {
+            return []
+        }
+        _ = posSnapshot0; _ = negSnapshot0  // type witness
+
+        var posCache: [(MLXArray, MLXArray)] = inference.lmCache.compactMap { $0.snapshot() }
+        var negCache: [(MLXArray, MLXArray)] = inference.negLmCache.compactMap { $0.snapshot() }
+        guard posCache.count == lm.config.hiddenLayers,
+              negCache.count == lm.config.hiddenLayers else {
+            return []
+        }
+        var posOffset = inference.lmCache[0].offset
+        var negOffset = inference.negLmCache[0].offset
 
         for _ in 0..<configuration.maxSpeechTokens {
             let logits = embedTokens.asLinear(currentHidden)  // [1, 1, vocab]
@@ -208,6 +244,7 @@ public final class VibeVoice15BTTSModel {
 
             if tokenId == speechEnd { break }
 
+            let stepEmbed: MLXArray
             if tokenId == speechDiff {
                 // Sample a new acoustic latent via diffusion conditioned on
                 // current hidden. Decode to audio. Feed connector back as the
@@ -225,25 +262,30 @@ public final class VibeVoice15BTTSModel {
 
                 // Feed acoustic_connector(latent) as next embed (no semantic
                 // during generation — only acoustic per reference).
-                let acEmbed = inference.model.acousticConnector(latent)
-                currentHidden = inference.model.languageModel.forwardWithEmbeddings(
-                    acEmbed, cache: inference.lmCache
-                )
-                negCurrentHidden = inference.model.languageModel.forwardWithEmbeddings(
-                    acEmbed, cache: inference.negLmCache
-                )
+                stepEmbed = inference.model.acousticConnector(latent)
             } else {
                 // Plain text token — embed + step.
                 let tokenArr = MLXArray([tokenId]).reshaped([1, 1])
-                currentHidden = inference.forwardWithAudio(
-                    inputIds: tokenArr, audioEmbeddings: nil, audioMask: nil,
-                    cache: &inference.lmCache
-                )
-                negCurrentHidden = inference.forwardWithAudio(
-                    inputIds: tokenArr, audioEmbeddings: nil, audioMask: nil,
-                    cache: &inference.negLmCache
-                )
+                stepEmbed = embedTokens(tokenArr)
             }
+
+            let (posHidden, posNew) = lm.executeStep(
+                embeddings: stepEmbed,
+                offset: MLXArray(Int32(posOffset)),
+                cache: posCache
+            )
+            posCache = posNew
+            posOffset += 1
+            currentHidden = posHidden
+
+            let (negHidden, negNew) = lm.executeStep(
+                embeddings: stepEmbed,
+                offset: MLXArray(Int32(negOffset)),
+                cache: negCache
+            )
+            negCache = negNew
+            negOffset += 1
+            negCurrentHidden = negHidden
         }
 
         if audioChunks.isEmpty { return [] }


### PR DESCRIPTION
**Stacked on top of #239** — please merge that first; this PR's base will auto-rebase onto \`main\`.

## The problem

The 1.5B unified-LM long-form path (\`audio vibevoice ... --long-form --reference-audio ... --reference-transcript ...\`, available after #239) takes ~22 minutes on a freshly built binary to synthesize ~7 s of audio (RTFx ~0.006). Once Apple's per-binary Metal shader cache is warm, the same generation drops to ~3.5 s (RTFx ~2.0). So nothing about the model is fundamentally slow — the cost is one-time JIT compilation, but it is paid every time the binary checksum changes (every \`brew install\`, every \`brew upgrade\`, every dev rebuild).

## Cause

Profiling traced the cold cost to MLX kernel JIT for the autoregressive decode. Each new token grew the KV cache by 1 → unique tensor shape per step → \`MLXFast.scaledDotProductAttention\` is shape-specialised → ~1600 fresh kernels (~57 audio tokens × 28 layers × q/k/v combinations) at ~1 s each.

Other models in the repo dodge this with the standard MLX-Swift pattern: hoist the per-token forward into a pure-functional step with explicit \`[(K, V)]\` cache and an \`MLXArray\` RoPE offset, then wrap it in \`MLX.compile(shapeless: true)\`. One graph services every cache length. See \`CosyVoiceTTS.LLM.setupCompilation()\` and \`Qwen3TTS.setupCompilation()\` for the same idea.

## What this PR does

Mirror that pattern for the 1.5B Qwen2 stack:

| File | Change |
|---|---|
| \`Models/Qwen2Attention.swift\` (+60) | New \`forwardStep(_, offset: MLXArray, attentionMask:, cache:) → (out, (K, V))\` — explicit (K, V) I/O, MLXArray offset for RoPE, no stateful cache mutation. |
| \`Models/Qwen2TransformerBlock.swift\` (+17) | \`forwardStep\` thin wrapper. |
| \`Models/Qwen2Model.swift\` (+84) | \`forwardStep\` + \`setupCompilation()\` + \`executeStep(...)\` — installs the shapeless compiled graph and dispatches through it. |
| \`Inference/KVCache.swift\` (+11) | \`KVCacheSimple.snapshot()\` extracts the valid \`[B,H,offset,D]\` slice as a fresh tuple to seed the compiled step from the prefilled state. |
| \`VibeVoice15BTTSModel.swift\` (~+58) | \`fromPretrained\` calls \`setupCompilation()\`; \`generate()\` snapshots the prefill cache once, then runs both the positive and negative-conditioning autoregressive paths through \`executeStep(...)\`. |

The original stateful \`callAsFunction\` / \`forwardWithEmbeddings\` API is **preserved unchanged** — used by the streaming Realtime-0.5B path and by the multi-token prefill, neither of which need the shapeless rewrite.

## Numbers

Measured on M2 Max, \`aufklarer/VibeVoice-1.5B-MLX-INT4\`, 20 DPM-Solver steps, 7-8 s output, same input prompt across runs:

| Variant | Wall time | RTFx |
|---|---:|---:|
| **before**, freshly built binary | **1355.2 s** | 0.0056 |
| **after**, freshly built binary | **5.0 s** | 1.6 |
| warm rerun (both versions) | 3.5 s | 2.0 |

Round-trip Parakeet-TDT v3 transcription of the warm-rerun output:

> "That's a seven billion parameter speech model running on my MacBook, no cloud, no API. Let me show you."

— word-perfect match for the input prompt. Voice clone preserved.

## Tests

- \`VibeVoiceTTSTests\`: 21/21 passing (2 model-dependent skips)
- \`AudioCLITests\`: 94/94 passing (from #239 verification)
- \`HuggingFaceDownloaderTests\`: 7/7 passing (from #239 verification)
- E2E hook clip with both fixes: cold + warm rerun both produce intelligible voice-cloned audio that round-trips correctly through Parakeet ASR