### PR TITLE
Qwen3-TTS: bf16 support + ICL stability fixes

### DIFF
--- a/Sources/AudioCommon/Tokenizer.swift
+++ b/Sources/AudioCommon/Tokenizer.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+// Library logs route to stderr so they don't corrupt a stdout-based IPC
+// channel (e.g. the speech-studio sidecar's NDJSON protocol).
+@inline(__always)
+private func logTokenizer(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
 // MARK: - Errors
 
 public enum TokenizerError: Error, LocalizedError {
@@ -59,7 +66,7 @@ public class Qwen3Tokenizer {
             try loadMerges(from: mergesUrl)
         }
 
-        print("Loaded tokenizer with \(idToToken.count) tokens, \(bpeMerges.count) merges")
+        logTokenizer("Loaded tokenizer with \(idToToken.count) tokens, \(bpeMerges.count) merges")
     }
 
     /// Load added tokens from tokenizer_config.json
@@ -84,7 +91,7 @@ public class Qwen3Tokenizer {
                 tokenToId[content] = id
                 addedCount += 1
             }
-            print("Loaded \(addedCount) added tokens from tokenizer_config.json")
+            logTokenizer("Loaded \(addedCount) added tokens from tokenizer_config.json")
         }
     }
 

--- a/Sources/MLXCommon/QuantizedMLP.swift
+++ b/Sources/MLXCommon/QuantizedMLP.swift
@@ -2,20 +2,21 @@ import Foundation
 import MLX
 import MLXNN
 
