### PR TITLE
CosyVoiceTTS: read DiT (flow) bits from bundle config

### DIFF
--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -82,22 +82,34 @@ public final class CosyVoiceTTSModel {
             }
         }
 
-        // Read the bundle's `config.json` so the LLM module is constructed with
-        // the correct quantization bit width. Without this, the model defaults
-        // to 4-bit and MLX's QuantizedLinear blows up on 8-bit weights.
+        // Read the bundle's `config.json` so each component (LLM, flow DiT) is
+        // constructed with the correct quantization bit width. Without this,
+        // they default to 4-bit and MLX's QuantizedLinear blows up on 8-bit
+        // weights at first forward pass.
         var config = CosyVoiceConfig.default
         let configURL = cacheDir.appendingPathComponent("config.json")
         if FileManager.default.fileExists(atPath: configURL.path),
            let data = try? Data(contentsOf: configURL),
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let quant = json["quantization"] as? [String: Any] {
-            // The convert.py emits BOTH `bits` (legacy default = 4) and a
-            // per-component override `llm_bits`. Prefer the LLM-specific value.
-            if let bits = (quant["llm_bits"] as? Int) ?? (quant["bits"] as? Int) {
-                config.llm.bits = bits
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            // LLM bits: convert.py emits BOTH `bits` (legacy default = 4) and
+            // a per-component override `llm_bits` inside `quantization`.
+            if let quant = json["quantization"] as? [String: Any] {
+                if let bits = (quant["llm_bits"] as? Int) ?? (quant["bits"] as? Int) {
+                    config.llm.bits = bits
+                }
+                if let gs = quant["group_size"] as? Int { config.llm.groupSize = gs }
             }
-            if let gs = quant["group_size"] as? Int { config.llm.groupSize = gs }
-            print("  Bundle quantization: \(config.llm.bits)-bit (group_size \(config.llm.groupSize))")
+            // DiT (flow) bits: convert.py with `--quantize-dit` emits a
+            // separate `dit_quantization` block; older bundles may carry
+            // `flow_bits` inside the main `quantization` block instead.
+            if let ditQuant = json["dit_quantization"] as? [String: Any] {
+                if let bits = ditQuant["bits"] as? Int { config.flow.dit.bits = bits }
+                if let gs = ditQuant["group_size"] as? Int { config.flow.dit.groupSize = gs }
+            } else if let quant = json["quantization"] as? [String: Any],
+                      let bits = quant["flow_bits"] as? Int {
+                config.flow.dit.bits = bits
+            }
+            print("  Bundle quantization: LLM \(config.llm.bits)-bit, DiT \(config.flow.dit.bits)-bit (group_size \(config.llm.groupSize))")
         }
         let model = CosyVoiceTTSModel(config: config)
 


### PR DESCRIPTION
## Summary

`CosyVoiceTTSModel.fromPretrained` was reading \`quantization.llm_bits\` (or fallback \`bits\`) to set the LLM module's bit width but never propagated bits to the DiT (flow) module. The DiT therefore always stayed at the struct default (4) — fine for the existing 4-bit-everywhere bundles, but trips MLX's \`quantized_matmul\` with a *"shapes incompatible based on bits and group_size"* panic when the bundle's DiT weights are 8-bit.

Surfaces when loading a new full-8-bit bundle (LLM 8-bit + Flow 8-bit), which exports a dedicated \`dit_quantization\` block in config.json:

```json
\"quantization\": {
  \"bits\": 4,
  \"group_size\": 64,
  \"llm_bits\": 8,
  \"flow_bits\": 8
},
\"dit_quantization\": {
  \"bits\": 8,
  \"group_size\": 64
}
```

## Fix

Read DiT bits in order of preference:
1. \`dit_quantization.bits\` + \`.group_size\` — current \`convert.py\` output when \`--quantize-dit\` is set
2. \`quantization.flow_bits\` — older \`convert.py\` outputs that put the per-component override inside the main quantization block

## Backward compatibility

- Existing 4-bit-everywhere bundles (\`aufklarer/CosyVoice3-0.5B-MLX-4bit\`) continue to load unchanged — no \`dit_quantization\` block, no \`flow_bits\` key, so DiT stays at the struct default (4) which matches their weights.
- The mixed LLM-8/DiT-4 bundle (\`aufklarer/CosyVoice3-0.5B-MLX-8bit\`) likewise unaffected — the \`dit_quantization\` it carries has \`bits: 4\` which matches its DiT weights.

## Test plan

- [x] Builds clean on top of \`origin/main\` (rebased at 6d7709b).
- [x] Manually verified against a locally-converted full-8-bit bundle: prints \`Bundle quantization: LLM 8-bit, DiT 8-bit (group_size 64)\` and warmUp() completes without the \`quantized_matmul\` panic.
- [ ] Maintainer to run existing CosyVoice tests.

## Related

Used by speech-studio's sidecar to switch from Qwen3-TTS to CosyVoice for voice cloning. The new full-8-bit bundle is being prepared at \`aufklarer/CosyVoice3-0.5B-MLX-8bit-full\` (upload in progress).