### PR TITLE
fix(ci): force CPU+GPU for CoreML in CI to avoid ANE-compile hang

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -29,6 +29,12 @@ jobs:
   e2e:
     runs-on: macos-15
     timeout-minutes: 90
+    # macos-15 runners are virtualized and have no usable Neural Engine, so
+    # loading a CoreML model with ANE targets triggers an on-device ANE
+    # compile that hangs on large graphs (a 27-min silent stall loading the
+    # Qwen3-ASR T=128 decoder). Force CPU+GPU in CI; on-device keeps the ANE.
+    env:
+      SPEECH_COREML_COMPUTE_UNITS: cpuAndGPU
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,10 @@ jobs:
   build-and-test:
     runs-on: macos-15
     timeout-minutes: 45
+    # No usable Neural Engine on the virtualized runner — force CPU+GPU so
+    # any CoreML model load skips the (hang-prone) on-device ANE compile.
+    env:
+      SPEECH_COREML_COMPUTE_UNITS: cpuAndGPU
     steps:
       - uses: actions/checkout@v5
 

--- a/Sources/AudioCommon/CoreMLComputeUnits.swift
+++ b/Sources/AudioCommon/CoreMLComputeUnits.swift
@@ -1,0 +1,49 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// Resolves the `MLComputeUnits` a CoreML model should load with, honoring
+/// the `SPEECH_COREML_COMPUTE_UNITS` environment override.
+///
+/// **Why this exists.** A `.mlmodelc` is compiled MIL, but the Apple Neural
+/// Engine program is chip-and-OS-specific and is generated the *first time*
+/// the model loads with `.cpuAndNeuralEngine` (or `.all`). On real M-series
+/// hardware that first-load ANE compile takes seconds; on a virtualized
+/// GitHub `macos-15` runner — which has no usable Neural Engine — the OS
+/// still attempts the ANE compile of a large graph and **hangs** (observed:
+/// a 27-minute silent stall loading the Qwen3-ASR T=128 decoder, vs ~5 min
+/// for every other shard).
+///
+/// On-device we keep the ANE (callers pass their normal default as
+/// `fallback`). In CI we set `SPEECH_COREML_COMPUTE_UNITS=cpuAndGPU` so the
+/// runner skips the ANE compile entirely — GPU/CPU execution is fast and
+/// deterministic (measured ~86 ms/step CPU for the T=128 decoder) and gives
+/// the same numerical results for our text-matching assertions.
+public enum CoreMLComputeUnitsResolver {
+    public static let envKey = "SPEECH_COREML_COMPUTE_UNITS"
+
+    /// Returns the env-overridden compute units, or `fallback` when unset/unrecognized.
+    /// Accepted env values (case-insensitive): `ane`/`cpuAndNeuralEngine`,
+    /// `gpu`/`cpuAndGPU`, `cpu`/`cpuOnly`, `all`.
+    public static func resolved(default fallback: MLComputeUnits) -> MLComputeUnits {
+        guard let raw = ProcessInfo.processInfo.environment[envKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(), !raw.isEmpty
+        else {
+            return fallback
+        }
+        switch raw {
+        case "ane", "cpuandneuralengine", "neuralengine":
+            return .cpuAndNeuralEngine
+        case "gpu", "cpuandgpu":
+            return .cpuAndGPU
+        case "cpu", "cpuonly":
+            return .cpuOnly
+        case "all":
+            return .all
+        default:
+            return fallback
+        }
+    }
+}
+#endif

--- a/Sources/Qwen3ASR/CoreMLASRModel.swift
+++ b/Sources/Qwen3ASR/CoreMLASRModel.swift
@@ -28,7 +28,7 @@ public class CoreMLASRModel {
         encoderModelId: String = CoreMLASREncoder.defaultModelId,
         decoderModelId: String = CoreMLASREncoder.defaultModelId,
         tokenizerModelId: String = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit",
-        computeUnits: MLComputeUnits = .all,
+        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all),
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil

--- a/Sources/Qwen3ASR/CoreMLEncoder.swift
+++ b/Sources/Qwen3ASR/CoreMLEncoder.swift
@@ -27,7 +27,7 @@ public class CoreMLASREncoder {
     /// Load encoder from a directory containing `encoder.mlmodelc`.
     public static func load(
         from directory: URL,
-        computeUnits: MLComputeUnits = .all
+        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all)
     ) throws -> CoreMLASREncoder {
         let modelURL = directory.appendingPathComponent("encoder.mlmodelc", isDirectory: true)
         guard FileManager.default.fileExists(atPath: modelURL.path) else {
@@ -45,7 +45,7 @@ public class CoreMLASREncoder {
     /// Load encoder from HuggingFace.
     public static func fromPretrained(
         modelId: String = defaultModelId,
-        computeUnits: MLComputeUnits = .all,
+        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all),
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil

--- a/Sources/Qwen3ASR/CoreMLTextDecoder.swift
+++ b/Sources/Qwen3ASR/CoreMLTextDecoder.swift
@@ -79,7 +79,7 @@ public class CoreMLTextDecoder {
     /// ``embedding.mlmodelc``, ``decoder_part1.mlmodelc`` and ``decoder_part2.mlmodelc``.
     public static func load(
         from directory: URL,
-        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
     ) throws -> CoreMLTextDecoder {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnits
@@ -137,7 +137,7 @@ public class CoreMLTextDecoder {
     /// Load from HuggingFace.
     public static func fromPretrained(
         modelId: String = defaultModelId,
-        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine),
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil

--- a/Tests/AudioCommonTests/CoreMLComputeUnitsTests.swift
+++ b/Tests/AudioCommonTests/CoreMLComputeUnitsTests.swift
@@ -1,0 +1,50 @@
+#if canImport(CoreML)
+import XCTest
+import CoreML
+@testable import AudioCommon
+
+final class CoreMLComputeUnitsResolverTests: XCTestCase {
+
+    // The resolver reads a process env var, which we can't mutate per-test
+    // reliably across platforms. Instead test the pure mapping by setting +
+    // unsetting the var around each case via setenv/unsetenv.
+
+    private func withEnv(_ value: String?, _ body: () -> Void) {
+        let key = CoreMLComputeUnitsResolver.envKey
+        let previous = ProcessInfo.processInfo.environment[key]
+        if let value { setenv(key, value, 1) } else { unsetenv(key) }
+        defer {
+            if let previous { setenv(key, previous, 1) } else { unsetenv(key) }
+        }
+        body()
+    }
+
+    func testUnsetReturnsFallback() {
+        withEnv(nil) {
+            XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine), .cpuAndNeuralEngine)
+            XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .all), .all)
+        }
+    }
+
+    func testGpuOverride() {
+        for v in ["cpuAndGPU", "gpu", "CPUANDGPU", " gpu "] {
+            withEnv(v) {
+                XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine), .cpuAndGPU,
+                               "env '\(v)' should map to cpuAndGPU")
+            }
+        }
+    }
+
+    func testCpuAndAneAndAll() {
+        withEnv("cpu") { XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .all), .cpuOnly) }
+        withEnv("ane") { XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .cpuOnly), .cpuAndNeuralEngine) }
+        withEnv("all") { XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .cpuOnly), .all) }
+    }
+
+    func testUnrecognizedFallsBack() {
+        withEnv("banana") {
+            XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine), .cpuAndNeuralEngine)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

