### PR TITLE
fix(ci): cpuOnly for all CoreML in CI; split nightly shards per family

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -29,12 +29,15 @@ jobs:
   e2e:
     runs-on: macos-15
     timeout-minutes: 90
-    # macos-15 runners are virtualized and have no usable Neural Engine, so
-    # loading a CoreML model with ANE targets triggers an on-device ANE
-    # compile that hangs on large graphs (a 27-min silent stall loading the
-    # Qwen3-ASR T=128 decoder). Force CPU+GPU in CI; on-device keeps the ANE.
+    # macos-15 runners are virtualized: no usable Neural Engine, and the
+    # paravirtual GPU can't JIT CoreML's first-load Metal program for stateful
+    # graphs. Both ANE and cpuAndGPU loads silently stall (a 17-27 min hang
+    # loading the Qwen3-ASR T=128 stateful decoder, observed on both). cpuOnly
+    # does no ANE/GPU codegen — pure CPU MIL execution — so it loads instantly
+    # and gives identical text for our roundtrip assertions. On-device keeps
+    # the ANE (env unset -> each loader's normal default).
     env:
-      SPEECH_COREML_COMPUTE_UNITS: cpuAndGPU
+      SPEECH_COREML_COMPUTE_UNITS: cpuOnly
     strategy:
       fail-fast: false
       matrix:
@@ -43,8 +46,23 @@ jobs:
           # target/class/method names. Targets like `Qwen3ASRTests` pull in
           # the entire module's tests (E2E + unit). Use `skip` to peel heavy
           # methods off into their own shard.
-          - name: light-coreml
-            filter: 'KokoroTTSTests|ParakeetASRTests|ParakeetStreamingASRTests|MagpieTTSCoreMLTests|SpeechEnhancementTests|SpeechWakeWordTests'
+          # CoreML model families, one shard each so a slow/failing model is
+          # isolated and each xctest process loads a bounded weight set. All
+          # run cpuOnly in CI via SPEECH_COREML_COMPUTE_UNITS (set above).
+          - name: kokoro
+            filter: 'KokoroTTSTests'
+            skip: ''
+          - name: parakeet
+            filter: 'ParakeetASRTests|ParakeetStreamingASRTests'
+            skip: ''
+          - name: magpie
+            filter: 'MagpieTTSCoreMLTests'
+            skip: ''
+          - name: speech-enhance
+            filter: 'SpeechEnhancementTests'
+            skip: ''
+          - name: wakeword
+            filter: 'SpeechWakeWordTests'
             skip: ''
           - name: vad-diar
             filter: 'SpeechVADTests'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,12 @@ jobs:
   build-and-test:
     runs-on: macos-15
     timeout-minutes: 45
-    # No usable Neural Engine on the virtualized runner — force CPU+GPU so
-    # any CoreML model load skips the (hang-prone) on-device ANE compile.
+    # The virtualized runner has no usable Neural Engine AND its paravirtual
+    # GPU can't JIT CoreML's first-load Metal program for stateful graphs, so
+    # both ANE and cpuAndGPU loads hang. Force cpuOnly — no ANE/GPU codegen,
+    # deterministic, and fine for correctness assertions. On-device keeps ANE.
     env:
-      SPEECH_COREML_COMPUTE_UNITS: cpuAndGPU
+      SPEECH_COREML_COMPUTE_UNITS: cpuOnly
     steps:
       - uses: actions/checkout@v5
 

--- a/Sources/AudioCommon/CoreMLComputeUnits.swift
+++ b/Sources/AudioCommon/CoreMLComputeUnits.swift
@@ -5,20 +5,20 @@ import Foundation
 /// Resolves the `MLComputeUnits` a CoreML model should load with, honoring
 /// the `SPEECH_COREML_COMPUTE_UNITS` environment override.
 ///
