### PR TITLE
fix(personaplex): load full-duplex voice prompts from the active model repo

### DIFF
--- a/Sources/PersonaPlex/PersonaPlex.swift
+++ b/Sources/PersonaPlex/PersonaPlex.swift
@@ -1013,7 +1013,7 @@ public final class PersonaPlexModel: Module {
                     let voiceCache: MLXArray?
                     do {
                         let modelDir = try HuggingFaceDownloader.getCacheDirectory(
-                            for: "aufklarer/PersonaPlex-7B-MLX-4bit")
+                            for: modelId)
                         let voiceFile = modelDir.appendingPathComponent("voices")
                             .appendingPathComponent("\(voice.rawValue).safetensors")
                         if FileManager.default.fileExists(atPath: voiceFile.path) {


### PR DESCRIPTION
## Summary

`PersonaPlexModel.respondRealtime(...)` resolved the voice-prompt directory from a
hardcoded repo — `aufklarer/PersonaPlex-7B-MLX-4bit` — instead of the model that was
actually loaded. When PersonaPlex is loaded from any other repo (most importantly the
recommended **8-bit** build, `aufklarer/PersonaPlex-7B-MLX-8bit`), the hardcoded 4-bit
`voices/` directory is missing or empty, so the voice prompt silently fails to load.

## Impact

With the voice prompt missing, `voiceFrameCount` falls to `0`, which cascades:

- the voice-embedding prefill is skipped,
- the delay-ring voice seed is skipped,
- generation starts with no speaker/acoustic anchor.

The 7B model then free-runs with no conditioning and collapses into incoherent —
often non-English — audio. Full-duplex is effectively broken for every variant except a
fully-populated 4-bit cache.

The turn-based `respond()` path was never affected: it already resolves the directory
from `modelId` (`Sources/PersonaPlex/PersonaPlex.swift:136`).

## Fix

Resolve the voice directory from `modelId`, exactly like `respond()` does — a one-line
change.

## Testing

A regression test for this path is end-to-end (it needs the 8-bit weights and produces
audio), so it's intentionally omitted to keep CI download-free. Happy to add an
`E2E`-prefixed test gated behind a model download if preferred.
