### PR TITLE
deps: pin swift-websocket to 1.5.x to unblock release CI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,11 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", "2.5.0"..<"2.17.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.6.0")
+        .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", "2.6.0"..<"2.7.0"),
+        // Pin swift-websocket to 1.5.x — 1.6.0 added `import NIOSSL` in WSCore/WebSocketHandler.swift
+        // without declaring swift-nio-ssl as a target dependency, so the module is unresolvable
+        // on a clean checkout. https://github.com/hummingbird-project/swift-websocket
+        .package(url: "https://github.com/hummingbird-project/swift-websocket.git", "1.5.0"..<"1.6.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

- `swift-websocket` 1.6.0 added `import NIOSSL` in `WSCore/WebSocketHandler.swift` without declaring `swift-nio-ssl` as a target dependency.
- Release CI for v0.0.16 hit `error: no such module 'NIOSSL'` because a fresh checkout re-resolved through the broken version.
- Pin `swift-websocket` as a direct dep to `1.5.0..<1.6.0` and tighten `hummingbird-websocket` to `2.6.0..<2.7.0` so transitive resolution stays in the known-good range.

Verified locally: `swift build -c release` completes in 56s on this branch (the same command fails on `main`).

## Test plan

- [x] `swift build -c release --disable-sandbox` succeeds locally.
- [ ] CI tests pass on this PR.
- [ ] Once merged: re-cut `v0.0.16` and confirm release workflow succeeds + brew tap formula updates.