-/// **Why this exists.** A `.mlmodelc` is compiled MIL, but the Apple Neural
-/// Engine program is chip-and-OS-specific and is generated the *first time*
-/// the model loads with `.cpuAndNeuralEngine` (or `.all`). On real M-series
-/// hardware that first-load ANE compile takes seconds; on a virtualized
-/// GitHub `macos-15` runner — which has no usable Neural Engine — the OS
-/// still attempts the ANE compile of a large graph and **hangs** (observed:
-/// a 27-minute silent stall loading the Qwen3-ASR T=128 decoder, vs ~5 min
-/// for every other shard).
+/// **Why this exists.** A `.mlmodelc` is compiled MIL, but the device-specific
+/// program (ANE *or* GPU/Metal) is generated the *first time* the model loads.
+/// On real M-series hardware that first-load codegen takes seconds; on a
+/// virtualized GitHub `macos-15` runner it **hangs**: the runner has no usable
+/// Neural Engine (so `.cpuAndNeuralEngine`/`.all` stall attempting the ANE
+/// compile) AND its paravirtual GPU can't JIT CoreML's Metal program for a
+/// stateful graph (so `.cpuAndGPU` stalls too). Both were observed as 17-27 min
+/// silent hangs loading the Qwen3-ASR T=128 stateful decoder.
 ///
