### PR TITLE
StableAudio3MusicGen: SA3 Medium INT8 default music engine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,10 @@ let package = Package(
             targets: ["MAGNeTMusicGen"]
         ),
         .library(
+            name: "StableAudio3MusicGen",
+            targets: ["StableAudio3MusicGen"]
+        ),
+        .library(
             name: "FlashSR",
             targets: ["FlashSR"]
         ),
@@ -281,6 +285,17 @@ let package = Package(
             ]
         ),
         .target(
+            name: "StableAudio3MusicGen",
+            dependencies: [
+                "AudioCommon",
+                "MLXCommon",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
+            ]
+        ),
+        .target(
             name: "FlashSR",
             dependencies: [
                 "AudioCommon",
@@ -393,6 +408,7 @@ let package = Package(
                 "VibeVoiceTTS",
                 "VoxCPM2TTS",
                 "MAGNeTMusicGen",
+                "StableAudio3MusicGen",
                 "FlashSR",
                 "MagpieTTS",
                 "MagpieTTSCoreML",
@@ -549,6 +565,14 @@ let package = Package(
             name: "MAGNeTMusicGenTests",
             dependencies: [
                 "MAGNeTMusicGen",
+                "AudioCommon",
+                .product(name: "MLX", package: "mlx-swift")
+            ]
+        ),
+        .testTarget(
+            name: "StableAudio3MusicGenTests",
+            dependencies: [
+                "StableAudio3MusicGen",
                 "AudioCommon",
                 .product(name: "MLX", package: "mlx-swift")
             ]

--- a/Sources/AudioCLILib/AudioCLI.swift
+++ b/Sources/AudioCLILib/AudioCLI.swift
@@ -17,6 +17,7 @@ public struct AudioCLI: ParsableCommand {
             DenoiseCommand.self,
             SeparateCommand.self,
             ComposeCommand.self,
+            SA3ParityCommand.self,
             UpsampleCommand.self,
             KokoroCommand.self,
             Qwen3TTSCoreMLCommand.self,

--- a/Sources/AudioCLILib/ComposeCommand.swift
+++ b/Sources/AudioCLILib/ComposeCommand.swift
@@ -1,43 +1,67 @@
 import Foundation
 import ArgumentParser
 import MAGNeTMusicGen
+import StableAudio3MusicGen
 import AudioCommon
 
 public struct ComposeCommand: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "compose",
-        abstract: "Generate 30s of music from a text prompt using MAGNeT (MLX, on-device)"
+        abstract: "Generate music from a text prompt (Stable Audio 3 by default; MAGNeT also available, MLX, on-device)"
     )
 
-    @Argument(help: "Text prompt describing the music to generate (e.g. \"happy rock\")")
+    @Argument(help: "Text prompt describing the music to generate (e.g. \"lofi house loop\")")
     public var prompt: String
 
-    @Option(name: .shortAndLong, help: "Output WAV path (32 kHz mono)")
-    public var output: String = "magnet.wav"
+    @Option(name: .shortAndLong, help: "Output WAV path (44.1 kHz stereo for sa3, 32 kHz mono for magnet)")
+    public var output: String = "music.wav"
 
     @Option(
         name: .long,
-        help: "Model variant: small-int4 | small-int8 | medium-int4 | medium-int8"
+        help: "Music engine: sa3 (default — Stable Audio 3 Medium INT8, 44.1 kHz stereo, variable length) | magnet (MAGNeT, 32 kHz mono, fixed 30 s)"
     )
-    public var variant: String = "small-int4"
+    public var engine: String = "sa3"
 
-    @Option(name: .long, help: "Sampling temperature (annealed linearly per stage)")
+    // MARK: SA3 options
+    @Option(name: .long, help: "SA3 variant: medium-int8 (default) | medium-int4 (Stable Audio 3 Small variants land in a follow-up)")
+    public var sa3Variant: String = "medium-int8"
+
+    @Option(name: .long, help: "SA3 output length in seconds (1.0–384.0)")
+    public var seconds: Float = 30.0
+
+    @Option(name: .long, help: "SA3 pingpong sampler steps (default 8 — distilled sweet spot)")
+    public var sa3Steps: Int = 8
+
+    @Option(name: .long, help: "SA3 classifier-free guidance (1.0 = off, >1 toward prompt)")
+    public var sa3Cfg: Float = 1.0
+
+    @Option(name: .long, help: "SA3 σmax — initial noise level (default 1.0)")
+    public var sigmaMax: Float = 1.0
+
+    @Option(name: .long, help: "SA3 local bundle override path — skip HF download and load from this directory (smoke-test / offline)")
+    public var sa3BundleDir: String?
+
+    // MARK: MAGNeT options
+    @Option(name: .long, help: "MAGNeT variant: small-int4 | small-int8 | medium-int4 | medium-int8")
+    public var magnetVariant: String = "small-int4"
+
+    @Option(name: .long, help: "MAGNeT sampling temperature (annealed linearly per stage)")
     public var temperature: Float = 3.0
 
-    @Option(name: .long, help: "Top-p (nucleus) sampling threshold")
+    @Option(name: .long, help: "MAGNeT top-p (nucleus) sampling threshold")
     public var topP: Float = 0.9
 
-    @Option(name: .long, help: "Max classifier-free guidance coefficient")
+    @Option(name: .long, help: "MAGNeT max classifier-free guidance coefficient")
     public var cfgMax: Float = 10.0
 
-    @Option(name: .long, help: "Min classifier-free guidance coefficient")
+    @Option(name: .long, help: "MAGNeT min classifier-free guidance coefficient")
     public var cfgMin: Float = 1.0
 
     @Option(
         name: .long,
-        help: "Comma-separated decoding steps per codebook (default: 20,10,10,10)"
+        help: "MAGNeT comma-separated decoding steps per codebook (default: 20,10,10,10)"
     )
-    public var steps: String = "20,10,10,10"
+    public var magnetSteps: String = "20,10,10,10"
 
     @Option(name: .long, help: "Random seed for reproducibility")
     public var seed: UInt64?
@@ -45,16 +69,64 @@ public struct ComposeCommand: ParsableCommand {
     public init() {}
 
     public func run() throws {
+        switch engine.lowercased() {
+        case "sa3", "stableaudio3", "stable-audio-3":
+            try runSA3()
+        case "magnet":
+            try runMAGNeT()
+        default:
+            throw ValidationError("Unknown --engine '\(engine)'. Use one of: sa3, magnet.")
+        }
+    }
+
+    private func runSA3() throws {
         try runAsync {
-            guard let variantEnum = MAGNeTVariant(rawValue: variant) else {
-                throw ValidationError("Unknown variant '\(variant)'. Use one of: \(MAGNeTVariant.allCases.map { $0.rawValue }.joined(separator: ", "))")
+            guard let variantEnum = StableAudio3Variant(rawValue: sa3Variant) else {
+                throw ValidationError(
+                    "Unknown --sa3-variant '\(sa3Variant)'. Use one of: "
+                  + StableAudio3Variant.allCases.map(\.rawValue).joined(separator: ", "))
             }
-            let decodingSteps = steps.split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+            print("Loading Stable Audio 3 \(sa3Variant)…")
+            let overrideURL = sa3BundleDir.map { URL(fileURLWithPath: $0) }
+            let model = try await StableAudio3MusicGen.fromPretrained(
+                variant: variantEnum,
+                tLatHint: StableAudio3MusicGen.computeTLat(seconds: seconds),
+                localBundleOverride: overrideURL,
+                progressHandler: { reportProgress($0, "downloading") })
+
+            print("Prompt: \"\(prompt)\"")
+            let params = StableAudio3GenerationParams(
+                seconds: seconds, steps: sa3Steps,
+                cfgScale: sa3Cfg, apg: 1.0,
+                sigmaMax: sigmaMax, seed: seed)
+
+            print("Generating \(seconds)s of audio…")
+            let start = Date()
+            let (left, right) = model.generate(prompt: prompt, params: params)
+            let elapsed = Date().timeIntervalSince(start)
+            let audioSec = Double(left.count) / Double(StableAudio3MusicGen.sampleRate)
+            print("  Generated \(left.count) frames per channel "
+                + "(\(String(format: "%.2f", audioSec))s @ \(StableAudio3MusicGen.sampleRate) Hz stereo)")
+            print("  Wall: \(String(format: "%.2f", elapsed))s  RTF: \(String(format: "%.2f", elapsed / audioSec))")
+
+            let outURL = URL(fileURLWithPath: output)
+            try WAVWriter.writeStereo(left: left, right: right,
+                                       sampleRate: StableAudio3MusicGen.sampleRate, to: outURL)
+            print("  Saved: \(outURL.path)")
+        }
+    }
+
+    private func runMAGNeT() throws {
+        try runAsync {
+            guard let variantEnum = MAGNeTVariant(rawValue: magnetVariant) else {
+                throw ValidationError("Unknown --magnet-variant '\(magnetVariant)'. Use one of: \(MAGNeTVariant.allCases.map { $0.rawValue }.joined(separator: ", "))")
+            }
+            let decodingSteps = magnetSteps.split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
             guard decodingSteps.count == 4 else {
-                throw ValidationError("--steps must be 4 comma-separated integers (one per codebook), got \(decodingSteps.count)")
+                throw ValidationError("--magnet-steps must be 4 comma-separated integers (one per codebook), got \(decodingSteps.count)")
             }
 
-            print("Loading MAGNeT \(variant)…")
+            print("Loading MAGNeT \(magnetVariant)…")
             let model = try await MAGNeTMusicGen.fromPretrained(
                 variant: variantEnum,
                 progressHandler: { reportProgress($0, "downloading") })
@@ -80,4 +152,9 @@ public struct ComposeCommand: ParsableCommand {
             print("  Saved: \(outURL.path)")
         }
     }
+}
+
+// Convenience accessor since StableAudio3MusicGen.sampleRate is the SA3 constant.
+extension StableAudio3MusicGen {
+    public static var sampleRate: Int { SA3Audio.sampleRate }
 }

--- a/Sources/AudioCLILib/SA3ParityCommand.swift
+++ b/Sources/AudioCLILib/SA3ParityCommand.swift
@@ -1,0 +1,154 @@
+import Foundation
+import ArgumentParser
+import MLX
+import MLXFast
+import AudioCommon
+import StableAudio3MusicGen
+
+/// Compare Swift SA3 inference against a Python reference dump produced by
+/// `models/stable-audio-3/export/scripts/dump_parity_ref.py`. Per stage,
+/// prints cosine similarity + max-abs-diff vs the reference tensors.
+///
+/// Stages: T5Gemma encode • conditioner • DiT single-step velocity • SAME-L decode.
+public struct SA3ParityCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "sa3-parity",
+        abstract: "Compare Swift SA3 outputs to a Python reference dump (per stage)."
+    )
+
+    @Option(name: .long, help: "Reference .safetensors dumped by scripts/dump_parity_ref.py")
+    public var ref: String
+
+    @Option(name: .long, help: "Local SA3 bundle directory (skip HF download).")
+    public var bundle: String
+
+    @Option(name: .long, help: "Prompt to run through Swift T5Gemma (must match Python dump).")
+    public var prompt: String = "lofi house loop"
+
+    @Option(name: .long, help: "Seconds to use when computing T_lat (must match Python).")
+    public var seconds: Float = 4.0
+
+    public init() {}
+
+    public func run() throws {
+        try runAsync {
+            try await self.runImpl()
+        }
+    }
+
+    private func runImpl() async throws {
+        let refURL = URL(fileURLWithPath: ref)
+        let bundleURL = URL(fileURLWithPath: bundle)
+
+        guard FileManager.default.fileExists(atPath: refURL.path) else {
+            throw ValidationError("--ref not found: \(refURL.path)")
+        }
+
+        print("Loading Swift bundle from \(bundle)…"); fflush(stdout)
+        let tLat = StableAudio3MusicGen.computeTLat(seconds: seconds)
+        let model = try await StableAudio3MusicGen.fromPretrained(
+            variant: .mediumInt8,
+            tLatHint: tLat,
+            localBundleOverride: bundleURL,
+            progressHandler: nil)
+        print("  bundle loaded"); fflush(stdout)
+
+        print("\nLoading reference: \(ref)"); fflush(stdout)
+        let refArrs = try MLX.loadArrays(url: refURL)
+        print("  ref loaded: \(refArrs.count) tensors"); fflush(stdout)
+
+        // ─── Stage 1: T5Gemma encode ─────────────────────────────────────
+        print("\n[1] T5Gemma encode"); fflush(stdout)
+        // (a) Swift tokenizer parity
+        let swiftIds = model.t5.tokenizer.encodeAsIds(prompt)
+        let refIdsArr = refArrs["input_ids"]!
+        // first `mask.sum()` ids are the actual non-pad tokens
+        let refMask = refArrs["mask"]!
+        let refKeep = Int(refMask.sum().item(Int32.self))
+        let refIdsAll = refIdsArr.asType(DType.int32).asArray(Int32.self)
+        let refIds = Array(refIdsAll.prefix(refKeep)).map { Int($0) }
+        print("  swift tokenizer: \(swiftIds.count) ids — \(swiftIds.prefix(8))")
+        print("  python tokenizer: \(refIds.count) ids — \(refIds.prefix(8))")
+        print("  ids match: \(swiftIds == refIds)")
+        fflush(stdout)
+
+        // (b) Encoder forward with PYTHON token ids (isolate tokenizer bug from encoder bugs)
+        print("  [1a] encoder forward using python ids…"); fflush(stdout)
+        let pyEmbeds = model.t5.encoder(refIdsArr, attentionMask: refMask)
+        eval(pyEmbeds)
+        compare(label: "embeds_pyIds", swift: pyEmbeds.asType(DType.float32),
+                ref: refArrs["embeds"]!.asType(DType.float32))
+
+        // (c) Encoder forward with SWIFT token ids (combined: tokenizer + encoder)
+        print("  [1b] encoder forward using swift ids…"); fflush(stdout)
+        let (embedsSwift, _) = model.t5.encode(prompt)
+        eval(embedsSwift)
+        compare(label: "embeds_swIds", swift: embedsSwift.asType(DType.float32),
+                ref: refArrs["embeds"]!.asType(DType.float32))
+
+        // ─── Stage 2: Conditioner ────────────────────────────────────────
+        print("\n[2] Conditioner (SecondsTotalEmbedder + apply_prompt_padding)")
+        let secsSwift = model.secondsEmbedder(seconds).asType(DType.float32)
+        eval(secsSwift)
+        compare(label: "secs_emb", swift: secsSwift,
+                ref: refArrs["seconds_embed"]!.asType(DType.float32))
+
+        // ─── Stage 3: DiT single-step velocity ───────────────────────────
+        print("\n[3] DiT single-step velocity")
+        let noise = refArrs["noise"]!.asType(DType.float16)
+        let crossAttn = refArrs["cross_attn"]!.asType(DType.float16)
+        let globalCond = refArrs["global_cond"]!.asType(DType.float16)
+        let t = refArrs["t"]!.asType(DType.float16)
+        let vSwift = model.dit(noise, t: t,
+                                crossAttnCondRaw: crossAttn,
+                                globalCondRaw: globalCond, localAddCond: nil)
+        eval(vSwift)
+        compare(label: "v", swift: vSwift.asType(DType.float32),
+                ref: refArrs["v"]!.asType(DType.float32))
+
+        // ─── Stage 4: SAME-L decoder ─────────────────────────────────────
+        print("\n[4] SAME-L decode (denoised → patches)")
+        let denoised = refArrs["denoised"]!.asType(DType.float32)
+        let patchesSwift = model.decoder(denoised)
+        eval(patchesSwift)
+        compare(label: "patches", swift: patchesSwift.asType(DType.float32),
+                ref: refArrs["patches"]!.asType(DType.float32))
+    }
+
+    /// Print cosine similarity + max-abs-diff for two same-shape MLX arrays.
+    private func compare(label: String, swift: MLXArray, ref: MLXArray) {
+        print("    [compare \(label)] enter; swift \(swift.shape) ref \(ref.shape)"); fflush(stdout)
+        let a = swift.reshaped([-1]).asType(DType.float32)
+        let b = ref.reshaped([-1]).asType(DType.float32)
+        eval(a, b)
+        let dot = (a * b).sum()
+        let normA = sqrt((a * a).sum())
+        let normB = sqrt((b * b).sum())
+        eval(dot, normA, normB)
+        let cosV = (dot / (normA * normB + MLXArray(Float(1e-12)))).item(Float.self)
+        let maxV = (a - b).abs().max().item(Float.self)
+        let aMean = a.mean().item(Float.self)
+        let bMean = b.mean().item(Float.self)
+        let aStd  = sqrt(((a - aMean) * (a - aMean)).mean()).item(Float.self)
+        let bStd  = sqrt(((b - bMean) * (b - bMean)).mean()).item(Float.self)
+        let shape = swift.shape == ref.shape ? "\(swift.shape)" : "\(swift.shape) vs ref \(ref.shape)"
+        let verdict = cosV > 0.99 ? "✓" : cosV > 0.90 ? "~" : "✗"
+        print("    \(verdict) \(label.padding(toLength: 12, withPad: " ", startingAt: 0)) "
+            + String(format: "cos=%.5f  max_abs=%.4f   swift μ=%+.4f σ=%.4f   ref μ=%+.4f σ=%.4f   shape=%@",
+                     cosV, maxV, aMean, aStd, bMean, bStd, shape))
+        fflush(stdout)
+    }
+}
+
+/// Helper: run an async block synchronously and return the result.
+func runAsyncReturning<T>(_ block: @escaping () async throws -> T) throws -> T {
+    let sem = DispatchSemaphore(value: 0)
+    var result: Result<T, Error>!
+    Task {
+        do { result = .success(try await block()) }
+        catch { result = .failure(error) }
+        sem.signal()
+    }
+    sem.wait()
+    return try result.get()
+}

--- a/Sources/StableAudio3MusicGen/Conditioner.swift
+++ b/Sources/StableAudio3MusicGen/Conditioner.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MLX
+
+/// Replicates ExpoFourierFeatures from sa3_pipeline.py — log-spaced frequencies
+/// in `[min_freq, max_freq]` projected onto cos+sin. Used by SecondsTotalEmbedder
+/// and the DiT's timestep features (same code, different `dim` and freq range).
+@inline(__always)
+func expoFourierFeatures(_ t: MLXArray, dim: Int,
+                          minFreq: Float, maxFreq: Float) -> MLXArray {
+    let half = dim / 2
+    let logMin = MLX.log(MLXArray(minFreq))
+    let logMax = MLX.log(MLXArray(maxFreq))
+    let ramp = MLXArray(0..<half).asType(.float32) / Float(max(half - 1, 1))
+    let freqs = MLX.exp(ramp * (logMax - logMin) + logMin) * MLXArray(2 * Float.pi)
+    let t32 = t.asType(.float32).reshaped([t.size, 1])      // [B, 1]
+    let args = t32 * freqs.reshaped([1, half])              // [B, half]
+    return MLX.concatenated([MLX.cos(args), MLX.sin(args)], axis: -1)  // [B, dim]
+}
+
+/// `NumberConditioner({min_val:0, max_val:384, fourier_features_type:"expo"})`
+/// → 768-d embedding: ExpoFourierFeatures(256) → Linear(256, 768) + bias.
+public final class SecondsTotalEmbedder {
+    public let weight: MLXArray    // (768, 256)
+    public let bias: MLXArray      // (768,)
+    public let minVal: Float
+    public let maxVal: Float
+    public let fourierDim: Int
+
+    public init(weight: MLXArray, bias: MLXArray,
+                minVal: Float = 0.0, maxVal: Float = 384.0, fourierDim: Int = 256) {
+        self.weight = weight
+        self.bias = bias
+        self.minVal = minVal
+        self.maxVal = maxVal
+        self.fourierDim = fourierDim
+    }
+
+    public func callAsFunction(_ seconds: Float) -> MLXArray {
+        let clipped = max(minVal, min(maxVal, seconds))
+        let norm = (clipped - minVal) / (maxVal - minVal)
+        let t = MLXArray([norm])
+        let ff = expoFourierFeatures(t, dim: fourierDim, minFreq: 0.5, maxFreq: 10_000)
+        let out = MLX.matmul(ff, weight.transposed()) + bias                   // [1, 768]
+        return out.expandedDimensions(axis: 1)                                  // [1, 1, 768]
+    }
+}
+
+/// Replace padded T5Gemma positions with the learned padding embedding.
+/// `embeds` [B,S,768] · `mask` [B,S] int32 · `paddingEmbedding` [768].
+public func applyPromptPadding(embeds: MLXArray, mask: MLXArray, paddingEmbedding: MLXArray) -> MLXArray {
+    let m = mask.asType(embeds.dtype).expandedDimensions(axis: -1)              // [B,S,1]
+    let pe = paddingEmbedding.asType(embeds.dtype).reshaped([1, 1, -1])
+    return embeds * m + pe * (MLXArray(Float(1.0)).asType(embeds.dtype) - m)
+}

--- a/Sources/StableAudio3MusicGen/Configuration.swift
+++ b/Sources/StableAudio3MusicGen/Configuration.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Stable Audio 3 model variant. Pairs each DiT family (Medium 1.4 B,
+/// Small-Music 50 M, Small-SFX 50 M) with its INT4 or INT8 quantization.
+/// All bundles ship the matching SAME codec (SAME-L for Medium, SAME-S for
+/// the Small variants) and T5Gemma text encoder alongside the DiT.
+public enum StableAudio3Variant: String, Sendable, CaseIterable {
+    case mediumInt8 = "medium-int8"
+    case mediumInt4 = "medium-int4"
+    case smallMusicInt8 = "small-music-int8"
+    case smallMusicInt4 = "small-music-int4"
+    case smallSFXInt8 = "small-sfx-int8"
+    case smallSFXInt4 = "small-sfx-int4"
+
+    public var huggingFaceRepoId: String {
+        switch self {
+        case .mediumInt8:      return "aufklarer/Stable-Audio-3-DiT-Medium-MLX-8bit"
+        case .mediumInt4:      return "aufklarer/Stable-Audio-3-DiT-Medium-MLX-4bit"
+        case .smallMusicInt8:  return "aufklarer/Stable-Audio-3-DiT-Small-Music-MLX-8bit"
+        case .smallMusicInt4:  return "aufklarer/Stable-Audio-3-DiT-Small-Music-MLX-4bit"
+        case .smallSFXInt8:    return "aufklarer/Stable-Audio-3-DiT-Small-SFX-MLX-8bit"
+        case .smallSFXInt4:    return "aufklarer/Stable-Audio-3-DiT-Small-SFX-MLX-4bit"
+        }
+    }
+
+    /// Bits for the DiT quantization. SAME codec stays FP32 in every bundle
+    /// (its differential attention cancels in FP16); T5Gemma stays FP16.
+    public var bits: Int {
+        switch self {
+        case .mediumInt8, .smallMusicInt8, .smallSFXInt8: return 8
+        case .mediumInt4, .smallMusicInt4, .smallSFXInt4: return 4
+        }
+    }
+
+    /// Which DiT family this variant belongs to. Drives module choice
+    /// (medium ⇒ DiT-Medium + SAME-L, small-* ⇒ DiT-Small + SAME-S).
+    public var family: StableAudio3Family {
+        switch self {
+        case .mediumInt8, .mediumInt4:           return .medium
+        case .smallMusicInt8, .smallMusicInt4:   return .smallMusic
+        case .smallSFXInt8, .smallSFXInt4:       return .smallSFX
+        }
+    }
+}
+
+public enum StableAudio3Family: Sendable {
+    case medium       // DiT-Medium (24 layers, 1536 dim, differential attn) + SAME-L
+    case smallMusic   // DiT-Small  (20 layers, 1024 dim, standard MHA)      + SAME-S
+    case smallSFX     // same shape as smallMusic but trained on SFX
+}
+
+/// SA3 DiT-Medium architecture constants (mirror dit_mlx_medium.py).
+public enum DiTMediumDims {
+    public static let ioChannels = 256
+    public static let embedDim = 1536
+    public static let depth = 24
+    public static let numHeads = 24
+    public static let headDim = 64
+    public static let ropeDims = 32
+    public static let condTokenDim = 768
+    public static let globalCondDim = 768
+    public static let localAddCondDim = 257
+    public static let numMemoryTokens = 64
+    public static let ffInner = 6144
+    public static let timestepFeatDim = 256
+    public static let normEps: Float = 1e-5
+    public static let qkNormEps: Float = 1e-6
+    public static let ropeBase: Float = 10000.0
+}
+
+/// SA3 DiT-Small architecture constants (mirror dit_mlx.py).
+public enum DiTSmallDims {
+    public static let ioChannels = 256
+    public static let embedDim = 1024
+    public static let depth = 20
+    public static let numHeads = 16
+    public static let headDim = 64
+    public static let ropeDims = 32
+    public static let condTokenDim = 768
+    public static let globalCondDim = 768
+    public static let localAddCondDim = 257
+    public static let numMemoryTokens = 64
+    public static let ffInner = 4096
+    public static let timestepFeatDim = 256
+    public static let normEps: Float = 1e-5
+    public static let qkNormEps: Float = 1e-6
+    public static let ropeBase: Float = 10000.0
+}
+
+/// SAME-L decoder constants (mirror same_l_decoder.py).
+public enum SAMELDims {
+    public static let latentDim = 256
+    public static let dim = 1536
+    public static let numHeads = 24
+    public static let headDim = 64
+    public static let ropeDims = 32
+    public static let numBlocks = 12
+    public static let ffInner = 4608
+    public static let sinStartBlock = 5
+    public static let outChannels = 512
+    public static let stride = 16
+    public static let subChunkSize = stride + 1     // 17
+    public static let sinPerPos = subChunkSize - 1  // 16
+    public static let ropeBase: Float = 10000.0
+}
+
+/// SAME-S decoder constants (mirror same_s_decoder.py).
+public enum SAMESDims {
+    public static let latentDim = 256
+    public static let dim = 768
+    public static let numHeads = 12
+    public static let headDim = 64
+    public static let ropeDims = 32
+    public static let numBlocks = 6
+    public static let ffInner = 2304
+    public static let sinStartBlock = 5
+    public static let outChannels = 512
+    public static let stride = 16
+    public static let subChunkSize = stride + 1
+    public static let sinPerPos = subChunkSize - 1
+    public static let ropeBase: Float = 10000.0
+}
+
+/// T5Gemma encoder dims (small Gemma2-style — 12 layers / 768 / 12 heads).
+public enum T5GemmaDims {
+    public static let hiddenSize = 768
+    public static let numLayers = 12
+    public static let numAttentionHeads = 12
+    public static let numKeyValueHeads = 12
+    public static let headDim = 64
+    public static let intermediateSize = 2048
+    public static let vocabSize = 256000
+    public static let maxPositionEmbeddings = 8192
+    public static let ropeTheta: Float = 10000.0
+    public static let rmsNormEps: Float = 1e-6
+    public static let attnLogitSoftcapping: Float = 50.0
+    public static let queryPreAttnScalar: Int = 64
+    public static let padTokenId: Int32 = 0
+}
+
+/// Audio pipeline constants.
+public enum SA3Audio {
+    public static let sampleRate = 44100
+    public static let samplesPerLatent = 4096
+    public static let channels = 2          // stereo
+    public static let patchSize = 256       // PatchedPretransform patch
+}
+
+/// Per-bundle component sub-directory names (must match the publisher layout
+/// in `speech-models/models/stable-audio-3/export/scripts/quantize.py`).
+public enum SA3Components {
+    public static let ditMedium = "dit_medium"
+    public static let ditSmallMusic = "dit_sm_music"
+    public static let ditSmallSFX = "dit_sm_sfx"
+    public static let sameLEncoder = "same_l_encoder"
+    public static let sameLDecoder = "same_l_decoder"
+    public static let sameSEncoder = "same_s_encoder"
+    public static let sameSDecoder = "same_s_decoder"
+    public static let t5gemma = "t5gemma"
+
+    /// Component sub-directory holding the DiT for a given variant.
+    public static func dit(for variant: StableAudio3Variant) -> String {
+        switch variant.family {
+        case .medium:     return ditMedium
+        case .smallMusic: return ditSmallMusic
+        case .smallSFX:   return ditSmallSFX
+        }
+    }
+
+    public static func sameEncoder(for variant: StableAudio3Variant) -> String {
+        variant.family == .medium ? sameLEncoder : sameSEncoder
+    }
+
+    public static func sameDecoder(for variant: StableAudio3Variant) -> String {
+        variant.family == .medium ? sameLDecoder : sameSDecoder
+    }
+}

--- a/Sources/StableAudio3MusicGen/DiTMedium.swift
+++ b/Sources/StableAudio3MusicGen/DiTMedium.swift
@@ -1,0 +1,385 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXFast
+
+// MARK: - Differential attention (DiT-Medium uses 5-way QKV split)
+
+/// `to_qkv(x) → q, k, v, q_diff, k_diff`. Two SDPAs, subtract. RoPE on first
+/// `ropeDims` of each head. QK-norm per-head (RMSNorm over head dim).
+/// Linears are INT-quantised when `bits ∈ {4,8}`, plain FP16 when `bits == 0`.
+public final class DiffSelfAttentionMedium: Module {
+    @ModuleInfo(key: "to_qkv") public var toQKV: QuantizedLinear
+    @ModuleInfo(key: "to_out") public var toOut: QuantizedLinear
+    @ModuleInfo(key: "q_norm") public var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") public var kNorm: RMSNorm
+
+    public let scale: Float
+
+    public init(bits: Int, groupSize: Int = 64) {
+        let E = DiTMediumDims.embedDim
+        let D = DiTMediumDims.headDim
+        self._toQKV.wrappedValue = QuantizedLinear(E, 5 * E, bias: false,
+                                                    groupSize: groupSize, bits: bits)
+        self._toOut.wrappedValue = QuantizedLinear(E, E, bias: false,
+                                                    groupSize: groupSize, bits: bits)
+        self._qNorm.wrappedValue = RMSNorm(dimensions: D, eps: DiTMediumDims.qkNormEps)
+        self._kNorm.wrappedValue = RMSNorm(dimensions: D, eps: DiTMediumDims.qkNormEps)
+        self.scale = 1.0 / Float(D).squareRoot()
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let B = x.dim(0), T = x.dim(1)
+        let H = DiTMediumDims.numHeads, D = DiTMediumDims.headDim
+        let qkv = toQKV(x)                                       // [B, T, 5E]
+        let parts = MLX.split(qkv, parts: 5, axis: -1)
+        var q = parts[0], k = parts[1], v = parts[2], qDiff = parts[3], kDiff = parts[4]
+
+        func toHeads(_ t: MLXArray) -> MLXArray {
+            t.reshaped([B, T, H, D]).transposed(0, 2, 1, 3)
+        }
+        q = toHeads(q); k = toHeads(k); v = toHeads(v)
+        qDiff = toHeads(qDiff); kDiff = toHeads(kDiff)
+
+        q     = qNorm(q);     k     = kNorm(k)
+        qDiff = qNorm(qDiff); kDiff = kNorm(kDiff)
+
+        q     = MLXFast.RoPE(q,     dimensions: DiTMediumDims.ropeDims, traditional: false,
+                              base: DiTMediumDims.ropeBase, scale: 1.0, offset: 0)
+        k     = MLXFast.RoPE(k,     dimensions: DiTMediumDims.ropeDims, traditional: false,
+                              base: DiTMediumDims.ropeBase, scale: 1.0, offset: 0)
+        qDiff = MLXFast.RoPE(qDiff, dimensions: DiTMediumDims.ropeDims, traditional: false,
+                              base: DiTMediumDims.ropeBase, scale: 1.0, offset: 0)
+        kDiff = MLXFast.RoPE(kDiff, dimensions: DiTMediumDims.ropeDims, traditional: false,
+                              base: DiTMediumDims.ropeBase, scale: 1.0, offset: 0)
+
+        let outMain = MLXFast.scaledDotProductAttention(queries: q, keys: k, values: v,
+                                                         scale: scale, mask: nil)
+        let outDiff = MLXFast.scaledDotProductAttention(queries: qDiff, keys: kDiff, values: v,
+                                                         scale: scale, mask: nil)
+        let outF = (outMain - outDiff).transposed(0, 2, 1, 3).reshaped([B, T, DiTMediumDims.embedDim])
+        return toOut(outF)
+    }
+}
+
+public final class DiffCrossAttentionMedium: Module {
+    @ModuleInfo(key: "to_q") public var toQ: QuantizedLinear        // E → 2E
+    @ModuleInfo(key: "to_kv") public var toKV: QuantizedLinear      // E → 3E
+    @ModuleInfo(key: "to_out") public var toOut: QuantizedLinear
+    @ModuleInfo(key: "q_norm") public var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") public var kNorm: RMSNorm
+    public let scale: Float
+
+    public init(bits: Int, groupSize: Int = 64) {
+        let E = DiTMediumDims.embedDim
+        let D = DiTMediumDims.headDim
+        self._toQ.wrappedValue = QuantizedLinear(E, 2 * E, bias: false,
+                                                  groupSize: groupSize, bits: bits)
+        self._toKV.wrappedValue = QuantizedLinear(E, 3 * E, bias: false,
+                                                   groupSize: groupSize, bits: bits)
+        self._toOut.wrappedValue = QuantizedLinear(E, E, bias: false,
+                                                    groupSize: groupSize, bits: bits)
+        self._qNorm.wrappedValue = RMSNorm(dimensions: D, eps: DiTMediumDims.qkNormEps)
+        self._kNorm.wrappedValue = RMSNorm(dimensions: D, eps: DiTMediumDims.qkNormEps)
+        self.scale = 1.0 / Float(D).squareRoot()
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, context: MLXArray) -> MLXArray {
+        let B = x.dim(0), Tx = x.dim(1), Tc = context.dim(1)
+        let H = DiTMediumDims.numHeads, D = DiTMediumDims.headDim
+        let qParts = MLX.split(toQ(x), parts: 2, axis: -1)
+        var q = qParts[0], qDiff = qParts[1]
+        let kvParts = MLX.split(toKV(context), parts: 3, axis: -1)
+        var k = kvParts[0], kDiff = kvParts[1]
+        let v = kvParts[2]
+
+        func qHeads(_ t: MLXArray) -> MLXArray {
+            t.reshaped([B, Tx, H, D]).transposed(0, 2, 1, 3)
+        }
+        func cHeads(_ t: MLXArray) -> MLXArray {
+            t.reshaped([B, Tc, H, D]).transposed(0, 2, 1, 3)
+        }
+        q = qHeads(q); qDiff = qHeads(qDiff)
+        k = cHeads(k); kDiff = cHeads(kDiff)
+        let vh = cHeads(v)
+
+        q = qNorm(q); k = kNorm(k)
+        qDiff = qNorm(qDiff); kDiff = kNorm(kDiff)
+
+        let outMain = MLXFast.scaledDotProductAttention(queries: q, keys: k, values: vh,
+                                                         scale: scale, mask: nil)
+        let outDiff = MLXFast.scaledDotProductAttention(queries: qDiff, keys: kDiff, values: vh,
+                                                         scale: scale, mask: nil)
+        let outF = (outMain - outDiff).transposed(0, 2, 1, 3).reshaped([B, Tx, DiTMediumDims.embedDim])
+        return toOut(outF)
+    }
+}
+
+// MARK: - GeGLU feed-forward
+
+/// `ff.0.proj(x) → split → silu(gate) * value` (FF inner = 6144).
+public final class GLUWrapMedium: Module {
+    @ModuleInfo public var proj: QuantizedLinear
+    public init(bits: Int, groupSize: Int = 64) {
+        self._proj.wrappedValue = QuantizedLinear(
+            DiTMediumDims.embedDim, 2 * DiTMediumDims.ffInner,
+            bias: true, groupSize: groupSize, bits: bits)
+        super.init()
+    }
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let p = proj(x)
+        let parts = MLX.split(p, parts: 2, axis: -1)
+        return parts[0] * silu(parts[1])
+    }
+}
+
+/// FeedForward path with `ff.0 = GLU`, `ff.2 = QuantizedLinear(ffInner, embed)`.
+/// We model the indexed list via custom @ModuleInfo keys "0" / "2". Both halves
+/// are INT-quantised (ffInner = 6144 / embed = 1536 — both divisible by 64).
+public final class FeedForwardMedium: Module {
+    /// Inner container — loader rewrites `ff.ff.{0,2}` → `ff.ff.{glu,out}`.
+    public final class Inner: Module {
+        @ModuleInfo public var glu: GLUWrapMedium
+        @ModuleInfo public var out: QuantizedLinear
+        public init(bits: Int, groupSize: Int = 64) {
+            self._glu.wrappedValue = GLUWrapMedium(bits: bits, groupSize: groupSize)
+            self._out.wrappedValue = QuantizedLinear(
+                DiTMediumDims.ffInner, DiTMediumDims.embedDim,
+                bias: true, groupSize: groupSize, bits: bits)
+            super.init()
+        }
+    }
+    @ModuleInfo public var ff: Inner
+    public init(bits: Int) {
+        self._ff.wrappedValue = Inner(bits: bits)
+        super.init()
+    }
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        ff.out(ff.glu(x))
+    }
+}
+
+/// Per-layer local-conditioning MLP: 257 → embed → embed with SiLU between.
+/// Checkpoint keys: `to_local_embed.seq.0.{weight,bias}`, `to_local_embed.seq.2.{weight,bias}`.
+/// `.0` has input 257 (not divisible by 64) so stays plain Linear.
+/// `.2` is embed→embed (1536→1536) — INT-quantised.
+public final class LocalEmbedSeqMedium: Module {
+    public final class Seq: Module {
+        @ModuleInfo public var inProj: Linear
+        @ModuleInfo public var outProj: QuantizedLinear
+        public init(bits: Int, groupSize: Int = 64) {
+            self._inProj.wrappedValue = Linear(DiTMediumDims.localAddCondDim, DiTMediumDims.embedDim, bias: true)
+            self._outProj.wrappedValue = QuantizedLinear(
+                DiTMediumDims.embedDim, DiTMediumDims.embedDim,
+                bias: true, groupSize: groupSize, bits: bits)
+            super.init()
+        }
+    }
+    @ModuleInfo public var seq: Seq
+    public init(bits: Int) {
+        self._seq.wrappedValue = Seq(bits: bits)
+        super.init()
+    }
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        seq.outProj(silu(seq.inProj(x)))
+    }
+}
+
+// MARK: - Transformer block (Medium)
+
+public final class TransformerBlockMedium: Module {
+    @ModuleInfo(key: "pre_norm") public var preNorm: RMSNorm
+    @ModuleInfo(key: "self_attn") public var selfAttn: DiffSelfAttentionMedium
+    @ModuleInfo(key: "cross_attend_norm") public var crossAttendNorm: RMSNorm
+    @ModuleInfo(key: "cross_attn") public var crossAttn: DiffCrossAttentionMedium
+    @ModuleInfo(key: "ff_norm") public var ffNorm: RMSNorm
+    @ModuleInfo public var ff: FeedForwardMedium
+    @ModuleInfo(key: "to_local_embed") public var toLocalEmbed: LocalEmbedSeqMedium
+    @ParameterInfo(key: "to_scale_shift_gate") public var toScaleShiftGate: MLXArray  // (6E,)
+
+    public init(bits: Int) {
+        let E = DiTMediumDims.embedDim
+        self._preNorm.wrappedValue = RMSNorm(dimensions: E, eps: DiTMediumDims.normEps)
+        self._selfAttn.wrappedValue = DiffSelfAttentionMedium(bits: bits)
+        self._crossAttendNorm.wrappedValue = RMSNorm(dimensions: E, eps: DiTMediumDims.normEps)
+        self._crossAttn.wrappedValue = DiffCrossAttentionMedium(bits: bits)
+        self._ffNorm.wrappedValue = RMSNorm(dimensions: E, eps: DiTMediumDims.normEps)
+        self._ff.wrappedValue = FeedForwardMedium(bits: bits)
+        self._toLocalEmbed.wrappedValue = LocalEmbedSeqMedium(bits: bits)
+        self._toScaleShiftGate.wrappedValue = MLXArray.zeros([6 * E])
+        super.init()
+    }
+
+    public func callAsFunction(_ xIn: MLXArray, context: MLXArray,
+                                globalCond: MLXArray, localEmbPadded: MLXArray) -> MLXArray {
+        // (to_scale_shift_gate + global_cond)[:, None, :] split into 6 chunks
+        let ssBase = toScaleShiftGate.asType(globalCond.dtype) + globalCond
+        let ss = ssBase.expandedDimensions(axis: 1)              // [B, 1, 6E]
+        let parts = MLX.split(ss, parts: 6, axis: -1)
+        let scaleSelf = parts[0], shiftSelf = parts[1], gateSelf = parts[2]
+        let scaleFF = parts[3],    shiftFF = parts[4],    gateFF = parts[5]
+        let one = MLXArray(Float(1.0)).asType(scaleSelf.dtype)
+
+        var x = xIn
+        var residual = x
+        var h = preNorm(x)
+        h = h * (one + scaleSelf) + shiftSelf
+        h = selfAttn(h)
+        h = h * MLX.sigmoid(one - gateSelf)
+        x = h + residual
+
+        x = x + crossAttn(crossAttendNorm(x), context: context)
+        x = x + localEmbPadded
+
+        residual = x
+        h = ffNorm(x)
+        h = h * (one + scaleFF) + shiftFF
+        h = ff(h)
+        h = h * MLX.sigmoid(one - gateFF)
+        x = h + residual
+        return x
+    }
+}
+
+// MARK: - Top transformer + DiT
+
+public final class GlobalCondEmbedderMedium: Module {
+    @ModuleInfo public var inProj: QuantizedLinear
+    @ModuleInfo public var outProj: QuantizedLinear
+    public init(bits: Int, groupSize: Int = 64) {
+        let E = DiTMediumDims.embedDim
+        self._inProj.wrappedValue = QuantizedLinear(
+            E, E, bias: true, groupSize: groupSize, bits: bits)
+        self._outProj.wrappedValue = QuantizedLinear(
+            E, 6 * E, bias: true, groupSize: groupSize, bits: bits)
+        super.init()
+    }
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        outProj(silu(inProj(x)))
+    }
+}
+
+public final class ContinuousTransformerMedium: Module {
+    @ModuleInfo(key: "project_in") public var projectIn: QuantizedLinear
+    @ModuleInfo(key: "project_out") public var projectOut: QuantizedLinear
+    @ParameterInfo(key: "memory_tokens") public var memoryTokens: MLXArray   // (M, E)
+    @ModuleInfo(key: "global_cond_embedder") public var globalCondEmbedder: GlobalCondEmbedderMedium
+    @ModuleInfo public var layers: [TransformerBlockMedium]
+
+    public init(bits: Int) {
+        let E = DiTMediumDims.embedDim
+        let groupSize = 64
+        self._projectIn.wrappedValue = QuantizedLinear(
+            DiTMediumDims.ioChannels, E, bias: false,
+            groupSize: groupSize, bits: bits)
+        self._projectOut.wrappedValue = QuantizedLinear(
+            E, DiTMediumDims.ioChannels, bias: false,
+            groupSize: groupSize, bits: bits)
+        self._memoryTokens.wrappedValue = MLXArray.zeros([DiTMediumDims.numMemoryTokens, E])
+        self._globalCondEmbedder.wrappedValue = GlobalCondEmbedderMedium(bits: bits)
+        self._layers.wrappedValue = (0..<DiTMediumDims.depth).map { _ in TransformerBlockMedium(bits: bits) }
+        super.init()
+    }
+
+    public func callAsFunction(_ xIn: MLXArray, context: MLXArray,
+                                globalEmbed: MLXArray, localAddCondZeros: MLXArray) -> MLXArray {
+        let B = xIn.dim(0)
+        let E = DiTMediumDims.embedDim
+        let M = DiTMediumDims.numMemoryTokens
+        var x = projectIn(xIn)
+        let mem = MLX.broadcast(
+            memoryTokens.expandedDimensions(axis: 0).asType(x.dtype),
+            to: [B, M, E])
+        x = MLX.concatenated([mem, x], axis: 1)
+
+        let g = globalCondEmbedder(globalEmbed)              // [B, 6E]
+
+        let pad = MLXArray.zeros([B, M, E], dtype: x.dtype)
+        for layer in layers {
+            let localEmb = layer.toLocalEmbed(localAddCondZeros)        // [B, T, E]
+            let localEmbPadded = MLX.concatenated([pad, localEmb], axis: 1)
+            x = layer(x, context: context, globalCond: g, localEmbPadded: localEmbPadded)
+        }
+        x = x[0..., M..., 0...]
+        return projectOut(x)
+    }
+}
+
+public final class CondEmbed2Medium: Module {
+    @ModuleInfo public var inProj: QuantizedLinear
+    @ModuleInfo public var outProj: QuantizedLinear
+    public init(inDim: Int, outDim: Int, bias: Bool, bits: Int, groupSize: Int = 64) {
+        self._inProj.wrappedValue = QuantizedLinear(
+            inDim, outDim, bias: bias, groupSize: groupSize, bits: bits)
+        self._outProj.wrappedValue = QuantizedLinear(
+            outDim, outDim, bias: bias, groupSize: groupSize, bits: bits)
+        super.init()
+    }
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        outProj(silu(inProj(x)))
+    }
+}
+
+public final class DiTMedium: Module {
+    @ModuleInfo(key: "preprocess_conv") public var preprocessConv: Conv1d
+    @ModuleInfo(key: "postprocess_conv") public var postprocessConv: Conv1d
+    @ModuleInfo(key: "to_cond_embed") public var toCondEmbed: CondEmbed2Medium
+    @ModuleInfo(key: "to_global_embed") public var toGlobalEmbed: CondEmbed2Medium
+    @ModuleInfo(key: "to_timestep_embed") public var toTimestepEmbed: CondEmbed2Medium
+    @ModuleInfo public var transformer: ContinuousTransformerMedium
+
+    public let tLat: Int
+    public let bits: Int
+
+    public init(tLat: Int, bits: Int) {
+        self.tLat = tLat
+        self.bits = bits
+        let IO = DiTMediumDims.ioChannels
+        let E = DiTMediumDims.embedDim
+        let CT = DiTMediumDims.condTokenDim
+        let GC = DiTMediumDims.globalCondDim
+        let TF = DiTMediumDims.timestepFeatDim
+
+        self._preprocessConv.wrappedValue  = Conv1d(inputChannels: IO, outputChannels: IO, kernelSize: 1, bias: false)
+        self._postprocessConv.wrappedValue = Conv1d(inputChannels: IO, outputChannels: IO, kernelSize: 1, bias: false)
+        self._toCondEmbed.wrappedValue     = CondEmbed2Medium(inDim: CT, outDim: E, bias: false, bits: bits)
+        self._toGlobalEmbed.wrappedValue   = CondEmbed2Medium(inDim: GC, outDim: E, bias: false, bits: bits)
+        self._toTimestepEmbed.wrappedValue = CondEmbed2Medium(inDim: TF, outDim: E, bias: true,  bits: bits)
+        self._transformer.wrappedValue     = ContinuousTransformerMedium(bits: bits)
+        super.init()
+    }
+
+    /// `x`: [B, 256, T_lat] channels-first. `t`: [B] (current sigma).
+    /// `crossAttnCondRaw`: [B, 257, 768]. `globalCondRaw`: [B, 768].
+    /// `localAddCond`: optional [B, T_lat, 257] for inpainting (nil otherwise).
+    /// Returns velocity prediction in [B, 256, T_lat].
+    public func callAsFunction(_ x: MLXArray, t: MLXArray,
+                                crossAttnCondRaw: MLXArray, globalCondRaw: MLXArray,
+                                localAddCond: MLXArray? = nil) -> MLXArray {
+        let B = x.dim(0)
+        let context = toCondEmbed(crossAttnCondRaw)
+        let globalPre = toGlobalEmbed(globalCondRaw)
+        let tf = expoFourierFeatures(t, dim: DiTMediumDims.timestepFeatDim,
+                                     minFreq: 0.5, maxFreq: 10_000)
+        let tEmbed = toTimestepEmbed(tf.asType(globalPre.dtype))
+        let globalEmbed = globalPre + tEmbed
+
+        // Conv1d in MLX-Swift takes [B, T, C]. Input is [B, C, T] → transpose.
+        let xLC = x.transposed(0, 2, 1)
+        let xPP = preprocessConv(xLC) + xLC
+
+        let local: MLXArray
+        if let lc = localAddCond {
+            local = lc
+        } else {
+            local = MLXArray.zeros([B, tLat, DiTMediumDims.localAddCondDim], dtype: xPP.dtype)
+        }
+
+        let h = transformer(xPP, context: context, globalEmbed: globalEmbed,
+                             localAddCondZeros: local)
+        let out = postprocessConv(h) + h
+        return out.transposed(0, 2, 1)
+    }
+}

