### PR TITLE
ci: fix nightly E2E shard problems (Parakeet skips, qwen3-asr OOM, Magpie diagnostic)

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -4,7 +4,7 @@ name: Nightly E2E
 # PR/push CI (`tests.yml`) deliberately skips these because each shard
 # downloads multi-GB models and runs real MLX/CoreML inference.
 #
-# Rollout: starts with 6 light shards (~1 GB of models each). Heavy shards
+# Rollout: starts with light shards (~1-3 GB models each). Heavy shards
 # (Qwen3-TTS, PersonaPlex, VibeVoice, VoxCPM2 bf16, Omnilingual 7B, etc.)
 # will be added once we've seen the workflow + Discord notify pass green.
 
@@ -33,23 +33,58 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          # Filter is a swift-test regex matched against target/class/method
-          # names. Targets in the matrix below pull in the entire module's
-          # tests (E2E + unit), which is the intended nightly coverage.
+          # `filter` and `skip` are swift-test regexes matched against
+          # target/class/method names. Targets like `Qwen3ASRTests` pull in
+          # the entire module's tests (E2E + unit). Use `skip` to peel heavy
+          # methods off into their own shard.
           - name: light-coreml
             filter: 'KokoroTTSTests|ParakeetASRTests|ParakeetStreamingASRTests|MagpieTTSCoreMLTests|SpeechEnhancementTests|SpeechWakeWordTests'
+            skip: ''
           - name: vad-diar
             filter: 'SpeechVADTests'
+            skip: ''
           - name: audio-infra
             filter: 'AudioCommonTests|AudioServerTests|SpeechUITests'
+            skip: ''
           - name: qwen3-chat
             filter: 'Qwen3ChatTests'
-          - name: qwen3-asr
+            skip: ''
+          # qwen3-asr was a single shard in the first nightly and OOM-killed
+          # the runner (~8 GB unique-weight footprint vs ~7 GB usable RAM on
+          # macos-15). Split into 4 sub-shards so each xctest process loads
+          # a bounded set of model variants.
+          - name: qwen3-asr-06b
             filter: 'Qwen3ASRTests'
+            # Peel off 1.7B, 8-bit, aligner, and streaming into their own
+            # shards; this one runs unit tests + 0.6B-4bit E2E + decoding.
+            skip: 'testLargeModel|testSmall8bit|ForcedAlignerTests|StreamingASRTests'
+          - name: qwen3-asr-17b
+            # Matches both `testLargeModel*` (1.7B-MLX-8bit) and
+            # `testSmall8bit*` (0.6B-MLX-8bit) methods inside
+            # E2EQwen3ASRIntegrationTests.
+            filter: 'testLargeModel|testSmall8bit'
+            skip: ''
+          - name: qwen3-asr-aligner
+            # 4-bit and bf16 forced-aligner variants — bf16 alone is ~2.3 GB
+            # working set, so keep isolated from main ASR shards.
+            filter: 'ForcedAlignerTests'
+            skip: ''
+          - name: qwen3-asr-streaming
+            # StreamingASR loads ASR-0.6B-4bit + SileroVAD per test method;
+            # 3 methods × fresh load = enough memory churn to deserve isolation.
+            filter: 'StreamingASRTests'
+            skip: ''
           - name: cosyvoice
             filter: 'CosyVoiceTTSTests'
+            skip: ''
 
     name: ${{ matrix.shard.name }}
+    env:
+      # Temporary diagnostic for the Magpie ASR-roundtrip failure in
+      # `light-coreml`. CoreMLASRModel.transcribe logs logits shape/strides
+      # /dtype + first 5 picked token IDs on first call when this is set.
+      # Remove once the strides hypothesis is confirmed and fixed.
+      SPEECH_DEBUG_ARGMAX: '1'
     steps:
       - name: Skip non-matching shard (workflow_dispatch with shard input)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.shard != '' && !contains(matrix.shard.name, github.event.inputs.shard)