-/// SwiGLU MLP with quantized linear layers — shared by ASR text decoder, TTS Talker, and Code Predictor
+/// SwiGLU MLP — shared by ASR text decoder, TTS Talker, and Code Predictor.
+/// Linear layers are quantized when `bits > 0`, plain Linear otherwise (bf16/fp32 path).
 public class QuantizedMLP: Module {
-    @ModuleInfo public var gateProj: QuantizedLinear
-    @ModuleInfo public var upProj: QuantizedLinear
-    @ModuleInfo public var downProj: QuantizedLinear
+    @ModuleInfo public var gateProj: Linear
+    @ModuleInfo public var upProj: Linear
+    @ModuleInfo public var downProj: Linear
 
     public init(hiddenSize: Int, intermediateSize: Int, groupSize: Int = 64, bits: Int = 4) {
-        self._gateProj.wrappedValue = QuantizedLinear(
+        self._gateProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, intermediateSize, bias: false,
             groupSize: groupSize, bits: bits)
-        self._upProj.wrappedValue = QuantizedLinear(
+        self._upProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, intermediateSize, bias: false,
             groupSize: groupSize, bits: bits)
-        self._downProj.wrappedValue = QuantizedLinear(
+        self._downProj.wrappedValue = makeMaybeQuantizedLinear(
             intermediateSize, hiddenSize, bias: false,
             groupSize: groupSize, bits: bits)
 

--- a/Sources/MLXCommon/WeightLoading.swift
+++ b/Sources/MLXCommon/WeightLoading.swift
@@ -2,6 +2,24 @@ import Foundation
 import MLX
 import MLXNN
 
+/// Build a Linear layer that is quantized when bits > 0, plain when bits == 0.
+/// QuantizedLinear inherits from Linear, so the return type is always Linear and
+/// caller code can store it in a single `@ModuleInfo var x: Linear` field.
+public func makeMaybeQuantizedLinear(
+    _ inputDimensions: Int,
+    _ outputDimensions: Int,
+    bias: Bool,
+    groupSize: Int,
+    bits: Int
+) -> Linear {
+    if bits > 0 {
+        return QuantizedLinear(inputDimensions, outputDimensions, bias: bias,
+                               groupSize: groupSize, bits: bits)
+    } else {
+        return Linear(inputDimensions, outputDimensions, bias: bias)
+    }
+}
+
 /// Generic weight loading utilities shared between ASR and TTS
 public enum CommonWeightLoader {
 
@@ -67,8 +85,12 @@ public enum CommonWeightLoader {
         }
     }
 
+    /// Apply weights to a Linear (or QuantizedLinear, since the latter inherits from
+    /// the former). When the layer is a QuantizedLinear, `.scales`/`.biases` are wired
+    /// in addition to `.weight`. For plain Linear those keys are absent in the
+    /// safetensors (bf16/fp32 model) and only `.weight` (+ optional `.bias`) apply.
     public static func applyQuantizedLinearWeights(
-        to linear: QuantizedLinear,
+        to linear: Linear,
         prefix: String,
         from weights: [String: MLXArray]
     ) {
@@ -77,14 +99,15 @@ public enum CommonWeightLoader {
         if let weight = weights["\(prefix).weight"] {
             params["weight"] = .value(weight)
         }
-        if let scales = weights["\(prefix).scales"] {
-            params["scales"] = .value(scales)
-        }
-        if let biases = weights["\(prefix).biases"] {
-            params["biases"] = .value(biases)
+        if linear is QuantizedLinear {
+            if let scales = weights["\(prefix).scales"] {
+                params["scales"] = .value(scales)
+            }
+            if let biases = weights["\(prefix).biases"] {
+                params["biases"] = .value(biases)
+            }
         }
         // Regular linear bias (separate from quantization biases)
-        // Qwen2.5 attention q/k/v projections have regular biases
         if let bias = weights["\(prefix).bias"] {
             params["bias"] = .value(bias)
         }

--- a/Sources/Qwen3TTS/CodePredictor.swift
+++ b/Sources/Qwen3TTS/CodePredictor.swift
@@ -12,10 +12,10 @@ public class CodePredictorAttention: Module {
     let headDim: Int
     let scale: Float
 
-    @ModuleInfo var qProj: QuantizedLinear
-    @ModuleInfo var kProj: QuantizedLinear
-    @ModuleInfo var vProj: QuantizedLinear
-    @ModuleInfo var oProj: QuantizedLinear
+    @ModuleInfo var qProj: Linear
+    @ModuleInfo var kProj: Linear
+    @ModuleInfo var vProj: Linear
+    @ModuleInfo var oProj: Linear
     @ModuleInfo var qNorm: RMSNorm
     @ModuleInfo var kNorm: RMSNorm
 
@@ -29,16 +29,16 @@ public class CodePredictorAttention: Module {
 
         let hiddenSize = config.hiddenSize
 
-        self._qProj.wrappedValue = QuantizedLinear(
+        self._qProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, numHeads * headDim, bias: false,
             groupSize: config.groupSize, bits: config.bits)
-        self._kProj.wrappedValue = QuantizedLinear(
+        self._kProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, numKVHeads * headDim, bias: false,
             groupSize: config.groupSize, bits: config.bits)
-        self._vProj.wrappedValue = QuantizedLinear(
+        self._vProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, numKVHeads * headDim, bias: false,
             groupSize: config.groupSize, bits: config.bits)
-        self._oProj.wrappedValue = QuantizedLinear(
+        self._oProj.wrappedValue = makeMaybeQuantizedLinear(
             numHeads * headDim, hiddenSize, bias: false,
             groupSize: config.groupSize, bits: config.bits)
 
@@ -140,9 +140,9 @@ public class CodePredictorModel: Module {
     @ModuleInfo var layers: [CodePredictorDecoderLayer]
     @ModuleInfo var norm: RMSNorm
     // 15 lm_head projections (one per remaining codebook group, quantized)
-    @ModuleInfo var lmHeads: [QuantizedLinear]
+    @ModuleInfo var lmHeads: [Linear]
     // Optional projection from embeddingDim → hiddenSize (1.7B: 2048 → 1024)
-    @ModuleInfo var smallToMtpProjection: QuantizedLinear?
+    @ModuleInfo var smallToMtpProjection: Linear?
 
     public init(config: CodePredictorConfig) {
         self.config = config
@@ -160,13 +160,13 @@ public class CodePredictorModel: Module {
 
         // 15 lm_heads for codebook groups 2-16 (quantized)
         self._lmHeads.wrappedValue = (0..<(config.numCodeGroups - 1)).map { _ in
-            QuantizedLinear(config.hiddenSize, config.vocabSize, bias: false,
+            makeMaybeQuantizedLinear(config.hiddenSize, config.vocabSize, bias: false,
                            groupSize: config.groupSize, bits: config.bits)
         }
 
         // Projection for 1.7B model (embeddingDim=2048 → hiddenSize=1024)
         if config.needsProjection {
-            self._smallToMtpProjection.wrappedValue = QuantizedLinear(
+            self._smallToMtpProjection.wrappedValue = makeMaybeQuantizedLinear(
                 config.embeddingDim, config.hiddenSize, bias: true,
                 groupSize: config.groupSize, bits: config.bits)
         }

--- a/Sources/Qwen3TTS/Configuration.swift
+++ b/Sources/Qwen3TTS/Configuration.swift
@@ -16,11 +16,14 @@ public enum TTSModelSize {
     }
 
     /// Detect quantization bits from a HuggingFace model ID.
-    /// Returns 4 by default if not specified.
+    /// Returns 4 by default if not specified; 0 means no quantization (bf16/fp32 path).
     public static func detectBits(from modelId: String) -> Int {
         let lower = modelId.lowercased()
         if lower.contains("8bit") || lower.contains("8-bit") {
             return 8
+        }
+        if lower.contains("bf16") || lower.contains("fp16") || lower.contains("fp32") {
+            return 0
         }
         return 4
     }
@@ -75,6 +78,20 @@ public struct TalkerConfig: Codable, Sendable {
         config.bits = 8
         return config
     }
+
+    /// 0.6B, bf16 (no quantization).
+    public static var smallBf16: TalkerConfig {
+        var config = TalkerConfig()
+        config.bits = 0
+        return config
+    }
+
+    /// 1.7B, bf16 (no quantization).
+    public static var largeBf16: TalkerConfig {
+        var config = large4bit
+        config.bits = 0
+        return config
+    }
 }
 
 // MARK: - Code Predictor Config
@@ -119,6 +136,20 @@ public struct CodePredictorConfig: Codable, Sendable {
     public static var large8bit: CodePredictorConfig {
         var config = large4bit
         config.bits = 8
+        return config
+    }
+
+    /// 0.6B, bf16 (no quantization).
+    public static var smallBf16: CodePredictorConfig {
+        var config = CodePredictorConfig()
+        config.bits = 0
+        return config
+    }
+
+    /// 1.7B, bf16 (no quantization).
+    public static var largeBf16: CodePredictorConfig {
+        var config = large4bit
+        config.bits = 0
         return config
     }
 }
@@ -276,8 +307,13 @@ public struct Qwen3TTSConfig: Codable, Sendable {
     }
 
     /// Build config for a given model size and quantization.
+    /// `bits == 0` selects the bf16 (no-quantization) path.
     public static func config(for size: TTSModelSize, bits: Int) -> Qwen3TTSConfig {
         switch (size, bits) {
+        case (.small, 0):
+            return Qwen3TTSConfig(talker: .smallBf16, codePredictor: .smallBf16)
+        case (.large, 0):
+            return Qwen3TTSConfig(talker: .largeBf16, codePredictor: .largeBf16)
         case (.small, 8):
             return Qwen3TTSConfig(talker: .small8bit, codePredictor: .small8bit)
         case (.large, 8):

--- a/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
@@ -5,6 +5,15 @@ import MLXFast
 import MLXCommon
 import AudioCommon
 
+/// Synthesis progress logs go to stderr so they don't corrupt a stdout-based
+/// IPC channel (e.g. speech-studio sidecar's NDJSON protocol). Swift's stdio
+/// `print()` is line-buffered and may flush at unexpected boundaries; routing
+/// to stderr keeps the stdout pipe clean for JSON responses.
+@inline(__always)
+private func iclLog(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
 // MARK: - ICL Voice Cloning
 
 extension Qwen3TTSModel {
@@ -62,7 +71,7 @@ extension Qwen3TTSModel {
         referenceAudio: [Float],
         referenceSampleRate: Int = 24000,
         referenceText: String,
-        language: String = "english",
+        language: String = "auto",
         sampling: SamplingConfig = .default,
         codecEncoder: SpeechTokenizerEncoder,
         trimReference: Bool = true
@@ -70,12 +79,21 @@ extension Qwen3TTSModel {
         guard let tokenizer = tokenizer else {
             fatalError("Tokenizer not loaded")
         }
-        guard let langId = CodecTokens.languageId(for: language) else {
-            print("Warning: Unknown language '\(language)', defaulting to English")
+        // "auto" (matches the QwenLM reference + mlx-audio default) skips the
+        // language-id token and switches the codec prefix to the codec_nothink
+        // branch. Any other value must resolve to a known language id.
+        let langId: Int?
+        let normalized = language.lowercased()
+        if normalized == "auto" || normalized.isEmpty {
+            langId = nil
+        } else if let id = CodecTokens.languageId(for: language) {
+            langId = id
+        } else {
+            iclLog("Warning: Unknown language '\(language)', falling back to auto")
             return synthesizeWithVoiceCloneICL(
                 text: text, referenceAudio: referenceAudio,
                 referenceSampleRate: referenceSampleRate,
-                referenceText: referenceText, language: "english",
+                referenceText: referenceText, language: "auto",
                 sampling: sampling, codecEncoder: codecEncoder,
                 trimReference: trimReference)
         }
@@ -86,7 +104,7 @@ extension Qwen3TTSModel {
         let refCodes: MLXArray
         if let cached = referenceAudioCache.codecRefCodes(for: referenceAudio, sampleRate: referenceSampleRate) {
             refCodes = cached
-            print("  ICL: codec tokens cache hit (\(cached.dim(2)) frames)")
+            iclLog("  ICL: codec tokens cache hit (\(cached.dim(2)) frames)")
         } else {
             let audio24k = referenceSampleRate == 24000
                 ? referenceAudio
@@ -95,7 +113,7 @@ extension Qwen3TTSModel {
             eval(codes)
             referenceAudioCache.storeCodecRefCodes(codes, audio: referenceAudio, sampleRate: referenceSampleRate)
             refCodes = codes
-            print("  ICL: encoded \(audio24k.count) samples → \(codes.dim(2)) codec frames")
+            iclLog("  ICL: encoded \(audio24k.count) samples → \(codes.dim(2)) codec frames")
         }
 
         // Step 3: Extract speaker embedding (ICL still uses x-vector for speaker conditioning; cached)
@@ -123,14 +141,27 @@ extension Qwen3TTSModel {
         eval(prefillEmbeds, trailingTextHidden, ttsPadEmbed)
         let t1 = CFAbsoluteTimeGetCurrent()
 
-        // Step 5: Autoregressive generation. The Python mlx-audio reference
-        // auto-boosts repetition_penalty to >= 1.5 for ICL because the long
-        // reference prefill makes codec tokens prone to degenerate repetition
-        // (audible as buzzy/robotic artifacts) without it. Match that.
+        // Step 5: Autoregressive generation. Auto-bump repetition_penalty to
+        // >= 1.5 ONLY when caller is sampling (T > 0). Under sampling the
+        // bump matches mlx-audio's recipe and prevents codec-token repetition
+        // artifacts. Under greedy the bump is a degeneration trap (argmax
+        // flips on Metal logit jitter) — leave the caller's value as-is.
         var iclSampling = sampling
-        if iclSampling.repetitionPenalty < 1.5 {
+        if iclSampling.temperature > 0 && iclSampling.repetitionPenalty < 1.5 {
             iclSampling.repetitionPenalty = 1.5
         }
+        // Cap maxTokens so under-EOS runaway outputs can't exhaust GPU memory.
+        // ICL generates [ref reproduction + target], so the budget must cover
+        // BOTH: ref-codec-frames (from the encoded reference) plus a per-target-
+        // text allowance. 6 codec frames per text token is a loose upper bound
+        // on natural speech rate (~12.5 fps / ~2 tok/s). Extra 1.5× safety
+        // margin on the reference portion handles model speech-rate variance.
+        let refCodecFrames = refCodes.dim(2)
+        let targetTokenCount = tokenizer.encode(text).count
+        let refBudget = refCodecFrames + refCodecFrames / 2  // 1.5x of ref frames
+        let targetBudget = max(75, targetTokenCount * 6)
+        let textDerivedCap = refBudget + targetBudget
+        iclSampling.maxTokens = min(iclSampling.maxTokens, textDerivedCap)
         let (allCodebooks, numFrames) = generateWithCodePredictor(
             prefillEmbeds: prefillEmbeds,
             trailingTextHidden: trailingTextHidden,
@@ -141,28 +172,36 @@ extension Qwen3TTSModel {
         let t2 = CFAbsoluteTimeGetCurrent()
 
         guard numFrames > 0 else {
-            print("Warning: ICL generation produced no tokens")
+            iclLog("Warning: ICL generation produced no tokens")
             return []
         }
 
         // Step 6: Decode codec tokens → waveform
         let outputSamples = numFrames * 1920
-        print("  ICL: decoding \(numFrames) frames → \(outputSamples) samples...")
+        iclLog("  ICL: decoding \(numFrames) frames → \(outputSamples) samples...")
         let waveform = codecDecoder.decode(codes: allCodebooks)
         let t3 = CFAbsoluteTimeGetCurrent()
 
         // Step 7: Optionally trim the reference echo from the start of the waveform.
-        // The model is conditioned on [ref_text + target_text] and produces codec for both,
-        // so the raw decoded waveform begins with a regeneration of the reference.
+        // The model is conditioned on [ref_text + target_text] and produces codec
+        // for both, so the raw decoded waveform begins with a regeneration of the
+        // reference. Trim by the text-token ratio (refTokens / totalTokens) — this
+        // is more robust than trimming by raw reference-audio sample count, because
+        // the model often reproduces the reference at a different speech rate
+        // than the original recording (slower → reference leaks into target).
         let trimmedWaveform: [Float]
         if trimReference {
-            let before = waveform.count
-            trimmedWaveform = Qwen3TTSModel.trimICLReferenceFromWaveform(
-                waveform, referenceAudio: referenceAudio,
+            let refTokenCount = tokenizer.encode(referenceText).count
+            let targetTokenCount = tokenizer.encode(text).count
+            trimmedWaveform = Qwen3TTSModel.trimICLReferenceByTokenRatio(
+                waveform,
+                referenceTokenCount: refTokenCount,
+                targetTokenCount: targetTokenCount,
+                referenceAudio: referenceAudio,
                 referenceSampleRate: referenceSampleRate)
-            if trimmedWaveform.count < before {
-                let removed = before - trimmedWaveform.count
-                print("  ICL: trimmed \(removed) reference samples (~\(String(format: "%.2f", Double(removed)/24000.0))s) from output start")
+            let removed = waveform.count - trimmedWaveform.count
+            if removed > 0 {
+                iclLog("  ICL: trimmed \(removed) reference samples (~\(String(format: "%.2f", Double(removed)/24000.0))s, refTok=\(refTokenCount) tgtTok=\(targetTokenCount)) from output start")
             }
         } else {
             trimmedWaveform = waveform
@@ -176,7 +215,7 @@ extension Qwen3TTSModel {
         let totTime = String(format: "%.3f", t3-t0)
         let audDur = String(format: "%.2f", audioDur)
         let rtf = String(format: "%.2f", (t3-t0)/max(audioDur, 0.001))
-        print("  ICL timing: encode=\(encTime)s | generate=\(genTime)s (\(numFrames) steps, \(msPerStep)ms/step) | decode=\(decTime)s | total=\(totTime)s | audio=\(audDur)s | RTF=\(rtf)")
+        iclLog("  ICL timing: encode=\(encTime)s | generate=\(genTime)s (\(numFrames) steps, \(msPerStep)ms/step) | decode=\(decTime)s | total=\(totTime)s | audio=\(audDur)s | RTF=\(rtf)")
 
         return trimmedWaveform
     }
@@ -206,6 +245,48 @@ extension Qwen3TTSModel {
         return Array(waveform.dropFirst(refSampleCount24k))
     }
 
+    /// Trim the reference reproduction by text-token proportion.
+    ///
+    /// The model generates [ref_reproduction + target] for `numFrames` codec frames
+    /// totalling `waveform.count` samples. Token-count ratio approximates the
+    /// time-domain split: the ref portion is `refTokens / (refTokens + targetTokens)`
+    /// of the output. We add a small safety margin (1 codec frame = 1920 samples
+    /// at 24 kHz = 80 ms) to account for the model's transition between ref and
+    /// target. Falls back to the audio-sample-based heuristic if token counts
+    /// are unavailable (zero or nonsensical).
+    static func trimICLReferenceByTokenRatio(
+        _ waveform: [Float],
+        referenceTokenCount: Int,
+        targetTokenCount: Int,
+        referenceAudio: [Float],
+        referenceSampleRate: Int
+    ) -> [Float] {
+        let total = referenceTokenCount + targetTokenCount
+        guard referenceTokenCount > 0, targetTokenCount > 0, total > 0 else {
+            return trimICLReferenceFromWaveform(waveform,
+                referenceAudio: referenceAudio,
+                referenceSampleRate: referenceSampleRate)
+        }
+        // Token-proportion estimate of where the target audio begins.
+        let proportional = waveform.count * referenceTokenCount / total
+        // Safety margin: 10 codec frames (~800 ms) catches the trailing word
+        // of the reference reproduction (e.g. "Ruddering.", "of fellows.").
+        let margin = 1920 * 10
+        let estimate = proportional + margin
+
+        // Floor on the target audio that survives the trim: rough estimate of
+        // how much audio a `targetTokenCount`-long sentence should produce —
+        // 6 codec frames per BPE token at 12.5 fps ≈ 0.48 s per token. With
+        // the floor we never trim INTO the target, even when MLX-Metal jitter
+        // makes the model produce an unusually short output and the
+        // proportional estimate over-shoots.
+        let minTargetSamples = max(1920 * 6, targetTokenCount * 6 * 1920)
+        let maxTrim = waveform.count - minTargetSamples
+        let trim = min(estimate, max(0, maxTrim))
+        guard trim > 0, trim < waveform.count else { return waveform }
+        return Array(waveform.dropFirst(trim))
+    }
+
     // MARK: - ICL Prefill Construction
 
     /// Build ICL prefill embeddings following the Python mlx-audio reference.
@@ -222,7 +303,7 @@ extension Qwen3TTSModel {
         referenceText: String,
         targetText: String,
         language: String,
-        languageId: Int,
+        languageId: Int?,
         speakerEmbed: MLXArray,     // [1, 1024]
         tokenizer: Qwen3Tokenizer
     ) -> (prefillEmbeds: MLXArray, trailingTextHidden: MLXArray, ttsPadEmbed: MLXArray) {
@@ -271,16 +352,41 @@ extension Qwen3TTSModel {
         let codecWithTextPad = codecEmbedICL + broadcast(ttsPadEmbed, to: [1, codecLens, hiddenSize])
         let iclInputEmbed = concatenated([textWithCodecPad, codecWithTextPad], axis: 1)
 
-        // 6. Codec prefix: [think, think_bos, lang, think_eos, speaker_embed, pad, bos]
-        let codecPrefixTokens = buildCodecPrefix(languageId: languageId)
+        // 6. Codec prefix. Two layouts (reference parity):
+        //   With language id: [codec_think, codec_think_bos, lang_id, codec_think_eos, pad, bos]
+        //                     speaker injected after think_eos → 7 tokens.
+        //   Without (auto):   [codec_nothink, codec_think_bos, codec_think_eos, pad, bos]
+        //                     speaker injected after think_eos → 6 tokens.
+        let codecPrefixTokens: [Int32]
+        let speakerInjectAt: Int
+        if let langId = languageId {
+            codecPrefixTokens = [
+                Int32(CodecTokens.codecThink),
+                Int32(CodecTokens.codecThinkBos),
+                Int32(langId),
+                Int32(CodecTokens.codecThinkEos),
+                Int32(CodecTokens.codecPad),
+                Int32(CodecTokens.codecBos),
+            ]
+            speakerInjectAt = 4
+        } else {
+            codecPrefixTokens = [
+                Int32(CodecTokens.codecNothink),
+                Int32(CodecTokens.codecThinkBos),
+                Int32(CodecTokens.codecThinkEos),
+                Int32(CodecTokens.codecPad),
+                Int32(CodecTokens.codecBos),
+            ]
+            speakerInjectAt = 3
+        }
         let codecPrefixArray = MLXArray(codecPrefixTokens).expandedDimensions(axis: 0)
-        var codecPrefixEmbed = talker.embedCodec(codecPrefixArray)  // [1, 6, D]
+        var codecPrefixEmbed = talker.embedCodec(codecPrefixArray)
 
-        // Inject speaker embedding
+        // Inject speaker embedding right after think_eos.
         let spkEmbedReshaped = speakerEmbed.reshaped([1, 1, hiddenSize])
-        let part0 = codecPrefixEmbed[0..., 0..<4, 0...]
-        let part1 = codecPrefixEmbed[0..., 4..., 0...]
-        codecPrefixEmbed = concatenated([part0, spkEmbedReshaped, part1], axis: 1)  // [1, 7, D]
+        let part0 = codecPrefixEmbed[0..., 0..<speakerInjectAt, 0...]
+        let part1 = codecPrefixEmbed[0..., speakerInjectAt..., 0...]
+        codecPrefixEmbed = concatenated([part0, spkEmbedReshaped, part1], axis: 1)
 
         let codecSuffixEmbed = talker.embedCodec(
             MLXArray([Int32(CodecTokens.codecPad), Int32(CodecTokens.codecBos)]).expandedDimensions(axis: 0))

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -1404,7 +1404,9 @@ public class Qwen3TTSModel {
         ttsPadEmbed: MLXArray,
         sampling: SamplingConfig
     ) -> (allCodebooks: MLXArray, numFrames: Int) {
-        let safeMaxTokens = min(sampling.maxTokens, 500)
+        // Reference (QwenLM + mlx-audio) uses 2048 here. Earlier 500 cap clipped
+        // long lines mid-word and produced hard-cut endings.
+        let safeMaxTokens = min(sampling.maxTokens, 2048)
 
         var talkerCache: [(MLXArray, MLXArray)]? = nil
         var generatedFirstCodebook: [Int32] = []

--- a/Sources/Qwen3TTS/TTSWeightLoading+Encoder.swift
+++ b/Sources/Qwen3TTS/TTSWeightLoading+Encoder.swift
@@ -17,7 +17,7 @@ extension TTSWeightLoader {
     ) throws {
         let allWeights = try CommonWeightLoader.loadAllSafetensors(from: directory)
 
-        print("Found \(allWeights.count) speech tokenizer weights total (encoder load)")
+        logLoad("Found \(allWeights.count) speech tokenizer weights total (encoder load)")
 
         // RVQ codebook weights — same codebooks as decoder, stored under encoder prefix
         loadEncoderRVQWeights(into: encoder.rvq, from: allWeights)
@@ -82,7 +82,7 @@ extension TTSWeightLoader {
             prefix: "encoder.pre_transformer.norm",
             from: allWeights)
 
-        print("Applied weights to Speech Tokenizer Encoder")
+        logLoad("Applied weights to Speech Tokenizer Encoder")
     }
 
     // MARK: - Encoder RVQ

--- a/Sources/Qwen3TTS/TTSWeightLoading.swift
+++ b/Sources/Qwen3TTS/TTSWeightLoading.swift
@@ -4,6 +4,13 @@ import MLX
 import MLXNN
 import AudioCommon
 
+/// Weight-loading progress logs go to stderr so they don't corrupt a stdout-based
+/// IPC channel (e.g. the speech-studio sidecar's NDJSON protocol).
+@inline(__always)
+internal func logLoad(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
 /// Weight loading for TTS components
 public enum TTSWeightLoader {
 
@@ -15,7 +22,7 @@ public enum TTSWeightLoader {
         from directory: URL
     ) throws {
         let allWeights = try CommonWeightLoader.loadAllSafetensors(from: directory)
-        print("Loaded \(allWeights.count) weights from safetensors")
+        logLoad("Loaded \(allWeights.count) weights from safetensors")
 
         // Split into talker and code predictor weights
         var talkerWeights: [String: MLXArray] = [:]
@@ -40,7 +47,7 @@ public enum TTSWeightLoader {
         to talker: TalkerModel,
         from talkerWeights: [String: MLXArray]
     ) {
-        print("Found \(talkerWeights.count) talker weights")
+        logLoad("Found \(talkerWeights.count) talker weights")
 
         // Codec embedding (float, not quantized)
         CommonWeightLoader.applyEmbeddingWeights(
@@ -76,7 +83,7 @@ public enum TTSWeightLoader {
             applyTalkerLayerWeights(to: layer, prefix: prefix, from: talkerWeights)
         }
 
-        print("Applied weights to Talker (\(talker.layers.count) layers)")
+        logLoad("Applied weights to Talker (\(talker.layers.count) layers)")
     }
 
     private static func applyTalkerLayerWeights(
@@ -117,7 +124,7 @@ public enum TTSWeightLoader {
         to codePredictor: CodePredictorModel,
         from cpWeights: [String: MLXArray]
     ) {
-        print("Found \(cpWeights.count) code predictor weights")
+        logLoad("Found \(cpWeights.count) code predictor weights")
 
         // Codec embeddings (15 tables — safetensors uses singular "codec_embedding")
         for i in 0..<codePredictor.codecEmbeddings.count {
@@ -154,7 +161,7 @@ public enum TTSWeightLoader {
             }
         }
 
-        print("Applied weights to Code Predictor (\(codePredictor.layers.count) layers)")
+        logLoad("Applied weights to Code Predictor (\(codePredictor.layers.count) layers)")
     }
 
     private static func applyCodePredictorLayerWeights(
@@ -193,7 +200,7 @@ public enum TTSWeightLoader {
     ) throws {
         let allWeights = try CommonWeightLoader.loadAllSafetensors(from: directory)
 
-        print("Found \(allWeights.count) speech tokenizer weights total")
+        logLoad("Found \(allWeights.count) speech tokenizer weights total")
 
         // Load RVQ codebook weights (decoder-side quantizer)
         loadRVQWeights(into: decoder.splitRVQ, from: allWeights)
@@ -243,7 +250,7 @@ public enum TTSWeightLoader {
         CommonWeightLoader.applyConv1dWeights(
             to: decoder.finalConv.conv, prefix: "decoder.decoder.6.conv", from: allWeights, transpose: true)
 
-        print("Applied weights to Speech Tokenizer Decoder")
+        logLoad("Applied weights to Speech Tokenizer Decoder")
     }
 
     // MARK: - RVQ Weight Loading
@@ -395,7 +402,7 @@ public enum TTSWeightLoader {
                 seWeights[String(key.dropFirst("speaker_encoder.".count))] = value
             }
         }
-        print("Found \(seWeights.count) speaker encoder weights")
+        logLoad("Found \(seWeights.count) speaker encoder weights")
 
         // Initial conv (blocks.0 = TimeDelayNetBlock wrapping Conv1d)
         // Weight key: blocks.0.conv.weight/bias → our initialConv (Conv1d)
@@ -430,7 +437,7 @@ public enum TTSWeightLoader {
         // FC (direct Conv1d)
         applySpeakerConv1dWeights(to: encoder.fc, prefix: "fc", from: seWeights)
 
-        print("Applied weights to Speaker Encoder")
+        logLoad("Applied weights to Speaker Encoder")
     }
 
     /// Apply Conv1d weights from safetensors. Speaker encoder weights are already in

--- a/Sources/Qwen3TTS/Talker.swift
+++ b/Sources/Qwen3TTS/Talker.swift
@@ -17,10 +17,10 @@ public class TalkerAttention: Module {
     let headDim: Int
     let scale: Float
 
-    @ModuleInfo var qProj: QuantizedLinear
-    @ModuleInfo var kProj: QuantizedLinear
-    @ModuleInfo var vProj: QuantizedLinear
-    @ModuleInfo var oProj: QuantizedLinear
+    @ModuleInfo var qProj: Linear
+    @ModuleInfo var kProj: Linear
+    @ModuleInfo var vProj: Linear
+    @ModuleInfo var oProj: Linear
     @ModuleInfo var qNorm: RMSNorm
     @ModuleInfo var kNorm: RMSNorm
 
@@ -34,16 +34,16 @@ public class TalkerAttention: Module {
 
         let hiddenSize = config.hiddenSize
 
-        self._qProj.wrappedValue = QuantizedLinear(
+        self._qProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, numHeads * headDim, bias: false,
             groupSize: config.groupSize, bits: config.bits)
-        self._kProj.wrappedValue = QuantizedLinear(
+        self._kProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, numKVHeads * headDim, bias: false,
             groupSize: config.groupSize, bits: config.bits)
-        self._vProj.wrappedValue = QuantizedLinear(
+        self._vProj.wrappedValue = makeMaybeQuantizedLinear(
             hiddenSize, numKVHeads * headDim, bias: false,
             groupSize: config.groupSize, bits: config.bits)
-        self._oProj.wrappedValue = QuantizedLinear(
+        self._oProj.wrappedValue = makeMaybeQuantizedLinear(
             numHeads * headDim, hiddenSize, bias: false,
             groupSize: config.groupSize, bits: config.bits)
 
@@ -147,14 +147,14 @@ public class TalkerDecoderLayer: Module {
 
 /// Text projection MLP: Linear(textHidden, textHidden) -> SiLU -> Linear(textHidden, hidden)
 public class TextProjectionMLP: Module {
-    @ModuleInfo var fc1: QuantizedLinear
-    @ModuleInfo var fc2: QuantizedLinear
+    @ModuleInfo var fc1: Linear
+    @ModuleInfo var fc2: Linear
 
     public init(textHiddenSize: Int, hiddenSize: Int, groupSize: Int = 64, bits: Int = 4) {
-        self._fc1.wrappedValue = QuantizedLinear(
+        self._fc1.wrappedValue = makeMaybeQuantizedLinear(
             textHiddenSize, textHiddenSize, bias: true,
             groupSize: groupSize, bits: bits)
-        self._fc2.wrappedValue = QuantizedLinear(
+        self._fc2.wrappedValue = makeMaybeQuantizedLinear(
             textHiddenSize, hiddenSize, bias: true,
             groupSize: groupSize, bits: bits)
 
@@ -178,7 +178,7 @@ public class TalkerModel: Module {
     @ModuleInfo var textProjection: TextProjectionMLP
     @ModuleInfo var layers: [TalkerDecoderLayer]
     @ModuleInfo var norm: RMSNorm
-    @ModuleInfo var codecHead: QuantizedLinear
+    @ModuleInfo var codecHead: Linear
 
     public init(config: TalkerConfig) {
         self.config = config
@@ -208,7 +208,7 @@ public class TalkerModel: Module {
         self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
 
         // Codec head (logits over codec vocabulary)
-        self._codecHead.wrappedValue = QuantizedLinear(
+        self._codecHead.wrappedValue = makeMaybeQuantizedLinear(
             config.hiddenSize, config.codecVocabSize, bias: false,
             groupSize: config.groupSize, bits: config.bits)
 


### PR DESCRIPTION
## Summary

Three concerns bundled because they were uncovered in lockstep while stabilizing the ICL voice-clone path against MLX-Metal cross-process variance.

1. **Non-quantized (bf16/fp32) model support.** Talker / CodePredictor / QuantizedMLP previously hard-coded `QuantizedLinear`. Introduce a \`bits == 0\` semantic + \`makeMaybeQuantizedLinear(...)\` helper. Field types become \`Linear\` (QuantizedLinear inherits → polymorphic). New \`smallBf16\` / \`largeBf16\` config presets; \`detectBits\` recognizes \`bf16\` / \`fp16\` / \`fp32\` in model IDs. \`applyQuantizedLinearWeights\` accepts \`Linear\` and only wires \`.scales\`/\`.biases\` when the layer is actually quantized.
2. **ICL stability fixes:**
   - \`safeMaxTokens\` for ICL now derived from \`refCodecFrames + refCodecFrames/2 + max(75, targetTokens × 6)\` — covers both reference reproduction window and target. The flat 500-frame ceiling let stochastic outputs run away to GPU OOM on long lines.
   - Auto-bump of \`repetition_penalty\` to ≥1.5 now fires **only under sampling** (\`temperature > 0\`). Under greedy decoding the bump is a degeneration trap — Metal logit jitter flips argmax, model never reaches EOS. Greedy callers retain their value (typ. 1.05).
   - Reference-echo trim is token-proportion-based with a 10 codec-frame margin and a hard floor: never leaves less than \`targetTokens × 6 × 1920\` samples, so an over-shooting proportional estimate can't eat the target audio.
   - \`language: \"auto\"\` (new default) routes through the \`codec_nothink\` three-token prefix, matching QwenLM canonical + mlx-audio.
   - \`generateWithCodePredictor\` hard cap raised 500 → 2048 frames (matches reference). ICL caller still text-length-caps before this layer.
3. **Stderr-routed library logs.** Model-load + ICL-synth \`print()\` calls now go to stderr instead of stdout. Stdout was being corrupted for stdio-based IPC consumers (NDJSON sidecars etc.). Behavior unchanged for tty consumers.

## Test plan

- [x] \`swift build\` clean on top of latest \`main\` (rebased on 2aafc0f).
- [x] e2e sidecar test (in downstream speech-studio repo) — \`demo_references_e2e\` passes against \`local/qwen3-tts-0.6b-bf16\`. 12 syntheses × 4 lines, all per-line means ≥50%, overall 73% ASR coverage (Parakeet-graded). Same test passed against \`aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit\` (76% overall) — backward compatibility holds.
- [ ] Maintainer to confirm existing speech-swift Qwen3-TTS tests still pass (not run from this branch).
- [ ] Bake-in test against bf16 1.7B (not yet converted in this branch — author has a converter script that does PyTorch safetensors → MLX bf16 + speaker-encoder pre-transpose).

## Notes for reviewer

- Draft because: bf16 conversion script lives in the downstream studio repo for now (\`speaker_encoder.*\` 3D conv weights need pre-transposing to MLX layout — speech-swift's \`applySpeakerConv1dWeights\` assumes already-MLX format, which is true for aufklarer's MLX models but not for raw PyTorch). Considering whether the script belongs here.
- Polymorphic Linear adds zero overhead for existing quantized callers — same \`callAsFunction\` dispatch, same construction path.
- No backward-compatibility break: existing 4-bit/8-bit aufklarer model IDs continue to work unchanged.