--- a/Sources/StableAudio3MusicGen/FlowMatchingSampler.swift
+++ b/Sources/StableAudio3MusicGen/FlowMatchingSampler.swift
@@ -1,0 +1,78 @@
+import Foundation
+import MLX
+import MLXRandom
+
+/// Build the pingpong sampling schedule used by SA3's rectified-flow denoiser.
+/// Linear σ from `sigmaMax → 0` in `steps+1` points, then warped by LogSNR
+/// shift (`anchor=-6.2, end=2.0`); endpoints clamped to (σmax, 0).
+public func buildPingPongSchedule(steps: Int, sigmaMax: Float = 1.0,
+                                   useLogSNRShift: Bool = true) -> MLXArray {
+    let t = MLX.linspace(sigmaMax, 0.0, count: steps + 1).asType(.float32)
+    if !useLogSNRShift {
+        return t
+    }
+    let anchorLogSNR: Float = -6.2
+    let logsnrEnd: Float = 2.0
+    let logsnr = MLXArray(logsnrEnd) - t * (MLXArray(logsnrEnd) - MLXArray(anchorLogSNR))
+    var warped = MLX.sigmoid(-logsnr)
+    // Preserve endpoints exactly.
+    let zeros = MLXArray.zeros(warped.shape, dtype: .float32)
+    let ones  = MLXArray.ones(warped.shape, dtype: .float32)
+    warped = MLX.where(t .<= MLXArray(Float(0.0)), zeros, warped)
+    warped = MLX.where(t .>= MLXArray(Float(1.0)), ones, warped)
+    // Re-anchor start to sigmaMax (preserves the literal sigma at i=0).
+    let head = MLXArray([sigmaMax])
+    return MLX.concatenated([head, warped[1...]], axis: 0)
+}
+
+/// Ping-pong sampler for rf_denoiser models. Per step:
+///   denoised = x - σ_curr * v(x, σ_curr)
+///   x_next   = (1 - σ_next) * denoised + σ_next * noise   (intermediate steps)
+///   x_final  = denoised                                     (last step)
+///
+/// `modelFn(x, t)` returns velocity prediction `v` matching `x.dtype`. `t` is
+/// shape `[B]` with the current sigma broadcast across the batch.
+public func sampleFlowPingPong(
+    modelFn: (MLXArray, MLXArray) -> MLXArray,
+    initial: MLXArray,
+    sigmas: MLXArray,
+    seed: UInt64,
+    onStep: ((Int, Int) -> Void)? = nil
+) -> MLXArray {
+    var x = initial
+    let numSteps = sigmas.dim(0) - 1
+    var key = MLXRandom.key(seed)
+    for i in 0..<numSteps {
+        let sigCurr = sigmas[i]
+        let sigNext = sigmas[i + 1]
+        let tTensor = MLXArray.ones([x.dim(0)], dtype: x.dtype) * sigCurr.asType(x.dtype)
+        let v = modelFn(x, tTensor)
+        let denoised = x - sigCurr.asType(x.dtype) * v
+        if i < numSteps - 1 && sigNext.item(Float.self) > 0 {
+            let split = MLXRandom.split(key: key)
+            key = split.0
+            let sub = split.1
+            let noise = MLXRandom.normal(x.shape, dtype: x.dtype, key: sub)
+            let mix = (MLXArray(Float(1.0)).asType(x.dtype) - sigNext.asType(x.dtype)) * denoised
+            x = mix + sigNext.asType(x.dtype) * noise
+        } else {
+            x = denoised
+        }
+        eval(x)
+        onStep?(i + 1, numSteps)
+    }
+    return x
+}
+
+/// Reverse of PatchedPretransform: `[B, 512, T*16] → [B, 2, T*4096]`.
+/// einops: `rearrange("b (c h) l -> b c (l h)", h=patchSize)`.
+public func patchedDecode(_ patches: MLXArray, patchSize: Int = 256, channels: Int = 2) -> MLXArray {
+    let B = patches.dim(0)
+    let CH = patches.dim(1)
+    let L = patches.dim(2)
+    precondition(CH == channels * patchSize, "Expected \(channels * patchSize) channels, got \(CH)")
+    let x = patches.reshaped([B, channels, patchSize, L])
+                    .transposed(0, 1, 3, 2)
+                    .reshaped([B, channels, L * patchSize])
+    return x
+}