-/// On-device we keep the ANE (callers pass their normal default as
-/// `fallback`). In CI we set `SPEECH_COREML_COMPUTE_UNITS=cpuAndGPU` so the
-/// runner skips the ANE compile entirely — GPU/CPU execution is fast and
-/// deterministic (measured ~86 ms/step CPU for the T=128 decoder) and gives
-/// the same numerical results for our text-matching assertions.
+/// On-device we keep the normal default (callers pass it as `fallback`; the env
+/// is unset so this is a no-op). In CI we set `SPEECH_COREML_COMPUTE_UNITS=cpuOnly`
+/// so every loader skips ANE *and* GPU codegen — pure CPU MIL execution loads
+/// instantly, is deterministic, and yields identical text for our roundtrip
+/// assertions (~86 ms/step for the T=128 decoder, fine for correctness tests).
 public enum CoreMLComputeUnitsResolver {
     public static let envKey = "SPEECH_COREML_COMPUTE_UNITS"
 

--- a/Sources/AudioCommon/CoreMLLoader.swift
+++ b/Sources/AudioCommon/CoreMLLoader.swift
@@ -67,6 +67,10 @@ public enum CoreMLLoader {
         configuration: MLModelConfiguration,
         name: String? = nil
     ) throws -> MLModel {
+        // Honor the SPEECH_COREML_COMPUTE_UNITS override (CI forces cpuOnly to
+        // skip the runner's hanging ANE/GPU first-load compile). No-op on device.
+        configuration.computeUnits = CoreMLComputeUnitsResolver.resolved(
+            default: configuration.computeUnits)
         let label = name ?? url.deletingPathExtension().lastPathComponent
         let unitsLabel = describe(units: configuration.computeUnits)
         let start = Date()

--- a/Sources/CosyVoiceTTS/CamPlusPlusSpeaker.swift
+++ b/Sources/CosyVoiceTTS/CamPlusPlusSpeaker.swift
@@ -59,7 +59,7 @@ public final class CamPlusPlusSpeaker {
         }
 
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = .cpuAndNeuralEngine
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
 
         let mlModel: MLModel
         do {

--- a/Sources/KokoroTTS/KokoroModel.swift
+++ b/Sources/KokoroTTS/KokoroModel.swift
@@ -13,7 +13,7 @@ class KokoroNetwork {
     /// Load E2E CoreML model from cache directory.
     init(directory: URL, computeUnits: MLComputeUnits = .all) throws {
         let config = MLModelConfiguration()
-        config.computeUnits = computeUnits
+        config.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
 
         let e2eNames = ["kokoro_5s", "kokoro_10s", "kokoro_15s", "kokoro"]
         var loaded: MLModel?

--- a/Sources/MagpieTTSCoreML/CoreMLHelpers.swift
+++ b/Sources/MagpieTTSCoreML/CoreMLHelpers.swift
@@ -1,5 +1,6 @@
 import CoreML
 import Foundation
+import AudioCommon
 
 /// FP32 / Int32 marshalling between Swift buffers and the
 /// `MLMultiArray` instances our `.mlmodelc` bundles consume. Our bundle is
@@ -51,8 +52,11 @@ enum MagpieCoreMLBridge {
         case "all":             config.computeUnits = .all
         case "cpuAndGPU":       config.computeUnits = .cpuAndGPU
         case "cpuOnly":         config.computeUnits = .cpuOnly
-        case "ane", nil:        config.computeUnits = .cpuAndNeuralEngine
-        default:                config.computeUnits = .all
+        case "ane":             config.computeUnits = .cpuAndNeuralEngine
+        // No Magpie-specific override: honor the global SPEECH_COREML_COMPUTE_UNITS
+        // (CI forces cpuOnly; on-device this stays ANE).
+        case nil:               config.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
+        default:                config.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .all)
         }
         do {
             return try MLModel(contentsOf: url, configuration: config)

--- a/Sources/NemotronStreamingASR/NemotronStreamingASR.swift
+++ b/Sources/NemotronStreamingASR/NemotronStreamingASR.swift
@@ -215,7 +215,7 @@ public class NemotronStreamingASRModel {
                 modelId: name, reason: "CoreML model not found at \(modelURL.path)")
         }
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = computeUnits
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
         return try MLModel(contentsOf: modelURL, configuration: mlConfig)
     }
 }

--- a/Sources/OmnilingualASR/OmnilingualASR.swift
+++ b/Sources/OmnilingualASR/OmnilingualASR.swift
@@ -148,7 +148,7 @@ public class OmnilingualASRModel {
         let configuration = MLModelConfiguration()
         // Match ParakeetASR default — ANE compilation is unreliable on some
         // devices, so target CPU+GPU for portability.
-        configuration.computeUnits = .cpuAndGPU
+        configuration.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndGPU)
 
         do {
             return try MLModel(contentsOf: compiledURL, configuration: configuration)

--- a/Sources/ParakeetASR/ParakeetASR.swift
+++ b/Sources/ParakeetASR/ParakeetASR.swift
@@ -448,7 +448,7 @@ public class ParakeetASRModel {
         }
 
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = computeUnits
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
 
         do {
             let model = try MLModel(contentsOf: modelURL, configuration: mlConfig)

--- a/Sources/ParakeetStreamingASR/ParakeetStreamingASR.swift
+++ b/Sources/ParakeetStreamingASR/ParakeetStreamingASR.swift
@@ -229,7 +229,7 @@ public class ParakeetStreamingASRModel {
                 modelId: name, reason: "CoreML model not found at \(modelURL.path)")
         }
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = computeUnits
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
         return try MLModel(contentsOf: modelURL, configuration: mlConfig)
     }
 }

--- a/Sources/Qwen3Chat/Qwen35CoreMLChat.swift
+++ b/Sources/Qwen3Chat/Qwen35CoreMLChat.swift
@@ -176,7 +176,7 @@ public final class Qwen35CoreMLChat: @unchecked Sendable {
         }
 
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = computeUnits
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
         return try await MLModel.load(contentsOf: compiledURL, configuration: mlConfig)
     }
 

--- a/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
+++ b/Sources/Qwen3TTSCoreML/Qwen3TTSCoreML.swift
@@ -77,7 +77,7 @@ public final class Qwen3TTSCoreMLModel {
             case "gpu": cfg.computeUnits = .cpuAndGPU
             case "cpu": cfg.computeUnits = .cpuOnly
             case "all": cfg.computeUnits = .all
-            default:    cfg.computeUnits = fallback
+            default:    cfg.computeUnits = CoreMLComputeUnitsResolver.resolved(default: fallback)
             }
             return cfg
         }

