### PR TITLE
docs(asr): describe new CoreML encoder interface + drop M2 Max table

### DIFF
--- a/docs/benchmarks/asr-wer.md
+++ b/docs/benchmarks/asr-wer.md
@@ -36,25 +36,6 @@ The `asr-bench` tool runs each engine in a separate child process (`--isolated`)
 
 The Qwen3-ASR-CoreML row in the table above is the **rebuilt** encoder (chunked block-attention export, [`aufklarer/Qwen3-ASR-CoreML`](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML)). The previous export ran unmasked global self-attention over the zero-padded mel input under `EnumeratedShapes`; padding-derived audio tokens contaminated the real ones via attention, causing the text decoder to emit `<|im_end|>` right after the first sentence-final period — **24.88% WER** on the same n=200 fixture. The rebuilt encoder mirrors upstream's 100-frame chunks + 800-frame attention windows (in-graph block-attention bias from a new `mel_length` input; outputs `(audio_embeddings, output_length)`); encoder time also drops from 113 ms to 24 ms per call.
 
-## Historical: per-engine on M2 Max (legacy table)
-
-The benchmark below was collected separately on M2 Max with the previous reproduction script (Python). Kept as a reference; the M5 Pro `asr-bench` results above are the canonical numbers for the engines they cover.
-
-| Model | Engine | Bits | Size | WER% | RTF | Model Load | Warmup |
-|-------|--------|------|------|------|-----|------------|--------|
-| Qwen3-ASR 1.7B | MLX (GPU) | 8-bit | 2.3 GB | 2.35 | 0.090 | 5.1s | 0.8s |
-| Qwen3-ASR 1.7B | MLX (GPU) | 4-bit | 1.2 GB | 2.57 | 0.045 | 3.2s | 0.4s |
-| Parakeet TDT 0.6B | CoreML (ANE) | INT8 | 634 MB | 2.74 | 0.089 | 128.9s | 2.0s |
-| Qwen3-ASR 0.6B | MLX (GPU) | 8-bit | 960 MB | 2.80 | 0.025 | 2.4s | 0.3s |
-| Qwen3-ASR 0.6B | MLX (GPU) | 4-bit | 675 MB | 3.34 | 0.023 | 2.4s | 0.3s |
-
-**Machine**: Apple M2 Max, 64 GB, macOS 14, release build with compiled metallib.
-
-**Key observations:**
-- Parakeet INT8 achieves the best WER (2.74%) but has a slow cold start (128.9s CoreML compilation)
-- Qwen3-ASR MLX is 10x faster to load (2.4s vs 129s) and has the fastest RTF (0.023)
-- CoreML cold start (first-ever load) compiles a device-specific execution plan: 129s for INT8. Warm start (cached) is 5.4s — CoreML caches compiled plans in `~/Library/Caches/com.apple.CoreML/`. The 129s only happens once per device. Encoder currently uses `.all` compute units; switching to `.cpuAndNeuralEngine` would skip GPU plan compilation
-
 ## Comparison with published models
 
 | Model | Params | Size | Precision | WER% (test-clean) | Source |

