### PR TITLE
release: ship all .bundle resources (fixes compose/magnet on brew)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,14 @@ jobs:
           cp .build/release/speech .build/release/speech-server dist/
           cp .build/release/audio .build/release/audio-server dist/
           cp .build/release/mlx.metallib dist/
-          # KokoroTTS loads fr/pt/hi pronunciation dicts via Bundle.module,
-          # which hard-crashes if the resource bundle isn't beside the binary (#212).
-          cp -R .build/release/Qwen3Speech_KokoroTTS.bundle dist/
+          # Copy every SPM-generated resource bundle next to the binary.
+          # KokoroTTS needs its own bundle for fr/pt/hi pronunciation dicts (#212);
+          # MAGNeT/VoxCPM2/etc. need swift-transformers_Hub.bundle for tokenizer
+          # downloads, and MagpieTTS ships baked speaker tables in its own bundle.
+          # Globbing keeps future modules from silently shipping broken.
+          cp -R .build/release/*.bundle dist/
           cd dist
-          tar czf speech-macos-arm64.tar.gz speech speech-server audio audio-server mlx.metallib Qwen3Speech_KokoroTTS.bundle
+          tar czf speech-macos-arm64.tar.gz speech speech-server audio audio-server mlx.metallib *.bundle
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- v0.0.16 brew binary crashes on \`speech compose\` because \`swift-transformers_Hub.bundle\` is missing from the tarball.
- The Package step only copied \`Qwen3Speech_KokoroTTS.bundle\` explicitly; modules added since (MAGNeT, VoxCPM2, MagpieTTS) need additional bundles that were silently dropped.
- Switch to \`*.bundle\` glob so every SPM-generated resource bundle lands in the tarball.

## Test plan

- [x] Reproduced \`compose\` crash from \`brew install soniqo/tap/speech\` v0.0.16: \"could not load resource bundle ... swift-transformers_Hub.bundle\".
- [x] Local release build with the missing bundle copied alongside the binary runs compose end-to-end (30 s @ RTF 0.37).
- [ ] After merge: cut v0.0.17, verify \`brew upgrade soniqo/tap/speech && speech compose 'happy rock' -o /tmp/m.wav\` produces audio.