--- a/Sources/StableAudio3MusicGen/SAMELDecoder.swift
+++ b/Sources/StableAudio3MusicGen/SAMELDecoder.swift
@@ -1,0 +1,324 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXFast
+
+// MARK: - Static SWA mask (17 × 51 band)
+
+/// Per-block-group SWA: a query group of 17 attends to 3 consecutive KV
+/// groups (51 KV tokens via padding + strided view). Mask shape: (17, 51).
+@inline(__always)
+func sameLSWAMask() -> MLXArray {
+    let block = SAMELDims.subChunkSize        // 17
+    let q  = MLXArray(0..<block).reshaped([block, 1])
+    let kv = MLXArray(0..<(3 * block)).reshaped([1, 3 * block])
+    // valid = (kv >= q) && (kv <= q + 2*block)
+    let lower: MLXArray = kv .>= q
+    let upper: MLXArray = kv .<= (q + 2 * block)
+    let valid: MLXArray = lower * upper                  // boolean AND via mult
+    return MLX.where(valid,
+                     MLXArray(Float(0.0)),
+                     MLXArray(Float(-1e9)))
+}
+
+// MARK: - DyT normalisation (γ * tanh(α * x) + β)
+
+public final class DyT: Module {
+    @ParameterInfo public var alpha: MLXArray    // scalar (shape [1])
+    @ParameterInfo public var gamma: MLXArray    // (dim,)
+    @ParameterInfo public var beta:  MLXArray    // (dim,)
+
+    public init(dim: Int) {
+        self._alpha.wrappedValue = MLXArray([Float(1.0)])
+        self._gamma.wrappedValue = MLXArray.ones([dim])
+        self._beta.wrappedValue  = MLXArray.zeros([dim])
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        gamma * MLX.tanh(alpha * x) + beta
+    }
+}
+
+// MARK: - Differential sliding-window attention
+
+public final class DiffSWA: Module {
+    @ModuleInfo(key: "to_qkv") public var toQKV: Linear      // FP32 in SAME-L
+    @ModuleInfo(key: "to_out") public var toOut: Linear
+    @ModuleInfo(key: "q_norm") public var qNorm: DyT
+    @ModuleInfo(key: "k_norm") public var kNorm: DyT
+
+    public let scale: Float
+
+    public override init() {
+        let D = SAMELDims.dim
+        self._toQKV.wrappedValue = Linear(D, 5 * D, bias: false)
+        self._toOut.wrappedValue = Linear(D, D, bias: false)
+        self._qNorm.wrappedValue = DyT(dim: SAMELDims.headDim)
+        self._kNorm.wrappedValue = DyT(dim: SAMELDims.headDim)
+        self.scale = 1.0 / Float(SAMELDims.headDim).squareRoot()
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, mask: MLXArray?, fullAttention: Bool) -> MLXArray {
+        let B = x.dim(0), T = x.dim(1)
+        let H = SAMELDims.numHeads, D = SAMELDims.headDim
+        let qkv = toQKV(x)
+        let parts = MLX.split(qkv, parts: 5, axis: -1)
+        var q1 = parts[0], k1 = parts[1]
+        let v0 = parts[2]
+        var q2 = parts[3], k2 = parts[4]
+
+        func toHeads(_ t: MLXArray) -> MLXArray {
+            t.reshaped([B, T, H, D]).transposed(0, 2, 1, 3)
+        }
+        q1 = toHeads(q1); k1 = toHeads(k1)
+        let v = toHeads(v0)
+        q2 = toHeads(q2); k2 = toHeads(k2)
+
+        q1 = qNorm(q1); k1 = kNorm(k1)
+        q2 = qNorm(q2); k2 = kNorm(k2)
+
+        q1 = MLXFast.RoPE(q1, dimensions: SAMELDims.ropeDims, traditional: false,
+                           base: SAMELDims.ropeBase, scale: 1.0, offset: 0)
+        k1 = MLXFast.RoPE(k1, dimensions: SAMELDims.ropeDims, traditional: false,
+                           base: SAMELDims.ropeBase, scale: 1.0, offset: 0)
+        q2 = MLXFast.RoPE(q2, dimensions: SAMELDims.ropeDims, traditional: false,
+                           base: SAMELDims.ropeBase, scale: 1.0, offset: 0)
+        k2 = MLXFast.RoPE(k2, dimensions: SAMELDims.ropeDims, traditional: false,
+                           base: SAMELDims.ropeBase, scale: 1.0, offset: 0)
+
+        let out: MLXArray
+        if fullAttention || T <= SAMELDims.subChunkSize {
+            out = diffSDPA(q1: q1, k1: k1, v: v, q2: q2, k2: k2, mask: nil)
+        } else {
+            out = swa(q1: q1, k1: k1, v: v, q2: q2, k2: k2, mask: mask)
+        }
+        let outF = out.transposed(0, 2, 1, 3).reshaped([B, T, SAMELDims.dim])
+        return toOut(outF)
+    }
+
+    private func diffSDPA(q1: MLXArray, k1: MLXArray, v: MLXArray,
+                           q2: MLXArray, k2: MLXArray, mask: MLXArray?) -> MLXArray {
+        let Q = MLX.concatenated([q1, q2], axis: 1)
+        let K = MLX.concatenated([k1, k2], axis: 1)
+        let V = MLX.concatenated([v, v], axis: 1)
+        let out = MLXFast.scaledDotProductAttention(queries: Q, keys: K, values: V,
+                                                     scale: scale, mask: mask)
+        let halves = MLX.split(out, parts: 2, axis: 1)
+        return halves[0] - halves[1]
+    }
+
+    private func swa(q1: MLXArray, k1: MLXArray, v: MLXArray,
+                      q2: MLXArray, k2: MLXArray, mask: MLXArray?) -> MLXArray {
+        let B = q1.dim(0), H = q1.dim(1), T = q1.dim(2), D = q1.dim(3)
+        let block = SAMELDims.subChunkSize
+        let G = T / block
+        let W = 3 * block
+
+        // Pad along seq dim by `block` on each side. MLXArray.padded uses
+        // `widths` of [(before, after), ...] per axis.
+        let pad: [IntOrPair] = [
+            IntOrPair((0, 0)), IntOrPair((0, 0)),
+            IntOrPair((block, block)), IntOrPair((0, 0)),
+        ]
+        let k1p = MLX.padded(k1, widths: pad)
+        let k2p = MLX.padded(k2, widths: pad)
+        let vp  = MLX.padded(v,  widths: pad)
+
+        let Tp = T + 2 * block
+        let winStrides = [H * Tp * D, Tp * D, block * D, D, 1]
+        let winShape   = [B, H, G, W, D]
+        let k1w = MLX.asStrided(k1p, winShape, strides: winStrides)
+        let k2w = MLX.asStrided(k2p, winShape, strides: winStrides)
+        let vw  = MLX.asStrided(vp,  winShape, strides: winStrides)
+
+        var q1g = q1.reshaped([B, H, G, block, D])
+        var q2g = q2.reshaped([B, H, G, block, D])
+
+        // Boundary mask suppresses zero-padded KV at sequence edges.
+        let gIdx = MLXArray(0..<G).reshaped([G, 1])
+        let wIdx = MLXArray(0..<W).reshaped([1, W])
+        let paddedPos = gIdx * block + wIdx
+        let inRange: MLXArray = (paddedPos .>= MLXArray(block)) * (paddedPos .< MLXArray(T + block))
+        let boundary = MLX.where(
+            inRange,
+            MLXArray(Float(0.0)),
+            MLXArray(Float(-1e9))
+        ).expandedDimensions(axis: 1).asType(q1.dtype)             // [G, 1, W]
+
+        let combinedRaw: MLXArray
+        if let m = mask {
+            combinedRaw = m + boundary   // broadcast [17,51] + [G,1,W] = [G,17,W]
+        } else {
+            combinedRaw = boundary
+        }
+        let combined = MLX.broadcast(combinedRaw.expandedDimensions(axis: 0),
+                                      to: [B, G, block, W])
+                          .reshaped([B * G, 1, block, W])
+
+        q1g = q1g.transposed(0, 2, 1, 3, 4).reshaped([B * G, H, block, D])
+        q2g = q2g.transposed(0, 2, 1, 3, 4).reshaped([B * G, H, block, D])
+        let k1g = k1w.transposed(0, 2, 1, 3, 4).reshaped([B * G, H, W, D])
+        let k2g = k2w.transposed(0, 2, 1, 3, 4).reshaped([B * G, H, W, D])
+        let vg  = vw.transposed(0, 2, 1, 3, 4).reshaped([B * G, H, W, D])
+
+        let Q = MLX.concatenated([q1g, q2g], axis: 1)
+        let K = MLX.concatenated([k1g, k2g], axis: 1)
+        let V = MLX.concatenated([vg, vg], axis: 1)
+        let out = MLXFast.scaledDotProductAttention(queries: Q, keys: K, values: V,
+                                                     scale: scale, mask: combined)
+        let halves = MLX.split(out, parts: 2, axis: 1)
+        let diff = halves[0] - halves[1]
+        return diff.reshaped([B, G, H, block, D])
+                    .transposed(0, 2, 1, 3, 4)
+                    .reshaped([B, H, T, D])
+    }
+}
+
+// MARK: - GeGLU / sin-gated feed-forward
+
+public final class FeedForwardSAML: Module {
+    @ModuleInfo(key: "glu_proj") public var gluProj: Linear
+    @ModuleInfo(key: "proj_out") public var projOut: Linear
+    public let useSin: Bool
+
+    public init(useSin: Bool) {
+        self.useSin = useSin
+        self._gluProj.wrappedValue = Linear(SAMELDims.dim, SAMELDims.ffInner * 2, bias: true)
+        self._projOut.wrappedValue = Linear(SAMELDims.ffInner, SAMELDims.dim, bias: true)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let p = gluProj(x)
+        let parts = MLX.split(p, parts: 2, axis: -1)
+        let value = parts[0], gate = parts[1]
+        let activated: MLXArray
+        if useSin {
+            activated = value * MLX.sin(gate * MLXArray(Float.pi))
+        } else {
+            activated = value * silu(gate)
+        }
+        return projOut(activated)
+    }
+}
+
+public final class TransformerBlockSAML: Module {
+    @ModuleInfo(key: "pre_norm") public var preNorm: DyT
+    @ModuleInfo public var attn: DiffSWA
+    @ModuleInfo(key: "ff_norm") public var ffNorm: DyT
+    @ModuleInfo public var ff: FeedForwardSAML
+
+    public init(blockIdx: Int) {
+        self._preNorm.wrappedValue = DyT(dim: SAMELDims.dim)
+        self._attn.wrappedValue = DiffSWA()
+        self._ffNorm.wrappedValue = DyT(dim: SAMELDims.dim)
+        self._ff.wrappedValue = FeedForwardSAML(useSin: blockIdx >= SAMELDims.sinStartBlock)
+        super.init()
+    }
+
+    public func callAsFunction(_ xIn: MLXArray, mask: MLXArray?, fullAttention: Bool) -> MLXArray {
+        var x = xIn
+        x = x + attn(preNorm(x), mask: mask, fullAttention: fullAttention)
+        x = x + ff(ffNorm(x))
+        return x
+    }
+}
+
+// MARK: - SAME-L decoder
+
+/// 426 M params, FP32. Input [B, 256, T_lat] → output [B, 512, T_lat*16].
+public final class SAMELDecoder: Module {
+    @ParameterInfo(key: "running_std") public var runningStd: MLXArray   // (1,)
+    @ModuleInfo(key: "project_in") public var projectIn: Linear
+    @ParameterInfo(key: "new_tokens") public var newTokens: MLXArray     // (1, 1, dim)
+    @ModuleInfo public var blocks: [TransformerBlockSAML]
+    /// Stored as Linear; the checkpoint Conv1d weight is reshaped (out, in, 1) → (out, in) at load.
+    @ModuleInfo public var mapping: Linear
+
+    private static let swaMaskFP32: MLXArray = sameLSWAMask()
+
+    public override init() {
+        self._runningStd.wrappedValue = MLXArray([Float(1.0)])
+        self._projectIn.wrappedValue = Linear(SAMELDims.latentDim, SAMELDims.dim, bias: true)
+        self._newTokens.wrappedValue = MLXArray.zeros([1, 1, SAMELDims.dim])
+        self._blocks.wrappedValue = (0..<SAMELDims.numBlocks).map { TransformerBlockSAML(blockIdx: $0) }
+        self._mapping.wrappedValue = Linear(SAMELDims.dim, SAMELDims.outChannels, bias: true)
+        super.init()
+    }
+
+    public func callAsFunction(_ latents: MLXArray, fullAttention: Bool = false) -> MLXArray {
+        let B = latents.dim(0)
+        let tLat = latents.dim(2)
+
+        // Softnorm bottleneck decode (scalar) — runningStd is shape [1].
+        var x = latents * runningStd.asType(latents.dtype)
+
+        // [B, 256, T_lat] → [B, T_lat, 256] → [B, T_lat, DIM]
+        x = projectIn(x.transposed(0, 2, 1))
+
+        // Single new_token broadcast to 16 positions per latent slot, with the
+        // original latent at position 0 of each 17-group.
+        let xE = x.expandedDimensions(axis: 2)                                   // [B, T_lat, 1, DIM]
+        let nt = MLX.broadcast(
+            newTokens.expandedDimensions(axis: 0).asType(x.dtype),
+            to: [B, tLat, SAMELDims.sinPerPos, SAMELDims.dim])
+        x = MLX.concatenated([xE, nt], axis: 2)                                  // [B, T_lat, 17, DIM]
+        x = x.reshaped([B, tLat * SAMELDims.subChunkSize, SAMELDims.dim])
+
+        let mask = fullAttention ? nil : Self.swaMaskFP32.asType(x.dtype)
+        for blk in blocks {
+            x = blk(x, mask: mask, fullAttention: fullAttention)
+        }
+
+        // Drop the original latent slot at index 0 of each 17-group; keep 16.
+        x = x.reshaped([B, tLat, SAMELDims.subChunkSize, SAMELDims.dim])
+        x = x[0..., 0..., 1..., 0...]
+        x = x.reshaped([B, tLat * SAMELDims.sinPerPos, SAMELDims.dim])
+
+        // [B, T_lat*16, DIM] → [B, T_lat*16, 512] → [B, 512, T_lat*16]
+        return mapping(x).transposed(0, 2, 1)
+    }
+}
+
+// MARK: - Chunked decode for long sequences
+
+/// Uniform-kernel chunked decode. Mirrors `decode_chunked` in the upstream
+/// Python — no zero-padding, three segments (first/interior/last) each see
+/// `kernel = chunk + 2*overlap` real latents.
+public func sameLDecodeChunked(_ model: SAMELDecoder, latents: MLXArray,
+                                chunkSize: Int, overlap: Int) -> MLXArray {
+    let T = latents.dim(2)
+    let kernel = chunkSize + 2 * overlap
+    if T <= kernel { return model(latents) }
+
+    var pieces: [MLXArray] = []
+
+    // 1) First decode covers output positions [0, chunk + overlap)
+    let firstOut = model(latents[0..., 0..., 0..<kernel])
+    let validFirst = chunkSize + overlap
+    pieces.append(firstOut[0..., 0..., 0..<(validFirst * SAMELDims.sinPerPos)])
+    var i = validFirst
+
+    // 2) Interior: stride by chunk
+    while i + chunkSize + overlap <= T {
+        let lo = i - overlap
+        let hi = i + chunkSize + overlap
+        let out = model(latents[0..., 0..., lo..<hi])
+        let pieceLo = overlap * SAMELDims.sinPerPos
+        let pieceHi = (overlap + chunkSize) * SAMELDims.sinPerPos
+        pieces.append(out[0..., 0..., pieceLo..<pieceHi])
+        i += chunkSize
+    }
+
+    // 3) Last decode covers remaining (T - i) output positions
+    let remaining = T - i
+    if remaining > 0 {
+        let lastOut = model(latents[0..., 0..., (T - kernel)..<T])
+        let tail = remaining * SAMELDims.sinPerPos
+        let total = lastOut.dim(2)
+        pieces.append(lastOut[0..., 0..., (total - tail)..<total])
+    }
+    return MLX.concatenated(pieces, axis: -1)
+}

