### PR TITLE
MAGNeT: parity-test LM first forward on medium-int8

### DIFF
--- a/Tests/MAGNeTMusicGenTests/E2EDiagnosticsTests.swift
+++ b/Tests/MAGNeTMusicGenTests/E2EDiagnosticsTests.swift
@@ -122,7 +122,40 @@ final class E2EDiagnosticsTests: XCTestCase {
     }
 
     func testLMFirstForwardMatchesPython() async throws {
-        let model = try await MAGNeTMusicGen.fromPretrained(variant: .smallInt4)
+        try await runLMFirstForwardParity(
+            variant: .smallInt4,
+            expectedCondFirst: 0.4557,
+            expectedCondFourth: 0.7347,
+            expectedUncondFirst: -0.4370)
+    }
+
+    /// Same probe as `testLMFirstForwardMatchesPython` but on the medium-int8
+    /// bundle. Catches silent weight-loading regressions in the larger model
+    /// (e.g. a renamed quantized linear key that falls through
+    /// `applyQuantizedLinearWeights` without raising and leaves the
+    /// construction-time random init in place).
+    ///
+    /// Python ground truth from speech-models/models/magnet/export, harness
+    /// in `scripts/probe_magnet_logits.py`, bundle
+    /// `aufklarer/MAGNeT-Medium-30secs-MLX-8bit`:
+    ///   cond_logits[0,0,0,:8]   = [-0.7593, -3.0587, -2.6864, -0.8878, 0.0120, -1.4776, -1.7772, -6.5137]
+    ///   uncond_logits[1,0,0,:8] = [-0.7963, -4.3300, -4.4330, -2.0338, -0.0135, -2.7047, -3.1290, -7.7294]
+    ///   stage-0 argmax histogram (top): {83: 99.9%, 172: 0.1%}
+    func testLMFirstForwardMatchesPythonMediumInt8() async throws {
+        try await runLMFirstForwardParity(
+            variant: .mediumInt8,
+            expectedCondFirst: -0.7593,
+            expectedCondFourth: -0.8878,
+            expectedUncondFirst: -0.7963)
+    }
+
+    private func runLMFirstForwardParity(
+        variant: MAGNeTVariant,
+        expectedCondFirst: Float,
+        expectedCondFourth: Float,
+        expectedUncondFirst: Float
+    ) async throws {
+        let model = try await MAGNeTMusicGen.fromPretrained(variant: variant)
 
         // Reproduce the exact Python probe: tokenize 'happy rock', T5 encode,
         // project to LM dim, build CFG batch, run LM forward at stage=0 on
@@ -137,21 +170,18 @@ final class E2EDiagnosticsTests: XCTestCase {
         let T = model.config.seqLen
         let K = model.config.nQ
         let maskId = model.config.maskTokenId
-        var gen = MLXArray.full([1, K, T], values: MLXArray(Int32(maskId)))
+        let gen = MLXArray.full([1, K, T], values: MLXArray(Int32(maskId)))
         let lmInput = MLX.concatenated([gen, gen], axis: 0).transposed(0, 2, 1)
         let allLogits = model._lm(lmInput, conditioning: conditioning, stage: 0)
         eval(allLogits)
 
-        // Print stats matching the Python probe.
         let arr = allLogits.asArray(Float.self)
-        // allLogits shape = [2, T, K, card]
         let card = model.config.card
         let cardOffset0 = 0 * card                                  // (b=0, t=0, k=0)
         let cardOffsetUncond0 = (1 * T * K + 0 * K + 0) * card      // (b=1, t=0, k=0)
-        print("[SWIFT] LM cond_logits[0,0,0,:8]   = \(Array(arr[cardOffset0..<(cardOffset0+8)]))")
-        print("[SWIFT] LM uncond_logits[1,0,0,:8] = \(Array(arr[cardOffsetUncond0..<(cardOffsetUncond0+8)]))")
+        print("[SWIFT \(variant)] LM cond_logits[0,0,0,:8]   = \(Array(arr[cardOffset0..<(cardOffset0+8)]))")
+        print("[SWIFT \(variant)] LM uncond_logits[1,0,0,:8] = \(Array(arr[cardOffsetUncond0..<(cardOffsetUncond0+8)]))")
 
-        // Argmax token histogram of stage-0 cond.
         var argmaxByT: [Int] = Array(repeating: 0, count: T)
         for t in 0..<T {
             let base = 0 * (T * K * card) + t * (K * card) + 0 * card
@@ -166,15 +196,16 @@ final class E2EDiagnosticsTests: XCTestCase {
         var hist: [Int: Int] = [:]
         for v in argmaxByT { hist[v, default: 0] += 1 }
         let top = hist.sorted { $0.value > $1.value }.prefix(5)
-        print("[SWIFT] stage-0 argmax histogram (top 5):")
+        print("[SWIFT \(variant)] stage-0 argmax histogram (top 5):")
         for (tok, count) in top {
             print("    token \(tok): \(count) times (\(Double(count) / Double(T) * 100)%)")
         }
 
-        // Spot-check first logit values vs Python.
-        XCTAssertEqual(arr[0], 0.4557, accuracy: 0.05, "cond_logits[0,0,0,0]")
-        XCTAssertEqual(arr[3], 0.7347, accuracy: 0.05, "cond_logits[0,0,0,3]")
-        XCTAssertEqual(arr[cardOffsetUncond0], -0.4370, accuracy: 0.05,
-                       "uncond_logits[1,0,0,0]")
+        XCTAssertEqual(arr[0], expectedCondFirst, accuracy: 0.05,
+                       "cond_logits[0,0,0,0] for \(variant)")
+        XCTAssertEqual(arr[3], expectedCondFourth, accuracy: 0.05,
+                       "cond_logits[0,0,0,3] for \(variant)")
+        XCTAssertEqual(arr[cardOffsetUncond0], expectedUncondFirst, accuracy: 0.05,
+                       "uncond_logits[1,0,0,0] for \(variant)")
     }
 }

--- a/scripts/probe_magnet_logits.py
+++ b/scripts/probe_magnet_logits.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Probe MAGNeT LM first-forward logits at stage=0 on an all-mask sequence.
+
+Mirrors the assertions in
+  Tests/MAGNeTMusicGenTests/E2EDiagnosticsTests.swift::testLMFirstForwardMatchesPython
+
+Run from the magnet/export directory inside the poetry env:
+
+  poetry run python /tmp/probe_magnet_logits.py --bundle <path-to-bundle>
+
+Prints the eight first cond/uncond logits and the stage-0 argmax histogram so
+you can paste the numbers into the Swift parity test for a different variant.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+import mlx.core as mx
+
+from test_mlx import load
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bundle", required=True, help="Path to bundle dir (config.json + model.safetensors)")
+    ap.add_argument("--text", default="happy rock")
+    args = ap.parse_args()
+
+    bundle = Path(args.bundle)
+    print(f"Loading {bundle} ...")
+    model, cfg = load(bundle)
+
+    # Step 1: text -> conditioning, build CFG batch.
+    cond = model.text_conditioner(args.text)        # (1, L, D)
+    uncond = mx.zeros_like(cond)
+    conditioning = mx.concatenate([cond, uncond], axis=0)  # (2, L, D)
+
+    # Step 2: all-mask audio token grid at the model's seq_len.
+    T = model.lm._seq_len
+    K = model.num_codebooks
+    mask_id = model.lm.mask_token_id
+    gen = mx.full((1, K, T), mask_id, dtype=mx.int32)
+
+    # Step 3: LM forward at stage=0 on (lm_input transposed to (B, T, K)).
+    lm_input = mx.concatenate([gen, gen], axis=0).transpose(0, 2, 1)  # (2, T, K)
+    all_logits = model.lm(lm_input, conditioning, stage=0)             # (2, T, K, card)
+    mx.eval(all_logits)
+
+    cond_logits = all_logits[:1]
+    uncond_logits = all_logits[1:2]
+
+    print(f"\n[PY] LM cond_logits[0,0,0,:8]   = {cond_logits[0, 0, 0, :8].tolist()}")
+    print(f"[PY] LM uncond_logits[1,0,0,:8] = {uncond_logits[0, 0, 0, :8].tolist()}")
+
+    # Argmax histogram across T for codebook 0 of cond.
+    argmax = mx.argmax(cond_logits[0, :, 0, :], axis=-1).tolist()
+    hist = Counter(argmax).most_common(5)
+    print("\n[PY] stage-0 argmax histogram (top 5):")
+    for tok, count in hist:
+        print(f"    token {tok}: {count} times ({100 * count / T:.1f}%)")
+
+    # Single-line summary for copy-paste into the Swift test docstring.
+    flat_cond = cond_logits[0, 0, 0, :8].tolist()
+    flat_uncond = uncond_logits[0, 0, 0, :8].tolist()
+    print(f"\n[PY-SUMMARY] cond_logits[0,0,0,:8] = {[round(v, 4) for v in flat_cond]}")
+    print(f"[PY-SUMMARY] uncond_logits[1,0,0,:8] = {[round(v, 4) for v in flat_uncond]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- \`testLMFirstForwardMatchesPython\` only covered \`small-int4\` — a silent weight-loading regression in the larger bundles (e.g. a renamed quantized linear key that falls through \`applyQuantizedLinearWeights\` without raising) would have been invisible until it surfaced as audio artefacts.
- Extract the probe into a private helper and add a \`medium-int8\` case with ground-truth logits regenerated from the export reference (\`models/magnet/export\` in the speech-models repo). Python harness checked in as \`scripts/probe_magnet_logits.py\` so anyone can regenerate ground truth for a new variant.
- Verified locally: both variants pass with \`accuracy: 0.05\`. Medium-INT8's stage-0 argmax histogram (99.93 % token 83) matches Python's 99.9 % token 83 — the Swift LM forward is bit-faithful at INT8.

## Background

Came out of an investigation into perceived audio noise in \`speech compose --variant medium-int8\`. The parity test now proves the LM is correct; the perceived quality drop is the documented CLAP regression for medium-INT8 vs small-INT8 (0.345 vs 0.438 in \`speech-models/models/magnet/export/README.md\`).

## Test plan

- [x] \`swift test --filter testLMFirstForwardMatchesPythonMediumInt8\` passes locally (4.4 s).
- [x] \`testLMFirstForwardMatchesPython\` (small-int4) still passes after refactor.
- [ ] CI green on this PR.