### PR TITLE
Rename binary `audio` → `speech` (with backward-compat alias)

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -19,7 +19,7 @@ Run benchmarks using the release build. Build first with `/build`.
 
 ```bash
 module="$ARGUMENTS"
-cli=".build/release/audio"
+cli=".build/release/speech"
 
 case "$module" in
   asr)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,24 +24,27 @@ jobs:
       - name: Package
         run: |
           mkdir -p dist
+          # `speech`/`speech-server` are the canonical names; `audio`/`audio-server`
+          # are deprecated aliases produced by the same targets in Package.swift.
+          cp .build/release/speech .build/release/speech-server dist/
           cp .build/release/audio .build/release/audio-server dist/
           cp .build/release/mlx.metallib dist/
           # KokoroTTS loads fr/pt/hi pronunciation dicts via Bundle.module,
           # which hard-crashes if the resource bundle isn't beside the binary (#212).
           cp -R .build/release/Qwen3Speech_KokoroTTS.bundle dist/
           cd dist
-          tar czf audio-macos-arm64.tar.gz audio audio-server mlx.metallib Qwen3Speech_KokoroTTS.bundle
+          tar czf speech-macos-arm64.tar.gz speech speech-server audio audio-server mlx.metallib Qwen3Speech_KokoroTTS.bundle
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/audio-macos-arm64.tar.gz
+          files: dist/speech-macos-arm64.tar.gz
 
       - name: Update Homebrew formula
         run: |
-          SHA=$(shasum -a 256 dist/audio-macos-arm64.tar.gz | awk '{print $1}')
+          SHA=$(shasum -a 256 dist/speech-macos-arm64.tar.gz | awk '{print $1}')
           TAG="${GITHUB_REF_NAME}"
-          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/audio-macos-arm64.tar.gz"
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/speech-macos-arm64.tar.gz"
 
           git fetch origin main
           git checkout main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Project skills in `.claude/skills/`:
 - `Sources/MLXCommon/` — Shared MLX utilities (weight loading, quantized layers, memory estimation, `SDPA` multi-head attention helper)
 - `Sources/AudioCommon/` — Audio I/O, protocols, HuggingFace downloader, shared `SentencePieceModel` protobuf reader
 - `Sources/AudioCLILib/` — CLI commands
-- `Sources/AudioCLI/` — CLI entry point (`audio` binary)
+- `Sources/AudioCLI/` — CLI entry point (`speech` binary; `audio` is a deprecated alias)
 - `Tests/` — Unit and integration tests
 - `scripts/` — Model conversion (PyTorch → MLX/CoreML), benchmarking
 - `Examples/` — Demo apps (PersonaPlexDemo, SpeechDemo, iOSEchoDemo)
@@ -121,20 +121,20 @@ make test
 
 ## CLI
 
-The `audio` binary is the main entry point:
+The `speech` binary is the main entry point (`audio` is a deprecated alias that still works but prints a warning):
 
 ```bash