@@ -85,7 +120,12 @@ jobs:
         run: df -h /
 
       - name: Run E2E tests
-        run: swift test --skip-build --filter "${{ matrix.shard.filter }}"
+        run: |
+          if [ -n "${{ matrix.shard.skip }}" ]; then
+            swift test --skip-build --filter "${{ matrix.shard.filter }}" --skip "${{ matrix.shard.skip }}"
+          else
+            swift test --skip-build --filter "${{ matrix.shard.filter }}"
+          fi
 
       - name: Disk space after tests
         if: always()

--- a/Sources/Qwen3ASR/CoreMLTextDecoder.swift
+++ b/Sources/Qwen3ASR/CoreMLTextDecoder.swift
@@ -26,6 +26,10 @@ public class CoreMLTextDecoder {
     /// Current position in the KV cache (incremented per step).
     private var currentPosition: Int = 0
 
+    /// Number of times `argmax` has been called since process start. Used to
+    /// throttle diagnostic logging (see `SPEECH_DEBUG_ARGMAX`).
+    private var debugArgmaxCallCount: Int = 0
+
     public static let defaultModelId = "aufklarer/Qwen3-ASR-CoreML"
 
     public init(
@@ -245,6 +249,24 @@ public class CoreMLTextDecoder {
                 }
             }
         }
+
+        // Diagnostic logging for the Magpie ASR-roundtrip CI failure where
+        // argmax appears to pick low-id tokens (likely strided MLMultiArray
+        // with non-unit stride[-1]). Opt-in via `SPEECH_DEBUG_ARGMAX=1`.
+        // Logs full layout once + the first 8 picked tokens, then goes quiet.
+        if ProcessInfo.processInfo.environment["SPEECH_DEBUG_ARGMAX"] == "1" {
+            if debugArgmaxCallCount == 0 {
+                print("[SPEECH_DEBUG_ARGMAX] logits.shape=\(logits.shape) " +
+                      "strides=\(logits.strides) dataType=\(logits.dataType.rawValue) " +
+                      "count=\(count) vocabSize=\(vocabSize)")
+            }
+            if debugArgmaxCallCount < 8 {
+                print("[SPEECH_DEBUG_ARGMAX] call=\(debugArgmaxCallCount) " +
+                      "pickedToken=\(maxIdx) maxVal=\(maxVal)")
+            }
+            debugArgmaxCallCount += 1
+        }
+
         return maxIdx
     }
 

--- a/Tests/ParakeetASRTests/ParakeetASRTests.swift
+++ b/Tests/ParakeetASRTests/ParakeetASRTests.swift
@@ -107,42 +107,14 @@ final class ParakeetASRTests: XCTestCase {
 final class E2EParakeetASRTests: XCTestCase {
 
     func testModelLoading() async throws {
-        // Skip if model is not cached locally
-        let modelId = ParakeetASRModel.defaultModelId
-        let cacheDir: URL
-        do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        } catch {
-            throw XCTSkip("Cannot resolve cache directory: \(error)")
-        }
-
-        let encoderPath = cacheDir.appendingPathComponent("encoder.mlmodelc")
-        guard FileManager.default.fileExists(atPath: encoderPath.path) else {
-            throw XCTSkip("Parakeet model not cached at \(cacheDir.path)")
-        }
-
-        let model = try await ParakeetASRModel.fromPretrained(modelId: modelId)
+        let model = try await ParakeetASRModel.fromPretrained(modelId: ParakeetASRModel.defaultModelId)
         XCTAssertEqual(model.config.sampleRate, 16000)
         XCTAssertEqual(model.config.encoderHidden, 1024)
     }
 
     func testTranscription() async throws {
-        let modelId = ParakeetASRModel.defaultModelId
-        let cacheDir: URL
-        do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        } catch {
-            throw XCTSkip("Cannot resolve cache directory: \(error)")
-        }
+        let model = try await ParakeetASRModel.fromPretrained(modelId: ParakeetASRModel.defaultModelId)
 
-        let encoderPath = cacheDir.appendingPathComponent("encoder.mlmodelc")
-        guard FileManager.default.fileExists(atPath: encoderPath.path) else {
-            throw XCTSkip("Parakeet model not cached at \(cacheDir.path)")
-        }
-
-        let model = try await ParakeetASRModel.fromPretrained(modelId: modelId)
-
-        // Load test audio
         guard let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
             throw XCTSkip("test_audio.wav not found in test resources")
         }