--- a/Sources/StableAudio3MusicGen/StableAudio3Downloader.swift
+++ b/Sources/StableAudio3MusicGen/StableAudio3Downloader.swift
@@ -1,0 +1,85 @@
+import Foundation
+import AudioCommon
+
+/// Downloads one published SA3 bundle from `aufklarer/Stable-Audio-3-…` and
+/// returns the per-component sub-directories the runtime expects:
+///   bundle/
+///     dit_{medium,sm_music,sm_sfx}/model.safetensors + manifest.json
+///     same_{l,s}_{encoder,decoder}/model.safetensors + manifest.json
+///     t5gemma/model.safetensors + manifest.json
+///     README.md, manifest.json
+public enum StableAudio3Downloader {
+
+    public struct BundlePaths: Sendable {
+        public let root: URL
+        public let dit: URL
+        public let sameEncoder: URL
+        public let sameDecoder: URL
+        public let t5gemma: URL
+    }
+
+    /// Ensure the variant's bundle is fully present in the HF cache, returning
+    /// the resolved per-component directories.
+    ///
+    /// If `localBundleOverride` is provided, the downloader skips HuggingFace
+    /// entirely and uses that directory as the bundle root — used by the
+    /// smoke-test harness to point at a pre-built local bundle without paying
+    /// the ~5 GB download cost.
+    public static func ensureDownloaded(
+        variant: StableAudio3Variant,
+        localBundleOverride: URL? = nil,
+        progressHandler: ((Double) -> Void)? = nil
+    ) async throws -> BundlePaths {
+        let repo = variant.huggingFaceRepoId
+        let root: URL
+        if let override = localBundleOverride {
+            root = override
+        } else {
+            root = try HuggingFaceDownloader.getCacheDirectory(for: repo)
+        }
+
+        let ditDir = SA3Components.dit(for: variant)
+        let encDir = SA3Components.sameEncoder(for: variant)
+        let decDir = SA3Components.sameDecoder(for: variant)
+
+        // Skip download when every component's model.safetensors is already
+        // present locally — handles both pre-warmed caches and the
+        // `localBundleOverride` smoke-test path.
+        let allPresent = [ditDir, encDir, decDir, SA3Components.t5gemma].allSatisfy { sub in
+            let f = root.appendingPathComponent(sub, isDirectory: true)
+                        .appendingPathComponent("model.safetensors")
+            return FileManager.default.fileExists(atPath: f.path)
+        }
+
+        if !allPresent {
+            // upload_folder writes one safetensors per component sub-dir plus a
+            // per-component manifest.json. swift-transformers Hub treats sub-dir
+            // entries as `<dir>/<file>` — listing them explicitly forces fetch.
+            let files: [String] = [
+                "manifest.json", "README.md",
+                "\(ditDir)/model.safetensors", "\(ditDir)/manifest.json",
+                "\(encDir)/model.safetensors", "\(encDir)/manifest.json",
+                "\(decDir)/model.safetensors", "\(decDir)/manifest.json",
+                "\(SA3Components.t5gemma)/model.safetensors",
+                "\(SA3Components.t5gemma)/manifest.json",
+            ]
+            try await HuggingFaceDownloader.downloadWeights(
+                modelId: repo,
+                to: root,
+                additionalFiles: files,
+                offlineMode: false,
+                progressHandler: progressHandler
+            )
+        } else {
+            progressHandler?(1.0)
+        }
+
+        return BundlePaths(
+            root: root,
+            dit: root.appendingPathComponent(ditDir, isDirectory: true),
+            sameEncoder: root.appendingPathComponent(encDir, isDirectory: true),
+            sameDecoder: root.appendingPathComponent(decDir, isDirectory: true),
+            t5gemma: root.appendingPathComponent(SA3Components.t5gemma, isDirectory: true)
+        )
+    }
+}

