### PR TITLE
Qwen3TTSCoreML: full ANE routing + chunked support + benchmark tests

### DIFF
--- a/Sources/Qwen3TTSCoreML/MultiCodeDecoderChunked.swift
+++ b/Sources/Qwen3TTSCoreML/MultiCodeDecoderChunked.swift
@@ -1,0 +1,237 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// Common interface so the synthesise loop can hold either the monolithic
+/// (legacy ``MultiCodeDecoderCoreML``) or the chunked ANE form behind a
+/// single field. ``Qwen3TTSCoreMLModel`` picks at load time based on which
+/// .mlmodelc files exist in the bundle.
+protocol MultiCodeDecoderInterface: AnyObject {
+    func predict(
+        hiddenState: MLMultiArray,
+        cb0Token: Int32,
+        codeEmbedder: CodeEmbedderModel,
+        multiCodeEmbedder: MultiCodeEmbedderModel,
+        temperature: Float,
+        topK: Int
+    ) throws -> [Int32]
+}
+
+extension MultiCodeDecoderCoreML: MultiCodeDecoderInterface {}
+
+/// Chunked ANE-friendly MultiCodeDecoder.
+///
+/// Background: the monolithic 5-layer MCD won't compile for ANE (op-count
+/// threshold; CoreML compiler silently falls back to CPU). Splitting into
+/// 2 chunks of ≤4 transformer blocks each, plus a separate head model,
+/// lets every sub-model land on ANE.
+///
+/// Layout in the bundle:
+///   - ``MultiCodeDecoder_chunk{i}of{N}.mlmodelc`` — N stateless block chunks
+///     Inputs:  ``hidden_in`` [1,1024,1,1] + cache_length + key_padding_mask
+///              + kv_cache_update_mask + ``key_cache``/``value_cache``
+///              [1, chunk_layers × kv_dim, 1, MCD_SEQ_LEN]
+///     Outputs: ``hidden_out`` + ``new_k_slots`` + ``new_v_slots``
+///              [1, chunk_layers × kv_dim, 1, 1] (just the new entry — Swift
+///              writes it into position `cache_length` of the cache buffer
+///              between calls. This keeps the model's output tensors small
+///              enough for ANE to accept the graph.)
+///
+///   - ``MultiCodeDecoder_head.mlmodelc`` — final RMSNorm + 15 codec heads.
+///     Input:  ``hidden_in`` [1,1024,1,1]
+///     Output: ``all_logits`` [1, 15, 2048]
+///
+/// One ``predict()`` call (a single position in the 16-step autoregressive
+/// loop) chains all N+1 sub-models. Per-chunk KV caches are kept in this
+/// instance as plain MLMultiArrays — one (key, value) pair per chunk, sized
+/// to that chunk's layer count.
+final class MultiCodeDecoderChunked: MultiCodeDecoderInterface {
+    private let chunks: [MLModel]
+    private let head: MLModel
+    /// kv_dim per layer (== num_kv_heads × head_dim). Same for all chunks.
+    private let layerKvDim: Int
+    /// Number of transformer layers in each chunk (read from input shape).
+    private let chunkLayerCounts: [Int]
+    private let maxSeqLen = 16
+    private let hiddenSize = 1024
+    private let numGroups = 15
+
+    init(chunks: [MLModel], head: MLModel) {
+        precondition(!chunks.isEmpty, "chunked MCD needs at least one chunk")
+        self.chunks = chunks
+        self.head = head
+
+        // Discover per-chunk layer count from each chunk's key_cache input.
+        // key_cache shape is [1, layers × kv_dim, 1, seq_len]. We don't know
+        // (layers, kv_dim) separately from one chunk alone, but layer count
+        // == chunk_channels / per_layer_kv_dim. We deduce per_layer_kv_dim
+        // from the smallest chunk's channels divided by its layer count —
+        // since we can't read both, we use the convention that the bundle
+        // also exposes ``new_k_slots`` of shape [1, layers × kv_dim, 1, 1].
+        // Per-layer kv_dim is therefore (slots_channels / layer_count).
+        // Easier path: assume the standard Qwen3-TTS MCD layout — 8 KV heads
+        // × 128 head_dim = 1024 per layer. Hard-coded matches our convert
+        // script (anything else would need a re-export anyway).
+        self.layerKvDim = 1024
+        self.chunkLayerCounts = chunks.map { chunk in
+            let desc = chunk.modelDescription.inputDescriptionsByName["key_cache"]!
+            let totalC = desc.multiArrayConstraint!.shape[1].intValue
+            return totalC / 1024
+        }
+    }
+
+    func predict(
+        hiddenState: MLMultiArray,
+        cb0Token: Int32,
+        codeEmbedder: CodeEmbedderModel,
+        multiCodeEmbedder: MultiCodeEmbedderModel,
+        temperature: Float = 0.9,
+        topK: Int = 50
+    ) throws -> [Int32] {
+        // Per-chunk KV cache buffers, fresh per predict() (cache resets
+        // cleanly between codec frames — same as the monolithic path).
+        var keyCaches: [MLMultiArray] = []
+        var valueCaches: [MLMultiArray] = []
+        for layers in chunkLayerCounts {
+            let totalC = layers * layerKvDim
+            keyCaches.append(makeZeros(shape: [1, totalC, 1, maxSeqLen]))
+            valueCaches.append(makeZeros(shape: [1, totalC, 1, maxSeqLen]))
+        }
+
+        // Position 0: feed hidden_states from CodeDecoder (no logits read)
+        var hidden = ensureNCHW(hiddenState, channels: hiddenSize)
+        hidden = try stepChunks(hidden: hidden, position: 0,
+                                keyCaches: &keyCaches, valueCaches: &valueCaches)
+
+        // Position 1: feed CodeEmbedder(CB0) → head → CB1 logits
+        let cb0Embed = ensureNCHW(try codeEmbedder.embed(Int(cb0Token)), channels: hiddenSize)
+        hidden = try stepChunks(hidden: cb0Embed, position: 1,
+                                keyCaches: &keyCaches, valueCaches: &valueCaches)
+        var logits = try runHead(hidden: hidden)
+        var prevToken = TTSSampler.sample(
+            logits: extractGroupLogits(logits, group: 0),
+            temperature: temperature, topK: topK)
+        var tokens = [prevToken]
+
+        // Positions 2..15: autoregressive CB2..CB15
+        for cbStep in 1..<numGroups {
+            let embed = ensureNCHW(
+                try multiCodeEmbedder.embed(codebookIdx: cbStep - 1, tokenId: Int(prevToken)),
+                channels: hiddenSize)
+            hidden = try stepChunks(hidden: embed, position: cbStep + 1,
+                                    keyCaches: &keyCaches, valueCaches: &valueCaches)
+            logits = try runHead(hidden: hidden)
+            prevToken = TTSSampler.sample(
+                logits: extractGroupLogits(logits, group: cbStep),
+                temperature: temperature, topK: topK)
+            tokens.append(prevToken)
+        }
+        return tokens
+    }
+
+    // MARK: - Sub-model calls
+
+    /// Run all chunks for a single position; threads hidden state through and
+    /// scatters the per-chunk new K/V slots into each chunk's cache at `position`.
+    private func stepChunks(hidden: MLMultiArray, position: Int,
+                            keyCaches: inout [MLMultiArray],
+                            valueCaches: inout [MLMultiArray]) throws -> MLMultiArray {
+        let (keyMask, updateMask, cacheLen) = try makeMasks(position: position)
+        var h = hidden
+        for i in 0..<chunks.count {
+            let result = try runChunk(chunkIdx: i, hidden: h, cacheLen: cacheLen,
+                                      keyMask: keyMask, updateMask: updateMask,
+                                      kc: keyCaches[i], vc: valueCaches[i])
+            h = result.hiddenOut
+            scatterWrite(into: keyCaches[i], slots: result.newKSlots, position: position)
+            scatterWrite(into: valueCaches[i], slots: result.newVSlots, position: position)
+        }
+        return h
+    }
+
+    private func runChunk(chunkIdx: Int, hidden: MLMultiArray, cacheLen: MLMultiArray,
+                          keyMask: MLMultiArray, updateMask: MLMultiArray,
+                          kc: MLMultiArray, vc: MLMultiArray)
+        throws -> (hiddenOut: MLMultiArray, newKSlots: MLMultiArray, newVSlots: MLMultiArray) {
+        let inputs: [String: MLFeatureValue] = [
+            "hidden_in": MLFeatureValue(multiArray: hidden),
+            "cache_length": MLFeatureValue(multiArray: cacheLen),
+            "key_padding_mask": MLFeatureValue(multiArray: keyMask),
+            "kv_cache_update_mask": MLFeatureValue(multiArray: updateMask),
+            "key_cache": MLFeatureValue(multiArray: kc),
+            "value_cache": MLFeatureValue(multiArray: vc),
+        ]
+        let provider = try MLDictionaryFeatureProvider(dictionary: inputs)
+        let result = try chunks[chunkIdx].prediction(from: provider)
+        return (
+            result.featureValue(for: "hidden_out")!.multiArrayValue!,
+            result.featureValue(for: "new_k_slots")!.multiArrayValue!,
+            result.featureValue(for: "new_v_slots")!.multiArrayValue!
+        )
+    }
+
+    private func runHead(hidden: MLMultiArray) throws -> MLMultiArray {
+        let provider = try MLDictionaryFeatureProvider(dictionary: [
+            "hidden_in": MLFeatureValue(multiArray: hidden),
+        ])
+        let result = try head.prediction(from: provider)
+        return result.featureValue(for: "all_logits")!.multiArrayValue!
+    }
+
+    // MARK: - Helpers
+
+    /// Build the (key_mask, update_mask, cache_length) tuple shared across
+    /// all chunks for a single position. Allocated once per position to
+    /// avoid 3N tiny allocations across the per-position chunk loop.
+    private func makeMasks(position: Int) throws
+        -> (keyMask: MLMultiArray, updateMask: MLMultiArray, cacheLen: MLMultiArray) {
+        let cacheLen = try MLMultiArray(shape: [1], dataType: .int32)
+        cacheLen.dataPointer.assumingMemoryBound(to: Int32.self)[0] = Int32(position)
+
+        let keyMask = try MLMultiArray(shape: [1, NSNumber(value: maxSeqLen)], dataType: .float16)
+        let kPtr = keyMask.dataPointer.assumingMemoryBound(to: Float16.self)
+        for i in 0..<maxSeqLen { kPtr[i] = i <= position ? Float16(0) : Float16(-1e4) }
+
+        let updateMask = try MLMultiArray(shape: [1, NSNumber(value: maxSeqLen)], dataType: .float16)
+        memset(updateMask.dataPointer, 0, maxSeqLen * 2)
+        updateMask.dataPointer.assumingMemoryBound(to: Float16.self)[position] = Float16(1.0)
+        return (keyMask, updateMask, cacheLen)
+    }
+
+    /// Scatter-write slots `[1, C, 1, 1]` into cache `[1, C, 1, S]` at index `position`
+    /// along the trailing axis. Both are contiguous fp16 NCHW; the cache
+    /// stride along the S axis is 1, so we copy C interleaved values.
+    private func scatterWrite(into cache: MLMultiArray, slots: MLMultiArray, position: Int) {
+        let channels = cache.shape[1].intValue
+        precondition(slots.shape[1].intValue == channels, "slot channel mismatch")
+        let cachePtr = cache.dataPointer.assumingMemoryBound(to: Float16.self)
+        let slotPtr = slots.dataPointer.assumingMemoryBound(to: Float16.self)
+        // Memory layout for NCHW with H=1 and S in W:
+        //   cache[c, s] is at offset c * S + s
+        //   slot[c]     is at offset c
+        for c in 0..<channels {
+            cachePtr[c * maxSeqLen + position] = slotPtr[c]
+        }
+    }
+
+    /// Extract logits for a specific codebook group from [1, 15, 2048].
+    private func extractGroupLogits(_ array: MLMultiArray, group: Int) -> [Float] {
+        let vocabSize = 2048
+        var result = [Float](repeating: 0, count: vocabSize)
+        let ndim = array.shape.count
+        for i in 0..<vocabSize {
+            var idx = [NSNumber](repeating: 0, count: ndim)
+            if ndim == 3 { idx[1] = group as NSNumber; idx[2] = i as NSNumber }
+            else if ndim == 2 { idx[0] = group as NSNumber; idx[1] = i as NSNumber }
+            result[i] = array[idx].floatValue
+        }
+        return result
+    }
+
+    private func makeZeros(shape: [Int]) -> MLMultiArray {
+        let a = try! MLMultiArray(shape: shape.map { NSNumber(value: $0) }, dataType: .float16)
+        memset(a.dataPointer, 0, shape.reduce(1, *) * 2)
+        return a
+    }
+}
+#endif

