### PR TITLE
docs(readme): fix Homebrew install command (all translations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 Requires native ARM Homebrew (`/opt/homebrew`). Rosetta/x86_64 Homebrew is not supported.
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 Then:

--- a/README_de.md
+++ b/README_de.md
@@ -132,8 +132,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 Erfordert natives ARM-Homebrew (`/opt/homebrew`). Rosetta/x86_64-Homebrew wird nicht unterstützt.
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 Dann:

--- a/README_es.md
+++ b/README_es.md
@@ -132,8 +132,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 Requiere Homebrew ARM nativo (`/opt/homebrew`). Homebrew Rosetta/x86_64 no está soportado.
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 Luego:

--- a/README_fr.md
+++ b/README_fr.md
@@ -132,8 +132,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 Necessite un Homebrew ARM natif (`/opt/homebrew`). Homebrew Rosetta/x86_64 n'est pas supporte.
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 Ensuite :

--- a/README_hi.md
+++ b/README_hi.md
@@ -132,8 +132,7 @@ struct DictateView: View {
 नेटिव ARM Homebrew (`/opt/homebrew`) आवश्यक है। Rosetta/x86_64 Homebrew समर्थित नहीं है।
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 फिर:

--- a/README_ja.md
+++ b/README_ja.md
@@ -132,8 +132,7 @@ struct DictateView: View {
 ネイティブARM Homebrew（`/opt/homebrew`）が必要です。Rosetta/x86_64 Homebrewはサポートされません。
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 その後：

--- a/README_ko.md
+++ b/README_ko.md
@@ -132,8 +132,7 @@ struct DictateView: View {
 네이티브 ARM Homebrew(`/opt/homebrew`)가 필요합니다. Rosetta/x86_64 Homebrew는 지원되지 않습니다.
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 그런 다음:

--- a/README_pt.md
+++ b/README_pt.md
@@ -132,8 +132,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 Requer Homebrew ARM nativo (`/opt/homebrew`). Homebrew Rosetta/x86_64 nao e suportado.
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 Depois:

--- a/README_ru.md
+++ b/README_ru.md
@@ -132,8 +132,7 @@ struct DictateView: View {
 Требуется нативный ARM Homebrew (`/opt/homebrew`). Rosetta/x86_64-версия Homebrew не поддерживается.
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 Затем:

--- a/README_zh.md
+++ b/README_zh.md
@@ -132,8 +132,7 @@ struct DictateView: View {
 需要原生 ARM Homebrew（`/opt/homebrew`），不支持 Rosetta/x86_64 Homebrew。
 
 ```bash
-brew tap soniqo/speech https://github.com/soniqo/speech-swift
-brew install speech
+brew install soniqo/tap/speech
 ```
 
 然后：


### PR DESCRIPTION
## Summary

Fixes the broken Homebrew install snippet in `README.md` and all 9 translations. The previous command pointed at a non-existent tap (`soniqo/speech`) and used an invalid third positional argument:

```
brew tap soniqo/speech https://github.com/soniqo/speech-swift
brew install speech
```

Replaced with the canonical one-liner that resolves against the live tap at https://github.com/soniqo/homebrew-tap:

```
brew install soniqo/tap/speech
```

The `soniqo/homebrew-tap` repository was just created and bootstrapped with `Formula/speech.rb` from the v0.0.14 release, so `brew install soniqo/tap/speech` works today.

## Test plan

- [x] `brew tap soniqo/tap` — succeeds
- [x] `brew info soniqo/tap/speech` — shows the formula
- [x] Followup: `brew install soniqo/tap/speech` should produce working `speech` + `speech-server` binaries (validated by tap-side `brew audit`)

## Follow-ups (separate PRs)

- Update `.github/workflows/release.yml` to also push the auto-bump to `soniqo/homebrew-tap` (needs a `HOMEBREW_TAP_TOKEN` repo secret).
- Once that lands, remove `Formula/speech.rb` from this repo — the tap becomes the single source of truth.
- ~30 days from the v0.0.14 release: submit a source-build formula to homebrew-core so users can `brew install speech` without the tap.