--- a/Sources/StableAudio3MusicGen/StableAudio3MusicGen.swift
+++ b/Sources/StableAudio3MusicGen/StableAudio3MusicGen.swift
@@ -1,0 +1,199 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+import AudioCommon
+
+// MARK: - Generation parameters
+
+public struct StableAudio3GenerationParams: Sendable {
+    public var seconds: Float
+    public var steps: Int
+    public var cfgScale: Float
+    public var apg: Float
+    public var sigmaMax: Float
+    public var seed: UInt64?
+
+    public init(
+        seconds: Float = 30.0,
+        steps: Int = 8,
+        cfgScale: Float = 1.0,
+        apg: Float = 1.0,
+        sigmaMax: Float = 1.0,
+        seed: UInt64? = nil
+    ) {
+        self.seconds = seconds
+        self.steps = steps
+        self.cfgScale = cfgScale
+        self.apg = apg
+        self.sigmaMax = sigmaMax
+        self.seed = seed
+    }
+}
+
+// MARK: - Main entry point
+
+public final class StableAudio3MusicGen {
+    public let variant: StableAudio3Variant
+    public let t5: T5GemmaText
+    public let dit: DiTMedium                 // medium only in this initial port
+    public let decoder: SAMELDecoder          // SAME-L for medium
+    public let padding: MLXArray              // [768]
+    public let secondsEmbedder: SecondsTotalEmbedder
+
+    private init(variant: StableAudio3Variant,
+                 t5: T5GemmaText, dit: DiTMedium, decoder: SAMELDecoder,
+                 padding: MLXArray, secondsEmbedder: SecondsTotalEmbedder) {
+        self.variant = variant
+        self.t5 = t5
+        self.dit = dit
+        self.decoder = decoder
+        self.padding = padding
+        self.secondsEmbedder = secondsEmbedder
+    }
+
+    // MARK: - Loading
+
+    /// Download and load a published SA3 bundle. The default variant is
+    /// `.mediumInt8` — corresponding to `aufklarer/Stable-Audio-3-DiT-Medium-MLX-8bit`.
+    ///
+    /// Only the Medium DiT family is supported in this initial port. Small DiT
+    /// variants (sm-music, sm-sfx) will throw `.unsupportedFamily`.
+    public static func fromPretrained(
+        variant: StableAudio3Variant = .mediumInt8,
+        tLatHint: Int? = nil,
+        localBundleOverride: URL? = nil,
+        progressHandler: ((Double) -> Void)? = nil
+    ) async throws -> StableAudio3MusicGen {
+        guard variant.family == .medium else {
+            throw StableAudio3Error.unsupportedFamily(
+                "Only the Medium DiT family is wired up in this port — got family=\(variant.family). "
+              + "Use --engine magnet for now if you need the small variant."
+            )
+        }
+        let paths = try await StableAudio3Downloader.ensureDownloaded(
+            variant: variant,
+            localBundleOverride: localBundleOverride,
+            progressHandler: progressHandler)
+
+        let tLat = tLatHint ?? computeTLat(seconds: 30.0)
+        let (ditModel, padding, secsEmb) = try sa3LoadDiTMedium(
+            dir: paths.dit, tLat: tLat, bits: variant.bits)
+        let decoder = try sa3LoadSAMELDecoder(dir: paths.sameDecoder)
+        let t5 = try sa3LoadT5Gemma(dir: paths.t5gemma)
+
+        return StableAudio3MusicGen(
+            variant: variant, t5: t5, dit: ditModel, decoder: decoder,
+            padding: padding, secondsEmbedder: secsEmb)
+    }
+
+    /// Compute the latent timesteps required to render `seconds` of audio.
+    /// `ceil(seconds * 44100 / 4096)`.
+    public static func computeTLat(seconds: Float) -> Int {
+        let samples = seconds * Float(SA3Audio.sampleRate)
+        return max(1, Int((samples / Float(SA3Audio.samplesPerLatent)).rounded(.up)))
+    }
+
+    // MARK: - Generation
+
+    /// Generate a stereo waveform from a text prompt. Returns interleaved
+    /// stereo Float32 PCM at 44.1 kHz with exactly `floor(seconds * 44100)`
+    /// frames per channel.
+    public func generate(
+        prompt: String,
+        params: StableAudio3GenerationParams = StableAudio3GenerationParams()
+    ) -> (left: [Float], right: [Float]) {
+        if let seed = params.seed { MLXRandom.seed(seed) }
+        let dtype: DType = .float16
+
+        // 1) Text encoding
+        let (embeds, mask) = t5.encode(prompt)
+        let embedsF16 = embeds.asType(dtype)
+        let embedsPadded = applyPromptPadding(
+            embeds: embedsF16,
+            mask: mask,
+            paddingEmbedding: padding.asType(dtype))
+        let secondsEmbed = secondsEmbedder(params.seconds).asType(dtype)   // [1,1,768]
+        let crossAttn = MLX.concatenated([embedsPadded, secondsEmbed], axis: 1)  // [1,257,768]
+        let globalCond = secondsEmbed[0..., 0, 0...]                              // [1,768]
+        eval(crossAttn, globalCond)
+
+        let nullCrossAttn: MLXArray? = params.cfgScale == 1.0
+            ? nil
+            : MLXArray.zeros(crossAttn.shape, dtype: dtype)
+
+        // 2) Initial latent
+        let tLat = Self.computeTLat(seconds: params.seconds)
+        let noise = MLXRandom.normal([1, DiTMediumDims.ioChannels, tLat], dtype: dtype)
+        eval(noise)
+
+        // 3) DiT sampling (rectified-flow pingpong)
+        let sigmas = buildPingPongSchedule(steps: params.steps, sigmaMax: params.sigmaMax,
+                                             useLogSNRShift: true)
+        let cfg = params.cfgScale
+        let apg = params.apg
+        let modelFn: (MLXArray, MLXArray) -> MLXArray = { [unowned self] x, t in
+            if cfg == 1.0 {
+                return self.dit(x, t: t, crossAttnCondRaw: crossAttn, globalCondRaw: globalCond,
+                                 localAddCond: nil)
+            }
+            // Batched CFG: cat([x, x]) on the batch dim.
+            let x2 = MLX.concatenated([x, x], axis: 0)
+            let t2 = MLX.concatenated([t, t], axis: 0)
+            let cross2 = MLX.concatenated([crossAttn, nullCrossAttn!], axis: 0)
+            let global2 = MLX.concatenated([globalCond, globalCond], axis: 0)
+            let vBatched = self.dit(x2, t: t2, crossAttnCondRaw: cross2, globalCondRaw: global2,
+                                     localAddCond: nil)
+            let halves = MLX.split(vBatched, parts: 2, axis: 0)
+            let condV = halves[0], uncondV = halves[1]
+            let sigma = t.reshaped([-1, 1, 1]).asType(.float32)
+            let condD   = x.asType(.float32) - condV.asType(.float32)   * sigma
+            let uncondD = x.asType(.float32) - uncondV.asType(.float32) * sigma
+            let diff = condD - uncondD
+
+            let cfgDiff: MLXArray
+            if apg <= 0.0 {
+                cfgDiff = diff
+            } else {
+                let norm = MLX.sqrt((condD * condD).sum(axes: [-2, -1], keepDims: true))
+                let unit = condD / MLX.maximum(norm, MLXArray(Float(1e-8)))
+                let parallel = (diff * unit).sum(axes: [-2, -1], keepDims: true) * unit
+                let diffOrth = diff - parallel
+                if apg >= 1.0 {
+                    cfgDiff = diffOrth
+                } else {
+                    cfgDiff = MLXArray(apg) * diffOrth + MLXArray(1.0 - apg) * diff
+                }
+            }
+            let cfgD = condD + MLXArray(cfg - 1.0) * cfgDiff
+            let cfgV = (x.asType(.float32) - cfgD) / sigma
+            return cfgV.asType(x.dtype)
+        }
+
+        let seed = params.seed ?? UInt64.random(in: 0..<UInt64(UInt32.max))
+        let latents = sampleFlowPingPong(modelFn: modelFn, initial: noise, sigmas: sigmas,
+                                          seed: seed &+ 1, onStep: nil)
+        eval(latents)
+
+        // 4) Decode latents → audio patches
+        let latentsFP32 = latents.asType(.float32)
+        let kernel = 128 + 2 * 8   // chunked decode defaults from upstream
+        let patches: MLXArray
+        if tLat > kernel {
+            patches = sameLDecodeChunked(decoder, latents: latentsFP32, chunkSize: 128, overlap: 8)
+        } else {
+            patches = decoder(latentsFP32)
+        }
+        eval(patches)
+
+        // 5) Unpatch → audio + crop to requested length
+        let audio = patchedDecode(patches, patchSize: SA3Audio.patchSize, channels: SA3Audio.channels)
+        let audioF32 = audio.asType(.float32)
+        eval(audioF32)
+        let requestedSamples = Int((params.seconds * Float(SA3Audio.sampleRate)).rounded(.down))
+        let trimmed = audioF32[0..., 0..., 0..<min(audioF32.dim(2), requestedSamples)]
+        let left = trimmed[0, 0, 0...]
+        let right = trimmed[0, 1, 0...]
+        return (left: left.asArray(Float.self), right: right.asArray(Float.self))
+    }
+}

