### PR TITLE
fix(download): abort wedged HF downloads instead of hanging

### DIFF
--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -6,6 +6,9 @@ import os
 public enum DownloadError: Error, LocalizedError {
     case failedToDownload(String)
     case invalidRemoteFileName(String)
+    /// A download attempt made no progress for `seconds` and was aborted
+    /// so the caller's retry loop can fire instead of hanging.
+    case stalled(modelId: String, seconds: Int)
 
     public var errorDescription: String? {
         switch self {
@@ -13,6 +16,8 @@ public enum DownloadError: Error, LocalizedError {
             return "Failed to download: \(file)"
         case .invalidRemoteFileName(let file):
             return "Refusing to write unsafe remote file name: \(file)"
+        case .stalled(let modelId, let seconds):
+            return "Download stalled for \(modelId): no progress in \(seconds)s"
         }
     }
 }
@@ -125,12 +130,18 @@ public enum HuggingFaceDownloader {
 
         // Retry with exponential backoff — HuggingFace can timeout on
         // slow connections or rate-limit. 3 attempts: 0s, 5s, 15s delays.
+        // Each attempt is wrapped in a progress-stall guard so a wedged
+        // mid-transfer (which `hub.snapshot` won't surface on its own)
+        // aborts and retries instead of hanging until the CI job is killed.
         let maxRetries = 3
         var lastError: Error?
         for attempt in 1...maxRetries {
             do {
-                try await hub.snapshot(from: repo, matching: globs) { progress in
-                    progressHandler?(progress.fractionCompleted)
+                try await withDownloadStallGuard(modelId: modelId) { reportProgress in
+                    try await hub.snapshot(from: repo, matching: globs) { progress in
+                        reportProgress(progress.fractionCompleted)
+                        progressHandler?(progress.fractionCompleted)
+                    }
                 }
                 return  // Success
             } catch {
@@ -167,8 +178,11 @@ public enum HuggingFaceDownloader {
         var lastError: Error?
         for attempt in 1...maxRetries {
             do {
-                try await hub.snapshot(from: repo, matching: globs) { progress in
-                    progressHandler?(progress.fractionCompleted)
+                try await withDownloadStallGuard(modelId: modelId) { reportProgress in
+                    try await hub.snapshot(from: repo, matching: globs) { progress in
+                        reportProgress(progress.fractionCompleted)
+                        progressHandler?(progress.fractionCompleted)
+                    }
                 }
                 return
             } catch {
@@ -180,6 +194,69 @@ public enum HuggingFaceDownloader {
             }
         }
         throw DownloadError.failedToDownload("\(modelId): \(lastError?.localizedDescription ?? "unknown")")
+    }
+
+    // MARK: - Download stall guard
+
+    /// Seconds of zero download progress after which an attempt is
+    /// considered wedged and aborted. `hub.snapshot` reports
+    /// `fractionCompleted` continuously while bytes flow, so a healthy
+    /// (even slow) transfer keeps resetting the clock; only a genuinely
+    /// stalled connection trips this. Overridable via
+    /// `HF_DOWNLOAD_STALL_TIMEOUT` for CI tuning.
+    static var downloadStallTimeoutSeconds: Int {
+        if let raw = ProcessInfo.processInfo.environment["HF_DOWNLOAD_STALL_TIMEOUT"],
+           let v = Int(raw), v > 0 {
+            return v
+        }
+        return 90
+    }
+
+    /// Thread-safe last-progress timestamp. `hub.snapshot`'s progress
+    /// callback may fire from a background queue, so guard with a lock.
+    private final class ProgressClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var last = Date()
+        func tick() { lock.lock(); last = Date(); lock.unlock() }
+        func idleSeconds() -> Double {
+            lock.lock(); defer { lock.unlock() }
+            return Date().timeIntervalSince(last)
+        }
+    }
+
+    /// Run a download `operation` that reports fractional progress, and
+    /// abort it if progress stalls for `downloadStallTimeoutSeconds`.
+    /// On stall the in-flight `hub.snapshot` task is cancelled (URLSession
+    /// honors cancellation) and `DownloadError.stalled` is thrown so the
+    /// caller's retry loop fires instead of hanging indefinitely.
+    static func withDownloadStallGuard(
+        modelId: String,
+        stallTimeoutSeconds: Int? = nil,
+        _ operation: @escaping (@escaping @Sendable (Double) -> Void) async throws -> Void
+    ) async throws {
+        let stall = stallTimeoutSeconds ?? downloadStallTimeoutSeconds
+        let clock = ProgressClock()
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await operation { _ in clock.tick() }
+            }
+            group.addTask {
+                // Poll on a fraction of the window so we detect a stall
+                // within ~stall..stall+pollStep seconds.
+                let pollStep = max(1, stall / 3)
+                while true {
+                    try await Task.sleep(for: .seconds(pollStep))
+                    if clock.idleSeconds() >= Double(stall) {
+                        throw DownloadError.stalled(modelId: modelId, seconds: stall)
+                    }
+                }
+            }
+            // Whichever finishes first wins; cancel the other (the poller
+            // on success, or the download on stall).
+            defer { group.cancelAll() }
+            try await group.next()
+        }
     }
 
     // MARK: - Security Helpers (kept for backward compat + security tests)

--- a/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
+++ b/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
@@ -253,4 +253,46 @@ final class HuggingFaceDownloaderTests: XCTestCase {
         XCTAssertTrue(progressReported)
         XCTAssertTrue(HuggingFaceDownloader.weightsExist(in: tmpDir))
     }
+
+    // MARK: - Download stall guard
+
+    /// A stalled operation (reports progress once, then sleeps forever)
+    /// must be aborted by the guard rather than hanging. Uses a 1 s
+    /// stall window so the test is fast.
+    func testStallGuardAbortsWedgedDownload() async throws {
+        let start = Date()
+        do {
+            try await HuggingFaceDownloader.withDownloadStallGuard(
+                modelId: "fake/wedged", stallTimeoutSeconds: 1
+            ) { reportProgress in
+                reportProgress(0.1)  // one tick, then never again
+                try await Task.sleep(for: .seconds(60))  // simulate a wedged transfer
+            }
+            XCTFail("expected stall guard to throw")
+        } catch let error as DownloadError {
+            guard case .stalled(let modelId, let seconds) = error else {
+                return XCTFail("expected .stalled, got \(error)")
+            }
+            XCTAssertEqual(modelId, "fake/wedged")
+            XCTAssertEqual(seconds, 1)
+        }
+        // Must abort within a few seconds, not wait out the 60 s sleep.
+        XCTAssertLessThan(Date().timeIntervalSince(start), 10,
+                          "stall guard should abort promptly after the window")
+    }
+
+    /// An operation that keeps reporting progress must NOT be tripped by
+    /// the guard even when it runs longer than the stall window.
+    func testStallGuardAllowsProgressingDownload() async throws {
+        try await HuggingFaceDownloader.withDownloadStallGuard(
+            modelId: "fake/healthy", stallTimeoutSeconds: 1
+        ) { reportProgress in
+            // Tick every 200 ms for ~1.6 s (> the 1 s stall window) so the
+            // clock keeps resetting; should complete without stalling.
+            for i in 1...8 {
+                try await Task.sleep(for: .milliseconds(200))
+                reportProgress(Double(i) / 8.0)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`HuggingFaceDownloader` retried `hub.snapshot` 3× with backoff but had **no per-attempt timeout**. A stalled mid-transfer (flaky network / HF rate-limit) blocks `hub.snapshot` forever — the retry never fires because the call never returns — so the process hangs until something external kills it.

This is the root cause of the intermittent **`qwen3-asr-aligner` nightly hang**: it passes in ~4.6 min when healthy but hangs ~47–48 min then gets killed (the failed run's E2E step produces *zero* output — it wedges during the model download in `setUp`, before any test body runs). The bug affects **any** E2E shard whose download stalls, not just the aligner.

## Fix

`withDownloadStallGuard` races each `hub.snapshot` attempt against a `ProgressClock`:
- `hub.snapshot` reports `fractionCompleted` continuously while bytes flow, so a healthy (even slow) transfer keeps resetting the clock.
- If no progress for `HF_DOWNLOAD_STALL_TIMEOUT` seconds (default **90**), it cancels the in-flight download (URLSession honors cancellation) and throws `DownloadError.stalled`, so the existing backoff loop retries.

Wired into both `downloadWeights` and `downloadFiles`. Worst-case bound is now ~3 × (90 s + backoff) ≈ 5 min instead of an open-ended hang.

## Test plan

- [x] `testStallGuardAbortsWedgedDownload` — op reports one tick then sleeps 60 s; guard aborts in ~1 s with a 1 s window (not the 60 s sleep)
- [x] `testStallGuardAllowsProgressingDownload` — op ticking every 200 ms for 1.6 s past a 1 s window completes without tripping
- [ ] Next nightly: `qwen3-asr-aligner` either passes or fails fast (~5 min) instead of hanging 48 min