### PR TITLE
feat(asr): bench scaffold + Qwen3-ASR CoreML encoder chunked-attention rebuild

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -128,6 +128,10 @@ let package = Package(
         .executable(
             name: "audio-server",
             targets: ["AudioServerCLI"]
+        ),
+        .executable(
+            name: "asr-bench",
+            targets: ["AsrBenchmark"]
         )
     ],
     dependencies: [
@@ -139,7 +143,9 @@ let package = Package(
         // Pin swift-websocket to 1.5.x — 1.6.0 added `import NIOSSL` in WSCore/WebSocketHandler.swift
         // without declaring swift-nio-ssl as a target dependency, so the module is unresolvable
         // on a clean checkout. https://github.com/hummingbird-project/swift-websocket
-        .package(url: "https://github.com/hummingbird-project/swift-websocket.git", "1.5.0"..<"1.6.0")
+        .package(url: "https://github.com/hummingbird-project/swift-websocket.git", "1.5.0"..<"1.6.0"),
+        // WhisperKit (Argmax) — used by the AsrBenchmark target only, for competitor comparison.
+        .package(url: "https://github.com/argmaxinc/WhisperKit", from: "1.0.0")
     ],
     targets: [
         .target(
@@ -424,6 +430,18 @@ let package = Package(
             name: "AudioCLI",
             dependencies: ["AudioCLILib"]
         ),
+        .executableTarget(
+            name: "AsrBenchmark",
+            dependencies: [
+                "AudioCommon",
+                "Qwen3ASR",
+                "ParakeetASR",
+                "NemotronStreamingASR",
+                "OmnilingualASR",
+                .product(name: "WhisperKit", package: "WhisperKit"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]
+        ),
         .target(
             name: "AudioServer",
             dependencies: [
@@ -434,7 +452,11 @@ let package = Package(
                 "SpeechEnhancement",
                 "AudioCommon",
                 .product(name: "Hummingbird", package: "hummingbird"),
-                .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket")
+                .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
+                // Pulled in via hummingbird-websocket but we keep the explicit
+                // pin (see top-level deps) so 1.6.0+ can't slip in; reference
+                // it here so SwiftPM doesn't warn that the pin is unused.
+                .product(name: "WSCore", package: "swift-websocket")
             ]
         ),
         .executableTarget(

--- a/Sources/AsrBenchmark/AsrBench.swift
+++ b/Sources/AsrBenchmark/AsrBench.swift
@@ -1,0 +1,220 @@
+import ArgumentParser
+import Foundation
+
+@main
+struct AsrBench: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "asr-bench",
+        abstract: "Benchmark ASR engines on the same dataset (WER + RTF, normalized)."
+    )
+
+    @Option(name: .shortAndLong, help: "Path to LibriSpeech-style directory (e.g. .../test-clean) OR a .tsv manifest.")
+    var dataset: String
+
+    @Option(name: .shortAndLong, parsing: .upToNextOption,
+            help: "Engines to run. Valid: \(EngineID.allCases.map { $0.rawValue }.joined(separator: ", ")).")
+    var engines: [String] = ["qwen3-coreml", "parakeet", "whisperkit-large-v3-turbo"]
+
+    @Option(name: .shortAndLong, help: "Max utterances per engine (omit = full set).")
+    var limit: Int?
+
+    @Option(name: .shortAndLong, help: "Optional path to write the JSON report.")
+    var output: String?
+
+    @Option(name: .long, help: "ISO language hint passed to engines that accept one (Qwen3/Parakeet).")
+    var language: String?
+
+    @Flag(name: .long,
+          help: "Run each engine in a separate process. The peak RSS column then reflects each engine's true cost instead of the sequential high-water mark.")
+    var isolated: Bool = false
+
+    mutating func run() async throws {
+        // stdout is block-buffered when the process runs with redirected
+        // output (background tasks, tee, etc.); progress lines get lost if
+        // the buffer never flushes. Line-buffer it so progress is live.
+        setlinebuf(stdout)
+
+        if isolated && engines.count > 1 {
+            try await runIsolated()
+            return
+        }
+
+        let datasetURL = URL(fileURLWithPath: dataset)
+        let utterances: [Utterance]
+        if datasetURL.pathExtension.lowercased() == "tsv" {
+            utterances = try Dataset.loadManifest(url: datasetURL, limit: limit)
+        } else {
+            utterances = try Dataset.loadLibriSpeech(root: datasetURL, limit: limit)
+        }
+        print("Loaded \(utterances.count) utterances from \(dataset)")
+
+        // Pre-decode all audio once — keeps each engine fair (audio I/O cost
+        // is not what we're measuring) and matches what a streaming pipeline
+        // would see.
+        print("Decoding audio (16 kHz mono)...")
+        let decoded: [(utt: Utterance, audio: [Float])] = try utterances.map {
+            (utt: $0, audio: try Dataset.loadAudio16k($0))
+        }
+        let totalAudioSec = decoded.reduce(0.0) { $0 + Double($1.audio.count) / 16000.0 }
+        print(String(format: "Total audio: %.1f s\n", totalAudioSec))
+
+        // Resolve engines.
+        var engineImpls: [BenchEngine] = []
+        for name in engines {
+            guard let id = EngineID(rawValue: name) else {
+                fputs("Unknown engine: \(name)\n", stderr)
+                throw ExitCode(2)
+            }
+            engineImpls.append(id.make())
+        }
+
+        // First utterance doubles as the warmup audio so every engine pays
+        // its compile cost up front and the per-utterance loop measures
+        // hot-path latency.
+        let warmup = decoded[0].audio
+
+        var results: [EngineResult] = []
+        for engine in engineImpls {
+            print("=== \(engine.name) ===")
+            let preLoadRSS = currentRSSBytes()
+            var peakRSS: UInt64 = preLoadRSS
+            do {
+                try await engine.load(warmupAudio: warmup, sampleRate: 16000)
+                peakRSS = max(peakRSS, currentRSSBytes())
+                print(String(format: "  loaded + warmed in %.1fs (RSS %.0f MB → %.0f MB)",
+                             engine.loadElapsed,
+                             Double(preLoadRSS) / (1024 * 1024),
+                             Double(peakRSS) / (1024 * 1024)))
+            } catch {
+                fputs("  load failed: \(error)\n", stderr)
+                continue
+            }
+
+            var subs = 0, ins = 0, dels = 0, refWords = 0
+            var rtfs: [Double] = []
+            var totalElapsed = 0.0
+            for (idx, item) in decoded.enumerated() {
+                do {
+                    let (text, t) = try await engine.transcribe(audio: item.audio, sampleRate: 16000, language: language)
+                    let hyp = Normalizer.normalize(text)
+                    let ref = Normalizer.normalize(item.utt.reference)
+                    let b = WER.compute(reference: ref, hypothesis: hyp)
+                    subs += b.substitutions
+                    ins += b.insertions
+                    dels += b.deletions
+                    refWords += b.referenceWords
+                    rtfs.append(t.rtf)
+                    totalElapsed += t.elapsed
+                    // RSS sampling is cheap (one mach call) but only useful
+                    // periodically — peak tends to settle after a few utts.
+                    if (idx + 1) % 25 == 0 || idx == decoded.count - 1 {
+                        peakRSS = max(peakRSS, currentRSSBytes())
+                        print(String(format: "  [%4d/%4d] rolling WER=%.2f%% RTF=%.3f peakRSS=%.0fMB",
+                                     idx + 1, decoded.count,
+                                     Double(subs + ins + dels) / Double(max(refWords, 1)) * 100,
+                                     rtfs.reduce(0, +) / Double(rtfs.count),
+                                     Double(peakRSS) / (1024 * 1024)))
+                    }
+                } catch {
+                    fputs("  utterance \(item.utt.id) failed: \(error)\n", stderr)
+                }
+            }
+
+            let mean = rtfs.isEmpty ? 0 : rtfs.reduce(0, +) / Double(rtfs.count)
+            let throughputXRT = mean > 0 ? 1.0 / mean : 0
+            results.append(EngineResult(
+                engine: engine.name,
+                utterances: rtfs.count,
+                werPercent: Double(subs + ins + dels) / Double(max(refWords, 1)) * 100,
+                substitutions: subs,
+                insertions: ins,
+                deletions: dels,
+                referenceWords: refWords,
+                rtfMean: mean,
+                rtfFirst: rtfs.first ?? 0,
+                loadElapsedSeconds: engine.loadElapsed,
+                audioSecondsTotal: totalAudioSec,
+                elapsedSecondsTotal: totalElapsed,
+                peakRSSBytes: peakRSS,
+                rssDeltaBytes: Int64(peakRSS) - Int64(preLoadRSS),
+                throughputXRT: throughputXRT
+            ))
+        }
+
+        let report = Report(
+            machine: ProcessInfo.processInfo.hostName,
+            datasetPath: dataset,
+            utterances: decoded.count,
+            results: results
+        )
+
+        print("\n" + ReportPrinter.table(report))
+
+        if let output {
+            try ReportPrinter.writeJSON(report, to: URL(fileURLWithPath: output))
+            print("Wrote JSON report to \(output)")
+        }
+    }
+
+    /// Re-executes the bench once per engine in a child process. Each child
+    /// gets a fresh MLX/CoreML state, so its peak RSS reflects only its own
+    /// allocations — not residual cache from the previous engine.
+    private func runIsolated() async throws {
+        let selfPath = CommandLine.arguments[0]
+        let runID = UUID().uuidString.prefix(8)
+        var merged: [EngineResult] = []
+        var failures: [String] = []
+        for engineName in engines {
+            let tempOut = "/tmp/asr-bench-iso-\(runID)-\(engineName).json"
+            var args: [String] = [
+                "--dataset", dataset,
+                "--engines", engineName,
+                "--output", tempOut
+            ]
+            if let limit { args += ["--limit", "\(limit)"] }
+            if let language { args += ["--language", language] }
+
+            print("\n──── isolated subrun: \(engineName) ────")
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: selfPath)
+            proc.arguments = args
+            proc.standardOutput = FileHandle.standardOutput
+            proc.standardError = FileHandle.standardError
+            try proc.run()
+            proc.waitUntilExit()
+
+            if proc.terminationStatus == 0,
+               let data = try? Data(contentsOf: URL(fileURLWithPath: tempOut)),
+               let child = try? JSONDecoder().decode(Report.self, from: data) {
+                merged.append(contentsOf: child.results)
+                try? FileManager.default.removeItem(atPath: tempOut)
+            } else {
+                failures.append(engineName)
+                fputs("subrun for \(engineName) failed (exit \(proc.terminationStatus))\n", stderr)
+            }
+        }
+
+        let datasetURL = URL(fileURLWithPath: dataset)
+        let uttCount: Int
+        if datasetURL.pathExtension.lowercased() == "tsv" {
+            uttCount = (try? Dataset.loadManifest(url: datasetURL, limit: limit).count) ?? 0
+        } else {
+            uttCount = (try? Dataset.loadLibriSpeech(root: datasetURL, limit: limit).count) ?? 0
+        }
+        let report = Report(
+            machine: ProcessInfo.processInfo.hostName,
+            datasetPath: dataset,
+            utterances: uttCount,
+            results: merged
+        )
+
+        print("\n" + ReportPrinter.table(report))
+        if !failures.isEmpty {
+            fputs("Failed subruns: \(failures.joined(separator: ", "))\n", stderr)
+        }
+        if let output {
+            try ReportPrinter.writeJSON(report, to: URL(fileURLWithPath: output))
+            print("Wrote merged JSON report to \(output)")
+        }
+    }
+}

--- a/Sources/AsrBenchmark/Dataset.swift
+++ b/Sources/AsrBenchmark/Dataset.swift
@@ -1,0 +1,85 @@
+import Foundation
+import AudioCommon
+
+public struct Utterance: Sendable {
+    public let id: String
+    public let audioURL: URL
+    public let reference: String
+}
+
+public enum Dataset {
+    /// Walks a LibriSpeech-style directory (e.g. `LibriSpeech/test-clean`) and
+    /// returns one `Utterance` per audio file. Layout:
+    ///
+    ///     test-clean/<speaker>/<chapter>/<speaker>-<chapter>.trans.txt
+    ///     test-clean/<speaker>/<chapter>/<speaker>-<chapter>-NNNN.flac
+    ///
+    /// `trans.txt` is `<id> <transcript>` per line. Audio can be `.flac` or
+    /// `.wav` — AVAudioFile handles both.
+    public static func loadLibriSpeech(root: URL, limit: Int? = nil) throws -> [Utterance] {
+        let fm = FileManager.default
+        guard let walker = fm.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey]) else {
+            throw BenchError.datasetEmpty(root.path)
+        }
+        var transcripts: [String: String] = [:]
+        var audioPaths: [(id: String, url: URL)] = []
+        for case let url as URL in walker {
+            let ext = url.pathExtension.lowercased()
+            if ext == "txt" && url.lastPathComponent.hasSuffix(".trans.txt") {
+                let content = try String(contentsOf: url, encoding: .utf8)
+                for raw in content.split(separator: "\n") {
+                    let line = raw.trimmingCharacters(in: .whitespaces)
+                    guard let spaceIdx = line.firstIndex(of: " ") else { continue }
+                    let id = String(line[..<spaceIdx])
+                    let text = String(line[line.index(after: spaceIdx)...])
+                    transcripts[id] = text
+                }
+            } else if ext == "flac" || ext == "wav" {
+                let id = url.deletingPathExtension().lastPathComponent
+                audioPaths.append((id: id, url: url))
+            }
+        }
+        audioPaths.sort { $0.id < $1.id }
+
+        var out: [Utterance] = []
+        for entry in audioPaths {
+            guard let ref = transcripts[entry.id] else { continue }
+            out.append(Utterance(id: entry.id, audioURL: entry.url, reference: ref))
+            if let limit, out.count >= limit { break }
+        }
+        if out.isEmpty {
+            throw BenchError.datasetEmpty(root.path)
+        }
+        return out
+    }
+
+    /// Loads a TSV manifest: `<audio path>\t<reference text>` per line.
+    /// Audio paths can be absolute or relative to the manifest file.
+    public static func loadManifest(url: URL, limit: Int? = nil) throws -> [Utterance] {
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let base = url.deletingLastPathComponent()
+        var out: [Utterance] = []
+        for (idx, raw) in content.split(separator: "\n").enumerated() {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            let parts = line.split(separator: "\t", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else {
+                throw BenchError.datasetMalformed("line \(idx + 1) is not <path>\\t<text>")
+            }
+            let p = String(parts[0])
+            let audioURL = p.hasPrefix("/") ? URL(fileURLWithPath: p) : base.appendingPathComponent(p)
+            out.append(Utterance(id: audioURL.deletingPathExtension().lastPathComponent,
+                                 audioURL: audioURL,
+                                 reference: String(parts[1])))
+            if let limit, out.count >= limit { break }
+        }
+        if out.isEmpty { throw BenchError.datasetEmpty(url.path) }
+        return out
+    }
+
+    /// Decodes an utterance to 16 kHz mono Float32 (the rate every engine
+    /// here expects). Resampling is handled by `AudioFileLoader`.
+    public static func loadAudio16k(_ utt: Utterance) throws -> [Float] {
+        return try AudioFileLoader.load(url: utt.audioURL, targetSampleRate: 16000)
+    }
+}

--- a/Sources/AsrBenchmark/Engine.swift
+++ b/Sources/AsrBenchmark/Engine.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Wall-clock timings collected for a single transcription call.
+public struct Timings: Sendable {
+    public var elapsed: Double       // synthesis time in seconds
+    public var audioDuration: Double // input audio duration in seconds
+
+    public var rtf: Double { elapsed / max(audioDuration, 1e-6) }
+}
+
+/// A single benchmark engine — model load up front, repeated transcribe calls.
+///
+/// Implementations are intentionally minimal: load the model, hold it, expose
+/// a transcribe call that returns text + wall-clock timing. The harness owns
+/// dataset, normalization, WER, and reporting.
+public protocol BenchEngine: AnyObject, Sendable {
+    /// Stable short name for the report row.
+    var name: String { get }
+
+    /// Time spent loading the model from disk + warming up, in seconds.
+    /// Populated by `load()`. `0` until then.
+    var loadElapsed: Double { get }
+
+    /// Loads weights and runs a single warmup transcription if the engine
+    /// benefits from one (most CoreML/MLX backends do). The warmup pass is
+    /// included in `loadElapsed`.
+    func load(warmupAudio: [Float], sampleRate: Int) async throws
+
+    /// Transcribes a single mono Float32 utterance. Returns hypothesis text +
+    /// the wall-clock elapsed time. The hypothesis is returned raw — caller
+    /// runs the normalizer before WER.
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings)
+}
+
+public enum EngineID: String, CaseIterable, Sendable {
+    case qwen3CoreML = "qwen3-coreml"
+    case qwen3MLX06b4bit = "qwen3-mlx-0.6b-4bit"
+    case qwen3MLX06b8bit = "qwen3-mlx-0.6b-8bit"
+    case qwen3MLX17b4bit = "qwen3-mlx-1.7b-4bit"
+    case qwen3MLX17b8bit = "qwen3-mlx-1.7b-8bit"
+    case parakeet = "parakeet"
+    case nemotron = "nemotron"
+    case omnilingual = "omnilingual"
+    case omnilingualMLX300m4bit = "omnilingual-mlx-300m-4bit"
+    case omnilingualMLX1b4bit = "omnilingual-mlx-1b-4bit"
+    case omnilingualMLX3b4bit = "omnilingual-mlx-3b-4bit"
+    case omnilingualMLX7b4bit = "omnilingual-mlx-7b-4bit"
+    case whisperKitLargeV3Turbo = "whisperkit-large-v3-turbo"
+    case whisperKitLargeV3 = "whisperkit-large-v3"
+    case whisperKitDistilLargeV3 = "whisperkit-distil-large-v3"
+
+    public func make() -> BenchEngine {
+        switch self {
+        case .qwen3CoreML: return Qwen3CoreMLEngine()
+        case .qwen3MLX06b4bit: return Qwen3MLXEngine(size: "0.6B", bits: 4)
+        case .qwen3MLX06b8bit: return Qwen3MLXEngine(size: "0.6B", bits: 8)
+        case .qwen3MLX17b4bit: return Qwen3MLXEngine(size: "1.7B", bits: 4)
+        case .qwen3MLX17b8bit: return Qwen3MLXEngine(size: "1.7B", bits: 8)
+        case .parakeet: return ParakeetEngine()
+        case .nemotron: return NemotronEngine()
+        case .omnilingual: return OmnilingualEngine()
+        case .omnilingualMLX300m4bit: return OmnilingualMLXEngine(variant: .m300, bits: 4)
+        case .omnilingualMLX1b4bit: return OmnilingualMLXEngine(variant: .b1, bits: 4)
+        case .omnilingualMLX3b4bit: return OmnilingualMLXEngine(variant: .b3, bits: 4)
+        case .omnilingualMLX7b4bit: return OmnilingualMLXEngine(variant: .b7, bits: 4)
+        case .whisperKitLargeV3Turbo: return WhisperKitEngine(model: "openai_whisper-large-v3-v20240930_turbo")
+        case .whisperKitLargeV3: return WhisperKitEngine(model: "openai_whisper-large-v3")
+        case .whisperKitDistilLargeV3: return WhisperKitEngine(model: "distil-whisper_distil-large-v3")
+        }
+    }
+}

--- a/Sources/AsrBenchmark/EngineNemotron.swift
+++ b/Sources/AsrBenchmark/EngineNemotron.swift
@@ -1,0 +1,28 @@
+import Foundation
+import NemotronStreamingASR
+
+final class NemotronEngine: BenchEngine, @unchecked Sendable {
+    let name = "nemotron-streaming-coreml-int8"
+    private(set) var loadElapsed: Double = 0
+    private var model: NemotronStreamingASRModel?
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let t0 = Date()
+        let m = try await NemotronStreamingASRModel.fromPretrained()
+        _ = try m.transcribeAudio(warmupAudio, sampleRate: sampleRate, language: nil)
+        self.model = m
+        self.loadElapsed = Date().timeIntervalSince(t0)
+    }
+
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
+        guard let m = model else { throw BenchError.notLoaded(name) }
+        var result: (text: String, elapsed: Double)!
+        try autoreleasepool {
+            let t0 = Date()
+            let text = try m.transcribeAudio(audio, sampleRate: sampleRate, language: language)
+            result = (text, Date().timeIntervalSince(t0))
+        }
+        let dur = Double(audio.count) / Double(sampleRate)
+        return (result.text, Timings(elapsed: result.elapsed, audioDuration: dur))
+    }
+}