--- a/Sources/StableAudio3MusicGen/StableAudio3WeightLoading.swift
+++ b/Sources/StableAudio3MusicGen/StableAudio3WeightLoading.swift
@@ -1,0 +1,180 @@
+import Foundation
+import MLX
+import MLXNN
+import AudioCommon
+
+/// Errors raised by the SA3 weight loader.
+public enum StableAudio3Error: Error, LocalizedError {
+    case missingFile(String)
+    case missingTensor(String)
+    case weightLoadFailed(String)
+    case tokenizerLoadFailed(String)
+    case unsupportedFamily(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingFile(let f): return "Stable Audio 3: missing file \(f)"
+        case .missingTensor(let k): return "Stable Audio 3: missing tensor \(k)"
+        case .weightLoadFailed(let m): return "Stable Audio 3: weight load failed: \(m)"
+        case .tokenizerLoadFailed(let m): return "Stable Audio 3: tokenizer load failed: \(m)"
+        case .unsupportedFamily(let m): return "Stable Audio 3: unsupported family: \(m)"
+        }
+    }
+}
+
+/// Internal: read one `model.safetensors` into a `[String: MLXArray]`.
+func sa3LoadBundleComponent(_ dir: URL) throws -> [String: MLXArray] {
+    let url = dir.appendingPathComponent("model.safetensors")
+    guard FileManager.default.fileExists(atPath: url.path) else {
+        throw StableAudio3Error.missingFile(url.path)
+    }
+    do {
+        return try MLX.loadArrays(url: url)
+    } catch {
+        throw StableAudio3Error.weightLoadFailed("\(url.lastPathComponent): \(error)")
+    }
+}
+
+/// Apply a flat `[String: MLXArray]` to an MLX module, verifying every
+/// parameter shape matches. Mirrors VoxCPM2 / MAGNeT pattern.
+func sa3ApplyFlatWeights(into module: Module, mapping: [String: MLXArray]) throws {
+    let params = ModuleParameters.unflattened(mapping)
+    try module.update(parameters: params, verify: .shapeMismatch)
+}
+
+/// Rewrite checkpoint keys for the DiT (medium) so that the numeric-string
+/// indices `.0.` / `.2.` (which MLX-Swift would deserialize as a 3-element
+/// list with a `none` at index 1) become named children `.inProj.` / `.outProj.`
+/// for the conditioner MLPs and `.glu.` / `.out.` for the GeGLU feed-forward.
+/// This lets `update(parameters:)` consume a `Module` with named ModuleInfo
+/// children instead of a `[Module?]` array.
+func sa3RewriteDiTMediumKeys(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+    let twoLinearOwners: [String] = [
+        "to_cond_embed", "to_global_embed", "to_timestep_embed",
+        "transformer.global_cond_embedder",
+        // per-layer paths handled below
+    ]
+    func rewrite(_ k: String) -> String {
+        var out = k
+        for owner in twoLinearOwners {
+            if out.hasPrefix(owner + ".0.") {
+                out = owner + ".inProj." + out.dropFirst((owner + ".0.").count)
+            } else if out.hasPrefix(owner + ".2.") {
+                out = owner + ".outProj." + out.dropFirst((owner + ".2.").count)
+            }
+        }
+        // Per-layer keys: transformer.layers.N.{ff.ff,to_local_embed.seq}.{0,2}.*
+        if let layerStart = out.range(of: "transformer.layers.") {
+            let tail = out[layerStart.upperBound...]
+            if let dotIdx = tail.firstIndex(of: ".") {
+                let n = String(tail[..<dotIdx])
+                let body = String(tail[tail.index(after: dotIdx)...])
+                let base = "transformer.layers.\(n)."
+                func mapList(_ owner: String, _ a: String, _ b: String) -> String? {
+                    if body.hasPrefix(owner + ".0.") {
+                        return base + owner + "." + a + "." + String(body.dropFirst((owner + ".0.").count))
+                    }
+                    if body.hasPrefix(owner + ".2.") {
+                        return base + owner + "." + b + "." + String(body.dropFirst((owner + ".2.").count))
+                    }
+                    return nil
+                }
+                if let rewritten = mapList("to_local_embed.seq", "inProj", "outProj") {
+                    out = rewritten
+                } else if let rewritten = mapList("ff.ff", "glu", "out") {
+                    out = rewritten
+                }
+            }
+        }
+        return out
+    }
+    var renamed: [String: MLXArray] = [:]
+    for (k, v) in weights {
+        renamed[rewrite(k)] = v
+    }
+    return renamed
+}
+
+/// Strip a prefix from a weight dict's keys, returning only the matching subset.
+func sa3StripPrefix(_ weights: [String: MLXArray], prefix: String) -> [String: MLXArray] {
+    var out: [String: MLXArray] = [:]
+    let pfx = prefix.hasSuffix(".") ? prefix : prefix + "."
+    for (k, v) in weights {
+        if k.hasPrefix(pfx) {
+            out[String(k.dropFirst(pfx.count))] = v
+        }
+    }
+    return out
+}
+
+/// Load + finalize the DiT (medium INT8/INT4). Returns `(model, conditioner)`
+/// where the conditioner is the SecondsTotalEmbedder + learned padding
+/// embedding bundled into the DiT safetensors under the `cond.` prefix.
+func sa3LoadDiTMedium(dir: URL, tLat: Int, bits: Int) throws
+    -> (model: DiTMedium, padding: MLXArray, secondsEmbedder: SecondsTotalEmbedder) {
+    var raw = try sa3LoadBundleComponent(dir)
+
+    // Extract the conditioner triplet before we hand the rest to load.
+    let padKey = "cond.padding_embedding"
+    let secsWKey = "cond.seconds_total_weight"
+    let secsBKey = "cond.seconds_total_bias"
+    guard let padding = raw.removeValue(forKey: padKey) else {
+        throw StableAudio3Error.missingTensor(padKey)
+    }
+    guard let secsW = raw.removeValue(forKey: secsWKey) else {
+        throw StableAudio3Error.missingTensor(secsWKey)
+    }
+    guard let secsB = raw.removeValue(forKey: secsBKey) else {
+        throw StableAudio3Error.missingTensor(secsBKey)
+    }
+    let secondsEmbedder = SecondsTotalEmbedder(
+        weight: secsW.asType(.float32), bias: secsB.asType(.float32))
+
+    let model = DiTMedium(tLat: tLat, bits: bits)
+    let rewritten = sa3RewriteDiTMediumKeys(raw)
+    try sa3ApplyFlatWeights(into: model, mapping: rewritten)
+    eval(model.parameters())
+    return (model, padding.asType(.float32), secondsEmbedder)
+}
+
+/// Load SAME-L decoder. Reshapes the `mapping.weight` from PyTorch Conv1d
+/// `(out, in, 1)` to Linear `(out, in)` if present in 3-D form.
+func sa3LoadSAMELDecoder(dir: URL) throws -> SAMELDecoder {
+    var raw = try sa3LoadBundleComponent(dir)
+    if let w = raw["mapping.weight"], w.ndim == 3 && w.dim(2) == 1 {
+        raw["mapping.weight"] = w.reshaped([w.dim(0), w.dim(1)])
+    }
+    let model = SAMELDecoder()
+    try sa3ApplyFlatWeights(into: model, mapping: raw)
+    eval(model.parameters())
+    return model
+}
+
+/// Load the T5Gemma encoder + bundled SentencePiece tokenizer.
+func sa3LoadT5Gemma(dir: URL) throws -> T5GemmaText {
+    var raw = try sa3LoadBundleComponent(dir)
+
+    // Tokenizer model bytes are baked into the safetensors under "TOKENIZER_MODEL"
+    // as a uint8 byte array. META holds the JSON config (we ignore it since we
+    // hard-code the dims; the bundle has fixed dims).
+    guard let tokBlobArr = raw.removeValue(forKey: "TOKENIZER_MODEL") else {
+        throw StableAudio3Error.missingTensor("TOKENIZER_MODEL")
+    }
+    _ = raw.removeValue(forKey: "META")
+    _ = raw.removeValue(forKey: "rope_inv_freq")  // we compute RoPE on the fly
+
+    // tokBlobArr is uint8 (N,). Parse SentencePiece proto then wrap in Unigram.
+    let tokenizer: UnigramTokenizer
+    do {
+        let bytes = tokBlobArr.asType(.uint8).asArray(UInt8.self)
+        let spModel = try SentencePieceModel(data: Data(bytes))
+        tokenizer = UnigramTokenizer(model: spModel)
+    } catch {
+        throw StableAudio3Error.tokenizerLoadFailed("\(error)")
+    }
+
+    let model = T5GemmaEncoderModel()
+    try sa3ApplyFlatWeights(into: model, mapping: raw)
+    eval(model.parameters())
+    return T5GemmaText(encoder: model, tokenizer: tokenizer)
+}

