### PR TITLE
SourceSeparation: MLX.compile fused LSTM step

### DIFF
--- a/Sources/SourceSeparation/OpenUnmixModel.swift
+++ b/Sources/SourceSeparation/OpenUnmixModel.swift
@@ -221,6 +221,11 @@ final class LSTMCell: Module {
     private var fusedWeightT: MLXArray?  // [input+hidden, 4*hidden]
     private var fusedBias: MLXArray?     // [4*hidden]
 
+    // MLX.compile-built step function. Fuses the matmul/bias/slice/activation
+    // chain into a smaller number of Metal kernels. Built in
+    // `prepareForInference()` if compile is enabled.
+    private var compiledStep: (([MLXArray]) -> [MLXArray])?
+
     init(inputSize: Int, hiddenSize: Int) {
         self.hiddenSize = hiddenSize
         let gateSize = 4 * hiddenSize
@@ -231,9 +236,11 @@ final class LSTMCell: Module {
     }
 
     /// Concatenate the input and hidden weight matrices (and their biases) so
-    /// each `step()` runs a single matmul + add instead of two of each. Must
-    /// be called after `update(parameters:)` — calling it before pretrained
-    /// weights are loaded will fuse zeros.
+    /// each `step()` runs a single matmul + add instead of two of each, then
+    /// build a `MLX.compile`-d step function that fuses the matmul + bias +
+    /// gate-split + activations + cell-update chain. Must be called after
+    /// `update(parameters:)` — calling it before pretrained weights are loaded
+    /// will fuse zeros.
     func prepareForInference() {
         // [4*hidden, input + hidden]
         let fused = concatenated([weightIH, weightHH], axis: 1)
@@ -243,12 +250,38 @@ final class LSTMCell: Module {
         eval(fusedT, bias)
         self.fusedWeightT = fusedT
         self.fusedBias = bias
+
+        // Build a compiled function over (x, h, c) that captures the fused
+        // weight/bias as graph constants. MLX fuses the small kernels
+        // (slices, sigmoids, tanh, element-wise ops) into the gemm output.
+        // Cell input/hidden shapes are fixed per LSTMCell instance, so the
+        // shape-aware compile path is the right fit (slice ops can't run
+        // shapeless).
+        let hs = hiddenSize
+        self.compiledStep = MLX.compile { args -> [MLXArray] in
+            let x = args[0], h = args[1], c = args[2]
+            let xh = concatenated([x, h], axis: -1)
+            let gates = matmul(xh, fusedT) + bias
+            let i = sigmoid(gates[0..., 0..<hs])
+            let f = sigmoid(gates[0..., hs..<(2*hs)])
+            let g = tanh(gates[0..., (2*hs)..<(3*hs)])
+            let o = sigmoid(gates[0..., (3*hs)..<(4*hs)])
+            let newC = f * c + i * g
+            let newH = o * tanh(newC)
+            return [newH, newC]
+        }
     }
 
     func step(_ x: MLXArray, h: MLXArray, c: MLXArray) -> (MLXArray, MLXArray) {
+        // Compiled fast path — single fused Metal kernel chain.
+        if let compiledStep {
+            let out = compiledStep([x, h, c])
+            return (out[0], out[1])
+        }
+
         let gates: MLXArray
         if let fusedWeightT, let fusedBias {
-            // Fused path: one matmul, one add.
+            // Fused weights, uncompiled — used if compile is disabled globally.
             let xh = concatenated([x, h], axis: -1)
             gates = matmul(xh, fusedWeightT) + fusedBias
         } else {


### PR DESCRIPTION
**Stacks on #257.** Review #257 first; this branch is just the one extra commit on top.

## Summary
Wrap the fused LSTM step (matmul + bias + slice ×4 + sigmoid ×3 + tanh + element-wise) in `MLX.compile` so the kernel chain fuses into fewer Metal dispatches per timestep. Each `LSTMCell` builds its own compiled closure during `prepareForInference()`, capturing its fused weights as graph constants.

## Numbers — M5 Pro / 48 GB, 30 s synthetic stereo, Wiener on (3-run avg)

| Stage | Main (before #257) | After #257 | + this PR | Δ vs main |
|---|---|---|---|---|
| Total | 1.715 s | 1.581 s | **1.116 s** | **−35%** |
| Model GPU eval | 1.343 s | 1.008 s | **0.591 s** | **−56%** |
| Wiener | 0.239 s | 0.237 s | 0.233 s | — |
| STFT (fwd+inv) | 0.133 s | 0.135 s | 0.135 s | — |
| **RTF** | 0.057 | 0.053 | **0.037** | **17.5× → 26.9× real-time** |

3 consecutive runs: 1.110 s, 1.124 s, 1.114 s — solid signal.

## Correctness
- `testLSTMCellFusedEqualsUnfused` passes at 1e-5 tolerance — it now implicitly exercises the compiled path because `prepareForInference()` builds the compiled closure as part of setup
- `testStemsApproximateInputEnergy` E2E ratio still 0.999
- All 19 SourceSeparation tests pass

## How
```swift
self.compiledStep = MLX.compile { args -> [MLXArray] in
    let x = args[0], h = args[1], c = args[2]
    let xh = concatenated([x, h], axis: -1)
    let gates = matmul(xh, fusedT) + bias
    // ...sigmoid/tanh/slice/cell-update chain...
    return [newH, newC]
}
```
`shapeless: false` — slice ops can't infer output shapes when shape-erased (compile crashes at runtime with "Slice cannot infer output shapes"). Each `LSTMCell` instance has fixed `inputSize` and `hiddenSize`, so per-cell shape-aware compile is the right fit. Compile cost (≤24 cells per separator) amortizes over ~60k step calls per 30 s track.

The legacy path (no `prepareForInference`) and the fused-but-not-compiled path (if compile disabled globally) both remain available for tests and the edge case.

## Test plan
- [x] `swift test -c release --filter SourceSeparationTests` — all 19 pass
- [x] Benchmark × 3 runs to confirm signal over noise
- [x] CLI consumer (`AudioCLILib.SeparateCommand`) compiles unchanged

Part of #256.