--- a/Sources/SpeechEnhancement/DeepFilterNet3Model.swift
+++ b/Sources/SpeechEnhancement/DeepFilterNet3Model.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreML
+import AudioCommon
 
 /// Core ML wrapper for the DeepFilterNet3 neural network.
 ///
@@ -18,7 +19,7 @@ class DeepFilterNet3Network {
     /// only ``.mlmodelc`` for this reason.
     init(modelURL: URL, computeUnits: MLComputeUnits = .all) throws {
         let config = MLModelConfiguration()
-        config.computeUnits = computeUnits
+        config.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
         self.model = try MLModel(contentsOf: modelURL, configuration: config)
     }
 

--- a/Sources/SpeechVAD/FireRedVAD.swift
+++ b/Sources/SpeechVAD/FireRedVAD.swift
@@ -85,7 +85,7 @@ public final class FireRedVADModel {
         }
 
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = .cpuAndNeuralEngine
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
 
         let model = try MLModel(contentsOf: modelURL, configuration: mlConfig)
 
@@ -109,7 +109,7 @@ public final class FireRedVADModel {
         }
 
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = .cpuAndNeuralEngine
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
 
         let model = try MLModel(contentsOf: modelURL, configuration: mlConfig)
         return FireRedVADModel(coremlModel: model)

--- a/Sources/SpeechVAD/SileroVAD.swift
+++ b/Sources/SpeechVAD/SileroVAD.swift
@@ -280,7 +280,7 @@ public final class SileroVADModel {
             }
 
             let mlConfig = MLModelConfiguration()
-            mlConfig.computeUnits = .cpuAndNeuralEngine
+            mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
 
             let model: MLModel
             do {

--- a/Sources/SpeechVAD/SortformerDiarizer.swift
+++ b/Sources/SpeechVAD/SortformerDiarizer.swift
@@ -92,7 +92,7 @@ public final class SortformerDiarizer {
         }
 
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = .cpuAndNeuralEngine
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
 
         let mlModel: MLModel
         do {

--- a/Sources/SpeechVAD/WeSpeaker.swift
+++ b/Sources/SpeechVAD/WeSpeaker.swift
@@ -148,7 +148,7 @@ public final class WeSpeakerModel {
             }
 
             let mlConfig = MLModelConfiguration()
-            mlConfig.computeUnits = .cpuAndNeuralEngine
+            mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
 
             let model: MLModel
             do {


### PR DESCRIPTION
## Summary
- PR #286 only routed Qwen3-ASR through the compute-units resolver, so the other CoreML models in the nightly shards (Kokoro, DeepFilterNet, Magpie, WakeWord, …) still ANE-compiled on the runner and hung. Separately, `cpuAndGPU` *itself* hangs the stateful Qwen3-ASR T=128 decoder on the runner's paravirtual GPU — the env override correctly reached all three sub-models, yet it still stalled 17 min with the 898 MB bundle fully downloaded.
- Route **every** CoreML loader through `CoreMLComputeUnitsResolver.resolved(default:)` so `SPEECH_COREML_COMPUTE_UNITS` controls all of them (plus the shared `CoreMLLoader`). On-device behavior unchanged (env unset → each loader's existing default).
- Switch CI to `cpuOnly` (`nightly-e2e.yml` + `tests.yml`) — no ANE and no GPU first-load codegen, so model load can't hang; deterministic and identical text for roundtrip assertions.
- Split the `light-coreml` shard into per-family shards: `kokoro`, `parakeet`, `magpie`, `speech-enhance`, `wakeword`.

## Test plan
- [x] `swift build --build-tests --disable-sandbox` — clean
- [ ] Nightly (`workflow_dispatch`) on this branch: CoreML shards finish in minutes instead of hanging (esp. `qwen3-asr-06b` stateful decoder, and the new per-family shards)