--- a/Sources/StableAudio3MusicGen/T5GemmaEncoder.swift
+++ b/Sources/StableAudio3MusicGen/T5GemmaEncoder.swift
@@ -1,0 +1,252 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXFast
+import AudioCommon
+
+/// Gemma-2-style RMSNorm: normalize in fp32, scale by (1 + weight), cast back.
+/// Stored as a raw parameter (no MLXNN.Module) — matches the npz layout where
+/// `(pre|post)_(self_attn|feedforward)_layernorm` are weight-only with no
+/// surrounding module path.
+@inline(__always)
+private func gemmaRMSNorm(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
+    let dtype = x.dtype
+    let x32 = x.asType(.float32)
+    let varX = (x32 * x32).mean(axis: -1, keepDims: true)
+    let n = x32 * MLX.rsqrt(varX + MLXArray(eps))
+    let scaled = n * (MLXArray(Float(1.0)) + weight.asType(.float32))
+    return scaled.asType(dtype)
+}
+
+/// Gemma RMSNorm wrapped as a Module so the checkpoint's `name.weight` key
+/// loads through the standard `update(parameters:)` path. Behaviour is
+/// `gamma * tanh-free RMSNorm(1 + weight)`.
+public final class GemmaNorm: Module {
+    @ParameterInfo public var weight: MLXArray
+    public let eps: Float
+    public init(dim: Int, eps: Float = T5GemmaDims.rmsNormEps) {
+        self._weight.wrappedValue = MLXArray.zeros([dim])
+        self.eps = eps
+        super.init()
+    }
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        gemmaRMSNorm(x, weight: weight, eps: eps)
+    }
+}
+
+@inline(__always)
+private func ropeCosSin(seqLen: Int, headDim: Int, theta: Float) -> (cos: MLXArray, sin: MLXArray) {
+    let half = headDim / 2
+    let dimIdx = MLXArray(stride(from: 0, to: headDim, by: 2).map { Float($0) })
+    let invFreq = MLXArray(Float(1.0)) / MLX.pow(MLXArray(theta), dimIdx / Float(headDim))
+    let pos = MLXArray(0..<seqLen).asType(.float32)
+    let freqs = pos.reshaped([seqLen, 1]) * invFreq.reshaped([1, half])
+    let emb = MLX.concatenated([freqs, freqs], axis: -1)         // half-half layout
+    return (MLX.cos(emb), MLX.sin(emb))
+}
+
+@inline(__always)
+private func rotateHalf(_ x: MLXArray) -> MLXArray {
+    let half = x.dim(-1) / 2
+    let lower = x[.ellipsis, 0..<half]
+    let upper = x[.ellipsis, half..<(2 * half)]
+    return MLX.concatenated([-upper, lower], axis: -1)
+}
+
+@inline(__always)
+private func applyRope(_ q: MLXArray, _ k: MLXArray, cos: MLXArray, sin: MLXArray) -> (MLXArray, MLXArray) {
+    let cosE = cos.expandedDimensions(axis: 0).expandedDimensions(axis: 0)  // [1,1,S,D]
+    let sinE = sin.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+    let qOut = (q * cosE.asType(q.dtype)) + (rotateHalf(q) * sinE.asType(q.dtype))
+    let kOut = (k * cosE.asType(k.dtype)) + (rotateHalf(k) * sinE.asType(k.dtype))
+    return (qOut, kOut)
+}
+
+// MARK: - T5Gemma encoder layer
+
+public final class T5GemmaSelfAttention: Module {
+    @ModuleInfo(key: "q_proj") public var qProj: Linear
+    @ModuleInfo(key: "k_proj") public var kProj: Linear
+    @ModuleInfo(key: "v_proj") public var vProj: Linear
+    @ModuleInfo(key: "o_proj") public var oProj: Linear
+
+    public let numHeads: Int
+    public let headDim: Int
+    public let scaling: Float
+    public let softcap: Float
+
+    public override init() {
+        let H = T5GemmaDims.numAttentionHeads
+        let D = T5GemmaDims.headDim
+        let HS = T5GemmaDims.hiddenSize
+        self.numHeads = H
+        self.headDim = D
+        self.scaling = 1.0 / Float(T5GemmaDims.queryPreAttnScalar).squareRoot()
+        self.softcap = T5GemmaDims.attnLogitSoftcapping
+
+        self._qProj.wrappedValue = Linear(HS, H * D, bias: false)
+        self._kProj.wrappedValue = Linear(HS, T5GemmaDims.numKeyValueHeads * D, bias: false)
+        self._vProj.wrappedValue = Linear(HS, T5GemmaDims.numKeyValueHeads * D, bias: false)
+        self._oProj.wrappedValue = Linear(H * D, HS, bias: false)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, cos: MLXArray, sin: MLXArray, addMask: MLXArray?) -> MLXArray {
+        let B = x.dim(0), S = x.dim(1)
+        let H = numHeads, D = headDim
+        var q = qProj(x).reshaped([B, S, H, D]).transposed(0, 2, 1, 3)
+        var k = kProj(x).reshaped([B, S, H, D]).transposed(0, 2, 1, 3)
+        let v = vProj(x).reshaped([B, S, H, D]).transposed(0, 2, 1, 3)
+        (q, k) = applyRope(q, k, cos: cos, sin: sin)
+
+        // Manual softcapped attention (MLXFast.scaledDotProductAttention has
+        // no softcap arg). [B, H, S, D] · [B, H, D, S] = [B, H, S, S].
+        var qk = MLX.matmul(q, k.transposed(0, 1, 3, 2)) * MLXArray(scaling)
+        qk = MLX.tanh(qk / MLXArray(softcap)) * MLXArray(softcap)
+        if let m = addMask {
+            qk = qk + m
+        }
+        let p = MLX.softmax(qk.asType(.float32), axis: -1).asType(v.dtype)
+        let out = MLX.matmul(p, v).transposed(0, 2, 1, 3).reshaped([B, S, H * D])
+        return oProj(out)
+    }
+}
+
+public final class T5GemmaMLP: Module {
+    @ModuleInfo(key: "gate_proj") public var gateProj: Linear
+    @ModuleInfo(key: "up_proj") public var upProj: Linear
+    @ModuleInfo(key: "down_proj") public var downProj: Linear
+
+    public override init() {
+        let HS = T5GemmaDims.hiddenSize
+        let IS = T5GemmaDims.intermediateSize
+        self._gateProj.wrappedValue = Linear(HS, IS, bias: false)
+        self._upProj.wrappedValue = Linear(HS, IS, bias: false)
+        self._downProj.wrappedValue = Linear(IS, HS, bias: false)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(geluApproximate(gateProj(x)) * upProj(x))
+    }
+}
+
+public final class T5GemmaEncoderLayer: Module {
+    @ModuleInfo(key: "self_attn") public var selfAttn: T5GemmaSelfAttention
+    @ModuleInfo public var mlp: T5GemmaMLP
+
+    // RMSNorm sub-modules — each loads `name.weight` directly via GemmaNorm.
+    @ModuleInfo(key: "pre_self_attn_layernorm")  public var preSelfAttnLN: GemmaNorm
+    @ModuleInfo(key: "post_self_attn_layernorm") public var postSelfAttnLN: GemmaNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm")  public var preFFLN: GemmaNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") public var postFFLN: GemmaNorm
+
+    public override init() {
+        let HS = T5GemmaDims.hiddenSize
+        self._selfAttn.wrappedValue = T5GemmaSelfAttention()
+        self._mlp.wrappedValue = T5GemmaMLP()
+        self._preSelfAttnLN.wrappedValue = GemmaNorm(dim: HS)
+        self._postSelfAttnLN.wrappedValue = GemmaNorm(dim: HS)
+        self._preFFLN.wrappedValue = GemmaNorm(dim: HS)
+        self._postFFLN.wrappedValue = GemmaNorm(dim: HS)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, cos: MLXArray, sin: MLXArray, addMask: MLXArray?) -> MLXArray {
+        var h = preSelfAttnLN(x)
+        h = selfAttn(h, cos: cos, sin: sin, addMask: addMask)
+        h = postSelfAttnLN(h)
+        var y = x + h
+        h = preFFLN(y)
+        h = mlp(h)
+        h = postFFLN(h)
+        y = y + h
+        return y
+    }
+}
+
+public final class T5GemmaEncoderModel: Module {
+    @ModuleInfo(key: "embed_tokens") public var embedTokens: Embedding
+    @ModuleInfo public var layers: [T5GemmaEncoderLayer]
+    @ModuleInfo public var norm: GemmaNorm
+
+    private let normalizer: Float
+
+    public override init() {
+        let HS = T5GemmaDims.hiddenSize
+        self._embedTokens.wrappedValue = Embedding(embeddingCount: T5GemmaDims.vocabSize, dimensions: HS)
+        self._layers.wrappedValue = (0..<T5GemmaDims.numLayers).map { _ in T5GemmaEncoderLayer() }
+        self._norm.wrappedValue = GemmaNorm(dim: HS)
+        self.normalizer = Float(HS).squareRoot()
+        super.init()
+    }
+
+    /// `inputIds`  : [B, S] int32. `attentionMask` : [B, S] int32 (1=real, 0=pad).
+    /// Returns `(hiddenStates [B, S, 768], same attention mask)` matching the
+    /// upstream Python signature.
+    public func callAsFunction(_ inputIds: MLXArray, attentionMask: MLXArray?) -> MLXArray {
+        var x = embedTokens(inputIds).asType(.float16)
+        x = x * MLXArray(normalizer).asType(.float16)
+        let (cos, sin) = ropeCosSin(seqLen: x.dim(1), headDim: T5GemmaDims.headDim,
+                                     theta: T5GemmaDims.ropeTheta)
+
+        var addMask: MLXArray? = nil
+        if let m = attentionMask {
+            let keep = m.asType(.float32)
+            let negInf = (MLXArray(Float(1.0)) - keep) * MLXArray(Float(-1e9))
+            // [B, S] → [B, 1, 1, S]
+            addMask = negInf.expandedDimensions(axis: 1).expandedDimensions(axis: 1).asType(x.dtype)
+        }
+        for layer in layers {
+            x = layer(x, cos: cos, sin: sin, addMask: addMask)
+        }
+        return norm(x)
+    }
+}
+
+// MARK: - Public T5Gemma wrapper
+
+/// High-level wrapper: tokenize raw strings → MLX embeddings.
+public final class T5GemmaText {
+    public let encoder: T5GemmaEncoderModel
+    public let tokenizer: UnigramTokenizer
+
+    public init(encoder: T5GemmaEncoderModel, tokenizer: UnigramTokenizer) {
+        self.encoder = encoder
+        self.tokenizer = tokenizer
+    }
+
+    /// Tokenize a single prompt to (input_ids, attention_mask), padded/truncated
+    /// to `maxLen`. Padding token id = 0.
+    public func tokenize(_ prompt: String, maxLen: Int = 256) -> (ids: MLXArray, mask: MLXArray) {
+        let raw = tokenizer.encodeAsIds(prompt)
+        let toks = raw.prefix(maxLen).map { Int32($0) }
+        var ids = [Int32](repeating: T5GemmaDims.padTokenId, count: maxLen)
+        var mask = [Int32](repeating: 0, count: maxLen)
+        for (i, t) in toks.enumerated() {
+            ids[i] = t
+            mask[i] = 1
+        }
+        return (MLXArray(ids, [1, maxLen]), MLXArray(mask, [1, maxLen]))
+    }
+
+    /// Encode one prompt and return (last_hidden_state [1, maxLen, 768] fp16,
+    /// attention_mask [1, maxLen] int32). An all-pad row gets a single
+    /// visible position before the forward pass to avoid an all-(-inf) row
+    /// in the softmax; the returned mask still reads pad=0 everywhere so the
+    /// caller's prompt-padding replacement works untouched.
+    public func encode(_ prompt: String, maxLen: Int = 256) -> (embeds: MLXArray, mask: MLXArray) {
+        let (ids, mask) = tokenize(prompt, maxLen: maxLen)
+        let sum = mask.sum().item(Int32.self)
+        let attn: MLXArray
+        if sum == 0 {
+            var fixed = [Int32](repeating: 0, count: maxLen)
+            fixed[0] = 1
+            attn = MLXArray(fixed, [1, maxLen])
+        } else {
+            attn = mask
+        }
+        let out = encoder(ids, attentionMask: attn)
+        return (out, mask)
+    }
+}

