### PR TITLE
fix: weightsExist recognises CoreML bundle layouts (.mlmodelc, .mlpac…

### DIFF
--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -51,46 +51,18 @@ public enum HuggingFaceDownloader {
 
     // MARK: - Weight Existence Check
 
-    /// File-extension stems recognised as cached model weights.
-    ///
-    /// - `safetensors`: canonical Hugging Face safetensors layout
-    ///   (sharded or single-file).
-    /// - `mlmodelc`: Apple CoreML compiled-model bundle (a directory
-    ///   ending in `.mlmodelc`). CoreML-only Hugging Face repositories
-    ///   ship one or more of these and no `.safetensors` files.
-    /// - `mlpackage`: Apple CoreML uncompiled package (a directory
-    ///   ending in `.mlpackage`). Less common in HF caches but
-    ///   recognised for symmetry.
+    /// Extensions recognised as cached model weights: the canonical
+    /// HF `.safetensors` layout plus Apple CoreML bundle directories
+    /// (`.mlmodelc`, `.mlpackage`) shipped by CoreML-only repos.
     public static let weightFileExtensions: Set<String> = [
         "safetensors", "mlmodelc", "mlpackage"
     ]
 
     /// Returns `true` when `directory` contains at least one entry
-    /// whose extension matches `weightFileExtensions`.
-    ///
-    /// Used by `downloadWeights` to short-circuit network requests
-    /// when `offlineMode: true` is set. Recognising both the safetensors
-    /// layout AND the Apple CoreML bundle layouts (`.mlmodelc/`,
-    /// `.mlpackage/`) is necessary because CoreML-only repositories
-    /// (e.g. `aufklarer/Parakeet-TDT-v3-CoreML-INT8`,
-    /// `aufklarer/WeSpeaker-ResNet34-LM-CoreML`,
-    /// `aufklarer/Sortformer-Diarization-CoreML`) ship their compiled
-    /// models as `.mlmodelc/` directories and contain zero
-    /// `.safetensors` files.
-    ///
-    /// Without recognising the CoreML extensions, `offlineMode: true`
-    /// always falls through to `hub.snapshot()`, which issues an HTTP
-    /// HEAD to `https://huggingface.co/api/models/<repo>/revision/main`
-    /// even when every byte of the model is already on disk. On
-    /// enterprise-managed networks where outbound traffic from
-    /// development-signed binaries is filtered by EDR (CrowdStrike
-    /// Falcon, Cisco AnyConnect with strict outbound policies, …),
-    /// that fetch is dropped or causes the calling process to be
-    /// SIGKILLed before any `catch` block can run. Field-confirmed
-    /// 2026-05-08 via macOS unified-log capture; downstream apps
-    /// have been working around this with a 0-byte `.safetensors`
-    /// marker file dropped into the cache directory after extracting
-    /// CoreML weights.
+    /// whose extension matches `weightFileExtensions`. Used by
+    /// `downloadWeights` to short-circuit network requests when
+    /// `offlineMode: true` is set on caches that contain only CoreML
+    /// bundles and no `.safetensors` files.
     public static func weightsExist(in directory: URL) -> Bool {
         let fm = FileManager.default
         guard fm.fileExists(atPath: directory.path) else { return false }

--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -51,7 +51,46 @@ public enum HuggingFaceDownloader {
 
     // MARK: - Weight Existence Check
 
-    /// Check if safetensors weights exist in a directory.
+    /// File-extension stems recognised as cached model weights.
+    ///
+    /// - `safetensors`: canonical Hugging Face safetensors layout
+    ///   (sharded or single-file).
+    /// - `mlmodelc`: Apple CoreML compiled-model bundle (a directory
+    ///   ending in `.mlmodelc`). CoreML-only Hugging Face repositories
+    ///   ship one or more of these and no `.safetensors` files.
+    /// - `mlpackage`: Apple CoreML uncompiled package (a directory
+    ///   ending in `.mlpackage`). Less common in HF caches but
+    ///   recognised for symmetry.
+    public static let weightFileExtensions: Set<String> = [
+        "safetensors", "mlmodelc", "mlpackage"
+    ]
+
+    /// Returns `true` when `directory` contains at least one entry
+    /// whose extension matches `weightFileExtensions`.
+    ///
+    /// Used by `downloadWeights` to short-circuit network requests
+    /// when `offlineMode: true` is set. Recognising both the safetensors
+    /// layout AND the Apple CoreML bundle layouts (`.mlmodelc/`,
+    /// `.mlpackage/`) is necessary because CoreML-only repositories
+    /// (e.g. `aufklarer/Parakeet-TDT-v3-CoreML-INT8`,
+    /// `aufklarer/WeSpeaker-ResNet34-LM-CoreML`,
+    /// `aufklarer/Sortformer-Diarization-CoreML`) ship their compiled
+    /// models as `.mlmodelc/` directories and contain zero
+    /// `.safetensors` files.
+    ///
+    /// Without recognising the CoreML extensions, `offlineMode: true`
+    /// always falls through to `hub.snapshot()`, which issues an HTTP
+    /// HEAD to `https://huggingface.co/api/models/<repo>/revision/main`
+    /// even when every byte of the model is already on disk. On
+    /// enterprise-managed networks where outbound traffic from
+    /// development-signed binaries is filtered by EDR (CrowdStrike
+    /// Falcon, Cisco AnyConnect with strict outbound policies, …),
+    /// that fetch is dropped or causes the calling process to be
+    /// SIGKILLed before any `catch` block can run. Field-confirmed
+    /// 2026-05-08 via macOS unified-log capture; downstream apps
+    /// have been working around this with a 0-byte `.safetensors`
+    /// marker file dropped into the cache directory after extracting
+    /// CoreML weights.
     public static func weightsExist(in directory: URL) -> Bool {
         let fm = FileManager.default
         guard fm.fileExists(atPath: directory.path) else { return false }
@@ -62,7 +101,7 @@ public enum HuggingFaceDownloader {
             AudioLog.download.debug("Could not list directory \(directory.path): \(error)")
             contents = []
         }
-        return contents.contains { $0.pathExtension == "safetensors" }
+        return contents.contains { weightFileExtensions.contains($0.pathExtension) }
     }
 
     // MARK: - Download

--- a/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
+++ b/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
@@ -101,6 +101,133 @@ final class HuggingFaceDownloaderTests: XCTestCase {
         XCTAssertFalse(HuggingFaceDownloader.weightsExist(in: tmpDir))
     }
 
+    // MARK: - weightsExist — Apple CoreML bundle layouts
+
+    /// CoreML-only repositories (e.g. `aufklarer/WeSpeaker-ResNet34-LM-CoreML`)
+    /// ship a `.mlmodelc/` directory and no `.safetensors` files. The
+    /// pre-fix `weightsExist` returned false for this layout, causing
+    /// every `offlineMode: true` load to fall through to `hub.snapshot()`
+    /// — which in turn issued an HTTP HEAD to huggingface.co even when
+    /// every byte of the model was on disk.
+    func testWeightsExistReturnsTrueForMlmodelcDirectory() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("weights_mlmodelc_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        XCTAssertFalse(HuggingFaceDownloader.weightsExist(in: tmpDir))
+
+        let mlmodelc = tmpDir.appendingPathComponent("wespeaker.mlmodelc", isDirectory: true)
+        try FileManager.default.createDirectory(at: mlmodelc, withIntermediateDirectories: true)
+
+        XCTAssertTrue(HuggingFaceDownloader.weightsExist(in: tmpDir),
+            "Directories ending in .mlmodelc must satisfy weightsExist — that's the cached-CoreML layout HF ships")
+    }
+
+    /// Multi-component CoreML models (e.g. Parakeet's encoder + decoder + joint)
+    /// ship multiple `.mlmodelc/` directories under the same repo. The
+    /// existence check fires on any one of them.
+    func testWeightsExistReturnsTrueForMultipleMlmodelcDirs() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("weights_multi_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        for name in ["encoder.mlmodelc", "decoder.mlmodelc", "joint.mlmodelc"] {
+            try FileManager.default.createDirectory(
+                at: tmpDir.appendingPathComponent(name, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+
+        XCTAssertTrue(HuggingFaceDownloader.weightsExist(in: tmpDir))
+    }
+
+    /// `.mlpackage/` is the uncompiled CoreML container. Less common
+    /// in HF caches but recognised for symmetry.
+    func testWeightsExistReturnsTrueForMlpackageDirectory() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("weights_mlpackage_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let mlpackage = tmpDir.appendingPathComponent("model.mlpackage", isDirectory: true)
+        try FileManager.default.createDirectory(at: mlpackage, withIntermediateDirectories: true)
+
+        XCTAssertTrue(HuggingFaceDownloader.weightsExist(in: tmpDir))
+    }
+
+    /// Mixed-layout repos that ship both `.safetensors` and `.mlmodelc/`
+    /// (rare but possible) must continue to satisfy `weightsExist`.
+    /// Pins that the broadened recogniser doesn't accidentally introduce
+    /// a regression on the canonical safetensors path.
+    func testWeightsExistReturnsTrueForMixedSafetensorsAndMlmodelc() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("weights_mixed_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        try Data([0x00]).write(to: tmpDir.appendingPathComponent("model.safetensors"))
+        try FileManager.default.createDirectory(
+            at: tmpDir.appendingPathComponent("encoder.mlmodelc", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        XCTAssertTrue(HuggingFaceDownloader.weightsExist(in: tmpDir))
+    }
+
+    /// A directory containing only unrelated files (`config.json`,
+    /// `.cache/`, `tokenizer.json`) must NOT satisfy `weightsExist`.
+    /// Preserves the "incomplete cache → fall through to download"
+    /// semantics that downstream consumers rely on.
+    func testWeightsExistReturnsFalseForDirectoryWithoutWeightFiles() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("weights_unrelated_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        try Data("{}".utf8).write(to: tmpDir.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: tmpDir.appendingPathComponent("tokenizer.json"))
+        try FileManager.default.createDirectory(
+            at: tmpDir.appendingPathComponent(".cache", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        XCTAssertFalse(HuggingFaceDownloader.weightsExist(in: tmpDir),
+            "Unrelated files (config, tokenizer, .cache) must NOT satisfy weightsExist — preserves 'incomplete cache → download' semantics")
+    }
+
+    // MARK: - offlineMode integration with CoreML caches
+
+    /// The behavioural counterpart to `testOfflineModeSkipsDownloadWhenWeightsExist`
+    /// — verifies that `downloadWeights(offlineMode: true)` short-circuits
+    /// (no network) when ONLY `.mlmodelc/` directories are present, without
+    /// any `.safetensors` files. This is the field-reported scenario that
+    /// motivated the patch.
+    func testOfflineModeSkipsDownloadWhenMlmodelcExists() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("offline_mlmodelc_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Populate cache with the WeSpeaker-style single-mlmodelc layout
+        // (no safetensors). Pre-fix, this would NOT short-circuit.
+        let mlmodelc = tmpDir.appendingPathComponent("wespeaker.mlmodelc", isDirectory: true)
+        try FileManager.default.createDirectory(at: mlmodelc, withIntermediateDirectories: true)
+
+        var progressReported = false
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: "fake/coreml-only-model",
+            to: tmpDir,
+            offlineMode: true,
+            progressHandler: { progress in
+                if progress >= 1.0 { progressReported = true }
+            }
+        )
+        XCTAssertTrue(progressReported,
+            "offlineMode: true must short-circuit (no network) when only .mlmodelc/ caches are present — same contract as for .safetensors")
+    }
+
     // MARK: - cacheDir (custom cache directory)
 
     func testCustomCacheDirSkipsDefaultResolution() async throws {


### PR DESCRIPTION
## Problem

`HuggingFaceDownloader.weightsExist(in:)` currently only matches files
with the `.safetensors` extension. CoreML-only Hugging Face repositories
ship as `.mlmodelc/` (or, less commonly, `.mlpackage/`) directories and
contain zero `.safetensors` files. Examples downstream consumers depend
on today:

- `aufklarer/Parakeet-TDT-v3-CoreML-INT8` — 3× `.mlmodelc/`
  (encoder/decoder/joint)
- `aufklarer/WeSpeaker-ResNet34-LM-CoreML` — 1× `.mlmodelc/`
- `aufklarer/Sortformer-Diarization-CoreML` — 1× `.mlmodelc/`

For these caches, every `downloadWeights(offlineMode: true)` call falls
past the offline short-circuit and reaches `HubApi.snapshot(...)`, which
issues an HTTP HEAD to `huggingface.co/api/models/<repo>/revision/main`
even when every byte of the model is already on disk.

On enterprise-managed networks where outbound traffic from a
development-signed binary is filtered (EDR signatures around "child
process phones home"), that call can be dropped or — in the field-captured
case — cause the loader process to be SIGKILLed before any Swift `catch`
block can run. Field-confirmed 2026-05-08 via macOS unified-log capture.

## Change

Source: `Sources/AudioCommon/HuggingFaceDownloader.swift`

Add a single `weightFileExtensions: Set<String>` containing
`{"safetensors", "mlmodelc", "mlpackage"}` and switch the contains check
to use it. Zero behaviour change for the existing safetensors layout —
the broadened recogniser is strictly additive.

Tests: 5 new cases in `HuggingFaceDownloaderTests`:

- single `.mlmodelc/` → satisfies `weightsExist`
- multi-component (encoder/decoder/joint) `.mlmodelc/` → satisfies
- `.mlpackage/` → satisfies (symmetry pin)
- mixed `.safetensors` + `.mlmodelc/` → satisfies (no regression on
  canonical layout)
- unrelated files (`config.json`, `tokenizer.json`, `.cache/`) → still
  returns false (preserves "incomplete cache → try download" semantics)
- `downloadWeights(offlineMode: true)` short-circuits cleanly on a
  CoreML-only cache (behavioural pin matching the safetensors counterpart)

## Backward compatibility

`.safetensors` remains in the set. Existing downloaders, snapshots, and
offlineMode short-circuits behave identically. Only the negative path
("CoreML-only directory" → false) changes to a positive.

## Motivation

Downstream apps (e.g. Scribio) currently work around this by writing a
0-byte `.safetensors` marker file into the cache directory after
extracting CoreML weights. With this patch the workaround becomes
unnecessary and the marker file is harmless if previously created.