@@ -159,20 +131,7 @@ final class E2EParakeetASRTests: XCTestCase {
     }
 
     func testWordConfidenceFromRealAudio() async throws {
-        let modelId = ParakeetASRModel.defaultModelId
-        let cacheDir: URL
-        do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        } catch {
-            throw XCTSkip("Cannot resolve cache directory: \(error)")
-        }
-
-        let encoderPath = cacheDir.appendingPathComponent("encoder.mlmodelc")
-        guard FileManager.default.fileExists(atPath: encoderPath.path) else {
-            throw XCTSkip("Parakeet model not cached at \(cacheDir.path)")
-        }
-
-        let model = try await ParakeetASRModel.fromPretrained(modelId: modelId)
+        let model = try await ParakeetASRModel.fromPretrained(modelId: ParakeetASRModel.defaultModelId)
 
         guard let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
             throw XCTSkip("test_audio.wav not found in test resources")
@@ -212,7 +171,7 @@ final class E2EParakeetASRTests: XCTestCase {
     }
 
     func testGermanTranscription() async throws {
-        let model = try await loadParakeetModel()
+        let model = try await ParakeetASRModel.fromPretrained(modelId: ParakeetASRModel.defaultModelId)
 
         guard let audioURL = Bundle.module.url(forResource: "test_audio_german", withExtension: "wav") else {
             throw XCTSkip("test_audio_german.wav not found in test resources")
@@ -229,38 +188,8 @@ final class E2EParakeetASRTests: XCTestCase {
         print("German transcription: \(result)")
     }
 
-    // MARK: - Helpers
-
-    private func loadParakeetModel() async throws -> ParakeetASRModel {
-        let modelId = ParakeetASRModel.defaultModelId
-        let cacheDir: URL
-        do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        } catch {
-            throw XCTSkip("Cannot resolve cache directory: \(error)")
-        }
-        let encoderPath = cacheDir.appendingPathComponent("encoder.mlmodelc")
-        guard FileManager.default.fileExists(atPath: encoderPath.path) else {
-            throw XCTSkip("Parakeet model not cached at \(cacheDir.path)")
-        }
-        return try await ParakeetASRModel.fromPretrained(modelId: modelId)
-    }
-
     func testWarmup() async throws {
-        let modelId = ParakeetASRModel.defaultModelId
-        let cacheDir: URL
-        do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        } catch {
-            throw XCTSkip("Cannot resolve cache directory: \(error)")
-        }
-
-        let encoderPath = cacheDir.appendingPathComponent("encoder.mlmodelc")
-        guard FileManager.default.fileExists(atPath: encoderPath.path) else {
-            throw XCTSkip("Parakeet model not cached at \(cacheDir.path)")
-        }
-
-        let model = try await ParakeetASRModel.fromPretrained(modelId: modelId)
+        let model = try await ParakeetASRModel.fromPretrained(modelId: ParakeetASRModel.defaultModelId)
 
         guard let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
             throw XCTSkip("test_audio.wav not found in test resources")
@@ -299,20 +228,7 @@ final class E2EParakeetASRTests: XCTestCase {
     // MARK: - Performance Tests
 
     func testTranscriptionLatency() async throws {
-        let modelId = ParakeetASRModel.defaultModelId
-        let cacheDir: URL
-        do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        } catch {
-            throw XCTSkip("Cannot resolve cache directory: \(error)")
-        }
-
-        let encoderPath = cacheDir.appendingPathComponent("encoder.mlmodelc")
-        guard FileManager.default.fileExists(atPath: encoderPath.path) else {
-            throw XCTSkip("Parakeet model not cached at \(cacheDir.path)")
-        }
-
-        let model = try await ParakeetASRModel.fromPretrained(modelId: modelId)
+        let model = try await ParakeetASRModel.fromPretrained(modelId: ParakeetASRModel.defaultModelId)
 
         guard let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
             throw XCTSkip("test_audio.wav not found in test resources")


### PR DESCRIPTION
First nightly run (#26460444790) was 4/6 green. This PR addresses all three problems uncovered.

## Diagnoses

| Shard | Symptom | Root cause |
|---|---|---|
| `light-coreml` | "passed" with 6 `ParakeetASRTests` E2E methods SKIPPED | Each method bailed via `guard fileExists(encoder.mlmodelc) else { XCTSkip }` before `fromPretrained` could download. Boilerplate from PR #40, unique to this module — every other E2E test in the repo just calls `fromPretrained` and lets it download. Zero real Parakeet coverage. |
| `qwen3-asr` | Runner died at 51 min, step log missing from archive | Likely OOM. Single xctest process accumulated 0.6B-4bit + 0.6B-8bit + 1.7B-8bit + Aligner-4bit + Aligner-bf16 + SileroVAD ≈ 8 GB unique resident weights against ~7 GB usable RAM on `macos-15`. Missing `9_Run E2E tests.txt` is the canonical OOM-kill signature (runner agent died before flushing). |
| `light-coreml` (real failure) | `MagpieTTSCoreMLTests.testAsrRoundTripEnglish` returned wall of Cyrillic `!б!б!б` × 448 tokens | First time `CoreMLASRModel` ran in CI. Top hypothesis: `CoreMLTextDecoder.argmax` iterates `ptr[i]` over the logits MLMultiArray assuming contiguous layout. On a cold runner without ANE warmup, CoreML may return a strided buffer → argmax silently picks low-id tokens (`!` = 0, `б` = byte-level BPE), never hits `imEndId` (151645), burns full 448 maxTokens (matches observed ~199s). |

## Fixes in this PR

1. **`Tests/ParakeetASRTests/ParakeetASRTests.swift`** — strip cache-dir resolution + `fileExists` guards from all 6 E2E methods; remove the dead `loadParakeetModel` helper. Methods now match the convention used in `KokoroTTSTests`, `OmnilingualASRTests`, `Qwen3ASRIntegrationTests`, etc. (-96 lines)
2. **`.github/workflows/nightly-e2e.yml`** — split `qwen3-asr` into 4 sub-shards (`qwen3-asr-06b`, `qwen3-asr-17b`, `qwen3-asr-aligner`, `qwen3-asr-streaming`). Adds a `skip:` field to matrix entries to support per-shard exclusion alongside `filter`. Sets `SPEECH_DEBUG_ARGMAX=1` job-wide for the diagnostic.
3. **`Sources/Qwen3ASR/CoreMLTextDecoder.swift`** — diagnostic logging in `argmax` gated on `SPEECH_DEBUG_ARGMAX=1`. Logs `logits.shape`, `strides`, `dataType`, `count`, `vocabSize` once + first 8 picked token IDs + max values. **Will be removed** in a follow-up after the next nightly confirms or refutes the strides hypothesis.

## Test plan
- [ ] Local `swift build` clean (verified, 265s, no new warnings)
- [ ] PR-CI `tests.yml` passes (it already skips ParakeetASRTests + the qwen3-asr-heavy classes wholesale, so no behavioral change for PR CI)
- [ ] After merge: kick off manual `workflow_dispatch` of nightly-e2e
  - [ ] `light-coreml` shard prints `[SPEECH_DEBUG_ARGMAX]` lines showing strides — diagnose Magpie hypothesis
  - [ ] All 4 `qwen3-asr-*` sub-shards complete without OOM
  - [ ] Parakeet E2E tests run for real (not skipped)