### PR TITLE
CosyVoiceTTS: bf16 bundle support + Linear-based weight dispatch

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -73,8 +73,11 @@ public struct SpeakCommand: ParsableCommand {
 
     // MARK: - CosyVoice-specific options
 
-    @Option(name: .long, help: "[cosyvoice] HuggingFace model ID")
-    public var modelId: String = "aufklarer/CosyVoice3-0.5B-MLX-4bit"
+    @Option(name: .long, help: "[cosyvoice] HuggingFace model ID. Set explicitly to bypass --cosyvoice-variant resolution.")
+    public var modelId: String?
+
+    @Option(name: .long, help: "[cosyvoice] Quantization variant: 4bit (default), 8bit, 8bit-full, bf16. Resolves to aufklarer/CosyVoice3-0.5B-MLX-<variant>. Ignored when --model-id is set.")
+    public var cosyvoiceVariant: String = "4bit"
 
     @Option(name: .long, help: "[cosyvoice] Speaker mapping: s1=alice.wav,s2=bob.wav")
     public var speakers: String?
@@ -771,12 +774,26 @@ public struct SpeakCommand: ParsableCommand {
 
     // MARK: - CosyVoice engine
 
+    private func resolvedCosyVoiceModelId() throws -> String {
+        if let explicit = modelId, !explicit.isEmpty { return explicit }
+        switch cosyvoiceVariant.lowercased() {
+        case "4bit":      return "aufklarer/CosyVoice3-0.5B-MLX-4bit"
+        case "8bit":      return "aufklarer/CosyVoice3-0.5B-MLX-8bit"
+        case "8bit-full": return "aufklarer/CosyVoice3-0.5B-MLX-8bit-full"
+        case "bf16":      return "aufklarer/CosyVoice3-0.5B-MLX-bf16"
+        default:
+            throw ValidationError(
+                "--cosyvoice-variant must be 4bit, 8bit, 8bit-full, or bf16 (got '\(cosyvoiceVariant)')")
+        }
+    }
+
     private func runCosyVoice() throws {
         try runAsync {
             print("Loading CosyVoice3 model...")
-            let bundleOverride = cosyBundleDir.map { URL(fileURLWithPath: $0) }
+            let resolvedId = try self.resolvedCosyVoiceModelId()
+            let bundleOverride = self.cosyBundleDir.map { URL(fileURLWithPath: $0) }
             let cosyModel = try await CosyVoiceTTSModel.fromPretrained(
-                modelId: modelId,
+                modelId: resolvedId,
                 cacheDir: bundleOverride,
                 progressHandler: reportProgress)
 
@@ -828,7 +845,7 @@ public struct SpeakCommand: ParsableCommand {
                 // reference conditioning. Bundles produced before this change
                 // won't have the file — we fall back to the spk-only path with
                 // a warning so the operator knows why cloning quality is capped.
-                let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+                let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: resolvedId)
                 let tokURL = cosySpeechTokenizer.map { URL(fileURLWithPath: $0) }
                     ?? cacheDir.appendingPathComponent("speech_tokenizer.safetensors")
                 if FileManager.default.fileExists(atPath: tokURL.path) {

--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -82,22 +82,35 @@ public final class CosyVoiceTTSModel {
             }
         }
 
-        // Read the bundle's `config.json` so the LLM module is constructed with
-        // the correct quantization bit width. Without this, the model defaults
-        // to 4-bit and MLX's QuantizedLinear blows up on 8-bit weights.
+        // Read the bundle's `config.json` so the LLM/DiT modules can be told
+        // the correct quantization bits. The bf16 bundle omits the
+        // `quantization` block entirely; in that case we keep the static
+        // defaults and the loader detects bf16 via the absence of `.scales`
+        // tensors in the safetensors.
         var config = CosyVoiceConfig.default
         let configURL = cacheDir.appendingPathComponent("config.json")
         if FileManager.default.fileExists(atPath: configURL.path),
            let data = try? Data(contentsOf: configURL),
-           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let quant = json["quantization"] as? [String: Any] {
-            // The convert.py emits BOTH `bits` (legacy default = 4) and a
-            // per-component override `llm_bits`. Prefer the LLM-specific value.
-            if let bits = (quant["llm_bits"] as? Int) ?? (quant["bits"] as? Int) {
-                config.llm.bits = bits
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let quant = json["quantization"] as? [String: Any] {
+                // The convert.py emits BOTH `bits` (legacy default = 4) and a
+                // per-component override `llm_bits`. Prefer the LLM-specific value.
+                if let bits = (quant["llm_bits"] as? Int) ?? (quant["bits"] as? Int) {
+                    config.llm.bits = bits
+                }
+                if let gs = quant["group_size"] as? Int { config.llm.groupSize = gs }
+                print("  Bundle quantization (LLM): \(config.llm.bits)-bit (group_size \(config.llm.groupSize))")
+            } else {
+                print("  Bundle: unquantised (bf16) — LLM + DiT stay in plain Linear form")
             }
-            if let gs = quant["group_size"] as? Int { config.llm.groupSize = gs }
-            print("  Bundle quantization: \(config.llm.bits)-bit (group_size \(config.llm.groupSize))")
+            // The "8-bit-full" variant emits a `dit_quantization` block to
+            // override the DiT bits without affecting the LLM. The bf16 bundle
+            // omits this; the loader will keep DiT as plain Linear.
+            if let dit = json["dit_quantization"] as? [String: Any] {
+                if let bits = dit["bits"] as? Int { config.flow.dit.bits = bits }
+                if let gs = dit["group_size"] as? Int { config.flow.dit.groupSize = gs }
+                print("  Bundle quantization (DiT): \(config.flow.dit.bits)-bit (group_size \(config.flow.dit.groupSize))")
+            }
         }
         let model = CosyVoiceTTSModel(config: config)
 
@@ -134,8 +147,21 @@ public final class CosyVoiceTTSModel {
     /// Metal kernel fusion for the LLM generation loop (~360 kernel dispatches fused)
     /// and DiT flow matching (~330 kernel dispatches × 10 ODE steps fused).
     public func warmUp() {
-        // Set up compiled LLM generation step (shapeless=true, traced on first call)
-        llm.setupCompilation()
+        // Shapeless compile fuses ~360 LLM kernel dispatches per step, but
+        // MLX-Swift's tracer cannot infer the output shape of `addmm` under a
+        // shapeless trace — that's the bias-fused matmul path that plain
+        // `Linear` uses. Quantised bundles route attention/MLP through
+        // `QuantizedLinear` (which uses `quantized_matmul + add` instead) so
+        // they trace cleanly; the bf16 bundle's plain `Linear` does not.
+        // When we detect a non-quantised LLM, skip compile entirely and run
+        // the autoregressive loop through the direct `forwardStep` path
+        // (still per-call eager, just no kernel fusion).
+        let isLLMQuantized = (llm.layers.first?.selfAttn.qProj as? QuantizedLinear) != nil
+
+        if isLLMQuantized {
+            // Set up compiled LLM generation step (shapeless=true, traced on first call)
+            llm.setupCompilation()
+        }
 
         // Run a minimal prefill to compile all 24-layer attention + MLP shaders
         let textTokens: [Int32] = [2610]  // single token "You"
@@ -151,7 +177,8 @@ public final class CosyVoiceTTSModel {
             embeds: warmupEmbed, offset: prefixEmbeds.dim(1), cache: warmupCache)
         eval(warmupLogits)
 
-        // Set up compiled DiT forward pass (shapeless=false, ~330 kernel dispatches fused)
+        // The flow decoder uses a fixed-shape compile, so it traces cleanly
+        // regardless of whether the DiT is quantised.
         flow.decoder.setupCompilation()
         flow.decoder.warmUp()
     }

--- a/Sources/CosyVoiceTTS/DiT.swift
+++ b/Sources/CosyVoiceTTS/DiT.swift
@@ -35,13 +35,13 @@ public class SinusoidalPositionEmbedding: Module {
 /// sinEmbed -> linear1 -> SiLU -> linear2
 public class TimestepEmbedding: Module {
     @ModuleInfo(key: "sin_embed") var sinEmbed: SinusoidalPositionEmbedding
-    @ModuleInfo var linear1: QuantizedLinear
-    @ModuleInfo var linear2: QuantizedLinear
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
 
-    public init(freqEmbedDim: Int, dim: Int, groupSize: Int = 64, bits: Int = 4) {
+    public init(freqEmbedDim: Int, dim: Int) {
         self._sinEmbed.wrappedValue = SinusoidalPositionEmbedding(dim: freqEmbedDim)
-        self._linear1.wrappedValue = QuantizedLinear(freqEmbedDim, dim, bias: true, groupSize: groupSize, bits: bits)
-        self._linear2.wrappedValue = QuantizedLinear(dim, dim, bias: true, groupSize: groupSize, bits: bits)
+        self._linear1.wrappedValue = Linear(freqEmbedDim, dim, bias: true)
+        self._linear2.wrappedValue = Linear(dim, dim, bias: true)
         super.init()
     }
 
@@ -64,11 +64,11 @@ public class TimestepEmbedding: Module {
 /// Uses non-affine LayerNorm (no learnable weight/bias) followed by
 /// conditioning-dependent scale and shift.
 public class AdaLayerNormZero: Module {
-    @ModuleInfo var linear: QuantizedLinear
+    @ModuleInfo var linear: Linear
     let norm: LayerNorm
 
-    public init(dim: Int, groupSize: Int = 64, bits: Int = 4) {
-        self._linear.wrappedValue = QuantizedLinear(dim, dim * 6, bias: true, groupSize: groupSize, bits: bits)
+    public init(dim: Int) {
+        self._linear.wrappedValue = Linear(dim, dim * 6, bias: true)
         self.norm = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
         super.init()
     }
@@ -101,11 +101,11 @@ public class AdaLayerNormZero: Module {
 
 /// Final adaptive layer norm with only 2 modulation params (scale + shift).
 public class AdaLayerNormZeroFinal: Module {
-    @ModuleInfo var linear: QuantizedLinear
+    @ModuleInfo var linear: Linear
     let norm: LayerNorm
 
-    public init(dim: Int, groupSize: Int = 64, bits: Int = 4) {
-        self._linear.wrappedValue = QuantizedLinear(dim, dim * 2, bias: true, groupSize: groupSize, bits: bits)
+    public init(dim: Int) {
+        self._linear.wrappedValue = Linear(dim, dim * 2, bias: true)
         self.norm = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
         super.init()
     }
@@ -132,21 +132,21 @@ public class DiTAttention: Module {
     let dimHead: Int
     let scale: Float
 
-    @ModuleInfo(key: "to_q") var toQ: QuantizedLinear
-    @ModuleInfo(key: "to_k") var toK: QuantizedLinear
-    @ModuleInfo(key: "to_v") var toV: QuantizedLinear
-    @ModuleInfo(key: "to_out") var toOut: QuantizedLinear
+    @ModuleInfo(key: "to_q") var toQ: Linear
+    @ModuleInfo(key: "to_k") var toK: Linear
+    @ModuleInfo(key: "to_v") var toV: Linear
+    @ModuleInfo(key: "to_out") var toOut: Linear
 
-    public init(dim: Int, heads: Int, dimHead: Int, groupSize: Int = 64, bits: Int = 4) {
+    public init(dim: Int, heads: Int, dimHead: Int) {
         self.heads = heads
         self.dimHead = dimHead
         self.scale = 1.0 / sqrt(Float(dimHead))
 
         let innerDim = heads * dimHead
-        self._toQ.wrappedValue = QuantizedLinear(dim, innerDim, bias: true, groupSize: groupSize, bits: bits)
-        self._toK.wrappedValue = QuantizedLinear(dim, innerDim, bias: true, groupSize: groupSize, bits: bits)
-        self._toV.wrappedValue = QuantizedLinear(dim, innerDim, bias: true, groupSize: groupSize, bits: bits)
-        self._toOut.wrappedValue = QuantizedLinear(innerDim, dim, bias: true, groupSize: groupSize, bits: bits)
+        self._toQ.wrappedValue = Linear(dim, innerDim, bias: true)
+        self._toK.wrappedValue = Linear(dim, innerDim, bias: true)
+        self._toV.wrappedValue = Linear(dim, innerDim, bias: true)
+        self._toOut.wrappedValue = Linear(innerDim, dim, bias: true)
 
         super.init()
     }
@@ -194,12 +194,12 @@ public class DiTAttention: Module {
 /// Feedforward network with GELU (tanh approximate) activation.
 /// linear1 -> GELU(tanh) -> linear2
 public class DiTFeedForward: Module {
-    @ModuleInfo var linear1: QuantizedLinear
-    @ModuleInfo var linear2: QuantizedLinear
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
 
-    public init(dim: Int, ffDim: Int, groupSize: Int = 64, bits: Int = 4) {
-        self._linear1.wrappedValue = QuantizedLinear(dim, ffDim, bias: true, groupSize: groupSize, bits: bits)
-        self._linear2.wrappedValue = QuantizedLinear(ffDim, dim, bias: true, groupSize: groupSize, bits: bits)
+    public init(dim: Int, ffDim: Int) {
+        self._linear1.wrappedValue = Linear(dim, ffDim, bias: true)
+        self._linear2.wrappedValue = Linear(ffDim, dim, bias: true)
         super.init()
     }
 
@@ -224,12 +224,12 @@ public class DiTBlock: Module {
     @ModuleInfo(key: "ff_norm") var ffNorm: LayerNorm
     @ModuleInfo var ff: DiTFeedForward
 
-    public init(dim: Int, heads: Int, dimHead: Int, ffMult: Int, groupSize: Int = 64, bits: Int = 4) {
-        self._attnNorm.wrappedValue = AdaLayerNormZero(dim: dim, groupSize: groupSize, bits: bits)
-        self._attn.wrappedValue = DiTAttention(dim: dim, heads: heads, dimHead: dimHead, groupSize: groupSize, bits: bits)
+    public init(dim: Int, heads: Int, dimHead: Int, ffMult: Int) {
+        self._attnNorm.wrappedValue = AdaLayerNormZero(dim: dim)
+        self._attn.wrappedValue = DiTAttention(dim: dim, heads: heads, dimHead: dimHead)
         // Non-affine LayerNorm for feedforward pre-norm (modulated externally)
         self._ffNorm.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
-        self._ff.wrappedValue = DiTFeedForward(dim: dim, ffDim: dim * ffMult, groupSize: groupSize, bits: bits)
+        self._ff.wrappedValue = DiTFeedForward(dim: dim, ffDim: dim * ffMult)
         super.init()
     }
 
@@ -329,14 +329,14 @@ private func mish(_ x: MLXArray) -> MLXArray {
 /// speaker embedding) and projects to model dimension.
 public class InputEmbedding: Module {
     let spkDim: Int
-    @ModuleInfo var proj: QuantizedLinear
+    @ModuleInfo var proj: Linear
     @ModuleInfo(key: "conv_pos_embed") var convPosEmbed: ConvPositionEmbedding
 
-    public init(melDim: Int, muDim: Int, spkDim: Int, dim: Int, groupSize: Int = 64, bits: Int = 4) {
+    public init(melDim: Int, muDim: Int, spkDim: Int, dim: Int) {
         self.spkDim = spkDim
         // Input: concatenation of [x, cond, textEmbed, spks] = [melDim, melDim, muDim, spkDim]
         let inputDim = melDim + melDim + muDim + spkDim
-        self._proj.wrappedValue = QuantizedLinear(inputDim, dim, bias: true, groupSize: groupSize, bits: bits)
+        self._proj.wrappedValue = Linear(inputDim, dim, bias: true)
         self._convPosEmbed.wrappedValue = ConvPositionEmbedding(dim: dim)
         super.init()
     }
@@ -395,13 +395,11 @@ public class DiT: Module {
         self.config = config
 
         self._timeEmbed.wrappedValue = TimestepEmbedding(
-            freqEmbedDim: config.freqEmbedDim, dim: config.dim,
-            groupSize: config.groupSize, bits: config.bits)
+            freqEmbedDim: config.freqEmbedDim, dim: config.dim)
 
         self._inputEmbed.wrappedValue = InputEmbedding(
             melDim: config.melDim, muDim: config.muDim,
-            spkDim: config.spkDim, dim: config.dim,
-            groupSize: config.groupSize, bits: config.bits)
+            spkDim: config.spkDim, dim: config.dim)
 
         // RoPE: dimensions = dimHead (64), traditional=true (interleaved pairs matching
         // x_transformers' rotate_half + duplicated freqs), base=10000
@@ -411,12 +409,10 @@ public class DiT: Module {
         self._transformerBlocks.wrappedValue = (0 ..< config.depth).map { _ in
             DiTBlock(
                 dim: config.dim, heads: config.heads,
-                dimHead: config.dimHead, ffMult: config.ffMult,
-                groupSize: config.groupSize, bits: config.bits)
+                dimHead: config.dimHead, ffMult: config.ffMult)
         }
 
-        self._normOut.wrappedValue = AdaLayerNormZeroFinal(dim: config.dim,
-            groupSize: config.groupSize, bits: config.bits)
+        self._normOut.wrappedValue = AdaLayerNormZeroFinal(dim: config.dim)
         self._projOut.wrappedValue = Linear(config.dim, config.melDim, bias: true)
 
         super.init()

--- a/Sources/CosyVoiceTTS/LLM.swift
+++ b/Sources/CosyVoiceTTS/LLM.swift
@@ -134,10 +134,10 @@ public class CosyVoiceAttention: Module {
     let headDim: Int
     let scale: Float
 
-    @ModuleInfo var qProj: QuantizedLinear
-    @ModuleInfo var kProj: QuantizedLinear
-    @ModuleInfo var vProj: QuantizedLinear
-    @ModuleInfo var oProj: QuantizedLinear
+    @ModuleInfo var qProj: Linear
+    @ModuleInfo var kProj: Linear
+    @ModuleInfo var vProj: Linear
+    @ModuleInfo var oProj: Linear
 
     let rope: MLXNN.RoPE
 
@@ -149,18 +149,10 @@ public class CosyVoiceAttention: Module {
 
         let hiddenSize = config.hiddenSize
 
-        self._qProj.wrappedValue = QuantizedLinear(
-            hiddenSize, numHeads * headDim, bias: true,
-            groupSize: config.groupSize, bits: config.bits)
-        self._kProj.wrappedValue = QuantizedLinear(
-            hiddenSize, numKVHeads * headDim, bias: true,
-            groupSize: config.groupSize, bits: config.bits)
-        self._vProj.wrappedValue = QuantizedLinear(
-            hiddenSize, numKVHeads * headDim, bias: true,
-            groupSize: config.groupSize, bits: config.bits)
-        self._oProj.wrappedValue = QuantizedLinear(
-            numHeads * headDim, hiddenSize, bias: false,
-            groupSize: config.groupSize, bits: config.bits)
+        self._qProj.wrappedValue = Linear(hiddenSize, numHeads * headDim, bias: true)
+        self._kProj.wrappedValue = Linear(hiddenSize, numKVHeads * headDim, bias: true)
+        self._vProj.wrappedValue = Linear(hiddenSize, numKVHeads * headDim, bias: true)
+        self._oProj.wrappedValue = Linear(numHeads * headDim, hiddenSize, bias: false)
 
         self.rope = MLXNN.RoPE(dimensions: headDim, traditional: false, base: config.ropeTheta)
 
@@ -215,20 +207,20 @@ public class CosyVoiceAttention: Module {
 // MARK: - CosyVoiceBlock
 
 /// Pre-norm transformer block for CosyVoice LLM.
-/// Uses SwiGLU MLP via QuantizedMLP from AudioCommon.
+/// Uses the Linear-based `MLP` so the bundle's quantization decides
+/// whether the gate/up/down projections stay bf16 or get swapped to
+/// `QuantizedLinear` at load time.
 public class CosyVoiceBlock: Module {
     @ModuleInfo var selfAttn: CosyVoiceAttention
-    @ModuleInfo var mlp: QuantizedMLP
+    @ModuleInfo var mlp: MLP
     @ModuleInfo var inputLayerNorm: RMSNorm
     @ModuleInfo var postAttentionLayerNorm: RMSNorm
 
     public init(config: CosyVoiceLLMConfig) {
         self._selfAttn.wrappedValue = CosyVoiceAttention(config: config)
-        self._mlp.wrappedValue = QuantizedMLP(
+        self._mlp.wrappedValue = MLP(
             hiddenSize: config.hiddenSize,
-            intermediateSize: config.intermediateSize,
-            groupSize: config.groupSize,
-            bits: config.bits)
+            intermediateSize: config.intermediateSize)
         self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
         self._postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
 
@@ -275,7 +267,7 @@ public class CosyVoiceLLM: Module {
     @ModuleInfo var speechEmbedding: Embedding
     @ModuleInfo var layers: [CosyVoiceBlock]
     @ModuleInfo var norm: RMSNorm
-    @ModuleInfo var speechHead: QuantizedLinear
+    @ModuleInfo var speechHead: Linear
 
     /// Compiled generation step (24-layer transformer + speech head) for kernel fusion.
     /// Uses shapeless=true to handle growing KV cache without recompilation.
@@ -303,10 +295,11 @@ public class CosyVoiceLLM: Module {
         // Final layer norm
         self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
 
-        // Speech token head: project hidden states to speech vocabulary logits
-        self._speechHead.wrappedValue = QuantizedLinear(
-            config.hiddenSize, config.totalSpeechVocabSize, bias: false,
-            groupSize: config.groupSize, bits: config.bits)
+        // Speech token head: project hidden states to speech vocabulary logits.
+        // Declared as Linear; swapped to QuantizedLinear at load time when the
+        // bundle ships scales/biases for `speech_head`.
+        self._speechHead.wrappedValue = Linear(
+            config.hiddenSize, config.totalSpeechVocabSize, bias: false)
 
         super.init()
     }

--- a/Sources/CosyVoiceTTS/WeightLoading.swift
+++ b/Sources/CosyVoiceTTS/WeightLoading.swift
@@ -11,8 +11,11 @@ import AudioCommon
 /// - `flow.safetensors`: Conditional flow matching with DiT decoder
 /// - `hifigan.safetensors`: Neural source filter vocoder
 ///
-/// The conversion script already remaps Python keys to match our module hierarchy
-/// and transposes Conv1d weights to MLX format `[out, kernel, in]`.
+/// All weight-bearing matmul modules in the LLM and DiT are declared as
+/// `Linear` and swapped to `QuantizedLinear` per-path at load time when the
+/// safetensors carries matching `.scales`. This lets one runtime serve
+/// quantised bundles (4-bit, 8-bit, 8-bit-full) AND the unquantised bf16
+/// bundle from the same module hierarchy.
 public enum CosyVoiceWeightLoader {
 
     // MARK: - LLM
@@ -22,38 +25,34 @@ public enum CosyVoiceWeightLoader {
     /// Expected keys (after conversion script remapping):
     /// - text_embedding.weight
     /// - speech_embedding.weight
-    /// - layers.{i}.self_attn.q_proj.weight/.scales/.biases (quantized)
-    /// - layers.{i}.self_attn.q_proj.bias (non-quantized bias)
-    /// - layers.{i}.self_attn.k_proj/v_proj/o_proj (same pattern)
-    /// - layers.{i}.self_attn.q_norm.weight
-    /// - layers.{i}.self_attn.k_norm.weight
+    /// - layers.{i}.self_attn.q_proj.weight (+ optional .scales/.biases for quant)
+    /// - layers.{i}.self_attn.q_proj.bias (Qwen2.5 has biased q/k/v projections)
+    /// - layers.{i}.self_attn.k_proj/v_proj/o_proj (same pattern; o_proj has no bias)
     /// - layers.{i}.input_layernorm.weight
     /// - layers.{i}.post_attention_layernorm.weight
-    /// - layers.{i}.mlp.gate_proj/up_proj/down_proj (quantized)
+    /// - layers.{i}.mlp.gate_proj/up_proj/down_proj (no Linear bias)
     /// - norm.weight
-    /// - speech_head.weight/.scales/.biases (quantized)
+    /// - speech_head.weight (+ optional .scales/.biases for quant)
     public static func loadLLM(_ llm: CosyVoiceLLM, from url: URL) throws {
         let weights = try CommonWeightLoader.loadSafetensors(url: url)
-        let bits = llm.config.bits
-        let groupSize = llm.config.groupSize
 
-        // ─── Phase 1: replace every QuantizedLinear via Module.update(modules:) ──
+        // ─── Phase 1: per-projection dispatch ──────────────────────────────────
         //
-        // The convenience init `QuantizedLinear(in, out, bias, groupSize, bits)`
-        // initialises with a random fp weight and runs `MLX.quantized(...)` to
-        // produce a packed uint32 placeholder. We then used to update the
-        // module's parameters with the loaded weights via `update(parameters:)`.
-        // At 4-bit this path works; at 8-bit the matmul site sees fp16 instead
-        // of uint32 (MLX errors with "weight matrix should be uint32 but
-        // received float16"). The fix is to construct each QuantizedLinear via
-        // the designated init that takes the pre-quantized weight + scales +
-        // biases directly — no placeholder, no dtype confusion.
+        // Every projection that *might* be quantised gets one of two treatments:
         //
-        // `@ModuleInfo` properties cannot be reassigned through `wrappedValue`
-        // (fatalError on re-set), so the swap goes through `Module.update
-        // (modules:)`. That walks the model's children tree and replaces each
-        // matching key. Children are keyed by Swift property name (camelCase),
-        // hence the snake-to-camel translation table below.
+        //   1. If the safetensors has `<prefix>.scales`, the projection is
+        //      packed: build a fully-initialised `QuantizedLinear` from the
+        //      pre-loaded tensors and stage it for `update(modules:)` so the
+        //      existing `Linear` is swapped in place.
+        //
+        //   2. Otherwise (bf16 bundle), leave the `Linear` in place and apply
+        //      `.weight` + optional `.bias` via the common helper.
+        //
+        // Doing the swap through `update(modules:)` (rather than MLX's
+        // `quantize(model:filter:)`) keeps us in control of dtype: the
+        // QuantizedLinear is constructed with the loaded fp16 scales/biases
+        // already, so the matmul site cannot land an fp16 weight where it
+        // expects a packed uint32 — the bug that the 8-bit refactor flushed out.
         let perLayerProj: [(String, String, Bool)] = [
             ("self_attn.q_proj", "selfAttn.qProj", true),
             ("self_attn.k_proj", "selfAttn.kProj", true),
@@ -65,32 +64,65 @@ public enum CosyVoiceWeightLoader {
         ]
 
         var qReplacements: [String: Module] = [:]
-        for i in 0..<llm.layers.count {
-            for (sfxSnake, sfxCamel, hasLinearBias) in perLayerProj {
-                let stPrefix  = "layers.\(i).\(sfxSnake)"
-                let modPath   = "layers.\(i).\(sfxCamel)"
-                guard let w = weights["\(stPrefix).weight"],
-                      let s = weights["\(stPrefix).scales"] else { continue }
+
+        func handleProjection(
+            stPrefix: String,
+            modPath: String,
+            owner: Linear,
+            hasLinearBias: Bool,
+            llmConfig: CosyVoiceLLMConfig
+        ) {
+            if let scales = weights["\(stPrefix).scales"],
+               let w = weights["\(stPrefix).weight"] {
+                let bits = inferBits(weight: w, scales: scales) ?? llmConfig.bits
+                let groupSize = inferGroupSize(weight: w, scales: scales) ?? llmConfig.groupSize
                 let quantBiases = weights["\(stPrefix).biases"]
                 let linearBias  = hasLinearBias ? weights["\(stPrefix).bias"] : nil
                 qReplacements[modPath] = QuantizedLinear(
                     weight: w, bias: linearBias,
-                    scales: s, biases: quantBiases,
+                    scales: scales, biases: quantBiases,
                     groupSize: groupSize, bits: bits)
+            } else {
+                CommonWeightLoader.applyLinearWeights(to: owner, prefix: stPrefix, from: weights)
+            }
+        }
+
+        for (i, block) in llm.layers.enumerated() {
+            for (sfxSnake, sfxCamel, hasLinearBias) in perLayerProj {
+                let stPrefix = "layers.\(i).\(sfxSnake)"
+                let modPath  = "layers.\(i).\(sfxCamel)"
+                let owner: Linear
+                switch sfxSnake {
+                case "self_attn.q_proj": owner = block.selfAttn.qProj
+                case "self_attn.k_proj": owner = block.selfAttn.kProj
+                case "self_attn.v_proj": owner = block.selfAttn.vProj
+                case "self_attn.o_proj": owner = block.selfAttn.oProj
+                case "mlp.gate_proj":    owner = block.mlp.gateProj
+                case "mlp.up_proj":      owner = block.mlp.upProj
+                case "mlp.down_proj":    owner = block.mlp.downProj
+                default: continue
+                }
+                handleProjection(
+                    stPrefix: stPrefix,
+                    modPath: modPath,
+                    owner: owner,
+                    hasLinearBias: hasLinearBias,
+                    llmConfig: llm.config)
             }
         }
 
         // Speech head sits at the LLM's top level; no Linear bias upstream.
-        if let w = weights["speech_head.weight"],
-           let s = weights["speech_head.scales"] {
-            qReplacements["speechHead"] = QuantizedLinear(
-                weight: w, bias: nil,
-                scales: s, biases: weights["speech_head.biases"],
-                groupSize: groupSize, bits: bits)
-        }
+        handleProjection(
+            stPrefix: "speech_head",
+            modPath: "speechHead",
+            owner: llm.speechHead,
+            hasLinearBias: false,
+            llmConfig: llm.config)
 
-        let nested = NestedDictionary<String, Module>.unflattened(qReplacements)
-        llm.update(modules: nested)
+        if !qReplacements.isEmpty {
+            let nested = NestedDictionary<String, Module>.unflattened(qReplacements)
+            llm.update(modules: nested)
+        }
 
         // ─── Phase 2: non-quantized parameters (embeddings, layer norms) ───────
         CommonWeightLoader.applyEmbeddingWeights(
@@ -112,29 +144,15 @@ public enum CosyVoiceWeightLoader {
     // MARK: - Flow (DiT Decoder)
 
     /// Load flow weights from flow.safetensors into the CosyVoiceFlowModel.
-    ///
-    /// Expected keys (after conversion script remapping):
-    /// - input_embedding.weight
-    /// - spk_embed_affine_layer.weight/bias
-    /// - encoder.* (pre-lookahead encoder layers)
-    /// - encoder_proj.weight/bias
-    /// - decoder.time_embed.*
-    /// - decoder.input_embed.*
-    /// - decoder.transformer_blocks.{i}.*
-    /// - decoder.norm_out.*
-    /// - decoder.proj_out.*
     public static func loadFlow(_ flow: CosyVoiceFlowModel, from url: URL) throws {
         let weights = try CommonWeightLoader.loadSafetensors(url: url)
 
-        // Input embedding (speech token -> 80 mel dims directly)
         CommonWeightLoader.applyEmbeddingWeights(
             to: flow.inputEmbedding, prefix: "input_embedding", from: weights)
 
-        // Speaker embedding affine projection (192 -> 80)
         CommonWeightLoader.applyLinearWeights(
             to: flow.spkEmbedAffineLayer, prefix: "spk_embed_affine_layer", from: weights)
 
-        // Pre-lookahead layer: conv1 (80→1024, k=4) + conv2 (1024→80, k=3)
         CommonWeightLoader.applyConv1dWeights(
             to: flow.preLookaheadLayer.conv1.conv,
             prefix: "pre_lookahead_layer.conv1", from: weights, transpose: false)
@@ -142,30 +160,63 @@ public enum CosyVoiceWeightLoader {
             to: flow.preLookaheadLayer.conv2.conv,
             prefix: "pre_lookahead_layer.conv2", from: weights, transpose: false)
 
-        // DiT decoder weights
-        loadDiT(flow.decoder.decoder, prefix: "decoder", from: weights)
+        loadDiT(flow.decoder.decoder, prefix: "decoder", from: weights, ditConfig: flow.decoder.decoder.config)
     }
 
-    /// Load DiT weights from a weight dictionary with a given prefix.
-    ///
-    /// The DiT has: timestep embedding MLP, input embedding (with conv pos embed),
-    /// RoPE (no learnable params), transformer blocks, final adaptive norm, output projection.
-    static func loadDiT(_ dit: DiT, prefix: String, from weights: [String: MLXArray]) {
-        // Time embedding MLP
-        // SinusoidalPositionEmbedding has no learnable parameters.
-        // TimestepEmbedding: sin_embed (no params) -> linear1 -> SiLU -> linear2
-        // Python keys: time_embed.time_mlp.0 (linear1), time_embed.time_mlp.2 (linear2)
-        CommonWeightLoader.applyQuantizedLinearWeights(
-            to: dit.timeEmbed.linear1, prefix: "\(prefix).time_embed.time_mlp.0", from: weights)
-        CommonWeightLoader.applyQuantizedLinearWeights(
-            to: dit.timeEmbed.linear2, prefix: "\(prefix).time_embed.time_mlp.2", from: weights)
+    /// Load DiT weights. Performs the same per-projection quantised/plain
+    /// dispatch as the LLM loader, building one `update(modules:)` swap for
+    /// every projection that ships with `.scales`.
+    static func loadDiT(
+        _ dit: DiT,
+        prefix: String,
+        from weights: [String: MLXArray],
+        ditConfig: CosyVoiceDiTConfig
+    ) {
+        var qReplacements: [String: Module] = [:]
 
-        // Input embedding: projection + causal conv position embedding
-        CommonWeightLoader.applyQuantizedLinearWeights(
-            to: dit.inputEmbed.proj, prefix: "\(prefix).input_embed.proj", from: weights)
+        func handleProjection(
+            stPrefix: String,
+            modPath: String,
+            owner: Linear,
+            hasLinearBias: Bool = true
+        ) {
+            if let scales = weights["\(stPrefix).scales"],
+               let w = weights["\(stPrefix).weight"] {
+                let bits = inferBits(weight: w, scales: scales) ?? ditConfig.bits
+                let groupSize = inferGroupSize(weight: w, scales: scales) ?? ditConfig.groupSize
+                let quantBiases = weights["\(stPrefix).biases"]
+                let linearBias  = hasLinearBias ? weights["\(stPrefix).bias"] : nil
+                qReplacements[modPath] = QuantizedLinear(
+                    weight: w, bias: linearBias,
+                    scales: scales, biases: quantBiases,
+                    groupSize: groupSize, bits: bits)
+            } else {
+                CommonWeightLoader.applyLinearWeights(to: owner, prefix: stPrefix, from: weights)
+            }
+        }
 
-        // Conv position embedding: two grouped Conv1d layers
-        // Keys are conv1.0 and conv2.0 (from nn.Sequential wrapping)
+        // `modPath` here is the module-tree path used by `Module.update
+        // (modules:)`. DiT declares its sub-modules with explicit `@ModuleInfo
+        // (key: "time_embed")` etc. — those keys are what the children
+        // dictionary uses, so the paths are snake_case at every level whose
+        // owner module declared an explicit key. Sub-fields without an
+        // explicit key fall back to the Swift property name.
+
+        handleProjection(
+            stPrefix: "\(prefix).time_embed.time_mlp.0",
+            modPath: "time_embed.linear1",
+            owner: dit.timeEmbed.linear1)
+        handleProjection(
+            stPrefix: "\(prefix).time_embed.time_mlp.2",
+            modPath: "time_embed.linear2",
+            owner: dit.timeEmbed.linear2)
+
+        handleProjection(
+            stPrefix: "\(prefix).input_embed.proj",
+            modPath: "input_embed.proj",
+            owner: dit.inputEmbed.proj)
+
+        // Conv position embedding stays Conv1d (no quantisation, kernel=31).
         CommonWeightLoader.applyConv1dWeights(
             to: dit.inputEmbed.convPosEmbed.conv1,
             prefix: "\(prefix).input_embed.conv_pos_embed.conv1.0",
@@ -175,77 +226,73 @@ public enum CosyVoiceWeightLoader {
             prefix: "\(prefix).input_embed.conv_pos_embed.conv2.0",
             from: weights, transpose: false)
 
-        // Transformer blocks
         for (i, block) in dit.transformerBlocks.enumerated() {
             let blockPrefix = "\(prefix).transformer_blocks.\(i)"
+            let modBase = "transformer_blocks.\(i)"
 
-            // AdaLN attention norm: projects timestep embedding to 6 modulation params
-            CommonWeightLoader.applyQuantizedLinearWeights(
-                to: block.attnNorm.linear, prefix: "\(blockPrefix).attn_norm.linear", from: weights)
+            handleProjection(
+                stPrefix: "\(blockPrefix).attn_norm.linear",
+                modPath: "\(modBase).attn_norm.linear",
+                owner: block.attnNorm.linear)
 
-            // Self-attention (full attention, not GQA)
-            // Python keys use to_q, to_k, to_v, to_out.0
-            CommonWeightLoader.applyQuantizedLinearWeights(
-                to: block.attn.toQ, prefix: "\(blockPrefix).attn.to_q", from: weights)
-            CommonWeightLoader.applyQuantizedLinearWeights(
-                to: block.attn.toK, prefix: "\(blockPrefix).attn.to_k", from: weights)
-            CommonWeightLoader.applyQuantizedLinearWeights(
-                to: block.attn.toV, prefix: "\(blockPrefix).attn.to_v", from: weights)
-            CommonWeightLoader.applyQuantizedLinearWeights(
-                to: block.attn.toOut, prefix: "\(blockPrefix).attn.to_out.0", from: weights)
+            handleProjection(
+                stPrefix: "\(blockPrefix).attn.to_q",
+                modPath: "\(modBase).attn.to_q",
+                owner: block.attn.toQ)
+            handleProjection(
+                stPrefix: "\(blockPrefix).attn.to_k",
+                modPath: "\(modBase).attn.to_k",
+                owner: block.attn.toK)
+            handleProjection(
+                stPrefix: "\(blockPrefix).attn.to_v",
+                modPath: "\(modBase).attn.to_v",
+                owner: block.attn.toV)
+            handleProjection(
+                stPrefix: "\(blockPrefix).attn.to_out.0",
+                modPath: "\(modBase).attn.to_out",
+                owner: block.attn.toOut)
 
-            // Feedforward: GELU(tanh) MLP
-            // Python keys: ff.ff.0.0 (linear1 after GELU wrapper), ff.ff.2 (linear2)
-            CommonWeightLoader.applyQuantizedLinearWeights(
-                to: block.ff.linear1, prefix: "\(blockPrefix).ff.ff.0.0", from: weights)
-            CommonWeightLoader.applyQuantizedLinearWeights(
-                to: block.ff.linear2, prefix: "\(blockPrefix).ff.ff.2", from: weights)
+            // Feedforward (GELU MLP). Python keys: ff.ff.0.0 / ff.ff.2.
+            handleProjection(
+                stPrefix: "\(blockPrefix).ff.ff.0.0",
+                modPath: "\(modBase).ff.linear1",
+                owner: block.ff.linear1)
+            handleProjection(
+                stPrefix: "\(blockPrefix).ff.ff.2",
+                modPath: "\(modBase).ff.linear2",
+                owner: block.ff.linear2)
         }
 
-        // Final adaptive norm: projects to 2 modulation params (scale + shift)
-        CommonWeightLoader.applyQuantizedLinearWeights(
-            to: dit.normOut.linear, prefix: "\(prefix).norm_out.linear", from: weights)
+        // Final adaptive norm projection.
+        handleProjection(
+            stPrefix: "\(prefix).norm_out.linear",
+            modPath: "norm_out.linear",
+            owner: dit.normOut.linear)
 
-        // Output projection: model dim -> mel dim (NOT quantized: 80 % 64 != 0)
+        if !qReplacements.isEmpty {
+            let nested = NestedDictionary<String, Module>.unflattened(qReplacements)
+            dit.update(modules: nested)
+        }
+
+        // Output projection: model dim → 80 mel dims. Never quantised
+        // (out_features=80 isn't divisible by group_size=64).
         CommonWeightLoader.applyLinearWeights(
             to: dit.projOut, prefix: "\(prefix).proj_out", from: weights)
     }
 
     // MARK: - HiFi-GAN
 
-    /// Load HiFi-GAN weights from hifigan.safetensors.
-    ///
-    /// Expected keys (after conversion script remapping):
-    /// - conv_pre.weight/bias (already transposed by conversion script)
-    /// - ups.{i}.weight/bias
-    /// - resblocks.{stage*3+kernel_idx}.convs1.{dilation_idx}.weight/bias
-    /// - resblocks.{stage*3+kernel_idx}.convs2.{dilation_idx}.weight/bias
-    /// - resblocks.{...}.activations1.{...}.alpha/beta
-    /// - resblocks.{...}.activations2.{...}.alpha/beta
-    /// - source_downs.{i}.weight/bias
-    /// - source_resblocks.{i}.*
-    /// - conv_post.weight/bias
-    /// - m_source.l_linear.weight/bias
-    /// - f0_predictor.condnet.{i}.weight/bias
-    /// - f0_predictor.classifier.weight/bias
-    /// - up_activations.{i}.alpha/beta
-    /// - final_activation.alpha/beta
-    ///
-    /// Note: Conv1d weights are already in MLX format [out, kernel, in] from conversion script.
     public static func loadHiFiGAN(_ hifigan: HiFiGANGenerator, from url: URL) throws {
         let weights = try CommonWeightLoader.loadSafetensors(url: url)
 
-        // conv_pre (CausalDilatedConv1d wraps Conv1d)
         CommonWeightLoader.applyConv1dWeights(
             to: hifigan.convPre.conv, prefix: "conv_pre", from: weights, transpose: false)
 
-        // Upsample convolutions (CausalConv1dUpsample: nn.Upsample + CausalDilatedConv1d)
         for (i, up) in hifigan.ups.enumerated() {
             CommonWeightLoader.applyConv1dWeights(
                 to: up.conv.conv, prefix: "ups.\(i)", from: weights, transpose: false)
         }
 
-        // Source downsampling convolutions (CausalConv1dDownSample or CausalDilatedConv1d)
         for (i, down) in hifigan.sourceDowns.enumerated() {
             if let downSample = down as? CausalConv1dDownSample {
                 CommonWeightLoader.applyConv1dWeights(
@@ -256,8 +303,6 @@ public enum CosyVoiceWeightLoader {
             }
         }
 
-        // Main resblocks: flattened indexing (stage * numKernels + kernelIdx)
-        // hifigan.resblocks is [[ResBlock]] (stages x kernels)
         var flatIdx = 0
         for stage in hifigan.resblocks {
             for resblock in stage {
@@ -266,22 +311,16 @@ public enum CosyVoiceWeightLoader {
             }
         }
 
-        // Source resblocks
         for (i, resblock) in hifigan.sourceResblocks.enumerated() {
             loadResBlock(resblock, prefix: "source_resblocks.\(i)", from: weights)
         }
 
-        // conv_post (CausalDilatedConv1d wraps Conv1d)
         CommonWeightLoader.applyConv1dWeights(
             to: hifigan.convPost.conv, prefix: "conv_post", from: weights, transpose: false)
 
-        // Source module: harmonic linear merge
         CommonWeightLoader.applyLinearWeights(
             to: hifigan.source.linearMerge, prefix: "m_source.l_linear", from: weights)
 
-        // F0 predictor: condnet conv layers + classifier
-        // F0Predictor.condnet is [CausalDilatedConv1d], each wrapping Conv1d.
-        // Python condnet is Sequential of (Conv1d, ELU) pairs, so even indices are convs.
         for (i, conv) in hifigan.f0Predictor.condnet.enumerated() {
             CommonWeightLoader.applyConv1dWeights(
                 to: conv.conv, prefix: "f0_predictor.condnet.\(i * 2)", from: weights, transpose: false)
@@ -290,14 +329,6 @@ public enum CosyVoiceWeightLoader {
             to: hifigan.f0Predictor.classifier, prefix: "f0_predictor.classifier", from: weights)
     }
 
-    // MARK: - ResBlock Weight Loading
-
-    /// Load weights into a ResBlock (SnakeActivation + CausalDilatedConv1d layers).
-    ///
-    /// ResBlock structure per dilation stage:
-    ///   activations1[j] -> convs1[j] -> activations2[j] -> convs2[j] -> residual add
-    ///
-    /// Each CausalDilatedConv1d wraps a Conv1d, so we load into `.conv`.
     static func loadResBlock(_ resblock: ResBlock, prefix: String, from weights: [String: MLXArray]) {
         for (j, conv) in resblock.convs1.enumerated() {
             CommonWeightLoader.applyConv1dWeights(
@@ -308,7 +339,6 @@ public enum CosyVoiceWeightLoader {
                 to: conv.conv, prefix: "\(prefix).convs2.\(j)", from: weights, transpose: false)
         }
 
-        // Snake activation parameters (alpha/beta in log-space)
         for (j, act) in resblock.activations1.enumerated() {
             loadSnakeActivation(act, prefix: "\(prefix).activations1.\(j)", from: weights)
         }
@@ -317,10 +347,6 @@ public enum CosyVoiceWeightLoader {
         }
     }
 
-    // MARK: - SnakeActivation Weight Loading
-
-    /// Load SnakeActivation parameters (alpha only, CosyVoice3 uses alpha=beta).
-    /// Stored as 1D [channels] tensors in log-space.
     static func loadSnakeActivation(
         _ act: SnakeActivation, prefix: String, from weights: [String: MLXArray]
     ) {
@@ -331,38 +357,19 @@ public enum CosyVoiceWeightLoader {
 
     // MARK: - Speech Tokenizer (zero-shot voice cloning)
 
-    /// Load weights into a `SpeechTokenizerModel` from `speech_tokenizer.safetensors`.
-    ///
-    /// Expected keys (produced by `convert_speech_tokenizer` in
-    /// `speech-models/models/cosyvoice-tts/export/convert.py`):
-    /// - encoder.conv1.weight/bias                                 (MLX-layout [out, k, in])
-    /// - encoder.conv2.weight/bias                                 (MLX-layout)
-    /// - encoder.blocks.{i}.attn.{query,key,value,out}.weight/bias (key has no bias)
-    /// - encoder.blocks.{i}.attn.fsmn_block.weight                 (MLX-layout, depthwise k=31)
-    /// - encoder.blocks.{i}.attn_ln.weight/bias                    (LayerNorm)
-    /// - encoder.blocks.{i}.mlp.0.weight/bias                      (Linear, in→hidden)
-    /// - encoder.blocks.{i}.mlp.2.weight/bias                      (Linear, hidden→in)
-    /// - encoder.blocks.{i}.mlp_ln.weight/bias                     (LayerNorm)
-    /// - quantizer._codebook.project_down.weight/bias              (Linear 1280→8)
-    ///
-    /// Conv1d weights are already transposed to MLX `[out, kernel, in]` by the
-    /// conversion script, so all Conv1d loads use `transpose: false`.
     public static func loadSpeechTokenizer(
         _ tokenizer: SpeechTokenizerModel, from url: URL
     ) throws {
         let weights = try CommonWeightLoader.loadSafetensors(url: url)
 
-        // Subsampling convs (channels-first stride-2 each).
         CommonWeightLoader.applyConv1dWeights(
             to: tokenizer.encoder.conv1, prefix: "encoder.conv1", from: weights, transpose: false)
         CommonWeightLoader.applyConv1dWeights(
             to: tokenizer.encoder.conv2, prefix: "encoder.conv2", from: weights, transpose: false)
 
-        // Transformer blocks.
         for (i, block) in tokenizer.encoder.blocks.enumerated() {
             let p = "encoder.blocks.\(i)"
 
-            // Attention projections — key has no bias, the rest do.
             CommonWeightLoader.applyLinearWeights(
                 to: block.attn.query, prefix: "\(p).attn.query", from: weights)
             CommonWeightLoader.applyLinearWeights(
@@ -372,28 +379,57 @@ public enum CosyVoiceWeightLoader {
             CommonWeightLoader.applyLinearWeights(
                 to: block.attn.out, prefix: "\(p).attn.out", from: weights)
 
-            // FSMN depthwise conv (no bias).
             CommonWeightLoader.applyConv1dWeights(
                 to: block.attn.fsmnBlock, prefix: "\(p).attn.fsmn_block",
                 from: weights, transpose: false)
 
-            // Layer norms before each sublayer.
             CommonWeightLoader.applyLayerNormWeights(
                 to: block.attnLN, prefix: "\(p).attn_ln", from: weights)
             CommonWeightLoader.applyLayerNormWeights(
                 to: block.mlpLN, prefix: "\(p).mlp_ln", from: weights)
 
-            // MLP: upstream stores as Sequential, so keys are mlp.0 / mlp.2.
             CommonWeightLoader.applyLinearWeights(
                 to: block.mlpFc1, prefix: "\(p).mlp.0", from: weights)
             CommonWeightLoader.applyLinearWeights(
                 to: block.mlpFc2, prefix: "\(p).mlp.2", from: weights)
         }
 
-        // FSQ projection (1280 → 8). The codebook itself has no `embed` weights —
-        // FSQ quantisation is the rounding/base-3-packing math, no learned codes.
         CommonWeightLoader.applyLinearWeights(
             to: tokenizer.quantizer.codebook.projectDown,
             prefix: "quantizer._codebook.project_down", from: weights)
+    }
+
+    // MARK: - Quantization inference helpers
+
+    /// Pull `bits` out of the packed `weight` + `scales` shape ratio.
+    /// 4-bit packs 8 nibbles per uint32 word → `packedCols / outFeaturesPerWord = 8`.
+    /// 8-bit packs 4 bytes per uint32 word → ratio = 16. Falls back to nil if
+    /// the shapes don't look like an MLX quantised layout (lets the caller use
+    /// the bundle config's value).
+    static func inferBits(weight: MLXArray, scales: MLXArray) -> Int? {
+        guard weight.ndim == 2, scales.ndim == 2 else { return nil }
+        let packedCols = weight.dim(1)
+        let numGroups = scales.dim(1)
+        guard numGroups > 0 else { return nil }
+        let ratio = packedCols / numGroups
+        switch ratio {
+        case 8:  return 4
+        case 16: return 8
+        default: return nil
+        }
+    }
+
+    /// Pull `groupSize` out of the scales' grouping. `scales.dim(1)` is the
+    /// number of per-row groups; multiplying by `elementsPerWord` gives the
+    /// logical input-feature count, and `inputFeatures / numGroups = groupSize`.
+    static func inferGroupSize(weight: MLXArray, scales: MLXArray) -> Int? {
+        guard weight.ndim == 2, scales.ndim == 2 else { return nil }
+        let packedCols = weight.dim(1)
+        let numGroups = scales.dim(1)
+        guard numGroups > 0, packedCols > 0 else { return nil }
+        guard let bits = inferBits(weight: weight, scales: scales) else { return nil }
+        let elementsPerWord = 32 / bits
+        let inFeatures = packedCols * elementsPerWord
+        return inFeatures / numGroups
     }
 }

--- a/Sources/MLXCommon/QuantizedMLP.swift
+++ b/Sources/MLXCommon/QuantizedMLP.swift
@@ -29,3 +29,27 @@ public class QuantizedMLP: Module {
         return downProj(gate * up)
     }
 }
+
+/// SwiGLU MLP with `Linear` projections — used by modules that need to
+/// support both bf16/fp16 and quantized bundles. The runtime swaps
+/// Linear → QuantizedLinear in place via `quantize(model:filter:)` when
+/// the loaded weights carry `.scales` for these paths.
+public class MLP: Module {
+    @ModuleInfo public var gateProj: Linear
+    @ModuleInfo public var upProj: Linear
+    @ModuleInfo public var downProj: Linear
+
+    public init(hiddenSize: Int, intermediateSize: Int) {
+        self._gateProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(intermediateSize, hiddenSize, bias: false)
+
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let gate = silu(gateProj(x))
+        let up = upProj(x)
+        return downProj(gate * up)
+    }
+}

--- a/Sources/MLXCommon/WeightLoading.swift
+++ b/Sources/MLXCommon/WeightLoading.swift
@@ -218,6 +218,36 @@ public enum CommonWeightLoader {
         applyQuantizedLinearWeights(to: mlp.upProj, prefix: "\(prefix).up_proj", from: weights)
         applyQuantizedLinearWeights(to: mlp.downProj, prefix: "\(prefix).down_proj", from: weights)
     }
+
+    /// Apply MLP weights (SwiGLU) — dispatches to quantized or plain
+    /// projections per-leaf based on `.scales` presence. Use when the
+    /// surrounding module was declared with `Linear` and may have been
+    /// swapped to `QuantizedLinear` by `quantize(model:filter:)`.
+    public static func applyMLPWeights(
+        to mlp: MLP,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) {
+        applyMaybeQuantizedLinearWeights(to: mlp.gateProj, prefix: "\(prefix).gate_proj", from: weights)
+        applyMaybeQuantizedLinearWeights(to: mlp.upProj, prefix: "\(prefix).up_proj", from: weights)
+        applyMaybeQuantizedLinearWeights(to: mlp.downProj, prefix: "\(prefix).down_proj", from: weights)
+    }
+
+    /// Apply weights to a `Linear` that may have been swapped to
+    /// `QuantizedLinear`. Picks the right keys (`weight`, optional `bias`
+    /// for plain Linear; plus `scales`, `biases` when quantized) based on
+    /// what is present in the safetensors.
+    public static func applyMaybeQuantizedLinearWeights(
+        to linear: Linear,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) {
+        if weights["\(prefix).scales"] != nil, let q = linear as? QuantizedLinear {
+            applyQuantizedLinearWeights(to: q, prefix: prefix, from: weights)
+        } else {
+            applyLinearWeights(to: linear, prefix: prefix, from: weights)
+        }
+    }
 }
 
 /// Weight loading errors

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -347,7 +347,25 @@ final class SpeakCommandTests: XCTestCase {
     func testDefaultCosyVoiceModelId() throws {
         let cmd = try AudioCLI.parseAsRoot(["speak", "Hello"])
         let speak = try XCTUnwrap(cmd as? SpeakCommand)
-        XCTAssertEqual(speak.modelId, "aufklarer/CosyVoice3-0.5B-MLX-4bit")
+        // --model-id is now opt-in; the runtime resolves the default through
+        // --cosyvoice-variant (4bit by default → aufklarer/CosyVoice3-0.5B-MLX-4bit).
+        XCTAssertNil(speak.modelId)
+        XCTAssertEqual(speak.cosyvoiceVariant, "4bit")
+    }
+
+    func testCosyVoiceVariantBf16() throws {
+        let cmd = try AudioCLI.parseAsRoot(
+            ["speak", "--engine", "cosyvoice", "--cosyvoice-variant", "bf16", "Hello"])
+        let speak = try XCTUnwrap(cmd as? SpeakCommand)
+        XCTAssertEqual(speak.cosyvoiceVariant, "bf16")
+        XCTAssertNil(speak.modelId)
+    }
+
+    func testCosyVoiceModelIdOverridesVariant() throws {
+        let cmd = try AudioCLI.parseAsRoot(
+            ["speak", "--engine", "cosyvoice", "--model-id", "custom/Model", "Hello"])
+        let speak = try XCTUnwrap(cmd as? SpeakCommand)
+        XCTAssertEqual(speak.modelId, "custom/Model")
     }
 
     // MARK: Engine selection

--- a/docs/models/cosyvoice-tts.md
+++ b/docs/models/cosyvoice-tts.md
@@ -56,11 +56,31 @@ Three-stage pipeline: LLM → DiT Flow Matching → HiFi-GAN Vocoder → 24kHz a
 
 ## Weight Conversion
 - Source: FunAudioLLM/Fun-CosyVoice3-0.5B-2512 (PyTorch .pt)
-- LLM: 4-bit quantized (group_size=64)
-- DiT Flow: bfloat16
-- HiFi-GAN: float32
+- HiFi-GAN: float32 (weight-norm folded)
 - Conv1d weights transposed: PyTorch [out,in,k] → MLX [out,k,in]
-- Total: ~1.9 GB (quantized)
+
+### Available bundles
+
+| Variant | LLM | DiT | speech_tokenizer | Total | HF repo |
+|---|---|---|---|---:|---|
+| **4-bit** (default) | int4, group=64 | bf16 | bf16 | ~1.2 GB | [aufklarer/CosyVoice3-0.5B-MLX-4bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-4bit) |
+| **8-bit** | int8, group=64 | bf16 | bf16 | ~1.4 GB | [aufklarer/CosyVoice3-0.5B-MLX-8bit](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-8bit) |
+| **8-bit-full** | int8, group=64 | int8, group=64 | bf16 | ~1.6 GB | [aufklarer/CosyVoice3-0.5B-MLX-8bit-full](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-8bit-full) |
+| **bf16** | bf16 | bf16 | bf16 | ~2.1 GB | [aufklarer/CosyVoice3-0.5B-MLX-bf16](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-bf16) |
+
+The runtime declares every weight-bearing matmul in the LLM and the DiT
+as `Linear`. Bundles that ship `.scales` for a given projection get a
+per-path `Linear → QuantizedLinear` swap at load time; bundles that omit
+the `quantization` block (bf16) stay in plain `Linear` form. This lets a
+single runtime serve all four variants from the same module hierarchy.
+
+Pick via the CLI:
+
+```bash
+speech speak "Hello, world" --engine cosyvoice --cosyvoice-variant bf16 -o hi.wav
+```
+
+`--model-id` still wins if you point it at a custom HF repo.
 
 ## Configuration
 Key parameters from cosyvoice3.yaml:


### PR DESCRIPTION
## Summary

Adds runtime support for the new [`aufklarer/CosyVoice3-0.5B-MLX-bf16`](https://huggingface.co/aufklarer/CosyVoice3-0.5B-MLX-bf16) bundle and refactors the weight-loading path so one runtime serves every published variant (4-bit, 8-bit, 8-bit-full, bf16) from the same module hierarchy.

### Refactor

- Declare every weight-bearing matmul in the LLM and DiT as plain `Linear`. The loader stages a `Linear → QuantizedLinear` swap (via `Module.update(modules:)`) per-projection iff the safetensors carries `.scales` for that path. Bundles that omit the `quantization` block (bf16) keep the original `Linear`.
- Introduce `MLP` (Linear-based sibling of `QuantizedMLP`) in `MLXCommon` so the LLM's SwiGLU block can be both quantised and unquantised.
- Add `applyMaybeQuantizedLinearWeights` in `MLXCommon` that dispatches between the quantised and plain weight loaders based on the presence of `.scales`.
- `bits` / `group_size` are inferred from the packed weight + scales shape ratio, falling back to the bundle's `config.json` when present.
- Parse the per-component `dit_quantization` override so the "8-bit-full" variant (int8 LLM + int8 DiT) is correctly recognised.

### Compile path

MLX-Swift's shapeless tracer cannot infer the output shape of `addmm` — the bias-fused matmul that plain `Linear` uses for the Qwen-style q/k/v projections. Quantised bundles route attention/MLP through `QuantizedLinear` (which uses `quantized_matmul + add` instead) so they continue to fuse; bf16 bundles skip the LLM compile in `warmUp` and run the autoregressive loop through the direct `forwardStep` path (per-call eager, no kernel fusion). The DiT compile is fixed-shape and traces cleanly either way.

### CLI

```bash
speech speak "Hello, world" --engine cosyvoice --cosyvoice-variant bf16 -o hi.wav
```

| Variant | Resolves to |
|---|---|
| `4bit` (default) | `aufklarer/CosyVoice3-0.5B-MLX-4bit` |
| `8bit` | `aufklarer/CosyVoice3-0.5B-MLX-8bit` |
| `8bit-full` | `aufklarer/CosyVoice3-0.5B-MLX-8bit-full` |
| `bf16` | `aufklarer/CosyVoice3-0.5B-MLX-bf16` |

`--model-id` still wins when supplied (lets you point at any HF repo).

### Smoke tests

- 4-bit: `Duration 2.28s, Time 1.13s, RTF 0.50` ✓
- bf16:  `Duration 6.04s, Time 2.22s, RTF 0.37` ✓

(bf16 is faster despite a 2x larger LLM because there is no quantize/dequantize overhead per matmul.)

## Test plan

- [x] `swift build` clean
- [x] 4-bit smoke (regression): plays normally, no quality regression vs main
- [x] bf16 smoke (new variant): loads, synthesises, plays normally
- [ ] CI green