--- a/Sources/AsrBenchmark/EngineOmnilingual.swift
+++ b/Sources/AsrBenchmark/EngineOmnilingual.swift
@@ -1,0 +1,28 @@
+import Foundation
+import OmnilingualASR
+
+final class OmnilingualEngine: BenchEngine, @unchecked Sendable {
+    let name = "omnilingual-ctc-300m-coreml-int8"
+    private(set) var loadElapsed: Double = 0
+    private var model: OmnilingualASRModel?
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let t0 = Date()
+        let m = try await OmnilingualASRModel.fromPretrained()
+        _ = try m.transcribeAudio(warmupAudio, sampleRate: sampleRate, language: nil)
+        self.model = m
+        self.loadElapsed = Date().timeIntervalSince(t0)
+    }
+
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
+        guard let m = model else { throw BenchError.notLoaded(name) }
+        var result: (text: String, elapsed: Double)!
+        try autoreleasepool {
+            let t0 = Date()
+            let text = try m.transcribeAudio(audio, sampleRate: sampleRate, language: language)
+            result = (text, Date().timeIntervalSince(t0))
+        }
+        let dur = Double(audio.count) / Double(sampleRate)
+        return (result.text, Timings(elapsed: result.elapsed, audioDuration: dur))
+    }
+}