--- a/Sources/StableAudio3MusicGen/UnigramTokenizer.swift
+++ b/Sources/StableAudio3MusicGen/UnigramTokenizer.swift
@@ -1,0 +1,90 @@
+import Foundation
+import AudioCommon
+
+/// Minimal Unigram (SentencePiece) Viterbi tokenizer.
+///
+/// Operates over the piece array exposed by `AudioCommon.SentencePieceModel`.
+/// Supports the subset of SP behaviour SA3 / T5Gemma needs:
+///   * "▁"-prefixing: spaces become U+2581, an additional U+2581 is prepended.
+///   * Forward-DP best-segmentation over UTF-8 byte positions of the input.
+///   * Unknown pieces are emitted as `unkId` (T5Gemma SP model: id = 3).
+///   * No byte-fallback (T5Gemma uses sufficient regular pieces for English).
+///
+/// This is enough for SA3 text prompts. It is not a general-purpose SP encoder.
+public final class UnigramTokenizer: @unchecked Sendable {
+    public let model: SentencePieceModel
+    public let pieceToId: [String: Int]
+    public let unkId: Int
+
+    public init(model: SentencePieceModel, unkId: Int = 3) {
+        self.model = model
+        var map = [String: Int](minimumCapacity: model.pieces.count)
+        for (i, p) in model.pieces.enumerated() {
+            map[p.text] = i
+        }
+        self.pieceToId = map
+        self.unkId = unkId
+    }
+
+    /// Encode a string to a sequence of piece ids.
+    ///
+    /// T5Gemma's `.model` is **BPE**, not Unigram — the per-piece "score" is
+    /// a merge rank stored as a negative integer. Higher-priority merges
+    /// have the **least-negative** (closest to zero) score and are applied
+    /// first. The algorithm here:
+    ///   1. Split the input on ASCII spaces. Each word but the first gets a
+    ///      leading `▁` (U+2581) so that "house" inside a sentence resolves
+    ///      to `▁house`.
+    ///   2. Each word starts as a list of single Unicode-scalar pieces.
+    ///   3. Repeatedly find the adjacent pair that, when concatenated, is in
+    ///      the vocab with the most-negative score, and apply the merge.
+    ///   4. Stop when no adjacent pair is in the vocab.
+    public func encodeAsIds(_ text: String) -> [Int] {
+        if text.isEmpty { return [] }
+        var ids: [Int] = []
+        let words = text.split(separator: " ", omittingEmptySubsequences: false)
+        for (idx, w) in words.enumerated() {
+            let segment = idx == 0 ? String(w) : "▁" + String(w)
+            if segment.isEmpty { continue }
+            bpeMergeAppend(&ids, segment: segment)
+        }
+        return ids
+    }
+
+    private func bpeMergeAppend(_ ids: inout [Int], segment: String) {
+        // Start as a list of single-grapheme pieces.
+        var pieces = segment.map { String($0) }
+        if pieces.isEmpty { return }
+
+        while pieces.count >= 2 {
+            // Find the adjacent pair with the highest priority — least-negative
+            // (closest to zero) score wins.
+            var bestIdx = -1
+            var bestScore = -Float.infinity
+            for i in 0..<(pieces.count - 1) {
+                let merged = pieces[i] + pieces[i + 1]
+                guard let pid = pieceToId[merged] else { continue }
+                let s = model.pieces[pid].score
+                if s > bestScore {
+                    bestScore = s
+                    bestIdx = i
+                }
+            }
+            if bestIdx < 0 { break }   // no more merges possible
+            let merged = pieces[bestIdx] + pieces[bestIdx + 1]
+            pieces.replaceSubrange(bestIdx...(bestIdx + 1), with: [merged])
+        }
+
+        for p in pieces {
+            if let id = pieceToId[p] {
+                ids.append(id)
+            } else {
+                ids.append(unkId)
+            }
+        }
+    }
+}
+
+/// Upper bound on a single piece's UTF-8 length. T5Gemma's longest pieces are
+/// around 24 bytes (multi-codepoint Asian-script words); 32 is comfortably safe.
+private let MaxPieceUTF8Length = 32

--- a/Tests/StableAudio3MusicGenTests/ConfigurationTests.swift
+++ b/Tests/StableAudio3MusicGenTests/ConfigurationTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import StableAudio3MusicGen
+
+final class ConfigurationTests: XCTestCase {
+    func testVariantRepoIds() {
+        XCTAssertEqual(StableAudio3Variant.mediumInt8.huggingFaceRepoId,
+                       "aufklarer/Stable-Audio-3-DiT-Medium-MLX-8bit")
+        XCTAssertEqual(StableAudio3Variant.smallMusicInt4.huggingFaceRepoId,
+                       "aufklarer/Stable-Audio-3-DiT-Small-Music-MLX-4bit")
+    }
+
+    func testVariantBits() {
+        for v in StableAudio3Variant.allCases {
+            XCTAssertTrue(v.bits == 4 || v.bits == 8)
+        }
+        XCTAssertEqual(StableAudio3Variant.mediumInt8.bits, 8)
+        XCTAssertEqual(StableAudio3Variant.mediumInt4.bits, 4)
+    }
+
+    func testVariantFamily() {
+        XCTAssertEqual(StableAudio3Variant.mediumInt8.family, .medium)
+        XCTAssertEqual(StableAudio3Variant.smallMusicInt4.family, .smallMusic)
+        XCTAssertEqual(StableAudio3Variant.smallSFXInt8.family, .smallSFX)
+    }
+
+    func testComponentRouting() {
+        XCTAssertEqual(SA3Components.dit(for: .mediumInt8), SA3Components.ditMedium)
+        XCTAssertEqual(SA3Components.dit(for: .smallMusicInt8), SA3Components.ditSmallMusic)
+        XCTAssertEqual(SA3Components.dit(for: .smallSFXInt8), SA3Components.ditSmallSFX)
+        XCTAssertEqual(SA3Components.sameEncoder(for: .mediumInt8), SA3Components.sameLEncoder)
+        XCTAssertEqual(SA3Components.sameDecoder(for: .smallMusicInt8), SA3Components.sameSDecoder)
+    }
+
+    func testComputeTLat() {
+        // 30s at 44100/4096 = ~323 latents
+        XCTAssertEqual(StableAudio3MusicGen.computeTLat(seconds: 30.0), 323)
+        XCTAssertEqual(StableAudio3MusicGen.computeTLat(seconds: 1.0), 11)
+        XCTAssertGreaterThan(StableAudio3MusicGen.computeTLat(seconds: 0.001), 0)
+    }
+}

--- a/Tests/StableAudio3MusicGenTests/E2EGenerationTests.swift
+++ b/Tests/StableAudio3MusicGenTests/E2EGenerationTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import MLX
+@testable import StableAudio3MusicGen
+
+/// End-to-end generation test for `aufklarer/Stable-Audio-3-DiT-Medium-MLX-8bit`.
+/// Downloads the bundle on first run (~5 GB) so it is gated behind the `E2E`
+/// prefix that CI's `make test` `--skip E2E` filter excludes.
+final class E2EGenerationTests: XCTestCase {
+
+    func testGenerateMediumInt8ShortClip() async throws {
+        let model = try await StableAudio3MusicGen.fromPretrained(
+            variant: .mediumInt8,
+            tLatHint: StableAudio3MusicGen.computeTLat(seconds: 2.0))
+
+        let (left, right) = model.generate(
+            prompt: "lofi house loop",
+            params: StableAudio3GenerationParams(
+                seconds: 2.0, steps: 4, cfgScale: 1.0,
+                sigmaMax: 1.0, seed: 42))
+
+        XCTAssertEqual(left.count, 2 * SA3Audio.sampleRate,
+                       "Expected exactly 2 s × 44.1 kHz frames per channel")
+        XCTAssertEqual(left.count, right.count, "Stereo channel lengths must match")
+
+        // Audio must be finite (no NaN/Inf) and non-silent.
+        XCTAssertTrue(left.allSatisfy { $0.isFinite }, "left channel has non-finite samples")
+        XCTAssertTrue(right.allSatisfy { $0.isFinite }, "right channel has non-finite samples")
+        let leftPeak = left.map(abs).max() ?? 0
+        let rightPeak = right.map(abs).max() ?? 0
+        XCTAssertGreaterThan(leftPeak, 0.001, "left channel is silent (peak=\(leftPeak))")
+        XCTAssertGreaterThan(rightPeak, 0.001, "right channel is silent (peak=\(rightPeak))")
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Stable Audio 3 Medium-INT8** as a new music-generation engine and makes it the default for `speech compose`. MAGNeT stays available as `--engine magnet`.

Bit-perfect parity with Stability AI's pure-MLX Python reference at every stage.

| Stage | Cosine vs Python | Verdict |
|---|---|---|
| BPE tokenizer | 4/4 ids identical | ✓ |
| T5Gemma encoder | 1.00000 | ✓ |
| SecondsTotalEmbedder | 1.00000 | ✓ |
| DiT-Medium velocity (1 step) | 1.00000 | ✓ |
| SAME-L decoder | 1.00000 | ✓ |

Validated via the new `speech sa3-parity` dev subcommand against a reference dump produced by speech-models' `scripts/dump_parity_ref.py`.

## Performance

10 s clip generated in **0.6 s wall (~16× realtime)** on M-class chip, stereo 44.1 kHz, peak RAM ~4 GB during DiT sampling.

## CLI

```bash
speech compose "lofi house loop"                              # SA3 by default
speech compose "ambient pad" --engine magnet                  # old default kept
speech compose "..." --sa3-variant medium-int4 --seconds 30   # variant + length
speech sa3-parity --ref dump.safetensors --bundle <dir>       # dev diagnostic
```

## Architecture port

| Module | Equivalent in Stability Python ref | LOC |
|---|---|---|
| `T5GemmaEncoder.swift` | `t5gemma_mlx.py` (Gemma-2 RMSNorm + RoPE + softcap + GeGLU) | 252 |
| `DiTMedium.swift` | `dit_mlx_medium.py` (5-way differential attn, AdaLN-Single, memory tokens) | 385 |
| `SAMELDecoder.swift` | `same_l_decoder.py` (DyT norm, differential SWA via `asStrided`, sin-gate FF) | 324 |
| `UnigramTokenizer.swift` | SentencePiece BPE encode (merge rank from piece score) | 90 |
| `FlowMatchingSampler.swift` | `sa3_pipeline.py` LogSNR + pingpong sampler | 78 |
| `Conditioner.swift` | `SecondsTotalEmbedder` + `apply_prompt_padding` | 54 |
| `StableAudio3MusicGen.swift` | orchestrator + CFG/APG batched path | 199 |
| `StableAudio3WeightLoading.swift` | bundle reader + key-rewrite for indexed children | 180 |
| `StableAudio3Downloader.swift` | HF download + offline override | 85 |
| `Configuration.swift` | variants / dim constants / component routing | 177 |

INT8 linears use MLX-Swift's `QuantizedLinear` (loaded directly from the `weight/scales/biases` triplets in the bundle — no manual dequantize); norms and small parameters stay float. SAME-L stays FP32 end-to-end (its differential attention catastrophically cancels in FP16 — same lesson as upstream).

## Bugs surfaced during the port

* `to_*_embed`, `global_cond_embedder`, `ff.ff.2`, `to_local_embed.seq.2` were INT8-quantised in our bundle but I initially declared them as plain `Linear` — fixed.
* `ModuleParameters.unflattened` collapses numeric-string keys (`.0.`, `.2.`) into 3-element list positions; needed an explicit key-rewrite to `.inProj.` / `.outProj.` / `.glu.` / `.out.` at load time.
* T5Gemma RMSNorms ship as sub-modules (`name.weight` key path), not raw parameters → introduced `GemmaNorm`.
* T5Gemma's `.model` is **BPE** (not Unigram). Scores are merge ranks stored as negative integers — encoder picks the least-negative score first.

## Scope

* `medium-int8` (default) and `medium-int4` only.
* `sm-music` / `sm-sfx` families land in a follow-up PR — they share T5Gemma + sampler but need DiT-Small (no differential attention, 20 layers / 1024 dim) and SAME-S decoder modules.

## Test plan

- [x] Unit tests pass (`make test --skip E2E`): variant routing, `computeTLat`, family/component mapping
- [x] Release build clean (warnings unchanged)
- [x] `speech compose "lofi house loop, mellow piano, deep bassline, 80 BPM" --seconds 10` produces audible coherent audio (peak 0.695, rms 0.103)
- [x] `speech sa3-parity` reports cos = 1.00000 on every stage
- [ ] Reviewer: confirm `make test --filter E2EGenerationTests` runs end-to-end against the HF bundle (~5 GB first-run download)