### PR TITLE
Remove tap instructions, move to Homebrew Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 Requires native ARM Homebrew (`/opt/homebrew`). Rosetta/x86_64 Homebrew is not supported.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Then:

--- a/README_ar.md
+++ b/README_ar.md
@@ -204,7 +204,7 @@ struct DictateView: View {
 </div>
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 <div dir="rtl">

--- a/README_de.md
+++ b/README_de.md
@@ -156,7 +156,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 Erfordert natives ARM-Homebrew (`/opt/homebrew`). Rosetta/x86_64-Homebrew wird nicht unterstützt.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Dann:

--- a/README_es.md
+++ b/README_es.md
@@ -156,7 +156,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 Requiere Homebrew ARM nativo (`/opt/homebrew`). Homebrew Rosetta/x86_64 no está soportado.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Luego:

--- a/README_fr.md
+++ b/README_fr.md
@@ -156,7 +156,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 Necessite un Homebrew ARM natif (`/opt/homebrew`). Homebrew Rosetta/x86_64 n'est pas supporte.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Ensuite :

--- a/README_hi.md
+++ b/README_hi.md
@@ -156,7 +156,7 @@ struct DictateView: View {
 नेटिव ARM Homebrew (`/opt/homebrew`) आवश्यक है। Rosetta/x86_64 Homebrew समर्थित नहीं है।
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 फिर:

--- a/README_ja.md
+++ b/README_ja.md
@@ -156,7 +156,7 @@ struct DictateView: View {
 ネイティブARM Homebrew（`/opt/homebrew`）が必要です。Rosetta/x86_64 Homebrewはサポートされません。
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 その後：

--- a/README_ko.md
+++ b/README_ko.md
@@ -156,7 +156,7 @@ struct DictateView: View {
 네이티브 ARM Homebrew(`/opt/homebrew`)가 필요합니다. Rosetta/x86_64 Homebrew는 지원되지 않습니다.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 그런 다음:

--- a/README_pt.md
+++ b/README_pt.md
@@ -156,7 +156,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 Requer Homebrew ARM nativo (`/opt/homebrew`). Homebrew Rosetta/x86_64 nao e suportado.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Depois:

--- a/README_ru.md
+++ b/README_ru.md
@@ -156,7 +156,7 @@ struct DictateView: View {
 Требуется нативный ARM Homebrew (`/opt/homebrew`). Rosetta/x86_64-версия Homebrew не поддерживается.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Затем:

--- a/README_th.md
+++ b/README_th.md
@@ -156,7 +156,7 @@ struct DictateView: View {
 ต้องใช้ Homebrew ARM แบบเนทีฟ (`/opt/homebrew`) ไม่รองรับ Homebrew แบบ Rosetta/x86_64
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 จากนั้น:

--- a/README_tr.md
+++ b/README_tr.md
@@ -156,7 +156,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 Yerel ARM Homebrew (`/opt/homebrew`) gerektirir. Rosetta/x86_64 Homebrew desteklenmez.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Ardından:

--- a/README_vi.md
+++ b/README_vi.md
@@ -156,7 +156,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 Yêu cầu Homebrew ARM gốc (`/opt/homebrew`). Homebrew Rosetta/x86_64 không được hỗ trợ.
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 Sau đó:

--- a/README_zh.md
+++ b/README_zh.md
@@ -156,7 +156,7 @@ struct DictateView: View {
 需要原生 ARM Homebrew（`/opt/homebrew`），不支持 Rosetta/x86_64 Homebrew。
 
 ```bash
-brew install soniqo/tap/speech
+brew install speech
 ```
 
 然后：


### PR DESCRIPTION
Speech Swift is now [available](https://github.com/Homebrew/homebrew-core/commit/dc86a2c61340bd4f7bb25f35142075bb084e63a9) to install directly via [Homebrew](https://brew.sh/).