--- a/Sources/AsrBenchmark/EngineOmnilingualMLX.swift
+++ b/Sources/AsrBenchmark/EngineOmnilingualMLX.swift
@@ -1,0 +1,33 @@
+import Foundation
+import OmnilingualASR
+
+final class OmnilingualMLXEngine: BenchEngine, @unchecked Sendable {
+    let name: String
+    private let variant: OmnilingualMLXConfig.Variant
+    private let bits: Int
+    private(set) var loadElapsed: Double = 0
+    private var model: OmnilingualASRMLXModel?
+
+    init(variant: OmnilingualMLXConfig.Variant, bits: Int) {
+        self.variant = variant
+        self.bits = bits
+        self.name = "omnilingual-mlx-\(variant.rawValue.lowercased())-\(bits)bit"
+    }
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let t0 = Date()
+        let m = try await OmnilingualASRMLXModel.fromPretrained(variant: variant, bits: bits)
+        _ = try m.transcribeAudio(warmupAudio, sampleRate: sampleRate, language: nil)
+        self.model = m
+        self.loadElapsed = Date().timeIntervalSince(t0)
+    }
+
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
+        guard let m = model else { throw BenchError.notLoaded(name) }
+        let t0 = Date()
+        let text = try m.transcribeAudio(audio, sampleRate: sampleRate, language: language)
+        let elapsed = Date().timeIntervalSince(t0)
+        let dur = Double(audio.count) / Double(sampleRate)
+        return (text, Timings(elapsed: elapsed, audioDuration: dur))
+    }
+}

--- a/Sources/AsrBenchmark/EngineParakeet.swift
+++ b/Sources/AsrBenchmark/EngineParakeet.swift
@@ -1,0 +1,32 @@
+import Foundation
+import ParakeetASR
+
+final class ParakeetEngine: BenchEngine, @unchecked Sendable {
+    let name = "parakeet-tdt-coreml-int8"
+    private(set) var loadElapsed: Double = 0
+    private var model: ParakeetASRModel?
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let t0 = Date()
+        let m = try await ParakeetASRModel.fromPretrained()
+        _ = try m.transcribeAudio(warmupAudio, sampleRate: sampleRate, language: nil)
+        self.model = m
+        self.loadElapsed = Date().timeIntervalSince(t0)
+    }
+
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
+        guard let m = model else { throw BenchError.notLoaded(name) }
+        // Wrap in an autoreleasepool so CoreML's per-prediction IOSurface
+        // backing buffers get released after each call instead of piling up.
+        // Without this the bench dies at ~10 utterances with
+        // 'Failed to allocate memory IOSurface object'.
+        var result: (text: String, elapsed: Double)!
+        try autoreleasepool {
+            let t0 = Date()
+            let text = try m.transcribeAudio(audio, sampleRate: sampleRate, language: language)
+            result = (text, Date().timeIntervalSince(t0))
+        }
+        let dur = Double(audio.count) / Double(sampleRate)
+        return (result.text, Timings(elapsed: result.elapsed, audioDuration: dur))
+    }
+}

--- a/Sources/AsrBenchmark/EngineQwen3CoreML.swift
+++ b/Sources/AsrBenchmark/EngineQwen3CoreML.swift
@@ -16,11 +16,16 @@ final class Qwen3CoreMLEngine: BenchEngine, @unchecked Sendable {
 
     func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
         guard let m = model else { throw BenchError.notLoaded(name) }
-        let t0 = Date()
-        let text = m.transcribe(audio: audio, sampleRate: sampleRate, language: language)
-        let elapsed = Date().timeIntervalSince(t0)
-        if ProcessInfo.processInfo.environment["BENCH_DUMP_HYP"] == "1" {
-            FileHandle.standardError.write(Data(("[\(name)] elapsed=\(elapsed)s hyp=\"\(text)\"\n").utf8))
+        // Wrap in an autoreleasepool so CoreML's per-prediction IOSurface
+        // buffers (MLMultiArray scratch, MLState backing pages) are released
+        // between calls instead of piling up. Without this the bench grows
+        // ~30 MB / utt and peaks above 9 GB by utt 200 on M5 Pro.
+        var text = ""
+        var elapsed: Double = 0
+        autoreleasepool {
+            let t0 = Date()
+            text = m.transcribe(audio: audio, sampleRate: sampleRate, language: language)
+            elapsed = Date().timeIntervalSince(t0)
         }
         let dur = Double(audio.count) / Double(sampleRate)
         return (text, Timings(elapsed: elapsed, audioDuration: dur))

--- a/Sources/AsrBenchmark/EngineQwen3CoreML.swift
+++ b/Sources/AsrBenchmark/EngineQwen3CoreML.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Qwen3ASR
+
+final class Qwen3CoreMLEngine: BenchEngine, @unchecked Sendable {
+    let name = "qwen3-asr-coreml"
+    private(set) var loadElapsed: Double = 0
+    private var model: CoreMLASRModel?
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let t0 = Date()
+        let m = try await CoreMLASRModel.fromPretrained()
+        _ = m.transcribe(audio: warmupAudio, sampleRate: sampleRate, language: nil)
+        self.model = m
+        self.loadElapsed = Date().timeIntervalSince(t0)
+    }
+
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
+        guard let m = model else { throw BenchError.notLoaded(name) }
+        let t0 = Date()
+        let text = m.transcribe(audio: audio, sampleRate: sampleRate, language: language)
+        let elapsed = Date().timeIntervalSince(t0)
+        if ProcessInfo.processInfo.environment["BENCH_DUMP_HYP"] == "1" {
+            FileHandle.standardError.write(Data(("[\(name)] elapsed=\(elapsed)s hyp=\"\(text)\"\n").utf8))
+        }
+        let dur = Double(audio.count) / Double(sampleRate)
+        return (text, Timings(elapsed: elapsed, audioDuration: dur))
+    }
+}
+
+enum BenchError: Error, CustomStringConvertible {
+    case notLoaded(String)
+    case datasetEmpty(String)
+    case datasetMalformed(String)
+    case engineFailed(String, underlying: Error)
+
+    var description: String {
+        switch self {
+        case .notLoaded(let n): return "engine '\(n)' was not loaded before transcribe()"
+        case .datasetEmpty(let p): return "no utterances found under \(p)"
+        case .datasetMalformed(let m): return "dataset malformed: \(m)"
+        case .engineFailed(let n, let e): return "engine '\(n)' failed: \(e)"
+        }
+    }
+}