--- a/Sources/Qwen3TTSCoreML/MultiCodeDecoderCoreML.swift
+++ b/Sources/Qwen3TTSCoreML/MultiCodeDecoderCoreML.swift
@@ -4,13 +4,20 @@ import Foundation
 
 /// CoreML MultiCodeDecoder: autoregressive CB1-15 prediction.
 /// 5-layer transformer with 15 lm_heads, scatter-write KV cache.
+///
+/// Supports both stateful (MLState) and stateless (explicit KV cache I/O).
+/// Stateful drops per-call cache I/O (~327 KB × 2000 inner calls per 10 s clip).
 final class MultiCodeDecoderCoreML {
     private let model: MLModel
     private let maxSeqLen = 16
     private let totalKVDim = 5120  // 5 layers * 8 KV heads * 128 head_dim
     private let numGroups = 15
+    private let isStateful: Bool
 
-    init(model: MLModel) { self.model = model }
+    init(model: MLModel) {
+        self.model = model
+        self.isStateful = !model.modelDescription.stateDescriptionsByName.isEmpty
+    }
 
     /// Predict 15 residual codebook tokens autoregressively.
     /// - Parameters:
@@ -26,20 +33,28 @@ final class MultiCodeDecoderCoreML {
         temperature: Float = 0.9,
         topK: Int = 50
     ) throws -> [Int32] {
-        // Init KV cache
-        var keyCache = makeZeros(shape: [1, totalKVDim, 1, maxSeqLen])
-        var valueCache = makeZeros(shape: [1, totalKVDim, 1, maxSeqLen])
+        // Per-predict() state. Stateful path: MLState lives only inside this
+        // call so the KV cache resets cleanly across frames. Stateless path:
+        // keep the explicit cache buffers in locals and round-trip them.
+        let mlState: MLState? = isStateful ? model.makeState() : nil
+        var keyCache: MLMultiArray? = nil
+        var valueCache: MLMultiArray? = nil
+        if !isStateful {
+            keyCache = makeZeros(shape: [1, totalKVDim, 1, maxSeqLen])
+            valueCache = makeZeros(shape: [1, totalKVDim, 1, maxSeqLen])
+        }
 
         // Position 0: feed hidden_states from CodeDecoder
-        var (_, kc, vc) = try step(
+        var (_, kc0, vc0) = try step(
             embed: ensureNCHW(hiddenState, channels: 1024),
-            position: 0, keyCache: keyCache, valueCache: valueCache)
-        keyCache = kc; valueCache = vc
+            position: 0, keyCache: keyCache, valueCache: valueCache, state: mlState)
+        if !isStateful { keyCache = kc0; valueCache = vc0 }
 
         // Position 1: feed CodeEmbedder(CB0) → read lm_head[0] → CB1
         let cb0Embed = ensureNCHW(try codeEmbedder.embed(Int(cb0Token)), channels: 1024)
-        var (logits, kc2, vc2) = try step(embed: cb0Embed, position: 1, keyCache: keyCache, valueCache: valueCache)
-        keyCache = kc2; valueCache = vc2
+        var (logits, kc1, vc1) = try step(embed: cb0Embed, position: 1,
+                                          keyCache: keyCache, valueCache: valueCache, state: mlState)
+        if !isStateful { keyCache = kc1; valueCache = vc1 }
 
         // Sample CB1 from lm_head[0]
         let cb1Logits = extractGroupLogits(logits, group: 0)
@@ -52,8 +67,10 @@ final class MultiCodeDecoderCoreML {
                 try multiCodeEmbedder.embed(codebookIdx: cbStep - 1, tokenId: Int(prevToken)),
                 channels: 1024)
             let pos = cbStep + 1
-            (logits, kc, vc) = try step(embed: embed, position: pos, keyCache: keyCache, valueCache: valueCache)
-            keyCache = kc; valueCache = vc
+            let (lg, kc, vc) = try step(embed: embed, position: pos,
+                                        keyCache: keyCache, valueCache: valueCache, state: mlState)
+            logits = lg
+            if !isStateful { keyCache = kc; valueCache = vc }
 
             let groupLogits = extractGroupLogits(logits, group: cbStep)
             prevToken = TTSSampler.sample(logits: groupLogits, temperature: temperature, topK: topK)
@@ -65,7 +82,8 @@ final class MultiCodeDecoderCoreML {
 
     // MARK: - Helpers
 
-    private func step(embed: MLMultiArray, position: Int, keyCache: MLMultiArray, valueCache: MLMultiArray)
+    private func step(embed: MLMultiArray, position: Int,
+                      keyCache: MLMultiArray?, valueCache: MLMultiArray?, state: MLState?)
         throws -> (logits: MLMultiArray, keyCache: MLMultiArray, valueCache: MLMultiArray) {
         let cacheLen = try MLMultiArray(shape: [1], dataType: .int32)
         cacheLen.dataPointer.assumingMemoryBound(to: Int32.self)[0] = Int32(position)
@@ -78,21 +96,35 @@ final class MultiCodeDecoderCoreML {
         memset(updateMask.dataPointer, 0, maxSeqLen * 2)
         updateMask.dataPointer.assumingMemoryBound(to: Float16.self)[position] = Float16(1.0)
 
-        let inputs: [String: MLFeatureValue] = [
+        var inputs: [String: MLFeatureValue] = [
             "input_embeds": MLFeatureValue(multiArray: embed),
             "cache_length": MLFeatureValue(multiArray: cacheLen),
-            "key_cache": MLFeatureValue(multiArray: keyCache),
             "key_padding_mask": MLFeatureValue(multiArray: keyMask),
             "kv_cache_update_mask": MLFeatureValue(multiArray: updateMask),
-            "value_cache": MLFeatureValue(multiArray: valueCache),
         ]
+        // Stateless path adds explicit KV cache I/O; stateful path leaves it
+        // to MLState (runtime keeps the buffers between predictions).
+        if !isStateful, let kc = keyCache, let vc = valueCache {
+            inputs["key_cache"] = MLFeatureValue(multiArray: kc)
+            inputs["value_cache"] = MLFeatureValue(multiArray: vc)
+        }
 
-        let result = try model.prediction(from: try MLDictionaryFeatureProvider(dictionary: inputs))
-        return (
-            result.featureValue(for: "all_logits")!.multiArrayValue!,
-            result.featureValue(for: "new_key_cache")!.multiArrayValue!,
-            result.featureValue(for: "new_value_cache")!.multiArrayValue!
-        )
+        let provider = try MLDictionaryFeatureProvider(dictionary: inputs)
+        let result: MLFeatureProvider
+        if let mlState = state {
+            result = try model.prediction(from: provider, using: mlState)
+        } else {
+            result = try model.prediction(from: provider)
+        }
+
+        let logits = result.featureValue(for: "all_logits")!.multiArrayValue!
+        // Stateful models don't expose new_key_cache / new_value_cache — return
+        // the input caches as placeholders (callers ignore them on stateful).
+        let nkc = result.featureValue(for: "new_key_cache")?.multiArrayValue
+            ?? (keyCache ?? logits)
+        let nvc = result.featureValue(for: "new_value_cache")?.multiArrayValue
+            ?? (valueCache ?? logits)
+        return (logits, nkc, nvc)
     }
 
     /// Extract logits for a specific group from [1, 15, 2048] (stride-safe).

--- a/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
+++ b/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
@@ -10,8 +10,8 @@ import AudioCommon
 public final class Qwen3TTSCoreMLModel {
     public static let defaultModelId = "aufklarer/Qwen3-TTS-CoreML"
 
-    private var codeDecoder: TalkerGenerator?
-    private var multiCodeDecoder: MultiCodeDecoderCoreML?
+    private var codeDecoder: CodeDecoderInterface?
+    private var multiCodeDecoder: MultiCodeDecoderInterface?
     private var speechDecoder: SpeechDecoderCoreML?
     private var textProjector: TextProjectorModel?
     private var codeEmbedder: CodeEmbedderModel?
@@ -60,17 +60,32 @@ public final class Qwen3TTSCoreMLModel {
         let cpuConfig = MLModelConfiguration()
         cpuConfig.computeUnits = .cpuOnly
 
-        // CodeDecoder/MultiCodeDecoder on CPU+GPU. They are stateful
-        // transformers and the MLState KV cache stays put across calls.
-        let defaultConfig = MLModelConfiguration()
-        defaultConfig.computeUnits = .cpuAndGPU
+        // CodeDecoder / MultiCodeDecoder / SpeechDecoder default to ANE.
+        // The bundle was exported with the CPU_AND_NE + FP32 recipe so the
+        // 28-layer transformer's logit precision stays stable on ANE — see
+        // models/qwen3-tts/export/convert_coreml.py. Routing the full
+        // decoder chain here lets the pipeline run with no GPU traffic.
+        //
+        // Per-model overrides (for benchmarking / debugging):
+        //   QWEN3TTS_ROUTE_CD  = ane|gpu|cpu|all   (CodeDecoder)
+        //   QWEN3TTS_ROUTE_MCD = ane|gpu|cpu|all   (MultiCodeDecoder)
+        //   QWEN3TTS_ROUTE_SD  = ane|gpu|cpu|all   (SpeechDecoder)
+        func route(_ key: String, _ fallback: MLComputeUnits) -> MLModelConfiguration {
+            let cfg = MLModelConfiguration()
+            switch ProcessInfo.processInfo.environment[key] {
+            case "ane": cfg.computeUnits = .cpuAndNeuralEngine
+            case "gpu": cfg.computeUnits = .cpuAndGPU
+            case "cpu": cfg.computeUnits = .cpuOnly
+            case "all": cfg.computeUnits = .all
+            default:    cfg.computeUnits = fallback
+            }
+            return cfg
+        }
+        let cdConfig = route("QWEN3TTS_ROUTE_CD", .cpuAndNeuralEngine)
+        let mcdConfig = route("QWEN3TTS_ROUTE_MCD", .cpuAndNeuralEngine)
+        let sdConfig = route("QWEN3TTS_ROUTE_SD", .cpuAndNeuralEngine)
 
-        // SpeechDecoder pinned to ANE. The vocoder is a single forward pass
-        // on a fixed 125-frame input — runs ~5x faster on ANE than on GPU
-        // (local A/B at 12.5s vs 75s for the same 10s clip) without any
-        // audible quality regression.
-        let sdConfig = MLModelConfiguration()
-        sdConfig.computeUnits = .cpuAndNeuralEngine
+        let defaultConfig = cdConfig
 
         let model = Qwen3TTSCoreMLModel()
 
@@ -87,8 +102,48 @@ public final class Qwen3TTSCoreMLModel {
         model.textProjector = TextProjectorModel(model: try loadML("TextProjector", cpuConfig))
         model.codeEmbedder = CodeEmbedderModel(model: try loadML("CodeEmbedder", cpuConfig))
         model.multiCodeEmbedder = MultiCodeEmbedderModel(model: try loadML("MultiCodeEmbedder", cpuConfig))
-        model.codeDecoder = TalkerGenerator(model: try loadML("CodeDecoder"))
-        model.multiCodeDecoder = MultiCodeDecoderCoreML(model: try loadML("MultiCodeDecoder"))
+
+        // Detect chunked decoder layouts emitted by `convert_coreml.py
+        // --ane-recipe`. Each decoder ships as N stateless ≤4-layer chunks
+        // plus a 1-of-a-kind head model. If the chunk artifacts are absent
+        // we fall back to the legacy monolithic single-model export.
+        let fm = FileManager.default
+        let bundleContents = (try? fm.contentsOfDirectory(atPath: resolvedCacheDir.path)) ?? []
+
+        // CD: prefer chunked layout when present.
+        let cdChunkFiles = bundleContents
+            .filter { $0.hasPrefix("CodeDecoder_chunk") && $0.hasSuffix(".mlmodelc") }
+            .sorted()
+        if !cdChunkFiles.isEmpty {
+            let cdChunks: [MLModel] = try cdChunkFiles.map { name in
+                let url = resolvedCacheDir.appendingPathComponent(name, isDirectory: true)
+                return try MLModel(contentsOf: url, configuration: cdConfig)
+            }
+            let cdHeadURL = resolvedCacheDir.appendingPathComponent(
+                "CodeDecoder_head.mlmodelc", isDirectory: true)
+            let cdHead = try MLModel(contentsOf: cdHeadURL, configuration: cdConfig)
+            model.codeDecoder = TalkerGeneratorChunked(chunks: cdChunks, head: cdHead)
+        } else {
+            model.codeDecoder = TalkerGenerator(model: try loadML("CodeDecoder", cdConfig))
+        }
+
+        // MCD: same detection pattern.
+        let chunkFiles = bundleContents
+            .filter { $0.hasPrefix("MultiCodeDecoder_chunk") && $0.hasSuffix(".mlmodelc") }
+            .sorted()
+        if !chunkFiles.isEmpty {
+            let chunks: [MLModel] = try chunkFiles.map { name in
+                let url = resolvedCacheDir.appendingPathComponent(name, isDirectory: true)
+                return try MLModel(contentsOf: url, configuration: mcdConfig)
+            }
+            let headURL = resolvedCacheDir.appendingPathComponent(
+                "MultiCodeDecoder_head.mlmodelc", isDirectory: true)
+            let headModel = try MLModel(contentsOf: headURL, configuration: mcdConfig)
+            model.multiCodeDecoder = MultiCodeDecoderChunked(chunks: chunks, head: headModel)
+        } else {
+            model.multiCodeDecoder = MultiCodeDecoderCoreML(model: try loadML("MultiCodeDecoder", mcdConfig))
+        }
+
         model.speechDecoder = SpeechDecoderCoreML(model: try loadML("SpeechDecoder", sdConfig))
 
         progressHandler?(0.9, "Loading embeddings...")
@@ -145,12 +200,20 @@ public final class Qwen3TTSCoreMLModel {
             throw TTSCoreMLError.modelNotLoaded
         }
 
+        // Per-stage timing — printed at the end when QWEN3TTS_BENCH=1
+        let benchOn = ProcessInfo.processInfo.environment["QWEN3TTS_BENCH"] == "1"
+        let tStart = CFAbsoluteTimeGetCurrent()
+        var tPromptEnd = tStart, tDecodeEnd = tStart, tVocoderEnd = tStart
+        var cdPrefillCalls = 0, cdDecodeCalls = 0, mcdPredictCalls = 0
+        var cdPrefillSec = 0.0, cdDecodeSec = 0.0, mcdSec = 0.0, embedSec = 0.0
+
         // Build non-streaming prefill (all text in prefill)
         let prefillEmbeds = try PromptBuilder.build(
             text: text, language: language, tokenizer: tokenizer,
             textProjector: textProjector, codeEmbedder: codeEmbedder,
             ttsPadEmbed: ttsPadEmbed, ttsBosEmbed: ttsBosEmbed,
             ttsEosEmbed: ttsEosEmbed, speakerEmbedding: speakerEmbedding)
+        tPromptEnd = CFAbsoluteTimeGetCurrent()
 
         // Cap decode tokens: min(requested, 8× prefill, remaining KV cache slots)
         let maxStepsByPrefill = 8 * prefillEmbeds.count
@@ -164,7 +227,10 @@ public final class Qwen3TTSCoreMLModel {
         var lastLogits = [Float]()
         var lastHidden = try MLMultiArray(shape: [1, 1024, 1, 1], dataType: .float16)
         for embed in prefillEmbeds {
+            let t = CFAbsoluteTimeGetCurrent()
             (lastLogits, _) = try codeDecoder.forward(embedArray: embed)
+            cdPrefillSec += CFAbsoluteTimeGetCurrent() - t
+            cdPrefillCalls += 1
         }
         lastHidden = codeDecoder.lastHiddenState!
 
@@ -180,10 +246,13 @@ public final class Qwen3TTSCoreMLModel {
         var generatedCB0 = [nextToken]
 
         // MultiCodeDecoder: predict CB1-15 for first frame
+        let tMcd0 = CFAbsoluteTimeGetCurrent()
         var cpTokens = try multiCodeDecoder.predict(
             hiddenState: lastHidden, cb0Token: nextToken,
             codeEmbedder: codeEmbedder, multiCodeEmbedder: multiCodeEmbedder,
             temperature: temperature, topK: topK)
+        mcdSec += CFAbsoluteTimeGetCurrent() - tMcd0
+        mcdPredictCalls += 1
         for (i, token) in cpTokens.enumerated() {
             allCodebooks[i + 1].append(token)
         }
@@ -195,6 +264,7 @@ public final class Qwen3TTSCoreMLModel {
             var sum32 = [Float](repeating: 0, count: hiddenSize)
 
             // Add CB0 embedding
+            let tEmb0 = CFAbsoluteTimeGetCurrent()
             let cb0Emb = ensureNCHW(try codeEmbedder.embed(Int(nextToken)), channels: hiddenSize)
             let cb0Ptr = cb0Emb.dataPointer.assumingMemoryBound(to: Float16.self)
             for i in 0..<hiddenSize { sum32[i] += Float(cb0Ptr[i]) }
@@ -207,6 +277,7 @@ public final class Qwen3TTSCoreMLModel {
                 let ptr = mceEmb.dataPointer.assumingMemoryBound(to: Float16.self)
                 for i in 0..<hiddenSize { sum32[i] += Float(ptr[i]) }
             }
+            embedSec += CFAbsoluteTimeGetCurrent() - tEmb0
 
             // Add tts_pad (FP32 from npy)
             if ttsPadEmbed.dataType == .float32 {
@@ -223,7 +294,10 @@ public final class Qwen3TTSCoreMLModel {
             for i in 0..<hiddenSize { outPtr[i] = Float16(sum32[i]) }
 
             // CodeDecoder forward
+            let tCd = CFAbsoluteTimeGetCurrent()
             (lastLogits, _) = try codeDecoder.forward(embedArray: stepInput)
+            cdDecodeSec += CFAbsoluteTimeGetCurrent() - tCd
+            cdDecodeCalls += 1
             lastHidden = codeDecoder.lastHiddenState!
 
             // Sample CB0 — suppress control tokens [2048, 3072) except EOS
@@ -247,24 +321,56 @@ public final class Qwen3TTSCoreMLModel {
             allCodebooks[0].append(nextToken)
 
             // MultiCodeDecoder: predict CB1-15
+            let tMcd = CFAbsoluteTimeGetCurrent()
             cpTokens = try multiCodeDecoder.predict(
                 hiddenState: lastHidden, cb0Token: nextToken,
                 codeEmbedder: codeEmbedder, multiCodeEmbedder: multiCodeEmbedder,
                 temperature: temperature, topK: topK)
+            mcdSec += CFAbsoluteTimeGetCurrent() - tMcd
+            mcdPredictCalls += 1
             for (i, token) in cpTokens.enumerated() {
                 allCodebooks[i + 1].append(token)
             }
         }
+        tDecodeEnd = CFAbsoluteTimeGetCurrent()
 
         // SpeechDecoder: all codes → audio
         guard !allCodebooks[0].isEmpty else { return [] }
         var audio = try speechDecoder.decode(codes: allCodebooks)
+        tVocoderEnd = CFAbsoluteTimeGetCurrent()
 
         // Normalize amplitude
         let peak = audio.map { abs($0) }.max() ?? 0
         if peak > 0.001 {
             let gain = min(0.9 / peak, 10.0)
             for i in 0..<audio.count { audio[i] *= gain }
+        }
+
+        if benchOn {
+            let total = tVocoderEnd - tStart
+            let audioSec = Double(audio.count) / 24000.0
+            let rtfx = audioSec / max(total, 1e-9)
+            let mcdPerCallMs = mcdPredictCalls > 0 ? mcdSec / Double(mcdPredictCalls) * 1000 : 0
+            let cdDecodePerCallMs = cdDecodeCalls > 0 ? cdDecodeSec / Double(cdDecodeCalls) * 1000 : 0
+            // MCD internally calls its CoreML model 16x per predict() (positions 0..15)
+            let mcdInnerCalls = mcdPredictCalls * 16
+            let mcdInnerPerCallMs = mcdInnerCalls > 0 ? mcdSec / Double(mcdInnerCalls) * 1000 : 0
+            func f(_ x: Double) -> String { String(format: "%6.3f", x) }
+            print("""
+
+            [BENCH Qwen3TTSCoreML]
+              text                = \"\(text)\"
+              audio output        = \(f(audioSec))s
+              wall total          = \(f(total))s   RTFx = \(String(format: "%.2f", rtfx))
+              prompt build        = \(f(tPromptEnd - tStart))s
+              CD prefill          = \(f(cdPrefillSec))s  (\(cdPrefillCalls) calls)
+              CD decode           = \(f(cdDecodeSec))s  (\(cdDecodeCalls) calls, \(String(format: "%.1f", cdDecodePerCallMs))ms/call)
+              MCD predict (outer) = \(f(mcdSec))s  (\(mcdPredictCalls) calls, \(String(format: "%.1f", mcdPerCallMs))ms/call)
+              MCD inner CoreML    = \(mcdInnerCalls) calls, \(String(format: "%.1f", mcdInnerPerCallMs))ms/call
+              embedder sum loop   = \(f(embedSec))s
+              SpeechDecoder       = \(f(tVocoderEnd - tDecodeEnd))s
+              accounted           = \(f(cdPrefillSec + cdDecodeSec + mcdSec + embedSec + (tVocoderEnd - tDecodeEnd) + (tPromptEnd - tStart)))s
+            """)
         }
 
         return audio

--- a/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
+++ b/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
@@ -56,14 +56,21 @@ public final class Qwen3TTSCoreMLModel {
             ) { progress in progressHandler?(progress * 0.7, "Downloading model...") }
         }
 
-        // Embedders on CPU (FP32 precision for accumulation, matching TTSKit)
-        // CodeDecoder/MCD/SD on default (let CoreML decide CPU/GPU/ANE)
+        // Embedders on CPU (FP32 precision for accumulation, matching TTSKit).
         let cpuConfig = MLModelConfiguration()
         cpuConfig.computeUnits = .cpuOnly
 
-        // With MLState, KV cache stays on ANE — use all compute units
+        // CodeDecoder/MultiCodeDecoder on CPU+GPU. They are stateful
+        // transformers and the MLState KV cache stays put across calls.
         let defaultConfig = MLModelConfiguration()
         defaultConfig.computeUnits = .cpuAndGPU
+
+        // SpeechDecoder pinned to ANE. The vocoder is a single forward pass
+        // on a fixed 125-frame input — runs ~5x faster on ANE than on GPU
+        // (local A/B at 12.5s vs 75s for the same 10s clip) without any
+        // audible quality regression.
+        let sdConfig = MLModelConfiguration()
+        sdConfig.computeUnits = .cpuAndNeuralEngine
 
         let model = Qwen3TTSCoreMLModel()
 
@@ -82,7 +89,7 @@ public final class Qwen3TTSCoreMLModel {
         model.multiCodeEmbedder = MultiCodeEmbedderModel(model: try loadML("MultiCodeEmbedder", cpuConfig))
         model.codeDecoder = TalkerGenerator(model: try loadML("CodeDecoder"))
         model.multiCodeDecoder = MultiCodeDecoderCoreML(model: try loadML("MultiCodeDecoder"))
-        model.speechDecoder = SpeechDecoderCoreML(model: try loadML("SpeechDecoder"))
+        model.speechDecoder = SpeechDecoderCoreML(model: try loadML("SpeechDecoder", sdConfig))
 
         progressHandler?(0.9, "Loading embeddings...")
 

--- a/Sources/Qwen3TTSCoreML/TalkerGeneratorChunked.swift
+++ b/Sources/Qwen3TTSCoreML/TalkerGeneratorChunked.swift
@@ -1,0 +1,202 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// Chunked ANE-friendly CodeDecoder runner.
+///
+/// Mirrors ``TalkerGenerator`` but executes the decoder as N stateless
+/// transformer chunks + 1 head model — the same chunking pattern that
+/// lets the MultiCodeDecoder fit on ANE (see ``MultiCodeDecoderChunked``
+/// for the design rationale).
+///
+/// Bundle layout (auto-detected by ``Qwen3TTSCoreMLModel.fromPretrained``):
+///   - ``CodeDecoder_chunk{i}of{N}.mlmodelc`` — N stateless ≤4-layer chunks.
+///     Inputs: ``hidden_in`` + cache_length + key_padding_mask + kv_cache_update_mask
+///             + ``key_cache``/``value_cache`` [1, chunk_layers × kv_dim, 1, MAX_SEQ_LEN]
+///     Outputs: ``hidden_out`` + ``new_k_slots`` + ``new_v_slots`` [1, chunk_layers × kv_dim, 1, 1]
+///   - ``CodeDecoder_head.mlmodelc`` — final RMSNorm + codec_head Linear.
+///     Inputs:  ``hidden_in`` [1, 1024, 1, 1]
+///     Outputs: ``logits`` [1, 1, vocab] + ``hidden_states`` [1, 1024, 1, 1]
+///              (pre-norm hidden, fed to MCD downstream)
+final class TalkerGeneratorChunked {
+    private let chunks: [MLModel]
+    private let head: MLModel
+    private let chunkLayerCounts: [Int]
+    private let layerKvDim: Int    // per-layer kv_dim (== num_kv_heads × head_dim)
+    private let maxSeqLen: Int
+    private let hiddenSize: Int
+    private let vocabSize: Int
+
+    private var keyCaches: [MLMultiArray] = []
+    private var valueCaches: [MLMultiArray] = []
+    private var currentPos: Int = 0
+
+    /// Last hidden state from the most recent forward pass — published so
+    /// the synthesise loop can feed it into the MultiCodeDecoder.
+    private(set) var lastHiddenState: MLMultiArray?
+
+    init(chunks: [MLModel], head: MLModel,
+         maxSeqLen: Int = 256, hiddenSize: Int = 1024,
+         layerKvDim: Int = 1024) {
+        precondition(!chunks.isEmpty)
+        self.chunks = chunks
+        self.head = head
+        self.maxSeqLen = maxSeqLen
+        self.hiddenSize = hiddenSize
+        self.layerKvDim = layerKvDim
+        // Read vocab from head's logits output shape.
+        if let logitsDesc = head.modelDescription.outputDescriptionsByName["logits"],
+           let constraint = logitsDesc.multiArrayConstraint {
+            self.vocabSize = constraint.shape.last!.intValue
+        } else {
+            self.vocabSize = 3072
+        }
+        self.chunkLayerCounts = chunks.map { chunk in
+            let desc = chunk.modelDescription.inputDescriptionsByName["key_cache"]!
+            let totalC = desc.multiArrayConstraint!.shape[1].intValue
+            return totalC / layerKvDim
+        }
+        resetCache()
+    }
+
+    func resetCache() {
+        keyCaches.removeAll(keepingCapacity: true)
+        valueCaches.removeAll(keepingCapacity: true)
+        for layers in chunkLayerCounts {
+            let totalC = layers * layerKvDim
+            keyCaches.append(makeZeros(shape: [1, totalC, 1, maxSeqLen]))
+            valueCaches.append(makeZeros(shape: [1, totalC, 1, maxSeqLen]))
+        }
+        currentPos = 0
+    }
+
+    func forward(embedArray: MLMultiArray) throws -> (logits: [Float], hidden: [Float16]) {
+        return try forwardInternal(inputEmbeds: ensureNCHW(embedArray, channels: hiddenSize))
+    }
+
+    func forward(embed: [Float16]) throws -> (logits: [Float], hidden: [Float16]) {
+        let inputEmbeds = try MLMultiArray(
+            shape: [1, NSNumber(value: hiddenSize), 1, 1], dataType: .float16)
+        let embPtr = inputEmbeds.dataPointer.assumingMemoryBound(to: Float16.self)
+        for i in 0..<hiddenSize { embPtr[i] = embed[i] }
+        return try forwardInternal(inputEmbeds: inputEmbeds)
+    }
+
+    private func forwardInternal(inputEmbeds: MLMultiArray) throws -> (logits: [Float], hidden: [Float16]) {
+        guard currentPos < maxSeqLen else { throw TalkerError.cacheFull }
+
+        let (keyMask, updateMask, cacheLen) = try makeMasks(position: currentPos)
+        var h = inputEmbeds
+        for i in 0..<chunks.count {
+            let result = try runChunk(chunkIdx: i, hidden: h, cacheLen: cacheLen,
+                                      keyMask: keyMask, updateMask: updateMask,
+                                      kc: keyCaches[i], vc: valueCaches[i])
+            h = result.hiddenOut
+            scatterWrite(into: keyCaches[i], slots: result.newKSlots, position: currentPos)
+            scatterWrite(into: valueCaches[i], slots: result.newVSlots, position: currentPos)
+        }
+        // Head produces logits + pre-norm hidden_states
+        let headProv = try MLDictionaryFeatureProvider(dictionary: [
+            "hidden_in": MLFeatureValue(multiArray: h),
+        ])
+        let headOut = try head.prediction(from: headProv)
+        let logitsArray = headOut.featureValue(for: "logits")!.multiArrayValue!
+        let hiddenArray = headOut.featureValue(for: "hidden_states")!.multiArrayValue!
+
+        currentPos += 1
+        lastHiddenState = ensureNCHW(hiddenArray, channels: hiddenSize)
+
+        // Extract logits (1, 1, vocab) → [Float] of vocab
+        var logits = [Float](repeating: 0, count: vocabSize)
+        let ndim = logitsArray.shape.count
+        for i in 0..<vocabSize {
+            var idx = [NSNumber](repeating: 0, count: ndim)
+            idx[ndim - 1] = i as NSNumber
+            logits[i] = logitsArray[idx].floatValue
+        }
+        var hidden = [Float16](repeating: 0, count: hiddenSize)
+        let hndim = hiddenArray.shape.count
+        for i in 0..<hiddenSize {
+            var idx = [NSNumber](repeating: 0, count: hndim)
+            if hndim >= 4 { idx[1] = i as NSNumber } else { idx[0] = i as NSNumber }
+            hidden[i] = Float16(hiddenArray[idx].floatValue)
+        }
+        return (logits, hidden)
+    }
+
+    func prefill(embeds: [[Float16]]) throws -> (logits: [Float], hidden: [Float16]) {
+        var lastLogits = [Float]()
+        var lastHidden = [Float16]()
+        for embed in embeds {
+            (lastLogits, lastHidden) = try forward(embed: embed)
+        }
+        return (lastLogits, lastHidden)
+    }
+
+    enum TalkerError: Error { case cacheFull }
+
+    // MARK: - Helpers
+
+    private func runChunk(chunkIdx: Int, hidden: MLMultiArray, cacheLen: MLMultiArray,
+                          keyMask: MLMultiArray, updateMask: MLMultiArray,
+                          kc: MLMultiArray, vc: MLMultiArray)
+        throws -> (hiddenOut: MLMultiArray, newKSlots: MLMultiArray, newVSlots: MLMultiArray) {
+        let inputs: [String: MLFeatureValue] = [
+            "hidden_in": MLFeatureValue(multiArray: hidden),
+            "cache_length": MLFeatureValue(multiArray: cacheLen),
+            "key_padding_mask": MLFeatureValue(multiArray: keyMask),
+            "kv_cache_update_mask": MLFeatureValue(multiArray: updateMask),
+            "key_cache": MLFeatureValue(multiArray: kc),
+            "value_cache": MLFeatureValue(multiArray: vc),
+        ]
+        let provider = try MLDictionaryFeatureProvider(dictionary: inputs)
+        let result = try chunks[chunkIdx].prediction(from: provider)
+        return (
+            result.featureValue(for: "hidden_out")!.multiArrayValue!,
+            result.featureValue(for: "new_k_slots")!.multiArrayValue!,
+            result.featureValue(for: "new_v_slots")!.multiArrayValue!
+        )
+    }
+
+    private func makeMasks(position: Int) throws
+        -> (keyMask: MLMultiArray, updateMask: MLMultiArray, cacheLen: MLMultiArray) {
+        let cacheLen = try MLMultiArray(shape: [1], dataType: .int32)
+        cacheLen.dataPointer.assumingMemoryBound(to: Int32.self)[0] = Int32(position)
+
+        let keyMask = try MLMultiArray(shape: [1, NSNumber(value: maxSeqLen)], dataType: .float16)
+        let kPtr = keyMask.dataPointer.assumingMemoryBound(to: Float16.self)
+        for i in 0..<maxSeqLen { kPtr[i] = i <= position ? Float16(0) : Float16(-1e4) }
+
+        let updateMask = try MLMultiArray(shape: [1, NSNumber(value: maxSeqLen)], dataType: .float16)
+        memset(updateMask.dataPointer, 0, maxSeqLen * 2)
+        updateMask.dataPointer.assumingMemoryBound(to: Float16.self)[position] = Float16(1.0)
+        return (keyMask, updateMask, cacheLen)
+    }
+
+    private func scatterWrite(into cache: MLMultiArray, slots: MLMultiArray, position: Int) {
+        let channels = cache.shape[1].intValue
+        let cachePtr = cache.dataPointer.assumingMemoryBound(to: Float16.self)
+        let slotPtr = slots.dataPointer.assumingMemoryBound(to: Float16.self)
+        for c in 0..<channels {
+            cachePtr[c * maxSeqLen + position] = slotPtr[c]
+        }
+    }
+
+    private func makeZeros(shape: [Int]) -> MLMultiArray {
+        let a = try! MLMultiArray(shape: shape.map { NSNumber(value: $0) }, dataType: .float16)
+        memset(a.dataPointer, 0, shape.reduce(1, *) * 2)
+        return a
+    }
+}
+
+// Common interface so synthesize() can hold either flavour in one field.
+protocol CodeDecoderInterface: AnyObject {
+    var lastHiddenState: MLMultiArray? { get }
+    func resetCache()
+    func forward(embedArray: MLMultiArray) throws -> (logits: [Float], hidden: [Float16])
+    func forward(embed: [Float16]) throws -> (logits: [Float], hidden: [Float16])
+}
+
+extension TalkerGenerator: CodeDecoderInterface {}
+extension TalkerGeneratorChunked: CodeDecoderInterface {}
+#endif

--- a/Tests/Qwen3TTSCoreMLTests/E2EQwen3TTSCoreMLBenchmarkTests.swift
+++ b/Tests/Qwen3TTSCoreMLTests/E2EQwen3TTSCoreMLBenchmarkTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import Qwen3TTSCoreML
+@testable import Qwen3ASR
+import AudioCommon
+import Foundation
+
+#if canImport(CoreML)
+/// Per-stage throughput benchmark for Qwen3-TTS CoreML.
+///
+/// Reports wall time, RTFx, and per-stage cost (prompt build, CD prefill,
+/// CD decode, MCD predict, embedder sum loop, SpeechDecoder) so we can
+/// target optimization at the actual bottleneck on the current routing.
+///
+/// Bundle source:
+///   - QWEN3TTS_BENCH_BUNDLE=<path>   load .mlmodelc bundle from path
+///   - default                        download aufklarer/Qwen3-TTS-CoreML
+///
+/// Run:
+///   QWEN3TTS_BENCH_BUNDLE=/tmp/qwen3tts-ane-export-full \
+///     swift test --filter Qwen3TTSCoreMLTests.E2EQwen3TTSCoreMLBenchmarkTests
+final class E2EQwen3TTSCoreMLBenchmarkTests: XCTestCase {
+
+    private static var _model: Qwen3TTSCoreMLModel?
+
+    override class func setUp() {
+        super.setUp()
+        // Force per-stage printout in synthesize()
+        setenv("QWEN3TTS_BENCH", "1", 1)
+    }
+
+    private func loadModel() async throws -> Qwen3TTSCoreMLModel {
+        if let m = Self._model { return m }
+        let bundlePath = ProcessInfo.processInfo.environment["QWEN3TTS_BENCH_BUNDLE"]
+        let m: Qwen3TTSCoreMLModel
+        do {
+            m = try await Qwen3TTSCoreMLModel.fromPretrained(localPath: bundlePath)
+        } catch {
+            throw XCTSkip("Model not available (bundle=\(bundlePath ?? "default")): \(error)")
+        }
+        Self._model = m
+        return m
+    }
+
+    /// Short prompt — exercises prefill-dominated path
+    func testBenchmarkShort() async throws {
+        let model = try await loadModel()
+        // Warm caches: ANE/CoreML first-call latency is unrepresentative
+        _ = try model.synthesize(text: "Warm up.", language: "english", maxTokens: 25)
+
+        let audio = try model.synthesize(
+            text: "Hello world.",
+            language: "english",
+            temperature: 0.0, topK: 1,        // deterministic for run-to-run comparability
+            maxTokens: 50)
+        XCTAssertGreaterThan(audio.count, 0)
+    }
+
+    /// Medium prompt — exercises both prefill and decode
+    func testBenchmarkMedium() async throws {
+        let model = try await loadModel()
+        _ = try model.synthesize(text: "Warm up.", language: "english", maxTokens: 25)
+
+        let audio = try model.synthesize(
+            text: "The quick brown fox jumps over the lazy dog.",
+            language: "english",
+            temperature: 0.0, topK: 1,
+            maxTokens: 125)
+        XCTAssertGreaterThan(audio.count, 0)
+    }
+
+    /// Long prompt — saturates decode (capped at maxTokens=125 = 10s audio)
+    func testBenchmarkLong() async throws {
+        let model = try await loadModel()
+        _ = try model.synthesize(text: "Warm up.", language: "english", maxTokens: 25)
+
+        let audio = try model.synthesize(
+            text: "Coreml on the Apple Neural Engine is fast for vocoders but the autoregressive decoder loop pays per call dispatch overhead.",
+            language: "english",
+            temperature: 0.0, topK: 1,
+            maxTokens: 125)
+        XCTAssertGreaterThan(audio.count, 0)
+    }
+
+    /// Roundtrip ASR check on the current bundle. Synthesizes a known prompt,
+    /// transcribes it with Qwen3-ASR, and asserts ≥3 keyword matches. This is
+    /// the gate that catches regressions where the bundle compiles + runs but
+    /// produces noise (precision drift, broken routing, etc.).
+    func testRoundtripIntelligibility() async throws {
+        let model = try await loadModel()
+
+        let asr: Qwen3ASRModel
+        do {
+            asr = try await Qwen3ASRModel.fromPretrained()
+        } catch {
+            throw XCTSkip("ASR model not available: \(error)")
+        }
+
+        let prompt = "The quick brown fox jumps over the lazy dog."
+        let audio = try model.synthesize(
+            text: prompt, language: "english",
+            temperature: 0.0, topK: 1, maxTokens: 125)
+        XCTAssertGreaterThan(audio.count, 0)
+
+        let transcript = asr.transcribe(audio: audio, sampleRate: 24000)
+        print("\n[ROUNDTRIP] input:  \"\(prompt)\"")
+        print("[ROUNDTRIP] output: \"\(transcript)\"")
+
+        let keywords = ["quick", "brown", "fox", "jumps", "lazy", "dog"]
+        let matched = keywords.filter { transcript.lowercased().contains($0) }
+        print("[ROUNDTRIP] matched \(matched.count)/\(keywords.count): \(matched)")
+
+        XCTAssertGreaterThanOrEqual(matched.count, 3,
+            "ANE bundle should produce intelligible speech. Got: \"\(transcript)\"")
+    }
+
+    /// Save the medium benchmark output to a WAV for manual playback when the
+    /// MLX-backed ASR isn't available (no Metal toolchain). Set
+    /// QWEN3TTS_BENCH_WAV=/path/to/out.wav to enable.
+    func testSaveBenchmarkAudio() async throws {
+        guard let wavPath = ProcessInfo.processInfo.environment["QWEN3TTS_BENCH_WAV"] else {
+            throw XCTSkip("set QWEN3TTS_BENCH_WAV=/path/to/out.wav to save")
+        }
+        let model = try await loadModel()
+        let text = ProcessInfo.processInfo.environment["QWEN3TTS_BENCH_TEXT"]
+            ?? "The quick brown fox jumps over the lazy dog."
+        let audio = try model.synthesize(
+            text: text,
+            language: "english",
+            temperature: 0.0, topK: 1, maxTokens: 125)
+        XCTAssertGreaterThan(audio.count, 0)
+        try WAVWriter.write(samples: audio, sampleRate: 24000,
+                            to: URL(fileURLWithPath: wavPath))
+        print("[WAV] saved to \(wavPath) (\(audio.count) samples, \(String(format: "%.2f", Double(audio.count)/24000))s)")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Companion to soniqo/speech-models qwen3tts-ane-recipe (commit `c5bd32c`). Routes all three decoders to ANE by default and adds infrastructure for the chunked ANE bundle layout (research-only, not shipped).

## Production changes (default routing)
- **CD + MCD + SD**: pin to `.cpuAndNeuralEngine`.
- Per-model env overrides for diagnostics: `QWEN3TTS_ROUTE_{CD,MCD,SD}` = `ane|gpu|cpu|all`.
- MCD client auto-detects stateful MLState.

## Chunked layout support (auto-detected; NOT in current ship bundle)
- `MultiCodeDecoderChunked` / `TalkerGeneratorChunked`: load N stateless block chunks + 1 head model. Thread hidden + per-chunk KV cache through each call, scatter-write new K/V slots between chunks.
- Behind a protocol so the synthesise loop holds either flavour in one field.
- Auto-detects `MultiCodeDecoder_chunk*.mlmodelc` / `CodeDecoder_chunk*.mlmodelc`; falls back to monolithic when chunk files are absent.
- **Not shipped**: chunked CD has FP16 precision drift across chunk boundaries that fails ASR roundtrip. Wired for future work.

## E2E benchmark + roundtrip test
- `testBenchmark{Short,Medium,Long}`: per-stage timing, gated on `QWEN3TTS_BENCH=1`.
- `testRoundtripIntelligibility`: synthesise → Qwen3-ASR → keyword match.
- `testSaveBenchmarkAudio`: WAV save for manual playback.
- `QWEN3TTS_BENCH_BUNDLE=/path` lets tests run against a local bundle (skips HF download).

## Validation
| Test | Status |
|---|---|
| testBenchmarkShort | ✅ pass |
| testBenchmarkMedium | ✅ pass |
| testBenchmarkLong | ✅ pass |
| testRoundtripIntelligibility | ✅ pass (matched 5/6 keywords — same as current FP32 ship) |

Multi-prompt ASR roundtrip on 6 diverse prompts: all transcribe correctly modulo same word-tail truncation behavior as current ship.

Bundle: 3.1 GB → 1.6 GB (−47%). Wall ~17s for 10s audio (parity with current ship).

## Test plan
- [x] CI build/test passes (4/4 E2E green)
- [x] Spot-check synthesis on multiple prompts via `QWEN3TTS_BENCH_BUNDLE` test
- [ ] Verify on a fresh-cache device after the matching HuggingFace bundle is published