### PR TITLE
test(perf): add PerfTracker + baseline measurements for Magpie + Qwen3-ASR

### DIFF
--- a/Sources/AudioCommon/PerfTracker.swift
+++ b/Sources/AudioCommon/PerfTracker.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Darwin
+
+/// Wall-time + resident-memory tracker for benchmark instrumentation.
+///
+/// Sample at construction, sample again at checkpoints (peak is tracked),
+/// then call `finish()` for a printable snapshot. Output format is grep-able
+/// from CI logs so we can diff numbers across runs.
+public final class PerfTracker {
+    private let label: String
+    private let startTime: CFAbsoluteTime
+    private let startRss: UInt64
+    private var peakRss: UInt64
+
+    public init(_ label: String) {
+        self.label = label
+        self.startTime = CFAbsoluteTimeGetCurrent()
+        self.startRss = currentRSS()
+        self.peakRss = self.startRss
+    }
+
+    /// Sample current RSS and update peak. Useful between long-running steps.
+    @discardableResult
+    public func checkpoint(_ name: String? = nil) -> UInt64 {
+        let cur = currentRSS()
+        if cur > peakRss { peakRss = cur }
+        if let name {
+            let elapsed = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+            print(String(format: "[PERF] %@ checkpoint=%@ t=%.0fms rss=%.0fMB",
+                         label, name, elapsed, Double(cur) / 1_048_576))
+        }
+        return cur
+    }
+
+    /// Final snapshot. Logs in a format easy to grep from CI / diff.
+    public func finish() {
+        checkpoint()
+        let elapsed = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+        let curRss = currentRSS()
+        print(String(format:
+            "[PERF] %@ total=%.0fms rssStart=%.0fMB rssEnd=%.0fMB rssPeak=%.0fMB rssDelta=%.0fMB",
+            label, elapsed,
+            Double(startRss) / 1_048_576,
+            Double(curRss) / 1_048_576,
+            Double(peakRss) / 1_048_576,
+            Double(Int64(peakRss) - Int64(startRss)) / 1_048_576))
+    }
+}
+
+/// Current process resident set size in bytes.
+public func currentRSS() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+    let result = withUnsafeMutablePointer(to: &info) {
+        $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+            task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+        }
+    }
+    return result == KERN_SUCCESS ? info.resident_size : 0
+}

--- a/Tests/MagpieTTSCoreMLTests/E2EMagpieCoreMLTests.swift
+++ b/Tests/MagpieTTSCoreMLTests/E2EMagpieCoreMLTests.swift
@@ -67,10 +67,18 @@ final class E2EMagpieCoreMLTests: XCTestCase {
         XCTAssertGreaterThan(audio.count, Int(MagpieTTSCoreML.sampleRate) / 2,
                              "fixture audio <0.5 s — file may be corrupt")
 
+        let tracker = PerfTracker("magpie-asr-roundtrip")
         let asr = try await CoreMLASRModel.fromPretrained()
+        tracker.checkpoint("asr-loaded")
+        let transcribeStart = CFAbsoluteTimeGetCurrent()
         let raw = asr.transcribe(audio: audio,
                                   sampleRate: Int(MagpieTTSCoreML.sampleRate),
                                   language: "english")
+        let transcribeMs = (CFAbsoluteTimeGetCurrent() - transcribeStart) * 1000
+        let audioMs = Double(audio.count) / Double(MagpieTTSCoreML.sampleRate) * 1000
+        print(String(format: "[PERF] magpie-asr-roundtrip transcribe=%.0fms audio=%.0fms rtf=%.3f",
+                     transcribeMs, audioMs, transcribeMs / audioMs))
+        tracker.finish()
         let normalised = raw
             .lowercased()
             .components(separatedBy: CharacterSet.alphanumerics.inverted)

--- a/Tests/Qwen3ASRTests/Qwen3ASRIntegrationTests.swift
+++ b/Tests/Qwen3ASRTests/Qwen3ASRIntegrationTests.swift
@@ -124,12 +124,17 @@ final class E2EQwen3ASRIntegrationTests: XCTestCase {
         }
 
         // Transcribe
+        let tracker = PerfTracker("qwen3-asr-06b-fullpipeline")
+        tracker.checkpoint("model-loaded")
         let start = Date()
         let result = model.transcribe(audio: audio, sampleRate: targetSampleRate)
         let elapsed = Date().timeIntervalSince(start)
 
+        let audioMs = Double(audio.count) / Double(targetSampleRate) * 1000
+        print(String(format: "[PERF] qwen3-asr-06b-fullpipeline transcribe=%.0fms audio=%.0fms rtf=%.3f",
+                     elapsed * 1000, audioMs, (elapsed * 1000) / audioMs))
+        tracker.finish()
         print("Transcription: \(result)")
-        print("Elapsed time: \(elapsed)s")
 
         // Verify correct transcription
         // Test audio contains: "Can you guarantee that the replacement part will be shipped tomorrow?"


### PR DESCRIPTION
Establishes a before-baseline for the ANE fix follow-up work. Adds a tiny RSS+wall-time tracker (\`Sources/AudioCommon/PerfTracker.swift\`) and instruments the two tests we care about.

## Numbers captured locally

| Test | Path | Wall | Audio | RTF | Peak RSS | Delta RSS |
|---|---|---|---|---|---|---|
| Magpie ASR roundtrip | CoreML INT8 (silently GPU) | 1.72s | 3.16s | 0.545 | 1127 MB | +1068 MB |
| Qwen3-ASR-0.6B-MLX-4bit | MLX (Metal) | 327ms | 20s | 0.016 (~60× RT) | 1311 MB | +686 MB |

CoreML INT8 path is **~34× slower** per-second-of-audio than MLX 4-bit. That's the headroom an actually-working ANE path would unlock.

## Implementation
- \`PerfTracker(\"label\")\` — capture start RSS + time
- \`.checkpoint(\"name\")\` — sample + update peak, optional log
- \`.finish()\` — emit \`[PERF] label total=Xms rssStart=YMB rssEnd=ZMB rssPeak=WMB rssDelta=±MB\`

Format is grep-able from CI logs for cross-run diffing.

## Test plan
- [x] Local build clean
- [x] Both instrumented tests pass with numbers above
- [ ] PR-CI green (only instruments E2E tests, which PR-CI skips)
- [ ] Numbers reproduce in next nightly \`light-coreml\` shard (will let us see local vs CI gap)

## Follow-up
- ANE conversion fix for Qwen3-ASR (separate PR) — these baseline numbers are what we'll measure against to show the improvement