--- a/Sources/AsrBenchmark/EngineQwen3MLX.swift
+++ b/Sources/AsrBenchmark/EngineQwen3MLX.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Qwen3ASR
+
+final class Qwen3MLXEngine: BenchEngine, @unchecked Sendable {
+    let name: String
+    private let modelId: String
+    private(set) var loadElapsed: Double = 0
+    private var model: Qwen3ASRModel?
+
+    init(size: String, bits: Int) {
+        let sizeUpper = size.uppercased()
+        self.modelId = "aufklarer/Qwen3-ASR-\(sizeUpper)-MLX-\(bits)bit"
+        self.name = "qwen3-asr-mlx-\(size.lowercased())-\(bits)bit"
+    }
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let t0 = Date()
+        let m = try await Qwen3ASRModel.fromPretrained(modelId: modelId)
+        _ = m.transcribe(audio: warmupAudio, sampleRate: sampleRate, language: nil)
+        self.model = m
+        self.loadElapsed = Date().timeIntervalSince(t0)
+    }
+
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
+        guard let m = model else { throw BenchError.notLoaded(name) }
+        let t0 = Date()
+        let text = m.transcribe(audio: audio, sampleRate: sampleRate, language: language)
+        let elapsed = Date().timeIntervalSince(t0)
+        let dur = Double(audio.count) / Double(sampleRate)
+        return (text, Timings(elapsed: elapsed, audioDuration: dur))
+    }
+}

--- a/Sources/AsrBenchmark/EngineWhisperKit.swift
+++ b/Sources/AsrBenchmark/EngineWhisperKit.swift
@@ -1,0 +1,34 @@
+import Foundation
+import WhisperKit
+
+final class WhisperKitEngine: BenchEngine, @unchecked Sendable {
+    let name: String
+    private let modelVariant: String
+    private(set) var loadElapsed: Double = 0
+    private var pipe: WhisperKit?
+
+    init(model: String) {
+        self.modelVariant = model
+        self.name = "whisperkit-\(model.replacingOccurrences(of: "openai_whisper-", with: ""))"
+    }
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let t0 = Date()
+        let config = WhisperKitConfig(model: modelVariant)
+        let pipe = try await WhisperKit(config)
+        _ = try await pipe.transcribe(audioArray: warmupAudio)
+        self.pipe = pipe
+        self.loadElapsed = Date().timeIntervalSince(t0)
+    }
+
+    func transcribe(audio: [Float], sampleRate: Int, language: String?) async throws -> (text: String, timings: Timings) {
+        guard let pipe = pipe else { throw BenchError.notLoaded(name) }
+        // WhisperKit expects 16 kHz mono Float32 — caller is responsible.
+        let t0 = Date()
+        let results = try await pipe.transcribe(audioArray: audio)
+        let elapsed = Date().timeIntervalSince(t0)
+        let text = results.map { $0.text }.joined(separator: " ")
+        let dur = Double(audio.count) / Double(sampleRate)
+        return (text, Timings(elapsed: elapsed, audioDuration: dur))
+    }
+}

--- a/Sources/AsrBenchmark/Memory.swift
+++ b/Sources/AsrBenchmark/Memory.swift
@@ -1,0 +1,18 @@
+import Darwin
+
+/// Returns the current process's resident set size, in bytes.
+///
+/// Uses Mach's `task_info` — same backing as Activity Monitor's
+/// "Memory" column — so the value reflects real physical-page footprint
+/// (not virtual address space). Returns 0 on error.
+public func currentRSSBytes() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info_data_t>.size / MemoryLayout<integer_t>.size)
+    let kerr = withUnsafeMutablePointer(to: &info) { ptr -> kern_return_t in
+        ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { p in
+            task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), p, &count)
+        }
+    }
+    guard kerr == KERN_SUCCESS else { return 0 }
+    return UInt64(info.resident_size)
+}