--- a/docs/inference/qwen3-asr-inference.md
+++ b/docs/inference/qwen3-asr-inference.md
@@ -69,13 +69,47 @@ let text = model.transcribe(
 The legacy overload `transcribe(audio:sampleRate:language:maxTokens:context:)`
 remains available and forwards into the new path with default options.
 
+## CoreML Encoder Backend (CoreMLEncoder.swift)
+
+The CoreML port of the audio encoder (`aufklarer/Qwen3-ASR-CoreML`) ships a model exported with the same **chunked block attention** the upstream PyTorch model is trained with (100-frame mel chunks → 13 tokens after 3× stride-2 conv, attention restricted to 800-frame / 8-chunk windows). The export uses a **single fixed mel shape** instead of `EnumeratedShapes` and signals real audio length through a dedicated input/output pair so the downstream consumer can slice the padded embeddings to the un-padded count.
+
+### Interface
+
+```
+Inputs
+  mel          MultiArray<Float32>  shape [1, 128, 3000]
+  mel_length   MultiArray<Int32>    shape [1]
+                  Number of real mel frames in mel; remaining frames
+                  are zero-padded and masked out by the in-graph
+                  block-attention bias.
+
+Outputs
+  audio_embeddings  MultiArray<Float16>  shape [1, 390, 1024]
+  output_length     MultiArray<Int32>    shape [1]
+                  Number of real audio tokens. Callers should iterate
+                  only embeddings[:, :output_length, :].
+```
+
+The 8× conv stride downsamples 3000 mel frames to up to 390 audio tokens. For shorter audio the in-graph mask discards the trailing chunks; `output_length` returns the precise real count (e.g. 64 tokens for a 4.9 s clip).
+
+### Swift consumer
+
+`CoreMLEncoder.encode(_:)` returns `(embeddings: MLXArray, outputLength: Int)`. `CoreMLASRModel.transcribe` uses `outputLength` directly as `numAudioTokens` when chunking the audio prefill into the decoder; this replaces the previous `ceil(realMelFrames / 8)` heuristic with the model-reported truth.
+
+### Why the rebuild
+
+The previous export ran **unmasked global self-attention** over mel padded to enumerated buckets `[100, 200, 400, 600, 800, 1000, 1500, 2000, 3000]`. Trailing zero-padded mel frames contaminated the real audio embeddings via attention, and the text decoder emitted `<|im_end|>` right after the first sentence-final period — 24.88% WER on LibriSpeech test-clean vs 1.82% for the same 0.6B-8bit weights via MLX. The rebuilt export brings WER on the same fixture to **3.02%** and is ~4.7× faster (24 ms vs 113 ms per call on M5 Pro).
+
 ## Performance
 
-| Model | Framework | RTF | 10s audio processed in |
-|-------|-----------|-----|------------------------|
-| Qwen3-ASR-0.6B (4-bit) | MLX Swift | ~0.06 | ~0.6s |
-| Whisper-large-v3 | whisper.cpp (Q5_0) | ~0.10 | ~1.0s |
-| Whisper-small | whisper.cpp (Q5_0) | ~0.04 | ~0.4s |
+| Model | Framework | WER% | RTF | xRT |
+|-------|-----------|------|-----|-----|
+| Qwen3-ASR 1.7B (MLX, 8-bit) | MLX Swift | 1.52 | 0.033 | 30.5× |
+| Qwen3-ASR 0.6B (MLX, 8-bit) | MLX Swift | 1.82 | 0.015 | 66.0× |
+| Qwen3-ASR 0.6B (MLX, 4-bit) | MLX Swift | 2.20 | 0.012 | 85.6× |
+| Qwen3-ASR 0.6B (CoreML INT8) | CoreML (ANE+CPU) | 3.02 | 0.098 | 10.2× |
+
+M5 Pro, 48 GB; LibriSpeech test-clean n=200; isolated per-engine. See [docs/benchmarks/asr-wer.md](../benchmarks/asr-wer.md) for the full cross-engine table including WhisperKit, Parakeet, Omnilingual, and Nemotron.
 
 ## Streaming / Partial Transcription
 


### PR DESCRIPTION
## Summary

Two doc follow-ups to PR #292.

### `inference/qwen3-asr-inference.md`
- New section **CoreML Encoder Backend** describing the rebuilt encoder shipped at [`aufklarer/Qwen3-ASR-CoreML`](https://huggingface.co/aufklarer/Qwen3-ASR-CoreML)
- Documents the `(mel, mel_length) -> (audio_embeddings, output_length)` interface, the single fixed `[1, 128, 3000]` mel shape, the in-graph block-attention bias, and how `CoreMLASRModel.transcribe` uses `output_length` as `numAudioTokens`
- Refreshes the Performance table with M5 Pro isolated bench numbers; points at `docs/benchmarks/asr-wer.md` for the full cross-engine table

### `benchmarks/asr-wer.md`
- Removes the *"Historical: per-engine on M2 Max (legacy table)"* section — the M5 Pro `asr-bench` table at the top of the file already covers the engines the legacy table referenced (1.7B 8-bit/4-bit, Parakeet, 0.6B 8-bit/4-bit)

## Test plan

- [ ] `make build` succeeds
- [ ] `docs/inference/qwen3-asr-inference.md` renders cleanly on GitHub
- [ ] No remaining links to the removed historical section