### PR TITLE
ci: bump checkout/cache actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -86,10 +86,10 @@ jobs:
           echo "Skipping ${{ matrix.shard.name }} — manual run filtered to '${{ github.event.inputs.shard }}'"
           exit 0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Cache SwiftPM build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build
           key: spm-nightly-${{ runner.os }}-${{ hashFiles('Package.swift', 'Package.resolved') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}


### PR DESCRIPTION
## Summary

`actions/checkout@v4` and `actions/cache@v4` run on **Node.js 20**, which GitHub is deprecating. The runner annotation on every CI job:

> Node.js 20 actions are deprecated … Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed Sept 16th, 2026.

Bumps both to `@v5` (the Node-24 majors: `checkout` v5.0.1+, `cache` v5.0.5) across all three workflows so CI keeps working through the cutover.

| File | change |
|---|---|
| `tests.yml` (PR CI) | `checkout@v4→v5`, `cache@v4→v5` |
| `nightly-e2e.yml` | `checkout@v4→v5`, `cache@v4→v5` |
| `release.yml` | `checkout@v4→v5` |

`softprops/action-gh-release@v2` and `actions/create-github-app-token@v2` were **not** flagged (already Node-24-compatible), so they're left as-is.

## Test plan

- [x] Diff is version-only (5 lines), no behavior changes
- [ ] PR CI (`tests.yml`) runs green on `checkout@v5` + `cache@v5` — this PR exercises it directly