--- a/Sources/AsrBenchmark/Normalizer.swift
+++ b/Sources/AsrBenchmark/Normalizer.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Text normalizer for cross-engine WER comparison.
+///
+/// Different ASR engines output different conventions (punctuation, casing,
+/// digit-vs-spelled numbers, possessives). Normalizing both reference and
+/// hypothesis to a common form makes WERs comparable. This is a simplified
+/// take on Whisper's `BasicTextNormalizer`: lowercase, strip punctuation,
+/// expand a handful of common contractions, collapse whitespace.
+public enum Normalizer {
+    public static func normalize(_ s: String) -> String {
+        var t = s
+
+        // Strip ChatML / Qwen-style special tokens (`<|im_end|>`, `<|asr_text|>`,
+        // `<|audio_end|>`, etc.) before lowercasing. If we let them through
+        // they get split into bogus words ("im end") by the punctuation pass.
+        t = t.replacingOccurrences(
+            of: #"<\|[^|>]*\|>"#,
+            with: " ",
+            options: .regularExpression
+        )
+
+        t = t.lowercased()
+
+        // Replace a few unicode quotes/dashes that survive case folding.
+        let unicodeMap: [(String, String)] = [
+            ("\u{2018}", "'"), ("\u{2019}", "'"),  // ‘ ’
+            ("\u{201C}", "\""), ("\u{201D}", "\""), // “ ”
+            ("\u{2013}", "-"), ("\u{2014}", "-"),  // – —
+            ("\u{00A0}", " ")                       // nbsp
+        ]
+        for (a, b) in unicodeMap { t = t.replacingOccurrences(of: a, with: b) }
+
+        // Expand a small fixed set of contractions. Whisper's normalizer has
+        // a much bigger table — we keep the high-frequency ones that move WER
+        // most across engines (Qwen, Whisper, Parakeet often disagree here).
+        let contractions: [(String, String)] = [
+            ("won't", "will not"), ("can't", "can not"), ("n't", " not"),
+            ("'re", " are"), ("'ve", " have"), ("'ll", " will"),
+            ("'d", " would"), ("'m", " am"), ("let's", "let us"),
+            ("it's", "it is"), ("'s", " is")
+        ]
+        for (a, b) in contractions {
+            t = t.replacingOccurrences(of: a, with: b)
+        }
+
+        // Drop all punctuation; keep letters, digits, spaces, apostrophes
+        // (apostrophes remain because the contraction pass may leave 's
+        // tokens we *want* to compare as-is for already-expanded forms).
+        var out = ""
+        out.reserveCapacity(t.count)
+        for ch in t.unicodeScalars {
+            if CharacterSet.letters.contains(ch) ||
+               CharacterSet.decimalDigits.contains(ch) ||
+               ch == " " || ch == "\t" || ch == "\n" {
+                out.unicodeScalars.append(ch)
+            } else {
+                out.unicodeScalars.append(" ")
+            }
+        }
+
+        // Collapse whitespace.
+        let collapsed = out.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/AsrBenchmark/Report.swift
+++ b/Sources/AsrBenchmark/Report.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct EngineResult: Codable, Sendable {
+    public var engine: String
+    public var utterances: Int
+    public var werPercent: Double
+    public var substitutions: Int
+    public var insertions: Int
+    public var deletions: Int
+    public var referenceWords: Int
+    public var rtfMean: Double          // mean per-utterance RTF after warmup
+    public var rtfFirst: Double         // first transcription (cold-after-load)
+    public var loadElapsedSeconds: Double
+    public var audioSecondsTotal: Double
+    public var elapsedSecondsTotal: Double
+    public var peakRSSBytes: UInt64     // peak resident memory observed during run
+    public var rssDeltaBytes: Int64     // peak RSS minus pre-load RSS
+    public var throughputXRT: Double    // audio seconds per wall second (= 1 / rtf)
+}
+
+public struct Report: Codable, Sendable {
+    public var machine: String
+    public var datasetPath: String
+    public var utterances: Int
+    public var results: [EngineResult]
+}
+
+public enum ReportPrinter {
+    public static func table(_ report: Report) -> String {
+        var s = ""
+        s += "Machine: \(report.machine)\n"
+        s += "Dataset: \(report.datasetPath)\n"
+        s += "Utterances: \(report.utterances)\n\n"
+        // NOTE: Swift `String` is NOT a C string; `%s` with a Swift String is
+        // undefined behavior (typically segfault). Use `%@` for objects, and
+        // pad/truncate manually for strings to keep the table clean.
+        s += pad("Engine", 32) + "  " + pad("WER%", 6) + "  " + pad("RTF", 6) + "  " +
+             pad("xRT", 6) + "  " + pad("Load(s)", 7) + "  " + pad("Peak(MB)", 8) + "  " +
+             pad("Δ(MB)", 7) + "\n"
+        s += String(repeating: "-", count: 88) + "\n"
+        for r in report.results {
+            s += pad(r.engine, 32) + "  " +
+                 String(format: "%6.2f", r.werPercent) + "  " +
+                 String(format: "%6.3f", r.rtfMean) + "  " +
+                 String(format: "%6.1f", r.throughputXRT) + "  " +
+                 String(format: "%7.1f", r.loadElapsedSeconds) + "  " +
+                 String(format: "%8.0f", Double(r.peakRSSBytes) / (1024 * 1024)) + "  " +
+                 String(format: "%+7.0f", Double(r.rssDeltaBytes) / (1024 * 1024)) + "\n"
+        }
+        return s
+    }
+
+    private static func pad(_ s: String, _ width: Int) -> String {
+        if s.count >= width { return String(s.prefix(width)) }
+        return s + String(repeating: " ", count: width - s.count)
+    }
+
+    public static func writeJSON(_ report: Report, to url: URL) throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try enc.encode(report)
+        try data.write(to: url)
+    }
+}

--- a/Sources/AsrBenchmark/WER.swift
+++ b/Sources/AsrBenchmark/WER.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+public struct WERBreakdown: Sendable {
+    public var substitutions: Int
+    public var insertions: Int
+    public var deletions: Int
+    public var referenceWords: Int
+
+    public var totalErrors: Int { substitutions + insertions + deletions }
+    public var wer: Double {
+        referenceWords == 0 ? 0 : Double(totalErrors) / Double(referenceWords)
+    }
+}
+
+/// Word error rate via Levenshtein on whitespace-tokenized strings.
+///
+/// Reference and hypothesis are assumed to be already normalized — see
+/// `Normalizer.normalize`. Substitutions, insertions, deletions all count as
+/// one edit; WER = (S+I+D) / |reference|.
+public enum WER {
+    public static func compute(reference: String, hypothesis: String) -> WERBreakdown {
+        let ref = reference.split(separator: " ").map(String.init)
+        let hyp = hypothesis.split(separator: " ").map(String.init)
+        let m = ref.count
+        let n = hyp.count
+
+        if m == 0 {
+            return WERBreakdown(substitutions: 0, insertions: n, deletions: 0, referenceWords: 0)
+        }
+
+        // dp[i][j] = edits to align ref[..i] with hyp[..j].
+        // op[i][j] = which operation led there: 0 match/sub, 1 insertion (hyp), 2 deletion (ref).
+        var dp = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+        var op = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+        for i in 0...m { dp[i][0] = i; op[i][0] = 2 }
+        for j in 0...n { dp[0][j] = j; op[0][j] = 1 }
+        op[0][0] = 0
+
+        for i in 1...m {
+            for j in 1...n {
+                let cost = ref[i-1] == hyp[j-1] ? 0 : 1
+                let sub = dp[i-1][j-1] + cost
+                let ins = dp[i][j-1] + 1
+                let del = dp[i-1][j] + 1
+                if sub <= ins && sub <= del {
+                    dp[i][j] = sub; op[i][j] = 0
+                } else if ins <= del {
+                    dp[i][j] = ins; op[i][j] = 1
+                } else {
+                    dp[i][j] = del; op[i][j] = 2
+                }
+            }
+        }
+
+        var subs = 0, ins = 0, dels = 0
+        var i = m, j = n
+        while i > 0 || j > 0 {
+            switch op[i][j] {
+            case 0:
+                if i > 0 && j > 0 && ref[i-1] != hyp[j-1] { subs += 1 }
+                i -= 1; j -= 1
+            case 1:
+                ins += 1; j -= 1
+            case 2:
+                dels += 1; i -= 1
+            default:
+                i = 0; j = 0
+            }
+        }
+        return WERBreakdown(substitutions: subs, insertions: ins, deletions: dels, referenceWords: m)
+    }
+}

--- a/Sources/Qwen3ASR/CoreMLASRModel.swift
+++ b/Sources/Qwen3ASR/CoreMLASRModel.swift
@@ -99,8 +99,11 @@ public class CoreMLASRModel {
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
         let t1 = CFAbsoluteTimeGetCurrent()
 
-        let audioEmbeds = try encoder.encode(melFeatures)
-        let numAudioTokens = audioEmbeds.dim(1)
+        // The encoder pads mel to a fixed 30 s shape and reports the real
+        // (un-padded) audio-token count via ``output_length``. We feed only
+        // the first ``numAudioTokens`` of the padded embeddings to the
+        // decoder so trailing zero-derived tokens don't pollute attention.
+        let (audioEmbeds, numAudioTokens) = try encoder.encode(melFeatures)
         let t2 = CFAbsoluteTimeGetCurrent()
 
         decoder.resetCache()
@@ -168,17 +171,39 @@ public class CoreMLASRModel {
             return "[CoreML decoder: no output]"
         }
 
+        // Known WER issue with this path (multi-sentence utterances on
+        // LibriSpeech test-clean): the CoreML port emits ``<|im_end|>``
+        // after the first sentence-final period with a wide logit margin
+        // (~6+ nats over the runner-up). The MLX path at the same
+        // effective bit width keeps generating. We tried both a
+        // logit-margin guard and a force-first-EOS-suppression; neither
+        // helps — the model's runner-up at the truncation point is also
+        // wrong (e.g. " The" instead of " on"), so substituting it just
+        // trades deletions for substitutions. The root cause is upstream
+        // — encoder INT8 quantization / mel padding leakage into audio
+        // embeddings, or position drift in chunked prefill. Tracked as
+        // a separate fix that requires model re-export, not a sampler
+        // change. The ``argmax(skipping:)`` / ``logit(_:at:)`` helpers
+        // stay for that future work.
         var generatedTokens: [Int32] = []
         var nextToken = decoder.argmax(logits: logits)
+        // First-token EOS would mean the model thinks the audio yielded an
+        // empty transcript — never right on real speech. Cheap to guard.
+        if nextToken == imEndId {
+            nextToken = decoder.argmax(logits: logits, skipping: imEndId)
+        }
         generatedTokens.append(nextToken)
 
         for _ in 1..<maxTokens {
             if nextToken == imEndId { break }
-
             let embedding = try decoder.embed(tokenId: nextToken)
             logits = try decoder.decoderStep(embedding: embedding)
             nextToken = decoder.argmax(logits: logits)
             generatedTokens.append(nextToken)
+        }
+        if profile {
+            let audioDuration = Double(audio.count) / Double(sampleRate)
+            print("[COREML-ASR-PROFILE] audio=\(audioDuration)s gen=\(generatedTokens.count)")
         }
         let t6 = CFAbsoluteTimeGetCurrent()
 
@@ -226,13 +251,15 @@ public class CoreMLASRModel {
         // 1. Extract mel features (pure CPU via Accelerate — no MLXArray)
         let melFeatures = featureExtractor.processRaw(audio, sampleRate: sampleRate)
 
-        // 2. Encode audio → MLMultiArray embeddings [1, T/8, 1024]
-        let audioEmbeds = try encoder.encode(
+        // 2. Encode audio → MLMultiArray embeddings + real (un-padded)
+        //    audio-token count from the encoder's ``output_length``.
+        let encoded = try encoder.encode(
             melData: melFeatures.data,
             melBins: melFeatures.melBins,
             timeFrames: melFeatures.timeFrames
         )
-        let numAudioTokens = audioEmbeds.shape[1].intValue
+        let audioEmbeds = encoded.embeddings
+        let numAudioTokens = encoded.outputLength
 
         // 3. Reset decoder KV cache
         decoder.resetCache()
@@ -284,18 +311,21 @@ public class CoreMLASRModel {
             lastLogits = try decoder.decoderStep(embedding: embedding)
         }
 
-        // 7. Autoregressive generation
+        // 7. Autoregressive generation (same EOS note as `transcribe()` —
+        // see that path for the background).
         guard var logits = lastLogits else {
             return "[CoreML decoder: no output]"
         }
 
         var generatedTokens: [Int32] = []
         var nextToken = decoder.argmax(logits: logits)
+        if nextToken == imEndId {
+            nextToken = decoder.argmax(logits: logits, skipping: imEndId)
+        }
         generatedTokens.append(nextToken)
 
         for _ in 1..<maxTokens {
             if nextToken == imEndId { break }
-
             let embedding = try decoder.embed(tokenId: nextToken)
             logits = try decoder.decoderStep(embedding: embedding)
             nextToken = decoder.argmax(logits: logits)

--- a/Sources/Qwen3ASR/CoreMLEncoder.swift
+++ b/Sources/Qwen3ASR/CoreMLEncoder.swift
@@ -10,18 +10,33 @@ import AudioCommon
 /// Produces audio embeddings that feed into the MLX text decoder. This enables
 /// lower power consumption on macOS and is a step toward full iOS deployment.
 ///
-/// The encoder processes mel spectrograms without chunking/block attention.
-/// For typical audio lengths (< 30s), this produces equivalent results to the
-/// chunked MLX encoder.
+/// The encoder uses a single fixed 30 s mel shape ``[1, 128, 3000]`` and
+/// applies upstream's chunked block-attention (100-frame chunks → 13 tokens
+/// each, 8-chunk attention windows). Mel input is zero-padded to 3000 frames
+/// and the real length is signaled via a separate ``mel_length`` input so
+/// the in-graph block-attention bias can mask out the padded frames; the
+/// model returns the matching real audio-token count via ``output_length``.
 public class CoreMLASREncoder {
     private let model: MLModel
-    private let enumeratedMelLengths: [Int]
+    /// Fixed mel length the chunked-attention encoder is exported with.
+    /// 3000 mel frames = 30 s @ 100 Hz hop, matching upstream training.
+    public static let paddedMelLength: Int = 3000
+    /// Max audio tokens out of the padded encoder (3000 mel / 8 conv stride ≈
+    /// 30 chunks × 13 tokens). The model writes the real count to ``output_length``.
+    public static let paddedAudioTokens: Int = 390
 
     public static let defaultModelId = "aufklarer/Qwen3-ASR-CoreML"
 
-    public init(model: MLModel, enumeratedMelLengths: [Int] = [100, 200, 400, 600, 800, 1000, 1500, 2000, 3000]) {
+    /// Embeddings + the real, un-padded audio-token count (from the model's
+    /// ``output_length`` output). Callers should iterate only the first
+    /// ``outputLength`` tokens of ``embeddings``.
+    public struct EncodedAudio {
+        public let embeddings: MLMultiArray
+        public let outputLength: Int
+    }
+
+    public init(model: MLModel) {
         self.model = model
-        self.enumeratedMelLengths = enumeratedMelLengths
     }
 
     /// Load encoder from a directory containing `encoder.mlmodelc`.
@@ -70,59 +85,21 @@ public class CoreMLASREncoder {
 
     /// Warm up the encoder with a short dummy input to trigger CoreML compilation.
     public func warmUp() throws {
-        let minT = enumeratedMelLengths.first ?? 100
-        let dummy = try MLMultiArray(shape: [1, 128, minT as NSNumber], dataType: .float32)
-        let input = try MLDictionaryFeatureProvider(dictionary: [
-            "mel": MLFeatureValue(multiArray: dummy),
-        ])
-        _ = try model.prediction(from: input)
+        // Use a small fake length so warmup doesn't depend on a real clip.
+        _ = try encodeRaw(melData: [Float](repeating: 0, count: 128 * Self.paddedMelLength),
+                          melBins: 128, realFrames: 100)
     }
 
-    /// Encode mel spectrogram to audio embeddings.
+    /// Encode a mel spectrogram and return embeddings as an MLXArray.
     ///
     /// - Parameter melFeatures: Mel spectrogram as MLXArray `[128, T]`
-    /// - Returns: Audio embeddings as MLXArray `[1, T/8, 1024]`
-    public func encode(_ melFeatures: MLXArray) throws -> MLXArray {
+    /// - Returns: `(embeddings: [1, paddedAudioTokens, 1024], outputLength)`
+    public func encode(_ melFeatures: MLXArray) throws -> (embeddings: MLXArray, outputLength: Int) {
         let melBins = melFeatures.dim(0)
         let melTime = melFeatures.dim(1)
-
-        guard let targetLength = enumeratedMelLengths.first(where: { $0 >= melTime }) else {
-            throw AudioModelError.inferenceFailed(
-                operation: "CoreML encoder",
-                reason: "Audio too long: \(melTime) mel frames exceeds max \(enumeratedMelLengths.last!)")
-        }
-
-        // Convert MLXArray [128, T] → MLMultiArray [1, 128, targetLength]
         let melData: [Float] = melFeatures.asArray(Float.self)
-        let melArray = try MLMultiArray(
-            shape: [1, melBins as NSNumber, targetLength as NSNumber],
-            dataType: .float32)
-        let ptr = melArray.dataPointer.assumingMemoryBound(to: Float.self)
-
-        for bin in 0..<melBins {
-            let srcOffset = bin * melTime
-            let dstOffset = bin * targetLength
-            for t in 0..<melTime {
-                ptr[dstOffset + t] = melData[srcOffset + t]
-            }
-            for t in melTime..<targetLength {
-                ptr[dstOffset + t] = 0
-            }
-        }
-
-        // Run prediction
-        let input = try MLDictionaryFeatureProvider(dictionary: [
-            "mel": MLFeatureValue(multiArray: melArray),
-        ])
-        let output = try model.prediction(from: input)
-
-        guard let embeddings = output.featureValue(for: "audio_embeddings")?.multiArrayValue else {
-            throw AudioModelError.inferenceFailed(
-                operation: "CoreML encoder", reason: "Missing audio_embeddings output")
-        }
-
-        // Convert MLMultiArray → MLXArray
-        return multiArrayToMLXArray(embeddings)
+        let raw = try encodeRaw(melData: melData, melBins: melBins, realFrames: melTime)
+        return (multiArrayToMLXArray(raw.embeddings), raw.outputLength)
     }
 
     // MARK: - MLX-free encoding (for iOS background / pure CoreML path)
@@ -139,36 +116,46 @@ public class CoreMLASREncoder {
     ///   - melBins: Number of mel frequency bins (typically 128)
     ///   - timeFrames: Number of time frames
     /// - Returns: Audio embeddings as `MLMultiArray` with shape `[1, T/8, 1024]`
-    public func encode(melData: [Float], melBins: Int, timeFrames: Int) throws -> MLMultiArray {
-        guard let targetLength = enumeratedMelLengths.first(where: { $0 >= timeFrames }) else {
+    public func encode(melData: [Float], melBins: Int, timeFrames: Int) throws -> EncodedAudio {
+        return try encodeRaw(melData: melData, melBins: melBins, realFrames: timeFrames)
+    }
+
+    /// Convenience: encode a `MelFeatures` struct directly.
+    public func encode(melFeatures: MelFeatures) throws -> EncodedAudio {
+        return try encodeRaw(melData: melFeatures.data,
+                             melBins: melFeatures.melBins,
+                             realFrames: melFeatures.timeFrames)
+    }
+
+    /// Shared core: zero-pads ``melData`` to the fixed ``paddedMelLength``,
+    /// runs the two-input/two-output graph, and returns the model's reported
+    /// ``output_length`` alongside the full padded embeddings.
+    private func encodeRaw(
+        melData: [Float], melBins: Int, realFrames: Int
+    ) throws -> EncodedAudio {
+        let padded = Self.paddedMelLength
+        guard realFrames <= padded else {
             throw AudioModelError.inferenceFailed(
                 operation: "CoreML encoder",
-                reason: "Audio too long: \(timeFrames) mel frames exceeds max \(enumeratedMelLengths.last!)")
+                reason: "Audio too long: \(realFrames) mel frames exceeds fixed shape \(padded). Segment with SpeechVAD or process in 30s windows.")
         }
-
-        // Create MLMultiArray [1, melBins, targetLength] directly from [Float]
+        // Mel input: [1, melBins, paddedMelLength], zero-padded past realFrames.
         let melArray = try MLMultiArray(
-            shape: [1, melBins as NSNumber, targetLength as NSNumber],
-            dataType: .float32)
-        let ptr = melArray.dataPointer.assumingMemoryBound(to: Float.self)
-
-        // melData layout is [melBins, timeFrames] (row-major)
-        // MLMultiArray layout is [1, melBins, targetLength] (row-major, batch dim = 1)
+            shape: [1, melBins as NSNumber, padded as NSNumber], dataType: .float32)
+        let mptr = melArray.dataPointer.assumingMemoryBound(to: Float.self)
         for bin in 0..<melBins {
-            let srcOffset = bin * timeFrames
-            let dstOffset = bin * targetLength
-            for t in 0..<timeFrames {
-                ptr[dstOffset + t] = melData[srcOffset + t]
-            }
-            // Zero-pad remaining time steps
-            for t in timeFrames..<targetLength {
-                ptr[dstOffset + t] = 0
-            }
+            let src = bin * realFrames
+            let dst = bin * padded
+            for t in 0..<realFrames { mptr[dst + t] = melData[src + t] }
+            for t in realFrames..<padded { mptr[dst + t] = 0 }
         }
+        // mel_length input: [1] int32 with the real (un-padded) frame count.
+        let lengthArray = try MLMultiArray(shape: [1], dataType: .int32)
+        lengthArray[0] = NSNumber(value: Int32(realFrames))
 
-        // Run prediction
         let input = try MLDictionaryFeatureProvider(dictionary: [
             "mel": MLFeatureValue(multiArray: melArray),
+            "mel_length": MLFeatureValue(multiArray: lengthArray),
         ])
         let output = try model.prediction(from: input)
 
@@ -176,13 +163,12 @@ public class CoreMLASREncoder {
             throw AudioModelError.inferenceFailed(
                 operation: "CoreML encoder", reason: "Missing audio_embeddings output")
         }
-
-        return embeddings
-    }
-
-    /// Convenience: encode a `MelFeatures` struct directly.
-    public func encode(melFeatures: MelFeatures) throws -> MLMultiArray {
-        return try encode(melData: melFeatures.data, melBins: melFeatures.melBins, timeFrames: melFeatures.timeFrames)
+        guard let lengthOut = output.featureValue(for: "output_length")?.multiArrayValue else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML encoder", reason: "Missing output_length output (encoder may be an older export without the chunked-attention mask)")
+        }
+        let outLen = max(0, Int(lengthOut[0].int32Value))
+        return EncodedAudio(embeddings: embeddings, outputLength: outLen)
     }
 
     private func multiArrayToMLXArray(_ array: MLMultiArray) -> MLXArray {
@@ -222,15 +208,20 @@ extension Qwen3ASRModel {
     ) throws -> String {
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
 
-        // CoreML encoder returns [1, T/8, 1024] (batch dim included)
-        let audioEmbeds = try coremlEncoder.encode(melFeatures)
+        // CoreML encoder returns the padded `[1, paddedAudioTokens, 1024]`
+        // embeddings + the real audio-token count via ``outputLength``.
+        let (audioEmbeds, audioLength) = try coremlEncoder.encode(melFeatures)
 
         guard let textDecoder = textDecoder else {
-            return "[CoreML encoded: \(audioEmbeds.shape)] - Text decoder not loaded"
+            return "[CoreML encoded: \(audioEmbeds.shape) length=\(audioLength)] - Text decoder not loaded"
         }
 
+        // Slice the embeddings to the real (un-padded) length before passing
+        // to the MLX text decoder, otherwise trailing zero-derived tokens
+        // would pollute decoder cross-attention.
+        let realEmbeds = audioEmbeds[0..., 0..<audioLength, 0...]
         return generateText(
-            audioEmbeds: audioEmbeds,
+            audioEmbeds: realEmbeds,
             textDecoder: textDecoder,
             language: language,
             maxTokens: maxTokens

--- a/Sources/Qwen3ASR/CoreMLTextDecoder.swift
+++ b/Sources/Qwen3ASR/CoreMLTextDecoder.swift
@@ -446,6 +446,33 @@ public class CoreMLTextDecoder {
     /// Expose the fixed batch size so callers can chunk audio prefill.
     public var prefillBatchSize: Int { batchSize }
 
+    /// Get argmax token ID, optionally excluding a single token.
+    ///
+    /// When ``skipToken`` is non-nil, the slot at that index is ignored —
+    /// used by the ASR generation loop to suppress premature ``<|im_end|>``
+    /// (see `CoreMLASRModel.transcribe`). When it's nil this is the plain
+    /// argmax over the full vocab.
+    public func argmax(logits: MLMultiArray, skipping skipToken: Int32? = nil) -> Int32 {
+        return argmaxImpl(logits: logits, skipIdx: skipToken.map { Int($0) })
+    }
+
+    /// Read a single logit by token index. Stride-aware (matches `argmax`).
+    public func logit(_ logits: MLMultiArray, at index: Int32) -> Float {
+        let lastStride = logits.strides.last?.intValue ?? 1
+        let i = Int(index) * lastStride
+        switch logits.dataType {
+        case .float16:
+            let ptr = logits.dataPointer.assumingMemoryBound(to: Float16.self)
+            return Float(ptr[i])
+        case .float32:
+            let ptr = logits.dataPointer.assumingMemoryBound(to: Float.self)
+            return ptr[i]
+        default:
+            let ptr = logits.dataPointer.assumingMemoryBound(to: Float.self)
+            return ptr[i]
+        }
+    }
+
     /// Get argmax token ID from logits.
     ///
     /// Stride-aware: walks ``vocabSize`` (the logical last-dim length)
@@ -455,7 +482,7 @@ public class CoreMLTextDecoder {
     /// previous flat ``ptr[i]`` loop with ``maxVal = -Float.infinity``
     /// would silently keep ``maxIdx = 0`` since IEEE-754 ``NaN > x``
     /// is always false).
-    public func argmax(logits: MLMultiArray) -> Int32 {
+    private func argmaxImpl(logits: MLMultiArray, skipIdx: Int?) -> Int32 {
         let vocab = logits.shape.last?.intValue ?? logits.count
         let lastStride = logits.strides.last?.intValue ?? 1
         var maxVal: Float = -Float.infinity
@@ -465,7 +492,7 @@ public class CoreMLTextDecoder {
         switch logits.dataType {
         case .float16:
             let ptr = logits.dataPointer.assumingMemoryBound(to: Float16.self)
-            for i in 0..<vocab {
+            for i in 0..<vocab where i != skipIdx {
                 let val = Float(ptr[i * lastStride])
                 if val.isNaN { nanCount += 1; continue }
                 if val > maxVal {
@@ -475,7 +502,7 @@ public class CoreMLTextDecoder {
             }
         case .float32:
             let ptr = logits.dataPointer.assumingMemoryBound(to: Float.self)
-            for i in 0..<vocab {
+            for i in 0..<vocab where i != skipIdx {
                 let val = ptr[i * lastStride]
                 if val.isNaN { nanCount += 1; continue }
                 if val > maxVal {
@@ -485,7 +512,7 @@ public class CoreMLTextDecoder {
             }
         default:
             let ptr = logits.dataPointer.assumingMemoryBound(to: Float.self)
-            for i in 0..<vocab {
+            for i in 0..<vocab where i != skipIdx {
                 let val = ptr[i * lastStride]
                 if val.isNaN { nanCount += 1; continue }
                 if val > maxVal {

--- a/docs/benchmarks/asr-wer.md
+++ b/docs/benchmarks/asr-wer.md
@@ -5,7 +5,40 @@
 - **LibriSpeech test-clean** — 2620 utterances, ~5.4 hours, English read speech (standard ASR benchmark)
 - **FLEURS** — multilingual (10 languages), ~400-900 utterances per language, freely downloadable
 
-## Results
+## Cross-engine isolated benchmark — M5 Pro, n=200
+
+The `asr-bench` tool runs each engine in a separate child process (`--isolated`) so the peak RSS column is the **real per-engine** allocation rather than a cumulative high-water mark across a sequential run. WER computed via a Whisper-style normalizer + Levenshtein on whitespace tokens.
+
+**Machine**: Apple M5 Pro, 48 GB, macOS 25.5, release build with compiled metallib. LibriSpeech test-clean, first 200 utterances (~30 min audio).
+
+| Engine | Backend | Quant | WER% | RTF | xRT | Peak RSS | Cold load |
+|---|---|---|---|---|---|---|---|
+| Qwen3-ASR 1.7B | MLX (GPU) | 8-bit | **1.52** | 0.033 | 30.5x | 2 706 MB | 2.5s |
+| WhisperKit Large-v3 Turbo | CoreML (ANE) | FP16 | 1.71 | 0.084 | 11.9x | 428 MB | 5.9s |
+| Qwen3-ASR 0.6B | MLX (GPU) | 8-bit | 1.82 | 0.015 | 66.0x | 1 306 MB | 2.2s |
+| Qwen3-ASR 0.6B | MLX (GPU) | 4-bit | 2.20 | 0.012 | 85.6x | 1 022 MB | 2.1s |
+| Parakeet TDT 0.6B v3 | CoreML (ANE) | INT8 | 2.37 | 0.009 | **117.4x** | 897 MB | 3.1s |
+| Qwen3-ASR 0.6B | CoreML (ANE) | INT8 | 3.02 | 0.098 | 10.2x | 1 379 MB | 7.3s |
+| Omnilingual CTC 300M | MLX (GPU) | 4-bit | 4.26 | 0.005 | **222.1x** | **384 MB** | 1.6s |
+| Omnilingual CTC 300M | CoreML (ANE) | INT8 | 5.67 | 0.128 | 7.8x | 543 MB | 2.6s |
+| Nemotron-Speech-Streaming | CoreML (ANE) | INT8 | 12.26 | 0.107 | 9.3x | 1 459 MB | 4.6s |
+
+**Headline picks:**
+- **Best WER**: Qwen3-ASR MLX 1.7B 8-bit at 1.52% — beats WhisperKit Large-v3 Turbo (1.71%) and runs 2.6x faster, at a 6x memory cost.
+- **Best WER under WhisperKit memory**: WhisperKit Large-v3 Turbo itself (1.71%, 428 MB) and Qwen3-ASR MLX 0.6B 4-bit (2.20%, 1 022 MB) for the next size class.
+- **Fastest English**: Parakeet TDT v3 INT8 — 117x real-time at 897 MB, English-only (25 European languages).
+- **Multilingual throughput leader**: Omnilingual MLX 300M 4-bit — 222x real-time, 384 MB peak, 1 672 languages, 4.26% WER on English test-clean.
+- **Streaming**: Nemotron at 12.26% on whole-utterance batch is the cost of 160 ms streaming chunks with 1-chunk right context — designed for low latency, not offline batch.
+
+**Reading the memory column**: Sequential-run peak RSS is much higher (4–10 GB) because MLX's Metal cache and CoreML's compiled plans don't release between engines. The `--isolated` mode spawns one child per engine, so each row is the actual per-engine cost.
+
+### Qwen3-ASR CoreML encoder rebuild
+
+The Qwen3-ASR-CoreML row in the table above is the **rebuilt** encoder (chunked block-attention export, [`aufklarer/Qwen3-ASR-CoreML`](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML)). The previous export ran unmasked global self-attention over the zero-padded mel input under `EnumeratedShapes`; padding-derived audio tokens contaminated the real ones via attention, causing the text decoder to emit `<|im_end|>` right after the first sentence-final period — **24.88% WER** on the same n=200 fixture. The rebuilt encoder mirrors upstream's 100-frame chunks + 800-frame attention windows (in-graph block-attention bias from a new `mel_length` input; outputs `(audio_embeddings, output_length)`); encoder time also drops from 113 ms to 24 ms per call.
+
+## Historical: per-engine on M2 Max (legacy table)
+
+The benchmark below was collected separately on M2 Max with the previous reproduction script (Python). Kept as a reference; the M5 Pro `asr-bench` results above are the canonical numbers for the engines they cover.
 
 | Model | Engine | Bits | Size | WER% | RTF | Model Load | Warmup |
 |-------|--------|------|------|------|-----|------------|--------|
@@ -93,30 +126,46 @@ RTF includes per-invocation model loading overhead (~3s). Pure inference RTF is 
 
 ## Reproduction
 
+The cross-engine table at the top is produced by the `asr-bench` tool that ships in this repo (`Sources/AsrBenchmark/`, executable `asr-bench`). It supports any LibriSpeech-style directory layout (`<speaker>/<chapter>/{*.flac,*.trans.txt}`) or a flat TSV manifest (`<audio_path>\t<reference_text>`).
+
 ```bash
+# Build (release + metallib)
 make build
-python scripts/benchmark_asr.py --batch --engine qwen3 --model 0.6B
-python scripts/benchmark_asr.py --batch --engine qwen3 --model 0.6B-8bit
-python scripts/benchmark_asr.py --batch --engine parakeet
-python scripts/benchmark_asr.py --batch --engine parakeet --model int8
+
+# Download LibriSpeech test-clean (~350 MB compressed)
+mkdir -p ~/Library/Caches/qwen3-speech/datasets
+cd ~/Library/Caches/qwen3-speech/datasets
+curl -L https://www.openslr.org/resources/12/test-clean.tar.gz | tar -xz
+
+# Cross-engine bench, isolated per-engine peak RSS
+.build/release/asr-bench \
+  --dataset ~/Library/Caches/qwen3-speech/datasets/LibriSpeech/test-clean \
+  --limit 200 \
+  --engines qwen3-mlx-1.7b-8bit qwen3-mlx-0.6b-8bit qwen3-mlx-0.6b-4bit \
+            qwen3-coreml parakeet omnilingual omnilingual-mlx-300m-4bit \
+            nemotron whisperkit-large-v3-turbo \
+  --isolated \
+  --output report.json
 ```
 
-First run downloads LibriSpeech test-clean (~350 MB). Results saved to `benchmarks/librispeech/`.
+Available engine IDs (see `Sources/AsrBenchmark/Engine.swift::EngineID`):
 
-### Long-form stability
+- `qwen3-coreml` — Qwen3-ASR 0.6B CoreML INT8 (full pipeline)
+- `qwen3-mlx-{0.6b,1.7b}-{4,8}bit` — Qwen3-ASR MLX variants
+- `parakeet` — Parakeet TDT 0.6B v3 CoreML INT8
+- `nemotron` — Nemotron Streaming ASR
+- `omnilingual` — Omnilingual CTC 300M CoreML INT8
+- `omnilingual-mlx-{300m,1b,3b,7b}-4bit` — Omnilingual CTC MLX variants
+- `whisperkit-large-v3-turbo` / `whisperkit-large-v3` / `whisperkit-distil-large-v3` — Argmax WhisperKit
 
-```bash
-# Download LibriSpeech test-clean first (~350 MB)
-# Then run sustained benchmark (all 2620 utterances, ~5.4 hours)
-python scripts/benchmark_longform.py --engine parakeet
-# Or a quick 200-utterance test (~30 min audio)
-python scripts/benchmark_longform.py --engine parakeet --max-utterances 200
-```
+Without `--isolated`, peak RSS reflects the sequential high-water mark across the whole run (MLX/CoreML caches don't release between engines). With `--isolated`, each engine runs in a child process and its peak RSS is its own.
 
-### FLEURS (multilingual, auto-download)
+### FLEURS (multilingual, separate runner)
 
 ```bash
 python scripts/benchmark_asr.py --dataset fleurs --language en_us --batch
 python scripts/benchmark_asr.py --dataset fleurs --language cmn_hans_cn --batch
 python scripts/benchmark_asr.py --dataset fleurs --language de_de --batch
 ```
+
+(FLEURS reproduction still lives in the legacy Python script; the FLEURS rows in this doc are historical.)


### PR DESCRIPTION
## Summary

- New cross-engine ASR benchmark harness (`asr-bench`) — 9 engine adapters, isolated per-engine peak RSS, xRT, S/I/D breakdown, on LibriSpeech-style datasets.
- Fixes a **24.88% → 3.02% WER** bug in the Qwen3-ASR CoreML port by adopting the new chunked block-attention encoder shipped in [soniqo/speech-models@12a386e](https://github.com/soniqo/speech-models/commit/12a386e) and uploaded to [`aufklarer/Qwen3-ASR-CoreML`](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML).
- Identifies WhisperKit-class competitors in our own stack and a multilingual throughput winner (Omnilingual MLX 300M 4-bit).

## What changed in the Qwen3-ASR CoreML encoder

The previous encoder ran **unmasked global self-attention over zero-padded mel input** under an `EnumeratedShapes` schema `[100, 200, 400, 600, 800, 1000, 1500, 2000, 3000]`. For a 4.9 s clip (490 mel frames) the encoder padded to 600 frames and produced 75 audio tokens, of which the trailing ~13 came from zero-padded silence and contaminated *every* real audio embedding via global attention. The text decoder then emitted `<|im_end|>` right after the first sentence-final period, truncating multi-sentence transcriptions. On `61-70968-0000.flac` ("HE BEGAN A CONFUSED COMPLAINT...ON THE LEFT") the model produced `"He began a confused complaint...behind the curtain."` — dropping `"on the left"`.

The new encoder mirrors upstream `Qwen3OmniMoeAudioEncoder`'s chunked block attention (100-frame chunks → 13 tokens each, 800-frame attention windows via `cu_seqlens`), with a single fixed `[1, 128, 3000]` mel shape. Interface is now `(mel, mel_length) → (audio_embeddings, output_length)`; the Swift consumer slices to `output_length` audio tokens before feeding the decoder.

Validated at cos > 0.99 vs upstream PyTorch eager attention. End-to-end LibriSpeech test-clean n=200 in this PR: **24.88% → 3.02% WER**. Encoder is also ~4.7× faster (24 ms vs 113 ms per call on M5 Pro).

## Bench results — n=200, Apple M5 Pro 48 GB, LibriSpeech test-clean (isolated mode)

| Engine | WER% | xRT | Load (s) | Peak (MB) |
|---|---|---|---|---|
| whisperkit-large-v3-turbo | 1.71 | 11.9 | 5.9 | 428 |
| qwen3-asr-mlx-1.7b-8bit | **1.52** | 30.5 | 2.5 | 2 706 |
| qwen3-asr-mlx-0.6b-8bit | 1.82 | 66.0 | 2.2 | 1 306 |
| qwen3-asr-mlx-0.6b-4bit | 2.20 | 85.6 | 2.1 | 1 022 |
| parakeet-tdt-coreml-int8 | 2.37 | **117.4** | 3.1 | 897 |
| **qwen3-asr-coreml (this PR)** | **3.02** | 9.4 | 7.3 | 1 184 |
| omnilingual-mlx-300m-4bit | 4.26 | **222.1** | 1.6 | 384 |
| omnilingual-ctc-300m-coreml-int8 | 5.67 | 7.8 | 2.6 | 543 |
| nemotron-streaming-coreml-int8 | 12.26 | 9.3 | 4.6 | 1 459 |

- **Qwen3-ASR MLX 1.7B 8-bit beats WhisperKit Large-v3-Turbo on WER + speed** (1.52% vs 1.71%, 30.5× vs 11.9× real-time) at a memory cost (2.7 GB vs 0.4 GB).
- **Omnilingual MLX 300M 4-bit** is the multilingual throughput leader: 222.1× real-time at 384 MB, supports 1,672 languages, 4.26% WER on test-clean. The CoreML port at 7.8× was masking how much faster the MLX path actually is.


## Test plan

- [ ] CI green (unit tests, no model downloads)
- [ ] Manual: `make build && .build/release/speech transcribe <LibriSpeech clip> --engine qwen3-coreml-full` recovers full multi-sentence transcripts
- [ ] Manual: `.build/release/asr-bench --dataset <LibriSpeech test-clean> --limit 200 --engines qwen3-coreml whisperkit-large-v3-turbo --isolated` reproduces the table above
- [ ] Confirm Hugging Face download cache invalidation works (existing users get the new encoder on next `fromPretrained`)