The fresh nightly (run 26559728255) had **two shards hang ~27 min then get cancelled** — `qwen3-asr-06b` and `light-coreml`, the only two that load the new **T=128 CoreML decoder**. The job log shows 27 minutes of silence after `[0/1] Planning build`, before any test output: the xctest binary hung at **model load**.

## Root cause

A `.mlmodelc` is compiled MIL, but the **Apple Neural Engine program is chip-and-OS-specific and is generated on first load** with `.cpuAndNeuralEngine`/`.all` (the `ANECCompile`/E5RT step). On real M-series hardware that takes seconds; on the **virtualized macos-15 runner, which has no usable Neural Engine**, the OS still attempts the ANE compile of the large T=128 graph and hangs.

Confirmed it's *not* execution: CPU-only runs the T=128 decoder at ~86 ms/step. It's purely the ANE compile attempt on a machine without an ANE.

## Fix

`CoreMLComputeUnitsResolver.resolved(default:)` reads `SPEECH_COREML_COMPUTE_UNITS`; absent the env it returns the caller's normal on-device default (ANE). `CoreMLASRModel` / `CoreMLASREncoder` / `CoreMLTextDecoder` default their `computeUnits` through it.

Both workflows set `SPEECH_COREML_COMPUTE_UNITS=cpuAndGPU`, so CI skips the ANE compile (no hang, deterministic, identical text-match results) while **on-device keeps the ANE** + the T=128 prefill speedup.

## Test plan

- [x] `Qwen3ASR` + `AudioCommonTests` compile clean
- [x] `CoreMLComputeUnitsResolverTests` covers the env→`MLComputeUnits` mapping (gpu/cpu/ane/all + fallback)
- [ ] Next nightly: `qwen3-asr-06b` + `light-coreml` finish in ~5 min instead of hanging