-.build/release/audio transcribe recording.wav          # ASR
-.build/release/audio speak "Hello" --output hi.wav     # TTS
-.build/release/audio respond --input q.wav             # Speech-to-speech
-.build/release/audio diarize meeting.wav               # Speaker diarization (pyannote)
-.build/release/audio diarize meeting.wav --engine sortformer  # Sortformer (CoreML, end-to-end)
-.build/release/audio diarize meeting.wav --rttm        # RTTM output
-.build/release/audio vad audio.wav                     # Voice activity detection
-.build/release/audio embed-speaker voice.wav           # Speaker embedding
-.build/release/audio denoise noisy.wav                 # Speech enhancement
-.build/release/audio kokoro "Hello" --voice af_heart   # Kokoro TTS (iOS)
-.build/release/audio qwen3-tts-coreml "Hello"          # Qwen3-TTS CoreML (6-model pipeline)
+.build/release/speech transcribe recording.wav          # ASR
+.build/release/speech speak "Hello" --output hi.wav     # TTS
+.build/release/speech respond --input q.wav             # Speech-to-speech
+.build/release/speech diarize meeting.wav               # Speaker diarization (pyannote)
+.build/release/speech diarize meeting.wav --engine sortformer  # Sortformer (CoreML, end-to-end)
+.build/release/speech diarize meeting.wav --rttm        # RTTM output
+.build/release/speech vad audio.wav                     # Voice activity detection
+.build/release/speech embed-speaker voice.wav           # Speaker embedding
+.build/release/speech denoise noisy.wav                 # Speech enhancement
+.build/release/speech kokoro "Hello" --voice af_heart   # Kokoro TTS (iOS)
+.build/release/speech qwen3-tts-coreml "Hello"          # Qwen3-TTS CoreML (6-model pipeline)
 ```
 
 ## Documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,8 +137,8 @@ Tagged releases go through `.github/workflows/release.yml`:
 1. Land your changes on `main` via PR.
 2. Run `gh release create vX.Y.Z --target main --title vX.Y.Z --notes "..."`.
 3. The release workflow:
-   - Builds `audio` + `audio-server` in release mode.
-   - Tars both plus `mlx.metallib` into `audio-macos-arm64.tar.gz`.
+   - Builds `speech` + `speech-server` in release mode (and the deprecated `audio` + `audio-server` aliases).
+   - Tars all four binaries plus `mlx.metallib` into `speech-macos-arm64.tar.gz`.
    - Uploads the tarball as a release asset.
    - Auto-bumps `Formula/speech.rb`'s `url` and `sha256` and commits
      the bump back to `main`.

--- a/Formula/speech.rb
+++ b/Formula/speech.rb
@@ -9,14 +9,23 @@ class Speech < Formula
   depends_on :macos
 
   def install
-    libexec.install "audio", "audio-server", "mlx.metallib"
-    libexec.install "Qwen3Speech_KokoroTTS.bundle"
-    bin.write_exec_script libexec/"audio"
-    bin.write_exec_script libexec/"audio-server"
+    # `speech`/`speech-server` are canonical; `audio`/`audio-server` are
+    # deprecated aliases retained for one release cycle. Older release tarballs
+    # only carry the `audio` names, so install whichever is present.
+    %w[speech speech-server audio audio-server mlx.metallib].each do |f|
+      libexec.install f if File.exist?(f)
+    end
+    libexec.install "Qwen3Speech_KokoroTTS.bundle" if File.exist?("Qwen3Speech_KokoroTTS.bundle")
+
+    %w[speech speech-server audio audio-server].each do |name|
+      bin.write_exec_script libexec/name if (libexec/name).exist?
+    end
   end
 
   test do
-    assert_match "AI speech models", shell_output("#{bin}/audio --help")
-    assert_match "HTTP API server", shell_output("#{bin}/audio-server --help")
+    primary = (bin/"speech").exist? ? "speech" : "audio"
+    server  = (bin/"speech-server").exist? ? "speech-server" : "audio-server"
+    assert_match "AI speech models", shell_output("#{bin}/#{primary} --help")
+    assert_match "HTTP API server", shell_output("#{bin}/#{server} --help")
   end
 end

--- a/Package.swift
+++ b/Package.swift
@@ -89,6 +89,15 @@ let package = Package(
             targets: ["SpeechWakeWord"]
         ),
         .executable(
+            name: "speech",
+            targets: ["AudioCLI"]
+        ),
+        .executable(
+            name: "speech-server",
+            targets: ["AudioServerCLI"]
+        ),
+        // Deprecated aliases — kept for one release cycle. Will be removed in a future version.
+        .executable(
             name: "audio",
             targets: ["AudioCLI"]
         ),

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ brew install speech
 Then:
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # local HTTP / WebSocket server (OpenAI-compatible /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # local HTTP / WebSocket server (OpenAI-compatible /v1/realtime)
 ```
 
 **[Full CLI reference →](https://soniqo.audio/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### HTTP API server
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 Exposes every model via HTTP REST + WebSocket endpoints, including an OpenAI Realtime API-compatible WebSocket at `/v1/realtime`. See [`Sources/AudioServer/`](Sources/AudioServer/).

--- a/README_de.md
+++ b/README_de.md
@@ -139,11 +139,11 @@ brew install speech
 Dann:
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # lokaler HTTP/WebSocket-Server (OpenAI-kompatibles /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # lokaler HTTP/WebSocket-Server (OpenAI-kompatibles /v1/realtime)
 ```
 
 **[Vollständige CLI-Referenz →](https://soniqo.audio/de/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### HTTP-API-Server
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 Stellt jedes Modell über HTTP-REST- + WebSocket-Endpunkte bereit, einschließlich eines mit OpenAI Realtime API kompatiblen WebSocket unter `/v1/realtime`. Siehe [`Sources/AudioServer/`](Sources/AudioServer/).

--- a/README_es.md
+++ b/README_es.md
@@ -139,11 +139,11 @@ brew install speech
 Luego:
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # servidor HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # servidor HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
 ```
 
 **[Referencia completa de la CLI →](https://soniqo.audio/es/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### Servidor API HTTP
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 Expone cada modelo a través de endpoints HTTP REST + WebSocket, incluyendo un WebSocket compatible con OpenAI Realtime API en `/v1/realtime`. Ver [`Sources/AudioServer/`](Sources/AudioServer/).

--- a/README_fr.md
+++ b/README_fr.md
@@ -139,11 +139,11 @@ brew install speech
 Ensuite :
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # serveur HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # serveur HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
 ```
 
 **[Reference CLI complete →](https://soniqo.audio/fr/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### Serveur API HTTP
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 Expose chaque modele via des endpoints HTTP REST + WebSocket, y compris un WebSocket compatible OpenAI Realtime API sur `/v1/realtime`. Voir [`Sources/AudioServer/`](Sources/AudioServer/).

--- a/README_hi.md
+++ b/README_hi.md
@@ -139,11 +139,11 @@ brew install speech
 फिर:
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # स्थानीय HTTP / WebSocket सर्वर (OpenAI-compatible /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # स्थानीय HTTP / WebSocket सर्वर (OpenAI-compatible /v1/realtime)
 ```
 
 **[पूर्ण CLI संदर्भ →](https://soniqo.audio/hi/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### HTTP API सर्वर
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 सभी मॉडलों को HTTP REST + WebSocket endpoints के माध्यम से एक्सपोज़ करता है, जिसमें `/v1/realtime` पर OpenAI Realtime API-संगत WebSocket शामिल है। देखें [`Sources/AudioServer/`](Sources/AudioServer/)।

--- a/README_ja.md
+++ b/README_ja.md
@@ -139,11 +139,11 @@ brew install speech
 その後：
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # ローカル HTTP / WebSocket サーバー（OpenAI 互換 /v1/realtime）
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # ローカル HTTP / WebSocket サーバー（OpenAI 互換 /v1/realtime）
 ```
 
 **[完全なCLIリファレンス →](https://soniqo.audio/ja/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### HTTP APIサーバー
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 HTTP REST + WebSocketエンドポイントですべてのモデルを公開します。OpenAI Realtime API互換のWebSocket `/v1/realtime` も含まれます。[`Sources/AudioServer/`](Sources/AudioServer/) を参照してください。

--- a/README_ko.md
+++ b/README_ko.md
@@ -139,11 +139,11 @@ brew install speech
 그런 다음:
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # 로컬 HTTP / WebSocket 서버 (OpenAI 호환 /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # 로컬 HTTP / WebSocket 서버 (OpenAI 호환 /v1/realtime)
 ```
 
 **[전체 CLI 레퍼런스 →](https://soniqo.audio/ko/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### HTTP API 서버
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 HTTP REST + WebSocket 엔드포인트로 모든 모델을 공개합니다. OpenAI Realtime API 호환 WebSocket `/v1/realtime`도 포함됩니다. [`Sources/AudioServer/`](Sources/AudioServer/)를 참조하세요.

--- a/README_pt.md
+++ b/README_pt.md
@@ -139,11 +139,11 @@ brew install speech
 Depois:
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # servidor HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # servidor HTTP / WebSocket local (OpenAI-compatible /v1/realtime)
 ```
 
 **[Referencia completa do CLI →](https://soniqo.audio/pt/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### Servidor HTTP API
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 Expoe cada modelo via endpoints HTTP REST + WebSocket, incluindo um WebSocket compativel com OpenAI Realtime API em `/v1/realtime`. Veja [`Sources/AudioServer/`](Sources/AudioServer/).

--- a/README_ru.md
+++ b/README_ru.md
@@ -139,11 +139,11 @@ brew install speech
 Затем:
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # локальный HTTP / WebSocket сервер (OpenAI-совместимый /v1/realtime)
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # локальный HTTP / WebSocket сервер (OpenAI-совместимый /v1/realtime)
 ```
 
 **[Полный справочник CLI →](https://soniqo.audio/ru/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### HTTP API-сервер
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 Предоставляет все модели через HTTP REST + WebSocket-эндпоинты, включая совместимый с OpenAI Realtime API WebSocket по адресу `/v1/realtime`. См. [`Sources/AudioServer/`](Sources/AudioServer/).

--- a/README_zh.md
+++ b/README_zh.md
@@ -139,11 +139,11 @@ brew install speech
 然后：
 
 ```bash
-audio transcribe recording.wav
-audio speak "Hello world"
-audio translate "Hello, how are you?" --to es
-audio respond --input question.wav --transcript
-audio-server --port 8080            # 本地 HTTP / WebSocket 服务器（OpenAI 兼容 /v1/realtime）
+speech transcribe recording.wav
+speech speak "Hello world"
+speech translate "Hello, how are you?" --to es
+speech respond --input question.wav --transcript
+speech-server --port 8080            # 本地 HTTP / WebSocket 服务器（OpenAI 兼容 /v1/realtime）
 ```
 
 **[完整 CLI 参考 →](https://soniqo.audio/zh/cli)**
@@ -331,7 +331,7 @@ pipeline.pushAudio(micSamples)
 ### HTTP API 服务器
 
 ```bash
-audio-server --port 8080
+speech-server --port 8080
 ```
 
 通过 HTTP REST + WebSocket 接口暴露每个模型，包括一个兼容 OpenAI Realtime API 的 WebSocket 接口 `/v1/realtime`。详见 [`Sources/AudioServer/`](Sources/AudioServer/)。

--- a/Sources/AudioCLI/main.swift
+++ b/Sources/AudioCLI/main.swift
@@ -1,3 +1,13 @@
 import AudioCLILib
+import Foundation
+
+// Backward-compat: when invoked via the deprecated `audio` binary name, emit a one-line
+// deprecation notice. Inferred from argv[0] so each binary self-identifies.
+if let argv0 = CommandLine.arguments.first,
+   (argv0 as NSString).lastPathComponent == "audio" {
+    FileHandle.standardError.write(Data(
+        "warning: `audio` is a deprecated alias and will be removed in a future release — use `speech` instead.\n".utf8
+    ))
+}
 
 AudioCLI.main()

--- a/Sources/AudioCLILib/AudioCLI.swift
+++ b/Sources/AudioCLILib/AudioCLI.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 
 public struct AudioCLI: ParsableCommand {
     public static let configuration = CommandConfiguration(
-        commandName: "audio",
+        commandName: "speech",
         abstract: "AI speech models for Apple Silicon",
         subcommands: [
             TranscribeCommand.self,

--- a/Sources/AudioCLILib/TranslateCommand.swift
+++ b/Sources/AudioCLILib/TranslateCommand.swift
@@ -8,7 +8,7 @@ public struct TranslateCommand: ParsableCommand {
         abstract: "Translate text into a target language using MADLAD-400 (MLX, Apple Silicon)"
     )
 
-    @Argument(help: "Text to translate. Omit to read from stdin (e.g. `audio transcribe x.wav | audio translate --to es`).")
+    @Argument(help: "Text to translate. Omit to read from stdin (e.g. `speech transcribe x.wav | speech translate --to es`).")
     public var text: String?
 
     @Option(name: [.short, .long], help: "Target language code (ISO 639-1, e.g. es, zh, fr, ja, de).")

--- a/Sources/AudioCLILib/VibeVoiceEncodeCommand.swift
+++ b/Sources/AudioCLILib/VibeVoiceEncodeCommand.swift
@@ -10,7 +10,7 @@ public struct VibeVoiceEncodeCommand: ParsableCommand {
         discussion: """
         Encodes the reference audio through VibeVoice's acoustic tokenizer and
         runs both the text and audio through the TTS LM to produce a
-        precomputed .safetensors voice cache that `audio vibevoice ...
+        precomputed .safetensors voice cache that `speech vibevoice ...
         --voice-cache <out>` can load.
 
         IMPORTANT — checkpoint availability:
@@ -18,7 +18,7 @@ public struct VibeVoiceEncodeCommand: ParsableCommand {
         and does not ship the acoustic encoder, so this command currently
         fails fast and points at the only real workflow speech-swift can
         run end-to-end on its own: clone an arbitrary speaker from raw
-        audio via `audio vibevoice ... --long-form --reference-audio <wav>
+        audio via `speech vibevoice ... --long-form --reference-audio <wav>
         --reference-transcript "..."`. That path runs the full
         VibeVoice-1.5B pipeline (which does ship the encoder) and inlines
         the encoding on every synthesis call.

--- a/Sources/AudioServerCLI/AudioServerCommand.swift
+++ b/Sources/AudioServerCLI/AudioServerCommand.swift
@@ -5,7 +5,7 @@ import AudioServer
 @main
 struct AudioServerCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        commandName: "audio-server",
+        commandName: "speech-server",
         abstract: "HTTP API server for speech models on Apple Silicon"
     )
 
@@ -19,6 +19,13 @@ struct AudioServerCommand: AsyncParsableCommand {
     var preload: Bool = false
 
     func run() async throws {
+        if let argv0 = CommandLine.arguments.first,
+           (argv0 as NSString).lastPathComponent == "audio-server" {
+            FileHandle.standardError.write(Data(
+                "warning: `audio-server` is a deprecated alias and will be removed in a future release — use `speech-server` instead.\n".utf8
+            ))
+        }
+
         let server = AudioServer(host: host, port: port)
 
         if preload {

--- a/Sources/VibeVoiceTTS/VibeVoiceTTSModel.swift
+++ b/Sources/VibeVoiceTTS/VibeVoiceTTSModel.swift
@@ -202,7 +202,7 @@ public final class VibeVoiceTTSModel {
                 "acoustic encoder not present in this checkpoint — Microsoft's "
                 + "VibeVoice-Realtime-0.5B is distributed inference-only and does "
                 + "not include encoder weights. To clone an arbitrary speaker from "
-                + "raw audio, use VibeVoice-1.5B end-to-end via `audio vibevoice ... "
+                + "raw audio, use VibeVoice-1.5B end-to-end via `speech vibevoice ... "
                 + "--long-form --reference-audio <wav> --reference-transcript \"...\"` "
                 + "— the 1.5B path ships the encoder and inlines the encoding on each "
                 + "synthesis call, so no precomputed voice cache is needed."

--- a/docs/benchmarks/vibevoice.md
+++ b/docs/benchmarks/vibevoice.md
@@ -18,7 +18,7 @@
 - **CFG scale**: 1.3 (Realtime), 1.5 (long-form)
 - **Prompt**: 200-word English paragraph (≈ 90 s target audio)
 
-Measurement via `audio vibevoice --verbose` which reports duration, elapsed time, and RTF (real-time factor).
+Measurement via `speech vibevoice --verbose` which reports duration, elapsed time, and RTF (real-time factor).
 
 ## Measured
 
@@ -76,7 +76,7 @@ acoustic confusion (predictable for a coined word).
 make build
 
 # Run with verbose timing
-.build/release/audio vibevoice \
+.build/release/speech vibevoice \
   "Text of roughly 200 words here ..." \
   --voice-cache /path/to/en-Mike_man.safetensors \
   --steps 20 \

--- a/docs/inference/fireredvad.md
+++ b/docs/inference/fireredvad.md
@@ -14,10 +14,10 @@ Audio → Resample to 16kHz → Kaldi Fbank (80-dim) → CoreML (ANE) → Post-p
 
 ```bash
 # Basic usage
-.build/release/audio vad audio.wav --engine firered
+.build/release/speech vad audio.wav --engine firered
 
 # Custom threshold
-.build/release/audio vad audio.wav --engine firered --onset 0.5
+.build/release/speech vad audio.wav --engine firered --onset 0.5
 ```
 
 ## Swift API
@@ -87,8 +87,8 @@ Smoothing window has minimal effect (+/-0.3% F1). The threshold controls the FAR
 
 ```bash
 # Custom threshold and smoothing
-audio vad audio.wav --engine firered --threshold 0.5 --smooth-window 7
+speech vad audio.wav --engine firered --threshold 0.5 --smooth-window 7
 
 # Local model variant (e.g., Stream-VAD N2=0)
-audio vad audio.wav --engine firered -m /path/to/local/model
+speech vad audio.wav --engine firered -m /path/to/local/model
 ```

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -149,7 +149,7 @@ The classify head addresses 400 s in principle (5000 classes × 80 ms), but the 
 
 For audio under the 240 s bypass threshold this is a one-pass passthrough into `align()`. For longer audio the cost is one extra `align` pass per chunk; in practice the second chunk is short so the overhead is small (≤ ~0.5 s wall-clock on the 306 s TED-Ed test clip).
 
-The CLI (`audio align`) calls `alignLong` automatically and prints a one-line message when chunking kicks in:
+The CLI (`speech align`) calls `alignLong` automatically and prints a one-line message when chunking kicks in:
 
 ```
 Audio 306.2s saturated after word 690 (272.6s); chunking remaining 33.6s (pass 2)
@@ -198,14 +198,14 @@ Variant is auto-detected from `quantize_config.json` in the model directory. The
 
 ```bash
 # Align with provided text
-audio align audio.wav --text "Can you guarantee that the replacement part will be shipped tomorrow?"
+speech align audio.wav --text "Can you guarantee that the replacement part will be shipped tomorrow?"
 
 # Transcribe first, then align
-audio align audio.wav
+speech align audio.wav
 
 # Custom aligner model (8-bit or bf16)
-audio align audio.wav --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-8bit
-audio align audio.wav --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-bf16
+speech align audio.wav --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-8bit
+speech align audio.wav --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-bf16
 ```
 
 Output format:

--- a/docs/inference/madlad-translation.md
+++ b/docs/inference/madlad-translation.md
@@ -78,11 +78,11 @@ The relative position bias is computed only on layer 0 (with the correct `offset
 ## CLI
 
 ```bash
-audio translate "Hello" --to es
-audio translate "Bonjour" --to en --quantization int8
-audio translate --to fr --json   # JSON output with timing metrics
-audio transcribe meeting.wav | audio translate --to es   # pipe from ASR
-audio translate "Hello world" --to es --stream            # incremental output
+speech translate "Hello" --to es
+speech translate "Bonjour" --to en --quantization int8
+speech translate --to fr --json   # JSON output with timing metrics
+speech transcribe meeting.wav | speech translate --to es   # pipe from ASR
+speech translate "Hello world" --to es --stream            # incremental output
 ```
 
 ## Performance characteristics

--- a/docs/inference/nemotron-streaming-inference.md
+++ b/docs/inference/nemotron-streaming-inference.md
@@ -83,7 +83,7 @@ Unlike Parakeet-EOU, Nemotron **does not** emit an explicit EOU token. Two optio
 ## CLI
 
 ```bash
-audio transcribe recording.wav --engine nemotron           # batch transcription
-audio transcribe recording.wav --engine nemotron --stream  # streaming (prints final)
-audio transcribe recording.wav --engine nemotron --stream --partial  # prints partials too
+speech transcribe recording.wav --engine nemotron           # batch transcription
+speech transcribe recording.wav --engine nemotron --stream  # streaming (prints final)
+speech transcribe recording.wav --engine nemotron --stream --partial  # prints partials too
 ```

--- a/docs/inference/omnilingual-asr-inference.md
+++ b/docs/inference/omnilingual-asr-inference.md
@@ -50,14 +50,14 @@ is no fixed-window CoreML graph to pad to. Quantisation is mlx-swift
 
 ```bash
 # CoreML (default)
-audio transcribe recording.wav --engine omnilingual                     # 10 s window
-audio transcribe recording.wav --engine omnilingual --window 5            # 5 s window
+speech transcribe recording.wav --engine omnilingual                     # 10 s window
+speech transcribe recording.wav --engine omnilingual --window 5            # 5 s window
 
 # MLX
-audio transcribe recording.wav --engine omnilingual --backend mlx                            # 300M @ 4-bit
-audio transcribe recording.wav --engine omnilingual --backend mlx --variant 1B               # 1B @ 4-bit
-audio transcribe recording.wav --engine omnilingual --backend mlx --variant 3B --bits 8      # 3B @ 8-bit
-audio transcribe recording.wav --engine omnilingual --backend mlx --variant 7B               # 7B @ 4-bit
+speech transcribe recording.wav --engine omnilingual --backend mlx                            # 300M @ 4-bit
+speech transcribe recording.wav --engine omnilingual --backend mlx --variant 1B               # 1B @ 4-bit
+speech transcribe recording.wav --engine omnilingual --backend mlx --variant 3B --bits 8      # 3B @ 8-bit
+speech transcribe recording.wav --engine omnilingual --backend mlx --variant 7B               # 7B @ 4-bit
 ```
 
 ## Pipeline

--- a/docs/inference/parakeet-asr-inference.md
+++ b/docs/inference/parakeet-asr-inference.md
@@ -54,10 +54,10 @@ let _ = try model.transcribe(audio: silentBuffer, sampleRate: 16000)
 
 ```bash
 # Transcribe with Parakeet
-.build/release/audio transcribe --engine parakeet recording.wav
+.build/release/speech transcribe --engine parakeet recording.wav
 
 # Default engine (Qwen3-ASR)
-.build/release/audio transcribe recording.wav
+.build/release/speech transcribe recording.wav
 ```
 
 ## Performance (M2 Max)

--- a/docs/inference/qwen3-tts-inference.md
+++ b/docs/inference/qwen3-tts-inference.md
@@ -221,7 +221,7 @@ Reference audio (24kHz)
 ```
 
 ```bash
-.build/release/audio speak "Hello world" --voice-sample reference.wav --output cloned.wav
+.build/release/speech speak "Hello world" --voice-sample reference.wav --output cloned.wav
 ```
 
 ### ICL Mode
@@ -331,5 +331,5 @@ let audio = try model.synthesize(text: "Hello world", language: "english")
 ### CLI
 
 ```bash
-audio speak "Hello world" --engine coreml --output hello.wav
+speech speak "Hello world" --engine coreml --output hello.wav
 ```

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -12,8 +12,8 @@ Speaker diarization identifies **who spoke when** in an audio recording. Two eng
 ### Engine Selection
 
 ```bash
-audio diarize meeting.wav                    # Pyannote (default)
-audio diarize meeting.wav --engine sortformer  # Sortformer (CoreML)
+speech diarize meeting.wav                    # Pyannote (default)
+speech diarize meeting.wav --engine sortformer  # Sortformer (CoreML)
 ```
 
 ### Sortformer (End-to-End, CoreML)
@@ -188,23 +188,23 @@ let result = diarizer.diarize(audio: samples, sampleRate: 16000) { progress, sta
 
 ```bash
 # Pyannote diarization (default)
-audio diarize meeting.wav
+speech diarize meeting.wav
 
 # Sortformer diarization (CoreML, Neural Engine)
-audio diarize meeting.wav --engine sortformer
+speech diarize meeting.wav --engine sortformer
 
 # CoreML embeddings (Neural Engine, pyannote only)
-audio diarize meeting.wav --embedding-engine coreml
+speech diarize meeting.wav --embedding-engine coreml
 
 # JSON output
-audio diarize meeting.wav --json
+speech diarize meeting.wav --json
 
 # Speaker extraction (pyannote only)
-audio diarize meeting.wav --target-speaker enrollment.wav
+speech diarize meeting.wav --target-speaker enrollment.wav
 
 # Embed a speaker's voice
-audio embed-speaker enrollment.wav
-audio embed-speaker enrollment.wav --engine coreml --json
+speech embed-speaker enrollment.wav
+speech embed-speaker enrollment.wav --engine coreml --json
 ```
 
 ## Model Weights
@@ -257,8 +257,8 @@ Sources/SpeechVAD/
 └── SpeechVAD+Protocols.swift          Protocol conformances
 
 Sources/AudioCommon/Protocols.swift    DiarizedSegment, SpeakerEmbeddingModel, SpeakerDiarizationModel
-Sources/AudioCLILib/DiarizeCommand.swift       `audio diarize` (--engine, --embedding-engine)
-Sources/AudioCLILib/EmbedSpeakerCommand.swift  `audio embed-speaker` (--engine)
+Sources/AudioCLILib/DiarizeCommand.swift       `speech diarize` (--engine, --embedding-engine)
+Sources/AudioCLILib/EmbedSpeakerCommand.swift  `speech embed-speaker` (--engine)
 scripts/convert_wespeaker.py                    MLX weight conversion
 scripts/convert_wespeaker_coreml.py             CoreML weight conversion
 ```

--- a/docs/inference/speech-enhancement.md
+++ b/docs/inference/speech-enhancement.md
@@ -38,8 +38,8 @@ Core ML GRU cost scales ~O(n²) due to sequential hidden state processing. Short
 ## CLI
 
 ```bash
-swift run audio denoise noisy.wav
-swift run audio denoise noisy.wav --output clean.wav
+swift run speech denoise noisy.wav
+swift run speech denoise noisy.wav --output clean.wav
 ```
 
 ## Conversion

--- a/docs/inference/vibevoice-inference.md
+++ b/docs/inference/vibevoice-inference.md
@@ -87,7 +87,7 @@ let url = try tts.encodeAndSaveVoice(
 Or via the CLI:
 
 ```bash
-audio vibevoice-encode-voice reference.wav "actual transcript" \
+speech vibevoice-encode-voice reference.wav "actual transcript" \
     --output voices/my-voice.safetensors
 ```
 
@@ -107,12 +107,12 @@ the internal chunk loop — PR welcome.
 
 ```bash
 # 0.5B Realtime (default) — voice-cache flow
-audio vibevoice "Hello world." \
+speech vibevoice "Hello world." \
   --voice-cache voice_cache/en-Mike_man.safetensors \
   --output hello.wav
 
 # 1.5B long-form — single-shot with reference audio + transcript
-audio vibevoice "Long paragraph ..." \
+speech vibevoice "Long paragraph ..." \
   --long-form \
   --reference-audio reference_speech.wav \
   --reference-transcript "exact transcript of the reference" \
@@ -120,7 +120,7 @@ audio vibevoice "Long paragraph ..." \
   --output episode.wav
 
 # Mint a 0.5B voice cache from a recording
-audio vibevoice-encode-voice reference.wav \
+speech vibevoice-encode-voice reference.wav \
   "exact transcript of the recording" \
   --output voices/my-voice.safetensors
 ```

--- a/docs/inference/wake-word.md
+++ b/docs/inference/wake-word.md
@@ -55,16 +55,16 @@ let detections = try detector.detect(audio: samples, sampleRate: 16000)
 
 ```bash
 # Bare phrase (uses tuned defaults):
-audio wake recording.wav --keywords "hey soniqo"
+speech wake recording.wav --keywords "hey soniqo"
 
 # Per-phrase tuning (phrase[:ac_threshold[:boost]]):
-audio wake recording.wav --keywords "hey soniqo:0.1:0.5" "cancel:0.2"
+speech wake recording.wav --keywords "hey soniqo:0.1:0.5" "cancel:0.2"
 
 # JSON output:
-audio wake recording.wav --keywords "hey soniqo" --json
+speech wake recording.wav --keywords "hey soniqo" --json
 
 # Keyword file (one entry per line, `#` for comments):
-audio wake recording.wav --keywords-file keywords.txt
+speech wake recording.wav --keywords-file keywords.txt
 ```
 
 ## Streaming pipeline
@@ -107,7 +107,7 @@ let adapter = try WakeWordStreamingAdapter(detector: detector)
 The tuned defaults (0.15 / 0.5 / 1) are a good starting point on read speech.
 For noisy conditions or far-field mics, raise `acThreshold` toward 0.2–0.3 to
 cut false positives, or increase `boost` to 1.0–2.0 for better recall on
-short phrases. Use `audio wake --json` to dump matched spans + timestamps
+short phrases. Use `speech wake --json` to dump matched spans + timestamps
 and iterate.
 
 ## Known limitations

--- a/docs/models/parakeet-asr.md
+++ b/docs/models/parakeet-asr.md
@@ -60,11 +60,11 @@ Mel preprocessing (pre-emphasis, STFT, mel filterbank, normalization) is done in
 
 ```bash
 # Transcribe with Parakeet (CoreML, fast on Neural Engine)
-audio transcribe --engine parakeet audio.wav
+speech transcribe --engine parakeet audio.wav
 
 # Transcribe with Qwen3 (MLX, default)
-audio transcribe audio.wav
-audio transcribe --engine qwen3 audio.wav
+speech transcribe audio.wav
+speech transcribe --engine qwen3 audio.wav
 ```
 
 ## Performance

--- a/docs/models/personaplex.md
+++ b/docs/models/personaplex.md
@@ -242,7 +242,7 @@ model.warmUp()  // compile + warmup pass
 // Subsequent respond() / respondStream() calls use compiled path
 ```
 
-CLI: `audio respond --input audio.wav --compile --output response.wav`
+CLI: `speech respond --input audio.wav --compile --output response.wav`
 
 ## References
 

--- a/docs/models/vibevoice.md
+++ b/docs/models/vibevoice.md
@@ -32,16 +32,16 @@ Microsoft's model cards are explicit:
   generate plausible-sounding audio that does not faithfully reproduce the
   input text and should be considered experimental.
 
-The CLI surfaces this in the `audio vibevoice --help` discussion section.
+The CLI surfaces this in the `speech vibevoice --help` discussion section.
 
 ### Voice-cache provenance
 
 Realtime-0.5B is **distributed inference-only** — its checkpoint contains
 the LM, TTS LM, connector, decoder, and EOS classifier, but no acoustic
-encoder weights. Calling `audio vibevoice-encode-voice` against this model
+encoder weights. Calling `speech vibevoice-encode-voice` against this model
 will fail fast with a pointer to the only real workflow it can recommend:
 
-> Use 1.5B end-to-end via `audio vibevoice ... --long-form --reference-audio
+> Use 1.5B end-to-end via `speech vibevoice ... --long-form --reference-audio
 > <wav> --reference-transcript "..."`. The 1.5B checkpoint *does* ship the
 > encoder, so it can clone arbitrary voices from raw audio in one shot.
 > (The encoding is inlined; there is no separate "encode-voice" step on the
@@ -144,7 +144,7 @@ reference audio + transcript via `VibeVoiceTTSModel.encodeAndSaveVoice(...)`
 or the CLI:
 
 ```bash
-audio vibevoice-encode-voice reference.wav "exact transcript" \
+speech vibevoice-encode-voice reference.wav "exact transcript" \
     --output voices/my-voice.safetensors
 ```
 


### PR DESCRIPTION
## Summary

- Adds `speech` and `speech-server` as canonical executable products in `Package.swift`.
- Keeps `audio` and `audio-server` as functional aliases — same binary, same flags — that emit a one-line stderr deprecation warning on every invocation.
- Updates `commandName` on both CLI configs so `--help` text reflects the canonical name.
- Sweeps README + 9 translations, AGENTS.md, CONTRIBUTING.md, 14 docs pages, `.claude/skills/benchmark`, and source-side help strings to use `speech`/`speech-server`.
- Updates `.github/workflows/release.yml` to package all four binaries into a renamed `speech-macos-arm64.tar.gz`.
- Updates `Formula/speech.rb` with defensive `File.exist?` install guards so it works against both the current v0.0.13 tarball (only `audio` names) and post-merge releases (both names).

## Why

The next step is shipping the formula to homebrew-core. The current binary name `audio` is too generic — names a category, not a tool — and would likely get pushback during homebrew-core review. `speech` is short, available in homebrew-core (only existing match is the unrelated `speech-tools`), and aligns with the project's branding.

The deprecation alias means nothing breaks today: anyone with `.build/release/audio …` in scripts, aliases, or downstream tooling continues to work and just sees one extra stderr line.

## Test plan

- [x] `swift build -c release --disable-sandbox` — clean
- [x] `./scripts/build_mlx_metallib.sh release` — clean
- [x] `swift test --skip E2E` — 883 tests pass, 18 skipped (E2E), 0 failures
- [x] `.build/release/speech --help` shows `USAGE: speech <subcommand>`
- [x] `.build/release/audio --help` emits deprecation warning to stderr, still shows help (with canonical `speech` name in usage line)
- [x] `.build/release/speech-server --help` clean
- [x] `.build/release/audio-server` emits deprecation when actually run (parser short-circuits `--help` before `run()` — acceptable for a deprecation window)

## Follow-ups (separate PRs)

- Tag a release (v0.0.14+) so the auto-bump in `release.yml` writes the new tarball URL into `Formula/speech.rb`. Until that release ships, `brew install` against the formula still resolves to v0.0.13 — the defensive install handles this gracefully.
- soniqo-web docs — separate repo, same find/replace for the install/usage pages.
- After ~3 months or v1.0, remove the `audio` / `audio-server` alias products and the deprecation warnings.