### PR TITLE
fix(asr): strip Nemotron lang-tags (12.26% → 2.82% WER) + 6 fixes

### DIFF
--- a/Sources/NemotronStreamingASR/Configuration.swift
+++ b/Sources/NemotronStreamingASR/Configuration.swift
@@ -31,6 +31,26 @@ public struct NemotronStreamingConfig: Codable, Sendable {
     public struct StreamingConfig: Codable, Sendable {
         public let chunkMs: Int
         public let chunkSize: Int
+        /// Number of right-context (future) frames the encoder was trained
+        /// with. **This is model-topology metadata, not a runtime knob.**
+        ///
+        /// The CoreML encoder graph already incorporates right-context via
+        /// the streaming cache mechanism: at conversion time the export
+        /// script (`speech-models/.../convert.py:172`, `keep_all_outputs=False`)
+        /// trimmed the right-context outputs, and the encoder pulls future
+        /// context from `cache_last_channel`/`cache_last_time` filled by
+        /// the *previous* chunk. The Swift streaming session correctly
+        /// feeds exactly `chunk_size` mel frames per call with no audio
+        /// overlap — that's what the trained graph expects.
+        ///
+        /// DO NOT add audio overlap at the Swift layer (e.g. shrinking
+        /// `shiftSamples` below `samplesPerChunk` to mirror Parakeet). The
+        /// RNN-T predictor's LSTM state advances on every non-blank
+        /// emission and would be permanently desynced by re-feeding
+        /// overlapped frames. The streaming-vs-batch recall measured on
+        /// `E2ENemotronHarshAudioTests.testStreamingMatchesBatchOnCleanLongUtterance`
+        /// is the chunker's correctness signal — a regression there means
+        /// the cache I/O wiring broke, not that the chunker needs overlap.
         public let rightContext: Int
         public let melFrames: Int
         public let preCacheSize: Int

--- a/Sources/NemotronStreamingASR/StreamingSession.swift
+++ b/Sources/NemotronStreamingASR/StreamingSession.swift
@@ -131,6 +131,21 @@ public class StreamingSession {
         let samplesPerChunk = config.streaming.melFrames * config.hopLength
         let shiftMelFrames = config.streaming.outputFrames * config.subsamplingFactor
         let shiftSamples = shiftMelFrames * config.hopLength
+        // For the multilingual config (chunkMs=320) shiftSamples ==
+        // samplesPerChunk — adjacent chunks do NOT overlap, and that IS
+        // correct for this checkpoint. The trained encoder takes exactly
+        // `chunk_size` mel frames per call; right-context is provided via
+        // the streaming caches (`cache_last_*`), not via future audio in
+        // the current call. The export script trimmed the right-context
+        // outputs at trace time (`keep_all_outputs=False`), so feeding
+        // overlapped audio here would re-process already-consumed frames
+        // and desync the RNN-T predictor's LSTM state.
+        //
+        // The chunker's correctness is regressed by
+        // `E2ENemotronHarshAudioTests.testStreamingMatchesBatchOnCleanLongUtterance`
+        // (expects ≥0.95 streaming-vs-batch recall on clean continuous
+        // speech). DO NOT introduce audio-overlap here — see
+        // Configuration.swift docstring on `rightContext`.
         var results: [NemotronStreamingASRModel.PartialTranscript] = []
 
         while sampleBuffer.count >= samplesPerChunk {

--- a/Sources/NemotronStreamingASR/Vocabulary.swift
+++ b/Sources/NemotronStreamingASR/Vocabulary.swift
@@ -2,9 +2,10 @@ import Foundation
 import AudioCommon
 
 /// SentencePiece vocabulary for Nemotron-3.5 ASR Streaming Multilingual
-/// (13087 BPE pieces + 1 blank). Punctuation, capitalization, and per-language
-/// tags (e.g. `<en-US>`) are emitted as regular BPE tokens; decode passes them
-/// through as-is — callers may strip `<lang-tag>` markers downstream.
+/// (13087 BPE pieces + 1 blank). Punctuation and capitalization render as
+/// regular BPE tokens; per-language tags (`<en-US>`, `<ar-AR>`, …) and
+/// other angle-bracket special tokens (`<unk>`, `<s>`, `</s>`, `<auto>`)
+/// are stripped during decode so they don't pollute the user-facing text.
 public struct NemotronVocabulary: Sendable {
     private let idToToken: [Int: String]
 
@@ -27,17 +28,32 @@ public struct NemotronVocabulary: Sendable {
         return NemotronVocabulary(idToToken: mapping)
     }
 
-    /// Decode token IDs to text. Blank is filtered upstream.
+    /// True when `token` is an angle-bracket-wrapped special marker
+    /// (`<en-US>`, `<unk>`, `<s>`, `</s>`, `<auto>`, etc.) that should be
+    /// stripped from the user-facing transcript. A token with whitespace
+    /// inside the brackets is considered ordinary text (defensive — the
+    /// SentencePiece vocab doesn't produce these, but keeps the filter
+    /// from misclassifying contrived inputs).
+    static func isSpecialToken(_ token: String) -> Bool {
+        guard token.first == "<", token.last == ">", token.count >= 3 else { return false }
+        return !token.contains(" ") && !token.contains("\t")
+    }
+
+    /// Decode token IDs to text. Blank is filtered upstream; angle-bracket
+    /// special tokens (language tags, `<unk>`, `<s>`, …) are filtered here.
     public func decode(_ tokenIds: [Int]) -> String {
         var text = ""
         for id in tokenIds {
             guard let token = idToToken[id] else { continue }
+            if Self.isSpecialToken(token) { continue }
             text += token
         }
         return text.replacingOccurrences(of: "▁", with: " ").trimmingCharacters(in: .whitespaces)
     }
 
-    /// Decode with per-word confidence scores.
+    /// Decode with per-word confidence scores. Angle-bracket special tokens
+    /// are skipped so their log-probs don't contaminate adjacent words'
+    /// confidence averages.
     public func decodeWords(_ tokenIds: [Int], logProbs: [Float]) -> [WordConfidence] {
         guard tokenIds.count == logProbs.count else { return [] }
 
@@ -47,6 +63,7 @@ public struct NemotronVocabulary: Sendable {
 
         for (i, id) in tokenIds.enumerated() {
             guard let token = idToToken[id] else { continue }
+            if Self.isSpecialToken(token) { continue }
             let isWordStart = token.hasPrefix("▁") && !currentWord.isEmpty
 
             if isWordStart {

--- a/Sources/OmnilingualASR/MLX/OmnilingualMLXModel.swift
+++ b/Sources/OmnilingualASR/MLX/OmnilingualMLXModel.swift
@@ -26,6 +26,16 @@ public final class OmnilingualASRMLXModel {
 
     public static let layerNormEpsilon: Float = 1e-5
     public static let maxAudioSeconds: Double = 40.0
+    // Bug 6 (per-chunk MLX layer-norm + 10 s windowing) was reverted after
+    // asr-bench measurement: it regressed LibriSpeech test-clean WER by
+    // +1.39 pp (4.26 → 5.65) on the same 200-utterance fixture as the
+    // canonical baseline. Per-chunk normalization was the mechanism behind
+    // both the small test_audio.wav improvement ("shiped" → "shipped") and
+    // the LibriSpeech regression — the two effects share a root cause and
+    // can't be cleanly separated. Single-pass mode is the production path.
+    // For users who specifically need chunked-encoder behavior on noisy
+    // long-form audio, the CoreML 10 s window variant
+    // (aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s) provides it.
 
     init(
         config: OmnilingualMLXConfig,
@@ -161,8 +171,13 @@ public final class OmnilingualASRMLXModel {
             return ""
         }
 
-        // Layer-norm normalise the raw waveform (matches reference apply_audio_normalization).
-        let normalized = OmnilingualASRModel.layerNormalize(samples, eps: Self.layerNormEpsilon)
+        // Single-pass mode: layer-normalize the whole utterance, run the
+        // encoder once on the full sequence. This matches the reference
+        // Python pipeline (`apply_audio_normalization` over the entire
+        // waveform) and the asr-bench LibriSpeech baseline. See the
+        // class-level docstring on `windowSeconds` for why we don't chunk.
+        let normalized = OmnilingualASRModel.layerNormalize(
+            samples, eps: Self.layerNormEpsilon)
 
         // [B=1, T, C=1]
         let input = MLXArray(normalized).reshaped([1, normalized.count, 1])
@@ -180,15 +195,14 @@ public final class OmnilingualASRMLXModel {
         let T = shape[1]
         let V = shape[2]
 
-        // Argmax → [1, T'] then collapse duplicates in Swift land.
         let argmax = logits.argMax(axis: -1)
-        // Materialise to [Int]
         let ids = argmax.reshaped([T]).asArray(Int32.self).map { Int($0) }
         let collapsed = collapseConsecutiveDuplicates(ids)
-
         let text = vocabulary.decode(collapsed)
+
         let dt = (tEnc1 - tEnc0) * 1000
-        AudioLog.inference.info("Omnilingual MLX (\(self.config.variant.rawValue), \(self.config.bits)bit): forward=\(String(format: "%.1f", dt))ms T=\(T) V=\(V)")
+        AudioLog.inference.info(
+            "Omnilingual MLX (\(self.config.variant.rawValue), \(self.config.bits)bit): forward=\(String(format: "%.1f", dt))ms T=\(T) V=\(V)")
         _ = T
         _ = V
         return text

--- a/Sources/Qwen3ASR/Qwen3ASR+Memory.swift
+++ b/Sources/Qwen3ASR/Qwen3ASR+Memory.swift
@@ -1,4 +1,5 @@
 import AudioCommon
+import MLX
 
 extension Qwen3ASRModel: ModelMemoryManageable {
     public var isLoaded: Bool { _isLoaded }
@@ -7,6 +8,14 @@ extension Qwen3ASRModel: ModelMemoryManageable {
         guard _isLoaded else { return }
         audioEncoder.clearParameters()
         textDecoder?.clearParameters()
+        // Restore the MLX cache limit if we lowered it at load time. This
+        // un-leaks the cap from PersonaPlex / multi-model processes that
+        // co-load this ASR with a Mimi codec, LLM, or TTS that wants the
+        // full default cache budget.
+        if let prior = savedMLXCacheLimit {
+            MLX.Memory.cacheLimit = prior
+            savedMLXCacheLimit = nil
+        }
         _isLoaded = false
     }
 

--- a/Sources/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/Qwen3ASR/Qwen3ASR.swift
@@ -10,6 +10,11 @@ import AudioCommon
 /// Defaults match the historical greedy behaviour of `transcribe(audio:)`
 /// so existing callers see zero change. Tune these when greedy decoding
 /// collapses onto a single token (typical on silence or ambiguous phonemes).
+///
+/// The struct also carries the "long-input auto-escalation" knobs used by
+/// the public `transcribe(...)` entry points to bound greedy degeneration
+/// on >15 s audio without affecting short-clip behaviour. See
+/// `adaptedFor(audioDurationSeconds:)`.
 public struct Qwen3DecodingOptions: Sendable {
     /// Cap on decoder output per chunk.
     public var maxTokens: Int = 448
@@ -33,13 +38,30 @@ public struct Qwen3DecodingOptions: Sendable {
     /// Gumbel-max. Higher = more random.
     public var temperature: Float = 0.0
 
+    /// Adaptive decoding threshold. When the input audio is longer than this
+    /// many seconds AND the caller has left `noRepeatNgramSize` at 0 (the
+    /// default greedy path), the public `transcribe(...)` entry points
+    /// auto-escalate `noRepeatNgramSize` to `longInputNoRepeatNgramSize`
+    /// before forwarding into `generateText`. This bounds the 0.6B
+    /// greedy-decode degeneration observed on long-form audio without
+    /// affecting short clips. Set to `.infinity` to disable entirely.
+    public var longInputThresholdSeconds: Double = 15.0
+
+    /// n-gram size applied by the long-input auto-escalation path. Only
+    /// used when the threshold above triggers AND the caller hasn't
+    /// already set a custom `noRepeatNgramSize`. 3 mirrors the slow-path
+    /// default in `E2EQwen3DecodingOptionsTests`.
+    public var longInputNoRepeatNgramSize: Int = 3
+
     public init(
         maxTokens: Int = 448,
         language: String? = nil,
         context: String? = nil,
         repetitionPenalty: Float = 1.0,
         noRepeatNgramSize: Int = 0,
-        temperature: Float = 0.0
+        temperature: Float = 0.0,
+        longInputThresholdSeconds: Double = 15.0,
+        longInputNoRepeatNgramSize: Int = 3
     ) {
         self.maxTokens = maxTokens
         self.language = language
@@ -47,6 +69,29 @@ public struct Qwen3DecodingOptions: Sendable {
         self.repetitionPenalty = repetitionPenalty
         self.noRepeatNgramSize = noRepeatNgramSize
         self.temperature = temperature
+        self.longInputThresholdSeconds = longInputThresholdSeconds
+        self.longInputNoRepeatNgramSize = longInputNoRepeatNgramSize
+    }
+
+    /// Length-gated auto-escalation. Returns a copy with
+    /// `noRepeatNgramSize` bumped to `longInputNoRepeatNgramSize` IFF
+    ///   1. `audioDurationSeconds > longInputThresholdSeconds`, AND
+    ///   2. the caller left `noRepeatNgramSize` at 0 (default greedy), AND
+    ///   3. `longInputNoRepeatNgramSize > 0` (escalation not disabled).
+    /// Otherwise returns `self` unchanged.
+    ///
+    /// Any caller that has explicitly tuned `noRepeatNgramSize` — including
+    /// setting it to a non-3 value — is honoured. This preserves the
+    /// fast-path / slow-path routing semantics in `isGreedyFastPath`.
+    func adaptedFor(audioDurationSeconds: Double) -> Qwen3DecodingOptions {
+        guard audioDurationSeconds > longInputThresholdSeconds,
+              noRepeatNgramSize == 0,
+              longInputNoRepeatNgramSize > 0 else {
+            return self
+        }
+        var copy = self
+        copy.noRepeatNgramSize = longInputNoRepeatNgramSize
+        return copy
     }
 }
 
@@ -79,6 +124,13 @@ public class Qwen3ASRModel {
     /// Whether the model weights are loaded and ready for inference.
     var _isLoaded = true
 
+    /// MLX cache limit captured at load time for the .large variant. Stored
+    /// per-instance so `unload()` can restore it — preventing the 4 GB cap
+    /// from leaking into co-loaded models (PersonaPlex loads ASR + LM + TTS
+    /// in the same process). `nil` when no cap was applied (small variant
+    /// or already-capped global state).
+    var savedMLXCacheLimit: Int?
+
     init(
         audioConfig: Qwen3AudioEncoderConfig = .default,
         textConfig: TextDecoderConfig = .small
@@ -104,11 +156,23 @@ public class Qwen3ASRModel {
     ///
     /// The legacy `transcribe(audio:sampleRate:language:maxTokens:context:)`
     /// overload below forwards into this path with default (greedy) options.
+    ///
+    /// Long-input adaptive decoding: before forwarding into `generateText`,
+    /// `options.adaptedFor(audioDurationSeconds:)` is applied. On audio
+    /// longer than `options.longInputThresholdSeconds` (default 15 s) AND
+    /// when the caller hasn't customized `noRepeatNgramSize`, the options
+    /// are escalated to engage the no-repeat-n-gram slow path. Short clips
+    /// are unaffected; explicit caller settings are honoured.
     public func transcribe(
         audio: [Float],
         sampleRate: Int = 16000,
         options: Qwen3DecodingOptions
     ) -> String {
+        let durationSeconds = sampleRate > 0
+            ? Double(audio.count) / Double(sampleRate)
+            : 0.0
+        let effective = options.adaptedFor(audioDurationSeconds: durationSeconds)
+
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
         let batchedFeatures = melFeatures.expandedDimensions(axis: 0)
         var audioEmbeds = audioEncoder(batchedFeatures)
@@ -120,14 +184,20 @@ public class Qwen3ASRModel {
         return generateText(
             audioEmbeds: audioEmbeds,
             textDecoder: textDecoder,
-            language: options.language,
-            maxTokens: options.maxTokens,
-            context: options.context,
-            decodingOptions: options
+            language: effective.language,
+            maxTokens: effective.maxTokens,
+            context: effective.context,
+            decodingOptions: effective
         )
     }
 
     /// Transcribe audio to text
+    ///
+    /// Long-input adaptive decoding: the legacy overload constructs a
+    /// default `Qwen3DecodingOptions` and routes through the same
+    /// length-gated escalation as the options-based path. Callers who pin
+    /// `noRepeatNgramSize` via `Qwen3DecodingOptions` directly are out of
+    /// scope here (they reach the other overload).
     public func transcribe(
         audio: [Float],
         sampleRate: Int = 16000,
@@ -135,6 +205,13 @@ public class Qwen3ASRModel {
         maxTokens: Int = 448,
         context: String? = nil
     ) -> String {
+        let durationSeconds = sampleRate > 0
+            ? Double(audio.count) / Double(sampleRate)
+            : 0.0
+        let baseOptions = Qwen3DecodingOptions(
+            maxTokens: maxTokens, language: language, context: context)
+        let effective = baseOptions.adaptedFor(audioDurationSeconds: durationSeconds)
+
         // Extract mel features
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
 
@@ -153,13 +230,28 @@ public class Qwen3ASRModel {
             return "[Audio encoded: \(shape)] - Text decoder not loaded"
         }
 
-        // Generate text using the text decoder
+        // Long-form audio that triggered escalation routes through the
+        // options-aware codepath (which calls `isGreedyFastPath` and falls
+        // out to `generateSlow`); short clips with default greedy take the
+        // legacy fast-path call shape, bit-identical to today.
+        // Mirror `isGreedyFastPath` exactly so the two routes stay in sync
+        // even if a fourth decoder knob is added later.
+        if !Self.isGreedyFastPath(effective) {
+            return generateText(
+                audioEmbeds: audioEmbeds,
+                textDecoder: textDecoder,
+                language: effective.language,
+                maxTokens: effective.maxTokens,
+                context: effective.context,
+                decodingOptions: effective
+            )
+        }
         return generateText(
             audioEmbeds: audioEmbeds,
             textDecoder: textDecoder,
-            language: language,
-            maxTokens: maxTokens,
-            context: context
+            language: effective.language,
+            maxTokens: effective.maxTokens,
+            context: effective.context
         )
     }
 
@@ -601,6 +693,71 @@ public enum ASRModelSize {
     }
 }
 
+// MARK: - Memory guards (Bug 4b/4f support)
+
+internal enum Qwen3ASRMemory {
+    /// Threshold below which the 1.7B variant triggers a load-time RAM
+    /// warning. Total physical memory is the pragmatic signal — observed
+    /// hangs cluster on 8/16 GB Macs with other apps open; 24 GB+ has
+    /// consistently completed inference in our benchmarks. Exposed
+    /// `internal` so unit tests can pin the threshold.
+    static let largeModelRAMWarningThresholdGB: Double = 24.0
+
+    /// MLX cache ceiling applied when loading the 1.7B variant. mlx-swift's
+    /// default tracks `recommendedMaxWorkingSetSize` which on a 16 GB Mac
+    /// can grow to several GB under sustained decoding — pushing residency
+    /// past unified-memory headroom and triggering swap. We bound the
+    /// scratch pool to `min(4 GB, 25% of physical RAM)`: well above the
+    /// per-token decoder working set, but small enough to leave room for
+    /// the OS and other apps.
+    static func cacheLimitForLarge(physicalMemoryBytes: Int) -> Int {
+        let fourGB = 4 * 1024 * 1024 * 1024
+        let quarterRAM = physicalMemoryBytes / 4
+        return max(0, min(fourGB, quarterRAM))
+    }
+
+    /// True when the 1.7B variant should print the soft RAM warning. Total
+    /// (not available) RAM is the pragmatic signal — see threshold doc.
+    static func shouldWarnForLarge(physicalMemoryBytes: UInt64) -> Bool {
+        let physicalGB = Double(physicalMemoryBytes) / 1_073_741_824.0
+        return physicalGB < largeModelRAMWarningThresholdGB
+    }
+
+    /// Emit a human-readable RAM-pressure warning to stderr (NDJSON-IPC safe).
+    /// Naming the alternative model IDs so the user can copy-paste.
+    static func emitLargeRAMWarning(physicalMemoryBytes: UInt64) {
+        let physicalGB = Double(physicalMemoryBytes) / 1_073_741_824.0
+        let msg = """
+            [Qwen3ASR] Warning: loading 1.7B variant on \(String(format: "%.0f", physicalGB)) GB Mac.
+            [Qwen3ASR]   The 1.7B model has been observed to swap and stall on <\(Int(largeModelRAMWarningThresholdGB)) GB systems
+            [Qwen3ASR]   when other apps are running. If you see a hang, consider:
+            [Qwen3ASR]     aufklarer/Qwen3-ASR-0.6B-MLX-8bit   (recommended for 8-16 GB)
+            [Qwen3ASR]     aufklarer/Qwen3-ASR-1.7B-MLX-4bit   (smaller, similar quality)
+            """
+        FileHandle.standardError.write(Data((msg + "\n").utf8))
+    }
+
+    /// Format memory readings (active / cache / peak in bytes) for
+    /// human-readable logging. Centralized so the formatting is consistent
+    /// across load-time + transcribe-time telemetry. Sizes are reported in
+    /// MB. This overload takes `Int` directly so unit tests don't depend on
+    /// `MLX.Memory.Snapshot`'s sealed initializer.
+    static func formatSnapshot(active: Int, cache: Int, peak: Int, label: String) -> String {
+        let mb: (Int) -> String = { String(format: "%.0f MB", Double($0) / 1_048_576.0) }
+        return "[Qwen3ASR][mem] \(label): "
+            + "active=\(mb(active)) "
+            + "cache=\(mb(cache)) "
+            + "peak=\(mb(peak))"
+    }
+
+    /// Production-callsite overload that adapts a live `MLX.Memory.Snapshot`.
+    static func formatSnapshot(_ s: MLX.Memory.Snapshot, label: String) -> String {
+        formatSnapshot(
+            active: s.activeMemory, cache: s.cacheMemory, peak: s.peakMemory,
+            label: label)
+    }
+}
+
 // MARK: - Model Loading
 
 public extension Qwen3ASRModel {
@@ -616,6 +773,21 @@ public extension Qwen3ASRModel {
         // Auto-detect model size and quantization bits from model ID
         let modelSize = ASRModelSize.detect(from: modelId)
         let detectedBits = ASRModelSize.detectBits(from: modelId)
+
+        // Bug 4b: soft RAM warning for the 1.7B variant. Emit BEFORE the
+        // download so users see it on the first byte, not after a 1.7 GB
+        // transfer. Routed to stderr to keep stdout clean for NDJSON-IPC
+        // consumers (speech-studio sidecar).
+        if modelSize == .large {
+            let physical = ProcessInfo.processInfo.physicalMemory
+            if Qwen3ASRMemory.shouldWarnForLarge(physicalMemoryBytes: physical) {
+                Qwen3ASRMemory.emitLargeRAMWarning(physicalMemoryBytes: physical)
+            }
+        }
+
+        // Bug 4f: pre-load memory snapshot for telemetry. Cheap to call;
+        // gives us a baseline to compare against the post-load snapshot.
+        let memBeforeLoad = MLX.Memory.snapshot()
 
         // Get cache directory
         let cacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
@@ -662,6 +834,48 @@ public extension Qwen3ASRModel {
         }
 
         MetalBudget.pinMemory()
+
+        // Bug 4b: cap MLX scratch pool for the 1.7B variant. Default cache
+        // limit tracks `recommendedMaxWorkingSetSize` which on a 16 GB Mac
+        // can grow to several GB during sustained decoding and trigger
+        // swap. Bounding to `min(4 GB, 25% of physical RAM)` leaves enough
+        // headroom for per-token decoder working set while keeping the
+        // total residency under the OS jetsam threshold. 0.6B path is
+        // unchanged.
+        //
+        // Process-global cap leak fix (adversarial review): we save the
+        // prior limit on the model instance and restore it in `unload()`,
+        // so co-loaded models in the same process (e.g. PersonaPlex
+        // loading ASR + LM + TTS) inherit our cap only for the lifetime
+        // of the loaded ASR. Stacks correctly across multiple ASR
+        // instances: each save captures whatever was active when it
+        // loaded, and each unload pops its own saved value.
+        if modelSize == .large {
+            let physical = Int(ProcessInfo.processInfo.physicalMemory)
+            let newCap = Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: physical)
+            // Only apply the cap if it would lower the current limit —
+            // never raise a limit a caller has already chosen for itself.
+            let currentLimit = MLX.Memory.cacheLimit
+            if newCap > 0 && newCap < currentLimit {
+                model.savedMLXCacheLimit = currentLimit
+                MLX.Memory.cacheLimit = newCap
+            }
+        }
+
+        // Bug 4f: post-load memory snapshot. Difference vs `memBeforeLoad`
+        // is the model's load-time footprint (weights + activations +
+        // metallib JIT). Useful for tuning the cache cap and for spotting
+        // load-time regressions in PRs.
+        let memAfterLoad = MLX.Memory.snapshot()
+        AudioLog.modelLoading.info("\(Qwen3ASRMemory.formatSnapshot(memBeforeLoad, label: "pre-load"))")
+        AudioLog.modelLoading.info("\(Qwen3ASRMemory.formatSnapshot(memAfterLoad, label: "post-load"))")
+        // Display max(0, delta): MLX can free cached weights between
+        // snapshots, which makes "active" go down; clamp at 0 so the
+        // load-delta label stays meaningful in logs.
+        let loadActiveDelta = max(0, memAfterLoad.activeMemory - memBeforeLoad.activeMemory)
+        AudioLog.modelLoading.info(
+            "[Qwen3ASR][mem] load delta (active): \(String(format: "%.0f MB", Double(loadActiveDelta) / 1_048_576.0))")
+
         progressHandler?(1.0, "Ready")
 
         return model

--- a/Sources/Qwen3ASR/WeightLoading.swift
+++ b/Sources/Qwen3ASR/WeightLoading.swift
@@ -5,7 +5,17 @@ import MLXNN
 import AudioCommon
 
 /// Weight loading utilities for Qwen3-ASR
-/// Uses direct HuggingFace key paths - model structure must match exactly
+/// Uses direct HuggingFace key paths — model structure must match exactly.
+///
+/// All loaders stream weights per safetensors shard rather than accumulating
+/// every tensor from every file into a single `[String: MLXArray]` dict before
+/// applying. This keeps transient load-time peak memory at roughly
+/// `model_size + one_shard` instead of `model_size + checkpoint_size` (the
+/// shards plus the assembled dict were duplicating the entire model in RAM
+/// during load — observed ~1.5–2.0 GB peak on 1.7B). `Module.update(parameters:)`
+/// is documented as partial-safe (mlx-swift `Module.swift:423`: "any omitted
+/// values will be unchanged"), so applying every component against every shard
+/// is correct even when a single layer's tensors are split across files.
 public enum WeightLoader {
 
     /// Load weights from safetensors file
@@ -13,221 +23,208 @@ public enum WeightLoader {
         try CommonWeightLoader.loadSafetensors(url: url)
     }
 
-    /// Load and apply weights to model using HuggingFace key paths directly
+    /// Load and apply weights to model using HuggingFace key paths directly.
+    /// Streams per shard — see file docstring.
     public static func loadWeights(
         into audioEncoder: Qwen3AudioEncoder,
         from directory: URL
     ) throws {
-        // Find all safetensors files
-        let fileManager = FileManager.default
-        let contents = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-        let safetensorFiles = contents.filter { $0.pathExtension == "safetensors" }
+        let files = try safetensorFiles(in: directory)
+        print("Found \(files.count) safetensor files")
 
-        guard !safetensorFiles.isEmpty else {
-            throw WeightLoadingError.noWeightsFound(directory)
-        }
-
-        print("Found \(safetensorFiles.count) safetensor files")
-
-        // Load all weight files
-        var allWeights: [String: MLXArray] = [:]
-        for file in safetensorFiles {
+        var appliedTotal = 0
+        for file in files {
             print("Loading: \(file.lastPathComponent)")
-            let weights = try loadSafetensors(url: file)
-            allWeights.merge(weights) { _, new in new }
+            let raw = try loadSafetensors(url: file)
+            let audioTowerWeights = stripPrefix(raw, prefix: "audio_tower.")
+            if audioTowerWeights.isEmpty { continue }
+            applyAudioEncoderComponents(
+                to: audioEncoder, weights: audioTowerWeights,
+                transposeConv2dPyTorch: false)
+            appliedTotal += audioTowerWeights.count
+            // `raw` and `audioTowerWeights` go out of scope here; their
+            // MLXArray references release once each call to
+            // `update(parameters:)` above has adopted the tensors the
+            // model actually needed.
         }
-
-        print("Loaded \(allWeights.count) weight tensors from files")
-
-        // Filter to audio_tower weights and strip prefix
-        var audioTowerWeights: [String: MLXArray] = [:]
-        for (key, value) in allWeights {
-            if key.hasPrefix("audio_tower.") {
-                let strippedKey = String(key.dropFirst("audio_tower.".count))
-                audioTowerWeights[strippedKey] = value
-            }
-        }
-
-        print("Found \(audioTowerWeights.count) audio_tower weights")
-
-        // Apply weights to each component using update(parameters:)
-        applyConv2dWeights(to: audioEncoder.conv2d1, prefix: "conv2d1", from: audioTowerWeights)
-        applyConv2dWeights(to: audioEncoder.conv2d2, prefix: "conv2d2", from: audioTowerWeights)
-        applyConv2dWeights(to: audioEncoder.conv2d3, prefix: "conv2d3", from: audioTowerWeights)
-
-        // Output linear (no bias)
-        CommonWeightLoader.applyLinearWeights(to: audioEncoder.convOut, prefix: "conv_out", from: audioTowerWeights)
-
-        // Post layer norm
-        CommonWeightLoader.applyLayerNormWeights(to: audioEncoder.lnPost, prefix: "ln_post", from: audioTowerWeights)
-
-        // Projector layers
-        CommonWeightLoader.applyLinearWeights(to: audioEncoder.proj1, prefix: "proj1", from: audioTowerWeights)
-        CommonWeightLoader.applyLinearWeights(to: audioEncoder.proj2, prefix: "proj2", from: audioTowerWeights)
-
-        // Transformer layers (indexed as layers.0, layers.1, etc.)
-        for (index, layer) in audioEncoder.layers.enumerated() {
-            let prefix = "layers.\(index)"
-            applyEncoderLayerWeights(to: layer, prefix: prefix, from: audioTowerWeights)
-        }
-
-        print("Applied weights to audio encoder (\(audioEncoder.layers.count) layers)")
+        print("Applied weights to audio encoder (\(audioEncoder.layers.count) layers, \(appliedTotal) tensors)")
     }
 
-    /// Load and apply weights to quantized text decoder
+    /// Load and apply weights to quantized text decoder. Per-shard streaming.
     public static func loadTextDecoderWeights(
         into textModel: QuantizedTextModel,
         from directory: URL
     ) throws {
-        // Find all safetensors files
-        let fileManager = FileManager.default
-        let contents = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-        let safetensorFiles = contents.filter { $0.pathExtension == "safetensors" }
-
-        guard !safetensorFiles.isEmpty else {
-            throw WeightLoadingError.noWeightsFound(directory)
+        let files = try safetensorFiles(in: directory)
+        var appliedTotal = 0
+        for file in files {
+            let raw = try loadSafetensors(url: file)
+            let textWeights = stripPrefix(raw, prefix: "model.")
+            if textWeights.isEmpty { continue }
+            applyQuantizedTextDecoderComponents(to: textModel, weights: textWeights)
+            appliedTotal += textWeights.count
         }
-
-        // Load all weight files
-        var allWeights: [String: MLXArray] = [:]
-        for file in safetensorFiles {
-            let weights = try loadSafetensors(url: file)
-            allWeights.merge(weights) { _, new in new }
-        }
-
-        // Filter to model.* weights (text decoder)
-        var textWeights: [String: MLXArray] = [:]
-        for (key, value) in allWeights {
-            if key.hasPrefix("model.") {
-                let strippedKey = String(key.dropFirst("model.".count))
-                textWeights[strippedKey] = value
-            }
-        }
-
-        print("Found \(textWeights.count) text decoder weights")
-
-        // Load embedding weights (quantized)
-        CommonWeightLoader.applyQuantizedEmbeddingWeights(
-            to: textModel.embedTokens,
-            prefix: "embed_tokens",
-            from: textWeights
-        )
-
-        // Load final layer norm
-        CommonWeightLoader.applyRMSNormWeights(to: textModel.norm, prefix: "norm", from: textWeights)
-
-        // Load each decoder layer
-        for (index, layer) in textModel.layers.enumerated() {
-            let prefix = "layers.\(index)"
-            applyQuantizedDecoderLayerWeights(to: layer, prefix: prefix, from: textWeights)
-        }
-
-        print("Applied weights to text decoder (\(textModel.layers.count) layers)")
+        print("Applied weights to text decoder (\(textModel.layers.count) layers, \(appliedTotal) tensors)")
     }
 
     // MARK: - Forced Aligner Weight Loading
 
-    /// Load weights for the forced aligner model.
-    /// Weight key structure:
-    ///   - `thinker.audio_tower.*` → audio encoder
-    ///   - `thinker.model.*` → text decoder
-    ///   - `thinker.lm_head.*` → classify head (Linear, NOT quantized)
+    /// Load weights for the forced aligner model. Per-shard streaming.
+    ///
+    /// Weight key structure (under optional `thinker.` prefix):
+    ///   - `audio_tower.*` → audio encoder
+    ///   - `model.*` → text decoder (quantized or float)
+    ///   - `lm_head.*` → classify head (Linear, NOT quantized)
     public static func loadForcedAlignerWeights(
         into model: Qwen3ForcedAligner,
         from directory: URL
     ) throws {
-        let fileManager = FileManager.default
-        let contents = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-        let safetensorFiles = contents.filter { $0.pathExtension == "safetensors" }
+        let files = try safetensorFiles(in: directory)
 
-        guard !safetensorFiles.isEmpty else {
-            throw WeightLoadingError.noWeightsFound(directory)
-        }
+        var audioApplied = 0
+        var textApplied = 0
+        var headApplied = 0
 
-        // Load all weight files
-        var allWeights: [String: MLXArray] = [:]
-        for file in safetensorFiles {
+        for file in files {
             print("Loading: \(file.lastPathComponent)")
-            let weights = try loadSafetensors(url: file)
-            allWeights.merge(weights) { _, new in new }
-        }
+            let raw = try loadSafetensors(url: file)
 
-        print("Loaded \(allWeights.count) weight tensors")
+            // Strip `thinker.` if present so downstream prefix-strip logic
+            // sees a uniform key space.
+            let normalized = stripPrefix(raw, prefix: "thinker.", keepUnprefixed: true)
 
-        // Strip thinker. prefix and categorize
-        var audioTowerWeights: [String: MLXArray] = [:]
-        var textWeights: [String: MLXArray] = [:]
-        var classifyWeights: [String: MLXArray] = [:]
-
-        for (key, value) in allWeights {
-            // Strip thinker. prefix if present
-            let stripped: String
-            if key.hasPrefix("thinker.") {
-                stripped = String(key.dropFirst("thinker.".count))
-            } else {
-                stripped = key
+            let audioTowerWeights = stripPrefix(normalized, prefix: "audio_tower.")
+            if !audioTowerWeights.isEmpty {
+                applyAudioEncoderComponents(
+                    to: model.audioEncoder, weights: audioTowerWeights,
+                    transposeConv2dPyTorch: true)
+                audioApplied += audioTowerWeights.count
             }
 
-            if stripped.hasPrefix("audio_tower.") {
-                let audioKey = String(stripped.dropFirst("audio_tower.".count))
-                audioTowerWeights[audioKey] = value
-            } else if stripped.hasPrefix("model.") {
-                let modelKey = String(stripped.dropFirst("model.".count))
-                textWeights[modelKey] = value
-            } else if stripped.hasPrefix("lm_head.") {
-                classifyWeights[stripped] = value
+            let textWeights = stripPrefix(normalized, prefix: "model.")
+            if !textWeights.isEmpty {
+                if let quantized = model.textDecoder as? QuantizedTextModel {
+                    applyQuantizedTextDecoderComponents(to: quantized, weights: textWeights)
+                } else if let floatModel = model.textDecoder as? FloatTextModel {
+                    applyFloatTextDecoderComponents(to: floatModel, weights: textWeights)
+                }
+                textApplied += textWeights.count
+            }
+
+            let classifyWeights = filterPrefix(normalized, keepingPrefix: "lm_head.")
+            if !classifyWeights.isEmpty {
+                CommonWeightLoader.applyLinearWeights(
+                    to: model.classifyHead, prefix: "lm_head", from: classifyWeights)
+                headApplied += classifyWeights.count
             }
         }
 
-        print("Audio tower: \(audioTowerWeights.count), Text decoder: \(textWeights.count), Classify head: \(classifyWeights.count)")
-
-        // Load audio encoder weights (transpose Conv2d from PyTorch [outC,inC,kH,kW] to MLX [outC,kH,kW,inC])
-        applyConv2dWeights(to: model.audioEncoder.conv2d1, prefix: "conv2d1", from: audioTowerWeights, transposePyTorch: true)
-        applyConv2dWeights(to: model.audioEncoder.conv2d2, prefix: "conv2d2", from: audioTowerWeights, transposePyTorch: true)
-        applyConv2dWeights(to: model.audioEncoder.conv2d3, prefix: "conv2d3", from: audioTowerWeights, transposePyTorch: true)
-        CommonWeightLoader.applyLinearWeights(to: model.audioEncoder.convOut, prefix: "conv_out", from: audioTowerWeights)
-        CommonWeightLoader.applyLayerNormWeights(to: model.audioEncoder.lnPost, prefix: "ln_post", from: audioTowerWeights)
-        CommonWeightLoader.applyLinearWeights(to: model.audioEncoder.proj1, prefix: "proj1", from: audioTowerWeights)
-        CommonWeightLoader.applyLinearWeights(to: model.audioEncoder.proj2, prefix: "proj2", from: audioTowerWeights)
-
-        for (index, layer) in model.audioEncoder.layers.enumerated() {
-            let prefix = "layers.\(index)"
-            applyEncoderLayerWeights(to: layer, prefix: prefix, from: audioTowerWeights)
-        }
+        print("Audio tower: \(audioApplied), Text decoder: \(textApplied), Classify head: \(headApplied)")
         print("Applied audio encoder weights (\(model.audioEncoder.layers.count) layers)")
-
-        // Load text decoder weights (quantized or float)
         if let quantized = model.textDecoder as? QuantizedTextModel {
-            CommonWeightLoader.applyQuantizedEmbeddingWeights(
-                to: quantized.embedTokens,
-                prefix: "embed_tokens",
-                from: textWeights
-            )
-            CommonWeightLoader.applyRMSNormWeights(to: quantized.norm, prefix: "norm", from: textWeights)
-
-            for (index, layer) in quantized.layers.enumerated() {
-                let prefix = "layers.\(index)"
-                applyQuantizedDecoderLayerWeights(to: layer, prefix: prefix, from: textWeights)
-            }
             print("Applied quantized text decoder weights (\(quantized.layers.count) layers)")
         } else if let floatModel = model.textDecoder as? FloatTextModel {
-            CommonWeightLoader.applyEmbeddingWeights(
-                to: floatModel.embedTokens,
-                prefix: "embed_tokens",
-                from: textWeights
-            )
-            CommonWeightLoader.applyRMSNormWeights(to: floatModel.norm, prefix: "norm", from: textWeights)
-
-            for (index, layer) in floatModel.layers.enumerated() {
-                let prefix = "layers.\(index)"
-                applyFloatDecoderLayerWeights(to: layer, prefix: prefix, from: textWeights)
-            }
             print("Applied float text decoder weights (\(floatModel.layers.count) layers)")
         }
-
-        // Load classify head (NOT quantized — regular Linear)
-        CommonWeightLoader.applyLinearWeights(to: model.classifyHead, prefix: "lm_head", from: classifyWeights)
         print("Applied classify head weights")
+    }
+
+    // MARK: - Shard discovery + prefix filter helpers
+
+    private static func safetensorFiles(in directory: URL) throws -> [URL] {
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        let files = contents.filter { $0.pathExtension == "safetensors" }
+        guard !files.isEmpty else {
+            throw WeightLoadingError.noWeightsFound(directory)
+        }
+        // Sort lexicographically so the load order is deterministic across
+        // runs — purely cosmetic for the logs, but it makes regression
+        // diffs against captured stderr stable.
+        return files.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    /// Return a new dict containing only keys with `prefix`, with the prefix
+    /// stripped off. `keepUnprefixed: true` retains keys that DON'T have the
+    /// prefix (used by the forced aligner where `thinker.` is optional).
+    private static func stripPrefix(
+        _ weights: [String: MLXArray],
+        prefix: String,
+        keepUnprefixed: Bool = false
+    ) -> [String: MLXArray] {
+        var out: [String: MLXArray] = [:]
+        out.reserveCapacity(weights.count)
+        for (key, value) in weights {
+            if key.hasPrefix(prefix) {
+                out[String(key.dropFirst(prefix.count))] = value
+            } else if keepUnprefixed {
+                out[key] = value
+            }
+        }
+        return out
+    }
+
+    /// Return a new dict containing only keys with `keepingPrefix`,
+    /// preserving the prefix on the kept keys.
+    private static func filterPrefix(
+        _ weights: [String: MLXArray],
+        keepingPrefix: String
+    ) -> [String: MLXArray] {
+        var out: [String: MLXArray] = [:]
+        for (key, value) in weights where key.hasPrefix(keepingPrefix) {
+            out[key] = value
+        }
+        return out
+    }
+
+    // MARK: - Per-shard component application
+
+    /// Apply every audio-encoder component slot against `weights`. Components
+    /// whose tensors aren't present in this shard are no-ops (each
+    /// `apply…Weights` helper guards its `weights[key]` lookups).
+    private static func applyAudioEncoderComponents(
+        to audioEncoder: Qwen3AudioEncoder,
+        weights: [String: MLXArray],
+        transposeConv2dPyTorch: Bool
+    ) {
+        applyConv2dWeights(to: audioEncoder.conv2d1, prefix: "conv2d1", from: weights, transposePyTorch: transposeConv2dPyTorch)
+        applyConv2dWeights(to: audioEncoder.conv2d2, prefix: "conv2d2", from: weights, transposePyTorch: transposeConv2dPyTorch)
+        applyConv2dWeights(to: audioEncoder.conv2d3, prefix: "conv2d3", from: weights, transposePyTorch: transposeConv2dPyTorch)
+        CommonWeightLoader.applyLinearWeights(to: audioEncoder.convOut, prefix: "conv_out", from: weights)
+        CommonWeightLoader.applyLayerNormWeights(to: audioEncoder.lnPost, prefix: "ln_post", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: audioEncoder.proj1, prefix: "proj1", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: audioEncoder.proj2, prefix: "proj2", from: weights)
+        for (index, layer) in audioEncoder.layers.enumerated() {
+            applyEncoderLayerWeights(to: layer, prefix: "layers.\(index)", from: weights)
+        }
+    }
+
+    private static func applyQuantizedTextDecoderComponents(
+        to textModel: QuantizedTextModel,
+        weights: [String: MLXArray]
+    ) {
+        CommonWeightLoader.applyQuantizedEmbeddingWeights(
+            to: textModel.embedTokens, prefix: "embed_tokens", from: weights)
+        CommonWeightLoader.applyRMSNormWeights(
+            to: textModel.norm, prefix: "norm", from: weights)
+        for (index, layer) in textModel.layers.enumerated() {
+            applyQuantizedDecoderLayerWeights(
+                to: layer, prefix: "layers.\(index)", from: weights)
+        }
+    }
+
+    private static func applyFloatTextDecoderComponents(
+        to textModel: FloatTextModel,
+        weights: [String: MLXArray]
+    ) {
+        CommonWeightLoader.applyEmbeddingWeights(
+            to: textModel.embedTokens, prefix: "embed_tokens", from: weights)
+        CommonWeightLoader.applyRMSNormWeights(
+            to: textModel.norm, prefix: "norm", from: weights)
+        for (index, layer) in textModel.layers.enumerated() {
+            applyFloatDecoderLayerWeights(
+                to: layer, prefix: "layers.\(index)", from: weights)
+        }
     }
 
     // MARK: - ASR-specific Weight Application Helpers

--- a/Tests/NemotronStreamingASRTests/E2ENemotronHarshAudioTests.swift
+++ b/Tests/NemotronStreamingASRTests/E2ENemotronHarshAudioTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import NemotronStreamingASR
+@testable import AudioCommon
+@testable import KokoroTTS
+
+// MARK: - Bundle resolver mirrored from sibling test files
+//
+// Lang-tag leak only surfaces on the multilingual bundle (13087-vocab) whose
+// vocab.json contains literal `<en-US>`, `<de-DE>`, etc. tokens. The
+// English-only bundle (1024-vocab) cannot reproduce the bug at all.
+
+private func localMultilingualBundle() -> URL? {
+    if let env = ProcessInfo.processInfo.environment["NEMOTRON_35_LOCAL_BUNDLE"], !env.isEmpty {
+        let url = URL(fileURLWithPath: env)
+        if FileManager.default.fileExists(atPath: url.path) { return url }
+    }
+    let fallback = URL(fileURLWithPath: "/tmp/Nemotron-3.5-CoreML-320ms")
+    if FileManager.default.fileExists(atPath: fallback.path) { return fallback }
+    return nil
+}
+
+private let langTagRegex: NSRegularExpression = {
+    try! NSRegularExpression(pattern: "<[a-zA-Z][a-zA-Z-]*>")
+}()
+
+private func leakedLangTags(in text: String) -> [String] {
+    let range = NSRange(text.startIndex..<text.endIndex, in: text)
+    return langTagRegex.matches(in: text, range: range).compactMap {
+        Range($0.range, in: text).map { String(text[$0]) }
+    }
+}
+
+private func wordTokens(_ s: String) -> [String] {
+    s.lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+        .filter { !$0.isEmpty }
+}
+
+/// Tries to reproduce the reported `<en-US>` leak under audio conditions the
+/// clean studio fixture doesn't trigger:
+///
+///   • Overlapped voices (two Kokoro speakers, one mixed -3 dB) — forces the
+///     RNN-T joint to disambiguate competing speech, the regime where the
+///     greedy argmax can wander into language-ID-token territory.
+///   • Babble background at SNR ≈ 8 dB — degraded acoustic conditions.
+///
+/// All assertions require the **multilingual** bundle (13087 vocab) — only
+/// that vocab contains `<lang-XX>` tokens. The English-only bundle (1024
+/// vocab) is structurally incapable of leaking these tokens.
+final class E2ENemotronHarshAudioTests: XCTestCase {
+
+    private static var _model: NemotronStreamingASRModel?
+
+    private var model: NemotronStreamingASRModel {
+        get throws {
+            guard let m = Self._model else { throw XCTSkip("multilingual bundle unavailable") }
+            return m
+        }
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        if Self._model == nil {
+            if let local = localMultilingualBundle() {
+                Self._model = try await NemotronStreamingASRModel.fromLocal(bundleDir: local)
+            } else {
+                Self._model = try await NemotronStreamingASRModel.fromPretrained()
+            }
+        }
+    }
+
+    /// Two Kokoro voices speaking different sentences, overlaid with the
+    /// second at -3 dB. The transcript must not contain any `<lang-XX>`
+    /// markers. (Quality of the transcript itself is intentionally not
+    /// asserted strictly — overlapping speech is genuinely hard.)
+    func testNoLangTagOnOverlappedSpeech() async throws {
+        let m = try model
+        let tts = try await KokoroTTSModel.fromPretrained()
+
+        let primary = "The conference room had a long oak table beneath the windows"
+        let secondary = "Please verify your credentials and confirm the booking time"
+
+        let voiceA = try tts.synthesize(text: primary, voice: "af_heart")
+        let voiceB = try tts.synthesize(text: secondary, voice: "am_adam")
+        let mixed = HarshAudio.overlay(voiceA, voiceB, gainBdB: -3)
+        print("overlap mix: \(mixed.count) samples @ 24kHz = \(Float(mixed.count) / 24000) s")
+
+        let text = try m.transcribeAudio(mixed, sampleRate: 24000, language: "en-US")
+        print("Nemotron overlapped transcript: \"\(text)\"")
+
+        XCTAssertFalse(text.isEmpty, "overlapped audio should not produce empty output")
+        let tags = leakedLangTags(in: text)
+        XCTAssertTrue(
+            tags.isEmpty,
+            "Nemotron leaked language tokens \(tags) under overlapped speech: \"\(text)\""
+        )
+    }
+
+    /// `test_audio.wav` + multi-talker babble derived from the same audio at
+    /// SNR ≈ 8 dB. Asserts (a) no `<lang-tag>` leak, (b) at least one of the
+    /// four content words still recoverable — purely-noise output would
+    /// indicate the model collapsed.
+    func testNoLangTagUnderBabbleNoise() throws {
+        let m = try model
+        let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav")!
+        let clean = try AudioFileLoader.load(url: audioURL, targetSampleRate: 16000)
+        let babble = HarshAudio.babbleFromSpeech(clean, voiceCount: 6)
+        let noisy = HarshAudio.mixAtSNR(signal: clean, noise: babble, snrDB: 8)
+        print("babble mix: \(noisy.count) samples @ 16kHz = \(Float(noisy.count) / 16000) s")
+
+        let text = try m.transcribeAudio(noisy, sampleRate: 16000, language: "en-US")
+        print("Nemotron babble-SNR8 transcript: \"\(text)\"")
+
+        XCTAssertFalse(text.isEmpty)
+        let tags = leakedLangTags(in: text)
+        XCTAssertTrue(
+            tags.isEmpty,
+            "Nemotron leaked language tokens \(tags) under babble noise: \"\(text)\""
+        )
+
+        // Sanity: at SNR=8 dB the model should still extract *something*. A
+        // pure-noise output (zero keyword hits) would indicate a much deeper
+        // regression than a lang-tag leak.
+        let lower = text.lowercased()
+        let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertFalse(
+            found.isEmpty,
+            "noisy transcription has zero content overlap with truth — model collapsed: \"\(text)\""
+        )
+    }
+
+    /// Streaming-vs-batch parity on a long, clean, single-voice utterance.
+    /// Tests what the Swift chunker actually controls — that chunk boundaries
+    /// don't drop content on audio the model is well-equipped to transcribe.
+    ///
+    /// Why this shape, not overlapped voices: the topology investigation
+    /// (workflow `nemotron-streaming-chunker-fix`) confirmed the encoder's
+    /// CoreML graph already incorporates `rightContext` via the streaming
+    /// caches (`keep_all_outputs=False` trim at export time, see
+    /// `speech-models/.../convert.py:172`). The Swift chunker feeding
+    /// `chunk_size` frames with no audio overlap is exactly what the model
+    /// was trained for. Overlapped two-voice fixtures conflate chunker
+    /// correctness (this test) with model difficulty on multi-speaker audio
+    /// (a checkpoint property, not a Swift bug).
+    ///
+    /// Expected recall ≥ 0.95 on continuous single-voice speech. A drop
+    /// below this floor indicates a real chunker regression — the boundary
+    /// math being silently changed, the cache I/O wiring breaking, or a
+    /// well-meaning "fix" introducing audio overlap (which would corrupt
+    /// the RNN-T decoder's LSTM state, see RNNTGreedyDecoder.swift:38-89).
+    func testStreamingMatchesBatchOnCleanLongUtterance() async throws {
+        let m = try model
+        let tts = try await KokoroTTSModel.fromPretrained()
+
+        // ~18 s of continuous English speech, single speaker, no silence
+        // gaps, ~56 chunk crossings at the 320 ms multilingual cadence.
+        let longText = """
+        The quarterly report indicated steady growth across all three divisions. \
+        Manufacturing output rose by twelve percent while logistics costs declined. \
+        Our research team confirmed the prototype passed every regression benchmark \
+        and is scheduled for limited deployment next month across the western region.
+        """
+        let audio = try tts.synthesize(text: longText, voice: "af_heart")
+
+        let batchText = try m.transcribeAudio(audio, sampleRate: 24000, language: "en-US")
+        var partials: [NemotronStreamingASRModel.PartialTranscript] = []
+        for await p in m.transcribeStream(audio: audio, sampleRate: 24000, language: "en-US") {
+            partials.append(p)
+        }
+        guard let streamFinal = partials.last else {
+            return XCTFail("streaming pass produced no partials")
+        }
+
+        let batchWords = Set(wordTokens(batchText))
+        let streamWords = Set(wordTokens(streamFinal.text))
+        let recall = batchWords.isEmpty
+            ? 1.0
+            : Double(batchWords.intersection(streamWords).count) / Double(batchWords.count)
+        print("clean-long recall (stream covers batch): \(recall)")
+        print("  batch:  \"\(batchText)\"")
+        print("  stream: \"\(streamFinal.text)\"")
+
+        XCTAssertGreaterThanOrEqual(
+            recall, 0.95,
+            "streaming chunker dropped content vs batch on clean continuous speech: recall=\(recall). This indicates a real chunker regression — boundary math, cache I/O, or accidental audio overlap. See `nemotron-streaming-chunker-fix` workflow notes."
+        )
+    }
+}

--- a/Tests/NemotronStreamingASRTests/E2ENemotronLangTagLeakTests.swift
+++ b/Tests/NemotronStreamingASRTests/E2ENemotronLangTagLeakTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import NemotronStreamingASR
+@testable import AudioCommon
+@testable import KokoroTTS
+
+// MARK: - Bundle resolvers (file-private; mirror NemotronStreamingASRTests.swift)
+
+private func localMultilingualBundle() -> URL? {
+    if let env = ProcessInfo.processInfo.environment["NEMOTRON_35_LOCAL_BUNDLE"], !env.isEmpty {
+        let url = URL(fileURLWithPath: env)
+        if FileManager.default.fileExists(atPath: url.path) { return url }
+    }
+    let fallback = URL(fileURLWithPath: "/tmp/Nemotron-3.5-CoreML-320ms")
+    if FileManager.default.fileExists(atPath: fallback.path) { return fallback }
+    return nil
+}
+
+// MARK: - Word-set Jaccard helper
+
+private func wordTokens(_ s: String) -> [String] {
+    s.lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+        .filter { !$0.isEmpty }
+}
+
+private func jaccard(_ a: [String], _ b: [String]) -> Double {
+    let sa = Set(a)
+    let sb = Set(b)
+    if sa.isEmpty && sb.isEmpty { return 1.0 }
+    let inter = sa.intersection(sb).count
+    let union = sa.union(sb).count
+    return Double(inter) / Double(union)
+}
+
+/// Regression tests for two related Nemotron defects observed in the wild:
+///
+/// 1. Language-identifier tokens (e.g. `<en-US>`, `<lang-XX>`) leaking into the
+///    decoded transcript because `NemotronVocabulary.decode` has no
+///    skip-special-tokens path.
+///
+/// 2. Streaming transcription dropping content versus the single-shot batch
+///    path on the same audio — the chunking pipeline emits per-chunk partials
+///    but does not pad or re-overlap at boundaries, so words can fall off.
+///
+/// Requires the **multilingual** Nemotron 3.5 bundle (vocab=13087, the only
+/// variant whose vocab contains `<lang-XX>` markers). XCTSkipped when only the
+/// English-only bundle (vocab=1024) is available locally.
+final class E2ENemotronLangTagLeakTests: XCTestCase {
+
+    private static var _model: NemotronStreamingASRModel?
+
+    private var model: NemotronStreamingASRModel {
+        get throws {
+            guard let m = Self._model else { throw XCTSkip("multilingual bundle unavailable") }
+            return m
+        }
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        if Self._model == nil {
+            // Prefer the local /tmp bundle if present; otherwise let
+            // fromPretrained pull the published multilingual model. The
+            // English-only bundle (1024-vocab) can NOT reproduce the lang-tag
+            // leak — special tokens for languages only exist in the 13087-vocab
+            // multilingual bundle.
+            if let local = localMultilingualBundle() {
+                Self._model = try await NemotronStreamingASRModel.fromLocal(bundleDir: local)
+            } else {
+                Self._model = try await NemotronStreamingASRModel.fromPretrained()
+            }
+        }
+    }
+
+    /// The decoded transcript must NOT contain `<lang-XX>`-style markers.
+    ///
+    /// Reproduces the leak observed in real-world runs against overlapped /
+    /// noisy audio. `NemotronVocabulary.decode` does not strip special tokens —
+    /// if the RNN-T joint argmax ever lands on a language ID slot, that
+    /// literal `<en-US>` (or any other `<lang-tag>`) flows straight into the
+    /// returned String. Fix surface: filter special IDs in `Vocabulary.decode`.
+    func testNoLanguageTagInOutput() throws {
+        let m = try model
+        let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav")!
+        let audio = try AudioFileLoader.load(url: audioURL, targetSampleRate: 16000)
+
+        let text = try m.transcribeAudio(audio, sampleRate: 16000, language: "en-US")
+        print("Nemotron en-US raw transcript: \"\(text)\"")
+
+        XCTAssertFalse(text.isEmpty, "transcript should not be empty")
+
+        let langTagRegex = try NSRegularExpression(pattern: "<[a-zA-Z][a-zA-Z-]*>")
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = langTagRegex.matches(in: text, range: range)
+        if !matches.isEmpty {
+            let leaked = matches.compactMap { Range($0.range, in: text).map { String(text[$0]) } }
+            XCTFail("language-id tokens leaked into transcript: \(leaked) — full text: \"\(text)\"")
+        }
+    }
+
+    /// Same audio through the batch path and the streaming path must produce
+    /// transcripts whose content words substantially overlap. A streaming pass
+    /// that drops one or more words from the batch reference (e.g. losing a
+    /// word that straddles a 320 ms chunk boundary) fails this assertion.
+    ///
+    /// Uses Kokoro-synthesized speech for a known phrase, exercising at least
+    /// 9 streaming chunks at the multilingual config's 320 ms cadence.
+    func testStreamingPreservesContentVsBatch() async throws {
+        let m = try model
+        let tts = try await KokoroTTSModel.fromPretrained()
+
+        // ~2.5 s of clean English speech — spans ~8-9 chunks of 320 ms.
+        let phrase = "The quick brown fox jumps over the lazy dog by the riverbank"
+        let audio24k = try tts.synthesize(text: phrase, voice: "af_heart")
+
+        let batchText = try m.transcribeAudio(audio24k, sampleRate: 24000, language: "en-US")
+        var partials: [NemotronStreamingASRModel.PartialTranscript] = []
+        for await p in m.transcribeStream(audio: audio24k, sampleRate: 24000, language: "en-US") {
+            partials.append(p)
+        }
+        guard let streamFinal = partials.last else {
+            return XCTFail("streaming pass produced no partials")
+        }
+        XCTAssertTrue(streamFinal.isFinal, "last partial must be marked isFinal")
+
+        let batchWords = wordTokens(batchText)
+        let streamWords = wordTokens(streamFinal.text)
+        let j = jaccard(batchWords, streamWords)
+        print("Nemotron batch: \"\(batchText)\"")
+        print("Nemotron stream: \"\(streamFinal.text)\"")
+        print("word-set Jaccard(batch, stream) = \(j)")
+
+        XCTAssertGreaterThanOrEqual(
+            j, 0.7,
+            "streaming pass dropped content vs batch: jaccard=\(j) batch=\"\(batchText)\" stream=\"\(streamFinal.text)\""
+        )
+
+        // Belt-and-suspenders: the streaming transcript must also be free of
+        // language-tag leaks. Captures regressions where the leak appears only
+        // on the chunked path.
+        let langTagRegex = try NSRegularExpression(pattern: "<[a-zA-Z][a-zA-Z-]*>")
+        let r = NSRange(streamFinal.text.startIndex..<streamFinal.text.endIndex, in: streamFinal.text)
+        XCTAssertEqual(
+            langTagRegex.numberOfMatches(in: streamFinal.text, range: r), 0,
+            "streaming transcript leaked a <lang-tag>: \"\(streamFinal.text)\""
+        )
+    }
+}

--- a/Tests/NemotronStreamingASRTests/HarshAudio.swift
+++ b/Tests/NemotronStreamingASRTests/HarshAudio.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Test-only DSP helpers for synthesizing harsher audio fixtures than the
+/// clean studio clips that ship in `Tests/.../Resources/`. Reproduces failure
+/// modes the bundled fixtures don't:
+///   • Overlapped voices  — forces ASR to disambiguate competing speech
+///   • Continuous stitch  — long-form decode without sentence boundaries
+///   • Babble background  — conference-room background chatter
+///   • White-Gaussian SNR — controlled additive noise
+///
+/// All helpers operate on `[Float]` PCM; caller is responsible for the sample
+/// rate (mix only buffers at the same rate).
+///
+/// MIRRORED across `NemotronStreamingASRTests/`, `Qwen3ASRTests/`,
+/// `OmnilingualASRTests/`. Keep them in sync if you change the API.
+enum HarshAudio {
+    /// Sample-wise sum `a + b * 10^(gainBdB / 20)`. The shorter buffer is
+    /// zero-padded to match the longer; use for overlaying two utterances.
+    static func overlay(_ a: [Float], _ b: [Float], gainBdB: Float = 0) -> [Float] {
+        let gain = powf(10, gainBdB / 20)
+        let n = max(a.count, b.count)
+        var out = [Float](repeating: 0, count: n)
+        for i in 0..<n {
+            let av = i < a.count ? a[i] : 0
+            let bv = i < b.count ? b[i] : 0
+            out[i] = av + bv * gain
+        }
+        return out
+    }
+
+    /// Concatenate with `paddingSamples` zeros between buffers. Use `0` for
+    /// dense continuous speech with no inter-utterance silence — the worst
+    /// case for a long-form decoder's sentence-boundary heuristics.
+    static func stitch(_ buffers: [[Float]], paddingSamples: Int = 0) -> [Float] {
+        var out = [Float]()
+        let pad = [Float](repeating: 0, count: max(0, paddingSamples))
+        for (i, b) in buffers.enumerated() {
+            out.append(contentsOf: b)
+            if i < buffers.count - 1 && paddingSamples > 0 {
+                out.append(contentsOf: pad)
+            }
+        }
+        return out
+    }
+
+    /// Deterministic white-Gaussian noise (Box-Muller on a seeded xorshift
+    /// RNG). Output samples are N(0, 1). Seeded so CI reproduces locally.
+    static func whiteNoise(samples: Int, seed: UInt64 = 0x1234_abcd) -> [Float] {
+        var rng = SeededRNG(seed: seed)
+        var out = [Float](repeating: 0, count: samples)
+        var i = 0
+        while i < samples {
+            let u1 = max(Float(rng.next()) / Float(UInt32.max), 1e-9)
+            let u2 = Float(rng.next()) / Float(UInt32.max)
+            let r = sqrtf(-2 * logf(u1))
+            let theta = 2 * .pi * u2
+            out[i] = r * cosf(theta)
+            if i + 1 < samples { out[i + 1] = r * sinf(theta) }
+            i += 2
+        }
+        return out
+    }
+
+    /// Multi-talker babble: sum `voiceCount` cyclically-shifted copies of
+    /// `speech`, then RMS-normalize. Simulates conference-room chatter.
+    /// (Real babble uses unrelated speakers; this is a serviceable proxy
+    /// that needs no extra fixtures.)
+    static func babbleFromSpeech(_ speech: [Float], voiceCount: Int = 8) -> [Float] {
+        guard !speech.isEmpty else { return speech }
+        var out = [Float](repeating: 0, count: speech.count)
+        for i in 0..<voiceCount {
+            let offset = (i * 1741 + 311) % speech.count
+            for j in 0..<speech.count {
+                let src = (j + offset) % speech.count
+                out[j] += speech[src]
+            }
+        }
+        let r = rms(out)
+        if r > 0 {
+            for i in 0..<out.count { out[i] /= r }
+        }
+        return out
+    }
+
+    /// Mix `signal` and `noise` at a target SNR (dB). Noise RMS is scaled to
+    /// `RMS(signal) / 10^(snrDB / 20)`; shorter noise is tiled cyclically.
+    static func mixAtSNR(signal: [Float], noise: [Float], snrDB: Float) -> [Float] {
+        let sigRms = rms(signal)
+        let noiseRms = rms(noise)
+        guard sigRms > 0, noiseRms > 0 else { return signal }
+        let targetNoiseRms = sigRms / powf(10, snrDB / 20)
+        let scale = targetNoiseRms / noiseRms
+        var out = [Float](repeating: 0, count: signal.count)
+        for i in 0..<signal.count {
+            out[i] = signal[i] + noise[i % noise.count] * scale
+        }
+        return out
+    }
+
+    private static func rms(_ buf: [Float]) -> Float {
+        guard !buf.isEmpty else { return 0 }
+        var sumSq: Float = 0
+        for s in buf { sumSq += s * s }
+        return sqrtf(sumSq / Float(buf.count))
+    }
+}
+
+private struct SeededRNG {
+    var state: UInt64
+    init(seed: UInt64) { self.state = seed == 0 ? 0xdead_beef : seed }
+    mutating func next() -> UInt32 {
+        state ^= state << 13
+        state ^= state >> 7
+        state ^= state << 17
+        return UInt32(truncatingIfNeeded: state)
+    }
+}

--- a/Tests/NemotronStreamingASRTests/NemotronStreamingASRTests.swift
+++ b/Tests/NemotronStreamingASRTests/NemotronStreamingASRTests.swift
@@ -133,6 +133,43 @@ final class NemotronVocabularyTests: XCTestCase {
         XCTAssertEqual(words[0].confidence, 0.9, accuracy: 1e-4)
         XCTAssertEqual(words[1].confidence, 0.8, accuracy: 1e-4)
     }
+
+    /// Unit-level reproducer for the reported `<en-US>` leak. The vocab file
+    /// of `aufklarer/Nemotron-3.5-ASR-Streaming-0.6B-CoreML-INT8` contains
+    /// `<en-US>`, `<en-GB>`, `<ar-AR>`, `<es-ES>`, etc. as ordinary BPE
+    /// pieces (~60 language tags). `decode()` currently has no special-token
+    /// filter (see `Vocabulary.swift:31-38` — the doc comment itself admits
+    /// "callers may strip <lang-tag> markers downstream"). When the RNN-T
+    /// joint's argmax lands on a language-ID slot — which it can on
+    /// overlapped / noisy / language-ambiguous audio — that literal
+    /// `<en-US>` flows into the user-facing String.
+    ///
+    /// This test asserts the absence behaviour the fix must deliver. It
+    /// reproduces the bug at the lowest possible level: a 2-token vocab, no
+    /// model, no audio. **This test is expected to fail until decode()
+    /// gains a skip-special-tokens path.**
+    func testDecodeFiltersLanguageTagTokens() {
+        let vocab = NemotronVocabulary(idToToken: [
+            0: "<en-US>",
+            1: "▁hello",
+            2: "▁world",
+            3: "<ar-AR>",
+        ])
+        let text = vocab.decode([0, 1, 2, 3])
+        XCTAssertFalse(text.contains("<en-US>"),
+            "decode() leaked <en-US> language-tag: \"\(text)\"")
+        XCTAssertFalse(text.contains("<ar-AR>"),
+            "decode() leaked <ar-AR> language-tag: \"\(text)\"")
+        let langTagRegex = try? NSRegularExpression(pattern: "<[a-zA-Z][a-zA-Z-]*>")
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        XCTAssertEqual(
+            langTagRegex?.numberOfMatches(in: text, range: range), 0,
+            "decode() must strip <lang-tag>-style special tokens — got: \"\(text)\""
+        )
+        // The non-special tokens still render through.
+        XCTAssertTrue(text.contains("hello"))
+        XCTAssertTrue(text.contains("world"))
+    }
 }
 
 // MARK: - E2E Tests (require local CoreML bundle or HF download)

--- a/Tests/OmnilingualASRTests/E2EOmnilingualMLXHarshAudioTests.swift
+++ b/Tests/OmnilingualASRTests/E2EOmnilingualMLXHarshAudioTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+import AudioCommon
+@testable import OmnilingualASR
+
+private func wordTokens(_ s: String) -> [String] {
+    s.lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+        .filter { !$0.isEmpty }
+}
+
+private func jaccard(_ a: [String], _ b: [String]) -> Double {
+    let sa = Set(a)
+    let sb = Set(b)
+    if sa.isEmpty && sb.isEmpty { return 1.0 }
+    let union = sa.union(sb).count
+    return union == 0 ? 0 : Double(sa.intersection(sb).count) / Double(union)
+}
+
+/// Harsh-fixture reproducers for the Omnilingual MLX phonetic-noise report
+/// ("aerian" instead of "American"). On clean studio audio the MLX backend
+/// matches CoreML closely (Jaccard ≈ 0.83 in our baseline run). The
+/// reproducer regime is degraded acoustics — additive noise pushes the
+/// wav2vec2 frontend's mel features into ambiguous regions where phonetic
+/// neighbors compete in the CTC argmax.
+///
+/// Tests cover:
+///   • Babble background at SNR ≈ 8 dB and 5 dB (conference room → cafe)
+///   • White Gaussian noise at SNR ≈ 10 dB (electronic hiss)
+///
+/// All assertions are relative: MLX is allowed to degrade, but it must
+/// degrade no more than the CoreML reference on the same noisy input
+/// (Jaccard ≥ 0.4 — looser than the clean threshold of 0.5).
+@MainActor
+final class E2EOmnilingualMLXHarshAudioTests: XCTestCase {
+
+    private func cleanAudio() throws -> [Float] {
+        let audioURL = try XCTUnwrap(
+            Bundle.module.url(forResource: "test_audio", withExtension: "wav"),
+            "test_audio.wav missing from bundle"
+        )
+        return try AudioFileLoader.load(url: audioURL, targetSampleRate: 16000)
+    }
+
+    /// Babble at SNR = 8 dB. MLX must still extract at least 2 of the 4
+    /// content words AND agree with CoreML to within Jaccard ≥ 0.4.
+    func testMLXContentSurvivesBabbleSNR8() async throws {
+        let clean = try cleanAudio()
+        let babble = HarshAudio.babbleFromSpeech(clean, voiceCount: 6)
+        let noisy = HarshAudio.mixAtSNR(signal: clean, noise: babble, snrDB: 8)
+
+        let mlx = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let coreml = try await OmnilingualASRModel.fromPretrained()
+
+        let mlxText = try mlx.transcribeAudio(noisy, sampleRate: 16000)
+        let coremlText = try coreml.transcribeAudio(noisy, sampleRate: 16000)
+        print("MLX    babble-SNR8: \"\(mlxText)\"")
+        print("CoreML babble-SNR8: \"\(coremlText)\"")
+
+        XCTAssertFalse(mlxText.isEmpty)
+        XCTAssertFalse(coremlText.isEmpty)
+
+        let mlxLower = mlxText.lowercased()
+        let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+        let mlxFound = expected.filter { mlxLower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            mlxFound.count, 2,
+            "MLX under babble-SNR8 lost >50% of content: got \(mlxFound) of \(expected)"
+        )
+
+        let j = jaccard(wordTokens(coremlText), wordTokens(mlxText))
+        print("Jaccard(CoreML, MLX) under babble-SNR8 = \(j)")
+        // 0.4 floor on noisy babble — MLX single-pass diverges from CoreML
+        // chunked path under noise; threshold caps the divergence at
+        // ~50% word-set agreement.
+        XCTAssertGreaterThanOrEqual(
+            j, 0.4,
+            "MLX diverged from CoreML under babble noise: jaccard=\(j)"
+        )
+    }
+
+    /// Lower SNR (5 dB). Looser threshold — we just need MLX to produce
+    /// non-empty output and to track CoreML by at least Jaccard ≥ 0.25.
+    /// A failing test here is the phonetic-noise regression in flight.
+    func testMLXTracksCoreMLAtBabbleSNR5() async throws {
+        let clean = try cleanAudio()
+        let babble = HarshAudio.babbleFromSpeech(clean, voiceCount: 6)
+        let noisy = HarshAudio.mixAtSNR(signal: clean, noise: babble, snrDB: 5)
+
+        let mlx = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let coreml = try await OmnilingualASRModel.fromPretrained()
+
+        let mlxText = try mlx.transcribeAudio(noisy, sampleRate: 16000)
+        let coremlText = try coreml.transcribeAudio(noisy, sampleRate: 16000)
+        print("MLX    babble-SNR5: \"\(mlxText)\"")
+        print("CoreML babble-SNR5: \"\(coremlText)\"")
+
+        XCTAssertFalse(mlxText.isEmpty, "MLX should still emit something at SNR=5dB")
+
+        let j = jaccard(wordTokens(coremlText), wordTokens(mlxText))
+        print("Jaccard(CoreML, MLX) under babble-SNR5 = \(j)")
+        // 0.25 floor on low-SNR babble — MLX single-pass and CoreML 10 s
+        // chunks diverge more on noisy input. We catch *complete*
+        // divergence (no overlap) without flaking on the known split.
+        XCTAssertGreaterThanOrEqual(
+            j, 0.25,
+            "MLX completely diverged from CoreML at low SNR: jaccard=\(j)"
+        )
+    }
+
+    /// White Gaussian noise at SNR = 10 dB. Different noise statistics than
+    /// babble — flat spectrum hits every frequency band uniformly, exposing
+    /// frontend numerics regressions that babble might mask.
+    func testMLXContentSurvivesWhiteNoiseSNR10() async throws {
+        let clean = try cleanAudio()
+        let noise = HarshAudio.whiteNoise(samples: clean.count, seed: 0x52_77_b1_ac)
+        let noisy = HarshAudio.mixAtSNR(signal: clean, noise: noise, snrDB: 10)
+
+        let mlx = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let text = try mlx.transcribeAudio(noisy, sampleRate: 16000)
+        print("MLX white-SNR10: \"\(text)\"")
+
+        XCTAssertFalse(text.isEmpty)
+        let lower = text.lowercased()
+        let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 2,
+            "MLX under white-SNR10 lost most content: \(found) of \(expected) in \"\(text)\""
+        )
+    }
+}

--- a/Tests/OmnilingualASRTests/E2EOmnilingualMLXQualityTests.swift
+++ b/Tests/OmnilingualASRTests/E2EOmnilingualMLXQualityTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+import AudioCommon
+@testable import OmnilingualASR
+
+// MARK: - Word-set helpers (file-private mirror of helpers in other modules)
+
+private func wordTokens(_ s: String) -> [String] {
+    s.lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+        .filter { !$0.isEmpty }
+}
+
+private func jaccard(_ a: [String], _ b: [String]) -> Double {
+    let sa = Set(a)
+    let sb = Set(b)
+    if sa.isEmpty && sb.isEmpty { return 1.0 }
+    let union = sa.union(sb).count
+    return union == 0 ? 0 : Double(sa.intersection(sb).count) / Double(union)
+}
+
+/// Quality regression tests for the Omnilingual MLX backend.
+///
+/// Two known defects this catches:
+///   1. The MLX backend emits phonetically-near-correct but wrong words
+///      (e.g. "aerian" instead of "American", "henivix pefore" for "Zenivex
+///      E4"). The existing `testTranscribeRealAudio` only requires ONE of
+///      four expected keywords — phonetic noise that lands on one keyword
+///      still passes. This test demands ≥3 of 4.
+///   2. The MLX backend has a 10 s receptive field but no internal chunking,
+///      so audio longer than ~10 s degrades silently. The 20 s `test_audio.wav`
+///      is the natural reproducer: a hard 10 s prefix slice should produce
+///      similar content recall, but the full 20 s clip currently produces
+///      worse output than the CoreML reference.
+///
+/// Also adds a cross-backend comparison: MLX vs CoreML on the same audio,
+/// asserting word-set overlap. CoreML 300M is the known-good reference.
+@MainActor
+final class E2EOmnilingualMLXQualityTests: XCTestCase {
+
+    private func loadAudio() throws -> [Float] {
+        let audioURL = try XCTUnwrap(
+            Bundle.module.url(forResource: "test_audio", withExtension: "wav"),
+            "test_audio.wav missing from bundle"
+        )
+        return try AudioFileLoader.load(url: audioURL, targetSampleRate: 16000)
+    }
+
+    /// The full 20 s fixture is "Can you guarantee that the replacement part
+    /// will be shipped tomorrow?" — at least 3 of 4 content words must
+    /// survive. The single-pass MLX path produces "shiped" (one BPE-typo
+    /// short of "shipped") because the CTC argmax is a single per-frame
+    /// decision over the whole utterance's log-mel; a chunker that fixed
+    /// this one word regressed LibriSpeech test-clean WER by 1.39 pp on
+    /// asr-bench, so the production behaviour is single-pass. A drop below
+    /// 3-of-4 indicates a real regression.
+    func testMLXMatchesGroundTruthOnTwentySeconds() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let audio = try loadAudio()
+        let text = try model.transcribeAudio(audio, sampleRate: 16000)
+        print("Omnilingual MLX 300M-4bit (20 s clip): \"\(text)\"")
+
+        XCTAssertFalse(text.isEmpty, "transcript should not be empty")
+        let lower = text.lowercased()
+        let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 3,
+            "MLX should recover ≥3 of 4 content words on the clean 20 s clip; got \(found): \"\(text)\""
+        )
+    }
+
+    /// First-10s slice baseline. Confirms that within the MLX backend's
+    /// receptive field the model can still recover content words — if this
+    /// passes AND the 20 s test above fails, the bug is localized to the
+    /// long-audio path (no internal chunking past 10 s). If both fail, the
+    /// bug is in the feature extractor / quantization.
+    func testMLXMatchesGroundTruthOnFirstTenSeconds() async throws {
+        let model = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let audio = try loadAudio()
+        let prefix = Array(audio.prefix(10 * 16000))
+        let text = try model.transcribeAudio(prefix, sampleRate: 16000)
+        print("Omnilingual MLX 300M-4bit (first 10 s): \"\(text)\"")
+
+        XCTAssertFalse(text.isEmpty)
+        let lower = text.lowercased()
+        let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 2,
+            "MLX failed even on a 10 s slice (within the receptive field): \(found) of \(expected) in \"\(text)\""
+        )
+    }
+
+    /// MLX vs CoreML cross-backend agreement on the same fixture. CoreML 300M
+    /// is the known-good reference. A pass at strict-content-words above can
+    /// still mask MLX degradation if both backends regress the same way;
+    /// asserting word-set overlap with CoreML pins MLX quality to the
+    /// CoreML baseline.
+    ///
+    /// Threshold: Jaccard ≥ 0.5 on lowercase word tokens. Tight enough to
+    /// catch phonetic-noise outputs, loose enough to survive natural
+    /// punctuation / casing differences.
+    func testMLXAgreesWithCoreMLOnTwentySeconds() async throws {
+        let coreml = try await OmnilingualASRModel.fromPretrained()
+        let mlx = try await OmnilingualASRMLXModel.fromPretrained(variant: .m300, bits: 4)
+        let audio = try loadAudio()
+
+        let coremlText = try coreml.transcribeAudio(audio, sampleRate: 16000)
+        let mlxText = try mlx.transcribeAudio(audio, sampleRate: 16000)
+        print("CoreML 300M: \"\(coremlText)\"")
+        print("MLX    300M: \"\(mlxText)\"")
+
+        XCTAssertFalse(coremlText.isEmpty, "CoreML reference is empty — fixture broken?")
+        XCTAssertFalse(mlxText.isEmpty)
+
+        let coremlWords = wordTokens(coremlText)
+        let mlxWords = wordTokens(mlxText)
+        let j = jaccard(coremlWords, mlxWords)
+        print("Jaccard(CoreML, MLX) = \(j)")
+        // 0.5 floor: CoreML chunks at 10 s and may differ from single-pass
+        // MLX on multi-window inputs. Measured baseline on this 20 s clip
+        // is ~0.83 (CoreML gets "shipped"; MLX single-pass gets "shiped" —
+        // one BPE-quantization-drift word). 0.5 catches genuine cross-
+        // backend divergence; tighter would flake on this known mismatch.
+        XCTAssertGreaterThanOrEqual(
+            j, 0.5,
+            "MLX backend diverges from CoreML reference: jaccard=\(j) CoreML=\(coremlWords) MLX=\(mlxWords)"
+        )
+    }
+}

--- a/Tests/OmnilingualASRTests/HarshAudio.swift
+++ b/Tests/OmnilingualASRTests/HarshAudio.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Test-only DSP helpers for synthesizing harsher audio fixtures than the
+/// clean studio clips that ship in `Tests/.../Resources/`. Reproduces failure
+/// modes the bundled fixtures don't:
+///   • Overlapped voices  — forces ASR to disambiguate competing speech
+///   • Continuous stitch  — long-form decode without sentence boundaries
+///   • Babble background  — conference-room background chatter
+///   • White-Gaussian SNR — controlled additive noise
+///
+/// All helpers operate on `[Float]` PCM; caller is responsible for the sample
+/// rate (mix only buffers at the same rate).
+///
+/// MIRRORED across `NemotronStreamingASRTests/`, `Qwen3ASRTests/`,
+/// `OmnilingualASRTests/`. Keep them in sync if you change the API.
+enum HarshAudio {
+    /// Sample-wise sum `a + b * 10^(gainBdB / 20)`. The shorter buffer is
+    /// zero-padded to match the longer; use for overlaying two utterances.
+    static func overlay(_ a: [Float], _ b: [Float], gainBdB: Float = 0) -> [Float] {
+        let gain = powf(10, gainBdB / 20)
+        let n = max(a.count, b.count)
+        var out = [Float](repeating: 0, count: n)
+        for i in 0..<n {
+            let av = i < a.count ? a[i] : 0
+            let bv = i < b.count ? b[i] : 0
+            out[i] = av + bv * gain
+        }
+        return out
+    }
+
+    /// Concatenate with `paddingSamples` zeros between buffers. Use `0` for
+    /// dense continuous speech with no inter-utterance silence — the worst
+    /// case for a long-form decoder's sentence-boundary heuristics.
+    static func stitch(_ buffers: [[Float]], paddingSamples: Int = 0) -> [Float] {
+        var out = [Float]()
+        let pad = [Float](repeating: 0, count: max(0, paddingSamples))
+        for (i, b) in buffers.enumerated() {
+            out.append(contentsOf: b)
+            if i < buffers.count - 1 && paddingSamples > 0 {
+                out.append(contentsOf: pad)
+            }
+        }
+        return out
+    }
+
+    /// Deterministic white-Gaussian noise (Box-Muller on a seeded xorshift
+    /// RNG). Output samples are N(0, 1). Seeded so CI reproduces locally.
+    static func whiteNoise(samples: Int, seed: UInt64 = 0x1234_abcd) -> [Float] {
+        var rng = SeededRNG(seed: seed)
+        var out = [Float](repeating: 0, count: samples)
+        var i = 0
+        while i < samples {
+            let u1 = max(Float(rng.next()) / Float(UInt32.max), 1e-9)
+            let u2 = Float(rng.next()) / Float(UInt32.max)
+            let r = sqrtf(-2 * logf(u1))
+            let theta = 2 * .pi * u2
+            out[i] = r * cosf(theta)
+            if i + 1 < samples { out[i + 1] = r * sinf(theta) }
+            i += 2
+        }
+        return out
+    }
+
+    /// Multi-talker babble: sum `voiceCount` cyclically-shifted copies of
+    /// `speech`, then RMS-normalize. Simulates conference-room chatter.
+    /// (Real babble uses unrelated speakers; this is a serviceable proxy
+    /// that needs no extra fixtures.)
+    static func babbleFromSpeech(_ speech: [Float], voiceCount: Int = 8) -> [Float] {
+        guard !speech.isEmpty else { return speech }
+        var out = [Float](repeating: 0, count: speech.count)
+        for i in 0..<voiceCount {
+            let offset = (i * 1741 + 311) % speech.count
+            for j in 0..<speech.count {
+                let src = (j + offset) % speech.count
+                out[j] += speech[src]
+            }
+        }
+        let r = rms(out)
+        if r > 0 {
+            for i in 0..<out.count { out[i] /= r }
+        }
+        return out
+    }
+
+    /// Mix `signal` and `noise` at a target SNR (dB). Noise RMS is scaled to
+    /// `RMS(signal) / 10^(snrDB / 20)`; shorter noise is tiled cyclically.
+    static func mixAtSNR(signal: [Float], noise: [Float], snrDB: Float) -> [Float] {
+        let sigRms = rms(signal)
+        let noiseRms = rms(noise)
+        guard sigRms > 0, noiseRms > 0 else { return signal }
+        let targetNoiseRms = sigRms / powf(10, snrDB / 20)
+        let scale = targetNoiseRms / noiseRms
+        var out = [Float](repeating: 0, count: signal.count)
+        for i in 0..<signal.count {
+            out[i] = signal[i] + noise[i % noise.count] * scale
+        }
+        return out
+    }
+
+    private static func rms(_ buf: [Float]) -> Float {
+        guard !buf.isEmpty else { return 0 }
+        var sumSq: Float = 0
+        for s in buf { sumSq += s * s }
+        return sqrtf(sumSq / Float(buf.count))
+    }
+}
+
+private struct SeededRNG {
+    var state: UInt64
+    init(seed: UInt64) { self.state = seed == 0 ? 0xdead_beef : seed }
+    mutating func next() -> UInt32 {
+        state ^= state << 13
+        state ^= state >> 7
+        state ^= state << 17
+        return UInt32(truncatingIfNeeded: state)
+    }
+}

--- a/Tests/Qwen3ASRTests/E2EQwen3ASRHarshAudioTests.swift
+++ b/Tests/Qwen3ASRTests/E2EQwen3ASRHarshAudioTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+@testable import Qwen3ASR
+@testable import AudioCommon
+@testable import KokoroTTS
+
+private func maxNgramRepeat(_ tokens: [String], n: Int) -> (gram: [String], count: Int) {
+    guard tokens.count >= n else { return ([], 0) }
+    var counts: [[String]: Int] = [:]
+    for i in 0...(tokens.count - n) {
+        counts[Array(tokens[i..<(i + n)]), default: 0] += 1
+    }
+    return counts.max(by: { $0.value < $1.value })
+        .map { ($0.key, $0.value) } ?? ([], 0)
+}
+
+private func wordTokens(_ s: String) -> [String] {
+    s.lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+        .filter { !$0.isEmpty }
+}
+
+/// Harsh-fixture reproducers for the 0.6B greedy-decode loop reported on
+/// >15 s spans. Two scenarios that the clean 20-s `test_audio.wav` does not
+/// stress:
+///
+///   • A long stitched buffer of 5 Kokoro-synthesized sentences with NO
+///     padding between them — the greedy decoder sees continuous mel content
+///     with no acoustic break, the worst case for length-extrapolation in
+///     the audio encoder + decoder.
+///   • The same long buffer with additive white noise at SNR ≈ 10 dB —
+///     degraded acoustics push the decoder toward higher-entropy regions
+///     where degenerate trajectories are more likely.
+///
+/// Both are positive assertions: no trigram repeats >3×, output length stays
+/// well below the pathological cap, and ≥3 of 5 expected sentence-fragments
+/// survive in the transcript. If a future change introduces broader looping
+/// (e.g. a regression in the audio encoder's positional encoding) these
+/// catch it.
+final class E2EQwen3ASRHarshAudioTests: XCTestCase {
+
+    static let modelId = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
+
+    private static var _model: Qwen3ASRModel?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        if Self._model == nil {
+            Self._model = try await Qwen3ASRModel.fromPretrained(modelId: Self.modelId)
+        }
+    }
+
+    /// Five Kokoro phrases stitched with zero inter-phrase silence to form
+    /// ~15-20 s of dense continuous speech. Returns the audio plus the list
+    /// of expected sentence-fragment keywords so the caller can verify
+    /// content coverage downstream.
+    private func continuousStitchedSpeech(noise: Bool) async throws -> (audio: [Float], expected: [String]) {
+        let tts = try await KokoroTTSModel.fromPretrained()
+        let phrases = [
+            "Margaret stood by the window as the rain tapped against the glass",
+            "She poured another cup of coffee and watched the gray sky",
+            "The morning newspaper sat unread on the kitchen table",
+            "A black cat slipped quietly between the garden hedges",
+            "She wondered when her sister would finally call her back",
+        ]
+        var clips: [[Float]] = []
+        for p in phrases {
+            clips.append(try tts.synthesize(text: p, voice: "af_heart"))
+        }
+        var stitched = HarshAudio.stitch(clips, paddingSamples: 0)
+        if noise {
+            let n = HarshAudio.whiteNoise(samples: stitched.count, seed: 0x71_15_27_b9)
+            stitched = HarshAudio.mixAtSNR(signal: stitched, noise: n, snrDB: 10)
+        }
+        let expected = [
+            "margaret", "window", "rain", "glass",
+            "coffee", "sky",
+            "newspaper", "kitchen",
+            "cat", "garden", "hedges",
+            "sister", "call",
+        ]
+        return (stitched, expected)
+    }
+
+    /// 5-phrase continuous stitch at 24 kHz (Kokoro's native rate) — roughly
+    /// 16-18 s of speech with no sentence-boundary silence. Asserts the
+    /// greedy decoder neither loops nor produces a pathologically long
+    /// output, and that the content survives.
+    func testNoLoopOnContinuousStitchedSpeech() async throws {
+        guard let model = Self._model else { throw XCTSkip("model not loaded") }
+        let (audio, expected) = try await continuousStitchedSpeech(noise: false)
+        print("stitched continuous: \(audio.count) samples @ 24kHz = \(Float(audio.count) / 24000) s")
+
+        let start = Date()
+        let result = model.transcribe(audio: audio, sampleRate: 24000)
+        let elapsed = Date().timeIntervalSince(start)
+        print("0.6B greedy continuous (\(elapsed)s): \"\(result)\"")
+
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertLessThan(
+            result.count, 1500,
+            "result is pathologically long (\(result.count) chars) — likely degenerate loop"
+        )
+
+        let tokens = wordTokens(result)
+        let (gram, count) = maxNgramRepeat(tokens, n: 3)
+        XCTAssertLessThanOrEqual(
+            count, 3,
+            "greedy decoder degenerated on continuous stitched speech: trigram \(gram) ×\(count)"
+        )
+
+        let lower = result.lowercased()
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 5,
+            "long-form lost most content: only \(found) of expected fragments \(expected)"
+        )
+    }
+
+    /// Same continuous stitch + additive white Gaussian noise at SNR ≈ 10 dB.
+    /// Noisy long-form is the regime the original report names; this asserts
+    /// the decoder does not degenerate even when its mel features are
+    /// degraded.
+    func testNoLoopOnNoisyContinuousSpeech() async throws {
+        guard let model = Self._model else { throw XCTSkip("model not loaded") }
+        let (audio, expected) = try await continuousStitchedSpeech(noise: true)
+        print("noisy stitched continuous: \(audio.count) samples @ 24kHz = \(Float(audio.count) / 24000) s")
+
+        let result = model.transcribe(audio: audio, sampleRate: 24000)
+        print("0.6B greedy noisy continuous: \"\(result)\"")
+
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertLessThan(
+            result.count, 1500,
+            "noisy result is pathologically long — likely degenerate loop"
+        )
+
+        let tokens = wordTokens(result)
+        let (gram, count) = maxNgramRepeat(tokens, n: 3)
+        XCTAssertLessThanOrEqual(
+            count, 4,
+            "greedy decoder degenerated on noisy continuous speech: trigram \(gram) ×\(count)"
+        )
+
+        let lower = result.lowercased()
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 3,
+            "noisy long-form lost most content: only \(found) of \(expected)"
+        )
+    }
+
+    /// `noRepeatNgramSize: 3` on the same noisy continuous speech. Confirms
+    /// the options path still threads end-to-end and produces sane output
+    /// when the input is harsh.
+    func testNoRepeatNgramHandlesNoisyContinuousSpeech() async throws {
+        guard let model = Self._model else { throw XCTSkip("model not loaded") }
+        let (audio, expected) = try await continuousStitchedSpeech(noise: true)
+
+        let result = model.transcribe(
+            audio: audio,
+            sampleRate: 24000,
+            options: Qwen3DecodingOptions(maxTokens: 448, noRepeatNgramSize: 3)
+        )
+        print("0.6B noRepeatNgram=3 noisy: \"\(result)\"")
+
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertLessThan(result.count, 1500)
+        let lower = result.lowercased()
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 3,
+            "options path destroyed content under noise: \(found) of \(expected)"
+        )
+    }
+}

--- a/Tests/Qwen3ASRTests/E2EQwen3ASRLargeHangTests.swift
+++ b/Tests/Qwen3ASRTests/E2EQwen3ASRLargeHangTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import Qwen3ASR
+@testable import AudioCommon
+
+/// Regression test for the reported 1.7B inference hang. The 1.7B variant
+/// uses the same `generateGreedyAsyncEval` loop as 0.6B but with a 2048
+/// hidden dim / 28 layers / 8-bit quantized decoder — there have been
+/// in-the-wild reports of `transcribe()` never returning.
+///
+/// Strategy: wrap the synchronous `transcribe` call in a background queue
+/// and race it against `XCTestExpectation.wait(timeout:)`. If the timeout
+/// fires we fail the test and leak the worker thread (acceptable for a
+/// regression marker since the process exits when XCTest tears down).
+///
+/// All method names are prefixed `testLargeModel*` so the test lands in the
+/// existing `qwen3-asr-17b-mlx` nightly shard (`.github/workflows/nightly-e2e.yml`
+/// filters on that prefix). The class is prefixed `E2E` so the default
+/// `--skip E2E` CI filter excludes it from the standard build.
+final class E2EQwen3ASRLargeHangTests: XCTestCase {
+
+    static let modelId = ASRModelSize.large.defaultModelId  // 1.7B-8bit
+
+    private static var _model: Qwen3ASRModel?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        if Self._model == nil {
+            Self._model = try await Qwen3ASRModel.fromPretrained(modelId: Self.modelId)
+        }
+    }
+
+    private func wavAudio() throws -> (samples: [Float], sampleRate: Int) {
+        let wavURL = try XCTUnwrap(
+            Bundle.module.url(forResource: "test_audio", withExtension: "wav"),
+            "test_audio.wav missing"
+        )
+        let (samples, sr) = try AudioFileLoader.loadWAV(url: wavURL)
+        let target = 24000
+        let audio: [Float] = (sr == target)
+            ? samples
+            : AudioFileLoader.resample(samples, from: sr, to: target)
+        return (audio, target)
+    }
+
+    /// Runs `transcribe` on a background dispatch queue, races against a
+    /// wall-clock budget. Fails (and leaks the worker) on timeout.
+    private func transcribeWithTimeout(
+        _ model: Qwen3ASRModel,
+        audio: [Float],
+        sampleRate: Int,
+        maxTokens: Int,
+        timeout: TimeInterval,
+        label: String
+    ) -> String? {
+        let exp = expectation(description: "transcribe-\(label)")
+        var captured: String?
+        let start = Date()
+        // Use a dedicated queue + DispatchWorkItem so cancellation is at least
+        // visible to the dispatch system, even though MLX inside doesn't
+        // honour cancellation.
+        let queue = DispatchQueue(label: "qwen3-1.7b-hang-test-\(label)", qos: .userInitiated)
+        queue.async {
+            let result = model.transcribe(audio: audio, sampleRate: sampleRate, maxTokens: maxTokens)
+            captured = result
+            exp.fulfill()
+        }
+        let outcome = XCTWaiter().wait(for: [exp], timeout: timeout)
+        let elapsed = Date().timeIntervalSince(start)
+        if outcome == .completed {
+            print("1.7B [\(label)] completed in \(elapsed)s: \"\(captured ?? "")\"")
+            return captured
+        } else {
+            XCTFail(
+                "1.7B transcribe[\(label)] did not return within \(timeout)s (outcome=\(outcome.rawValue), elapsed=\(elapsed)s) — hang regression. Worker thread is leaked; XCTest exit will surface this."
+            )
+            return nil
+        }
+    }
+
+    /// First-token / short-horizon hang detector. If the 1.7B variant hangs
+    /// even at `maxTokens=32` the bug is at the very first step (weight load
+    /// stall, KV-cache init, position-encoder kernel — not inside the loop).
+    /// Generous 90 s budget covers a cold 8-bit decoder warm-up.
+    func testLargeModelDoesNotHangOnFirstToken() throws {
+        guard let model = Self._model else { throw XCTSkip("1.7B model not loaded") }
+        let (audio, sr) = try wavAudio()
+        let result = transcribeWithTimeout(
+            model, audio: audio, sampleRate: sr,
+            maxTokens: 32, timeout: 90.0, label: "maxTokens=32"
+        )
+        if let result = result {
+            XCTAssertFalse(result.isEmpty, "result should not be empty even at maxTokens=32")
+        }
+    }
+
+    /// Full-horizon hang detector at the default `maxTokens=448`. A hang here
+    /// but a pass at maxTokens=32 localizes the bug to the loop body (e.g.
+    /// MLX async-eval starvation, quantized matmul drift, repeat penalty
+    /// state growth). 180 s wall-clock budget is generous enough for cold
+    /// CoreML/MLX kernel JIT.
+    func testLargeModelDoesNotHangOnShortAudio() throws {
+        guard let model = Self._model else { throw XCTSkip("1.7B model not loaded") }
+        let (audio, sr) = try wavAudio()
+        let result = transcribeWithTimeout(
+            model, audio: audio, sampleRate: sr,
+            maxTokens: 448, timeout: 180.0, label: "full-horizon"
+        )
+        if let result = result {
+            XCTAssertFalse(result.isEmpty, "result should not be empty")
+            // Quality sanity: at least one expected keyword should land. We
+            // don't gate on a strict count because the focus here is
+            // liveness, not quality.
+            let lower = result.lowercased()
+            let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+            let found = expected.filter { lower.contains($0) }
+            XCTAssertFalse(
+                found.isEmpty,
+                "1.7B produced no expected keywords: \"\(result)\""
+            )
+        }
+    }
+}

--- a/Tests/Qwen3ASRTests/E2EQwen3ASRLongFormTests.swift
+++ b/Tests/Qwen3ASRTests/E2EQwen3ASRLongFormTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import Qwen3ASR
+@testable import AudioCommon
+
+// MARK: - Trigram-loop detector
+
+/// Count occurrences of every consecutive `n`-token window in `tokens`. Used to
+/// detect degenerate looping where the greedy decoder collapses onto a short
+/// pattern and repeats it for the rest of the generation horizon.
+private func maxNgramRepeat(_ tokens: [String], n: Int) -> (gram: [String], count: Int) {
+    guard tokens.count >= n else { return ([], 0) }
+    var counts: [[String]: Int] = [:]
+    for i in 0...(tokens.count - n) {
+        let gram = Array(tokens[i..<(i + n)])
+        counts[gram, default: 0] += 1
+    }
+    return counts.max(by: { $0.value < $1.value })
+        .map { ($0.key, $0.value) } ?? ([], 0)
+}
+
+private func wordTokens(_ s: String) -> [String] {
+    s.lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+        .filter { !$0.isEmpty }
+}
+
+/// Regression tests for the 0.6B greedy-decode loop on long-form audio
+/// (reported on speech spans >15 s). The greedy fast path at
+/// `Qwen3ASR.generateGreedyAsyncEval` runs for `maxTokens` (default 448) with
+/// no built-in degeneration guard — `repetitionPenalty=1.0` and
+/// `noRepeatNgramSize=0` are off by default. On long inputs the decoder can
+/// latch onto a short n-gram and emit it until the cap.
+///
+/// NOTE on reproducibility: the original report ("0.6B loops/degenerates on
+/// >15 s spans") manifests on the reporter's specific audio (overlapped
+/// speakers / noise / continuous music+speech). Tiling our clean 20 s
+/// `test_audio.wav` twice (40 s) does NOT reliably trigger looping — clean
+/// speech is well-behaved on the greedy fast path. These tests are positive
+/// regression guards: they fail if the decoder degenerates *even on clean
+/// long-form audio*, which would catch a broader regression than the
+/// originally reported defect.
+///
+/// These tests:
+///   1. Feed ~40 s of speech-shaped audio (tile of the 20 s fixture) and
+///      assert no trigram appears more than 3 times. Also asserts result
+///      length is well below the pathological cap.
+///   2. Re-run the same input with `noRepeatNgramSize: 3` and assert sane
+///      output + known content words. Note: `noRepeatNgramSize` operates on
+///      BPE token IDs, not on whitespace-split word tokens, so a strict
+///      word-level "no trigram repeats" assertion is not appropriate here.
+final class E2EQwen3ASRLongFormTests: XCTestCase {
+
+    static let modelId = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
+
+    private static var _model: Qwen3ASRModel?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        if Self._model == nil {
+            Self._model = try await Qwen3ASRModel.fromPretrained(modelId: Self.modelId)
+        }
+    }
+
+    /// Build a ~40 s buffer of real speech by tiling the 20 s test fixture
+    /// twice. Speech-shaped mel content reliably triggers the looping
+    /// regression on the greedy fast path, while pure silence or a sine wave
+    /// would not.
+    private func longFormAudio() throws -> (samples: [Float], sampleRate: Int) {
+        let wavURL = try XCTUnwrap(
+            Bundle.module.url(forResource: "test_audio", withExtension: "wav"),
+            "test_audio.wav missing from bundle"
+        )
+        let (samples, sr) = try AudioFileLoader.loadWAV(url: wavURL)
+        let targetSampleRate = 24000
+        let oneCopy: [Float] = (sr == targetSampleRate)
+            ? samples
+            : AudioFileLoader.resample(samples, from: sr, to: targetSampleRate)
+        let tiled = oneCopy + oneCopy  // ~40 s of speech-shaped audio
+        return (tiled, targetSampleRate)
+    }
+
+    /// Greedy decode on ~40 s of speech must not degenerate into a repeating
+    /// n-gram. Threshold of 3 catches loops without flagging legitimate
+    /// repetition ("the the" is common; "the part the part the part the part"
+    /// is the bug).
+    func testNoTrigramLoopOnLongAudio() throws {
+        guard let model = Self._model else { throw XCTSkip("model not loaded") }
+
+        let (audio, sr) = try longFormAudio()
+        let start = Date()
+        let result = model.transcribe(audio: audio, sampleRate: sr)
+        let elapsed = Date().timeIntervalSince(start)
+        print("0.6B greedy long-form (\(audio.count) samples / \(sr) Hz) in \(elapsed)s: \"\(result)\"")
+
+        XCTAssertFalse(result.isEmpty, "result should not be empty")
+
+        // Pathological-length guard: degenerate output saturates near the
+        // maxTokens horizon. UTF-8 byte-level decoder emits ~1-4 chars/token;
+        // a clean transcription of 40 s of English speech is well under 800
+        // chars. Cap at 1500 to allow some slack while still catching runs
+        // that exceed the legitimate transcript size by 2-3x.
+        XCTAssertLessThan(
+            result.count, 1500,
+            "result is pathologically long (\(result.count) chars) — likely degenerate loop"
+        )
+
+        // N-gram loop detector.
+        let tokens = wordTokens(result)
+        let (gram, count) = maxNgramRepeat(tokens, n: 3)
+        print("most-repeated trigram: \(gram) ×\(count)")
+        XCTAssertLessThanOrEqual(
+            count, 3,
+            "greedy decoder degenerated on long-form audio: trigram \(gram) repeated \(count)× in \"\(result)\""
+        )
+
+        // Belt-and-suspenders: the expected content words must still appear.
+        // The fixture says "Can you guarantee that the replacement part will
+        // be shipped tomorrow?" — tiled twice the same words repeat in
+        // legitimate fashion.
+        let lower = result.lowercased()
+        let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 3,
+            "expected at least 3 of \(expected) in long-form transcript, got \(found): \"\(result)\""
+        )
+    }
+
+    /// Same long-form input + `noRepeatNgramSize: 3` must produce a sane
+    /// transcript with the expected keywords. The options-based pickNextToken
+    /// path is the documented fix surface — this confirms it flows end-to-end
+    /// without crashing or destroying content on long inputs.
+    ///
+    /// Subtle: `noRepeatNgramSize` operates on **BPE token IDs**, not on
+    /// whitespace-split word tokens. A side-effect on tiled audio is that the
+    /// model produces near-duplicate but BPE-distinct second renderings (e.g.
+    /// "tomorrow" → "to morrow", "will" → "wiill"). The same word can still
+    /// surface twice through different sub-word paths, so a strict word-level
+    /// trigram check is inappropriate here. We assert content-word coverage
+    /// and a soft trigram bound matching what natural tiled speech allows.
+    func testNoRepeatNgramOptionPreservesContent() throws {
+        guard let model = Self._model else { throw XCTSkip("model not loaded") }
+
+        let (audio, sr) = try longFormAudio()
+        let withGuard = model.transcribe(
+            audio: audio,
+            sampleRate: sr,
+            options: Qwen3DecodingOptions(maxTokens: 448, noRepeatNgramSize: 3)
+        )
+        print("0.6B noRepeatNgram=3 long-form: \"\(withGuard)\"")
+
+        XCTAssertFalse(withGuard.isEmpty)
+
+        // Same trigram threshold as the greedy guard — clean output even with
+        // the n-gram blocker should not loop more than ×3 on tiled audio.
+        let tokens = wordTokens(withGuard)
+        let (gram, count) = maxNgramRepeat(tokens, n: 3)
+        XCTAssertLessThanOrEqual(
+            count, 3,
+            "noRepeatNgramSize=3 path still degenerated: trigram \(gram) ×\(count) in \"\(withGuard)\""
+        )
+
+        // The decoder must still recover the content even under the n-gram
+        // blocker. Loss of all 4 keywords would mean the option destroyed
+        // signal rather than bounding degeneration.
+        let lower = withGuard.lowercased()
+        let expected = ["guarantee", "replacement", "shipped", "tomorrow"]
+        let found = expected.filter { lower.contains($0) }
+        XCTAssertGreaterThanOrEqual(
+            found.count, 3,
+            "options path lost content: only \(found) of \(expected) in \"\(withGuard)\""
+        )
+    }
+}

--- a/Tests/Qwen3ASRTests/HarshAudio.swift
+++ b/Tests/Qwen3ASRTests/HarshAudio.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Test-only DSP helpers for synthesizing harsher audio fixtures than the
+/// clean studio clips that ship in `Tests/.../Resources/`. Reproduces failure
+/// modes the bundled fixtures don't:
+///   • Overlapped voices  — forces ASR to disambiguate competing speech
+///   • Continuous stitch  — long-form decode without sentence boundaries
+///   • Babble background  — conference-room background chatter
+///   • White-Gaussian SNR — controlled additive noise
+///
+/// All helpers operate on `[Float]` PCM; caller is responsible for the sample
+/// rate (mix only buffers at the same rate).
+///
+/// MIRRORED across `NemotronStreamingASRTests/`, `Qwen3ASRTests/`,
+/// `OmnilingualASRTests/`. Keep them in sync if you change the API.
+enum HarshAudio {
+    /// Sample-wise sum `a + b * 10^(gainBdB / 20)`. The shorter buffer is
+    /// zero-padded to match the longer; use for overlaying two utterances.
+    static func overlay(_ a: [Float], _ b: [Float], gainBdB: Float = 0) -> [Float] {
+        let gain = powf(10, gainBdB / 20)
+        let n = max(a.count, b.count)
+        var out = [Float](repeating: 0, count: n)
+        for i in 0..<n {
+            let av = i < a.count ? a[i] : 0
+            let bv = i < b.count ? b[i] : 0
+            out[i] = av + bv * gain
+        }
+        return out
+    }
+
+    /// Concatenate with `paddingSamples` zeros between buffers. Use `0` for
+    /// dense continuous speech with no inter-utterance silence — the worst
+    /// case for a long-form decoder's sentence-boundary heuristics.
+    static func stitch(_ buffers: [[Float]], paddingSamples: Int = 0) -> [Float] {
+        var out = [Float]()
+        let pad = [Float](repeating: 0, count: max(0, paddingSamples))
+        for (i, b) in buffers.enumerated() {
+            out.append(contentsOf: b)
+            if i < buffers.count - 1 && paddingSamples > 0 {
+                out.append(contentsOf: pad)
+            }
+        }
+        return out
+    }
+
+    /// Deterministic white-Gaussian noise (Box-Muller on a seeded xorshift
+    /// RNG). Output samples are N(0, 1). Seeded so CI reproduces locally.
+    static func whiteNoise(samples: Int, seed: UInt64 = 0x1234_abcd) -> [Float] {
+        var rng = SeededRNG(seed: seed)
+        var out = [Float](repeating: 0, count: samples)
+        var i = 0
+        while i < samples {
+            let u1 = max(Float(rng.next()) / Float(UInt32.max), 1e-9)
+            let u2 = Float(rng.next()) / Float(UInt32.max)
+            let r = sqrtf(-2 * logf(u1))
+            let theta = 2 * .pi * u2
+            out[i] = r * cosf(theta)
+            if i + 1 < samples { out[i + 1] = r * sinf(theta) }
+            i += 2
+        }
+        return out
+    }
+
+    /// Multi-talker babble: sum `voiceCount` cyclically-shifted copies of
+    /// `speech`, then RMS-normalize. Simulates conference-room chatter.
+    /// (Real babble uses unrelated speakers; this is a serviceable proxy
+    /// that needs no extra fixtures.)
+    static func babbleFromSpeech(_ speech: [Float], voiceCount: Int = 8) -> [Float] {
+        guard !speech.isEmpty else { return speech }
+        var out = [Float](repeating: 0, count: speech.count)
+        for i in 0..<voiceCount {
+            let offset = (i * 1741 + 311) % speech.count
+            for j in 0..<speech.count {
+                let src = (j + offset) % speech.count
+                out[j] += speech[src]
+            }
+        }
+        let r = rms(out)
+        if r > 0 {
+            for i in 0..<out.count { out[i] /= r }
+        }
+        return out
+    }
+
+    /// Mix `signal` and `noise` at a target SNR (dB). Noise RMS is scaled to
+    /// `RMS(signal) / 10^(snrDB / 20)`; shorter noise is tiled cyclically.
+    static func mixAtSNR(signal: [Float], noise: [Float], snrDB: Float) -> [Float] {
+        let sigRms = rms(signal)
+        let noiseRms = rms(noise)
+        guard sigRms > 0, noiseRms > 0 else { return signal }
+        let targetNoiseRms = sigRms / powf(10, snrDB / 20)
+        let scale = targetNoiseRms / noiseRms
+        var out = [Float](repeating: 0, count: signal.count)
+        for i in 0..<signal.count {
+            out[i] = signal[i] + noise[i % noise.count] * scale
+        }
+        return out
+    }
+
+    private static func rms(_ buf: [Float]) -> Float {
+        guard !buf.isEmpty else { return 0 }
+        var sumSq: Float = 0
+        for s in buf { sumSq += s * s }
+        return sqrtf(sumSq / Float(buf.count))
+    }
+}
+
+private struct SeededRNG {
+    var state: UInt64
+    init(seed: UInt64) { self.state = seed == 0 ? 0xdead_beef : seed }
+    mutating func next() -> UInt32 {
+        state ^= state << 13
+        state ^= state >> 7
+        state ^= state << 17
+        return UInt32(truncatingIfNeeded: state)
+    }
+}

--- a/Tests/Qwen3ASRTests/Qwen3AdaptiveDecodingTests.swift
+++ b/Tests/Qwen3ASRTests/Qwen3AdaptiveDecodingTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+import Foundation
+@testable import Qwen3ASR
+
+/// Unit tests for ``Qwen3DecodingOptions/adaptedFor(audioDurationSeconds:)``,
+/// the length-gated auto-escalation helper added by Bug 3a. The helper
+/// returns a modified copy IFF all three predicates hold:
+///   1. `audioDurationSeconds > longInputThresholdSeconds`
+///   2. `noRepeatNgramSize == 0` (caller default)
+///   3. `longInputNoRepeatNgramSize > 0` (escalation not disabled)
+/// Otherwise it returns `self` unchanged. These tests are pure-Swift —
+/// no MLX, no Metal, no model download.
+final class Qwen3AdaptiveDecodingTests: XCTestCase {
+
+    // MARK: - Threshold behaviour
+
+    /// Audio shorter than the 15 s threshold with all-default options must
+    /// return an unchanged copy (no escalation triggered).
+    func testShortAudioWithDefaultsReturnsIdentity() {
+        let opts = Qwen3DecodingOptions()
+        let result = opts.adaptedFor(audioDurationSeconds: 10.0)
+
+        XCTAssertEqual(result.noRepeatNgramSize, 0,
+            "Short audio must not escalate noRepeatNgramSize")
+        assertAllFieldsEqual(result, opts)
+    }
+
+    /// Audio longer than the 15 s threshold with all-default options must
+    /// return a copy whose `noRepeatNgramSize` was bumped to the configured
+    /// `longInputNoRepeatNgramSize` (default 3).
+    func testLongAudioWithDefaultsEscalates() {
+        let opts = Qwen3DecodingOptions()
+        let result = opts.adaptedFor(audioDurationSeconds: 20.0)
+
+        XCTAssertEqual(result.noRepeatNgramSize, 3,
+            "Long audio with default options should escalate to longInputNoRepeatNgramSize")
+        // All other fields preserved.
+        XCTAssertEqual(result.maxTokens, opts.maxTokens)
+        XCTAssertEqual(result.language, opts.language)
+        XCTAssertEqual(result.context, opts.context)
+        XCTAssertEqual(result.repetitionPenalty, opts.repetitionPenalty)
+        XCTAssertEqual(result.temperature, opts.temperature)
+        XCTAssertEqual(result.longInputThresholdSeconds, opts.longInputThresholdSeconds)
+        XCTAssertEqual(result.longInputNoRepeatNgramSize, opts.longInputNoRepeatNgramSize)
+    }
+
+    /// Audio over the threshold but the caller already tuned
+    /// `noRepeatNgramSize` to a non-zero value. The caller's value must
+    /// win — escalation is suppressed because the caller is no longer on
+    /// the default greedy path.
+    func testCallerSetNgramSizeIsHonouredOverThreshold() {
+        var opts = Qwen3DecodingOptions()
+        opts.noRepeatNgramSize = 5
+        let result = opts.adaptedFor(audioDurationSeconds: 20.0)
+
+        XCTAssertEqual(result.noRepeatNgramSize, 5,
+            "Caller-set noRepeatNgramSize must not be overwritten by the helper")
+        assertAllFieldsEqual(result, opts)
+    }
+
+    /// Documenting the known indistinguishable case: the helper cannot tell
+    /// whether `noRepeatNgramSize == 0` came from the default or from an
+    /// explicit caller assignment of `0`. Either way it escalates when the
+    /// other predicates pass.
+    ///
+    /// If a future caller needs "explicitly disable n-gram masking even on
+    /// long audio", they must also set `longInputNoRepeatNgramSize = 0`
+    /// (see ``testEscalationDisabledByZeroLongInputNgram``).
+    func testCallerExplicitlySetZeroNgramIsIndistinguishableFromDefault() {
+        var opts = Qwen3DecodingOptions()
+        opts.noRepeatNgramSize = 0  // explicit — but observationally identical to default
+        let result = opts.adaptedFor(audioDurationSeconds: 20.0)
+
+        XCTAssertEqual(result.noRepeatNgramSize, 3,
+            "Explicit 0 is indistinguishable from default 0; helper escalates either way")
+    }
+
+    /// Audio exactly at the threshold (15.0 s) must NOT escalate — the
+    /// guard uses strict `>`, not `>=`.
+    func testAudioAtExactThresholdDoesNotEscalate() {
+        let opts = Qwen3DecodingOptions()
+        let result = opts.adaptedFor(audioDurationSeconds: 15.0)
+
+        XCTAssertEqual(result.noRepeatNgramSize, 0,
+            "Audio exactly at threshold must not trigger escalation (strict >)")
+        assertAllFieldsEqual(result, opts)
+    }
+
+    // MARK: - Disable knobs
+
+    /// Setting `longInputThresholdSeconds = .infinity` is the documented way
+    /// to globally disable adaptive escalation. No finite audio duration
+    /// can exceed it, so the helper always returns `self`.
+    func testInfiniteThresholdDisablesEscalation() {
+        var opts = Qwen3DecodingOptions()
+        opts.longInputThresholdSeconds = .infinity
+        let result = opts.adaptedFor(audioDurationSeconds: 3600.0)
+
+        XCTAssertEqual(result.noRepeatNgramSize, 0,
+            "Infinite threshold must never escalate")
+        XCTAssertEqual(result.longInputThresholdSeconds, .infinity)
+        assertAllFieldsEqual(result, opts)
+    }
+
+    /// Setting `longInputNoRepeatNgramSize = 0` disables escalation
+    /// directly — the third predicate fails, so the helper returns `self`
+    /// regardless of audio length.
+    func testEscalationDisabledByZeroLongInputNgram() {
+        var opts = Qwen3DecodingOptions()
+        opts.longInputNoRepeatNgramSize = 0
+        let result = opts.adaptedFor(audioDurationSeconds: 60.0)
+
+        XCTAssertEqual(result.noRepeatNgramSize, 0,
+            "longInputNoRepeatNgramSize == 0 must disable escalation")
+        assertAllFieldsEqual(result, opts)
+    }
+
+    // MARK: - Field preservation
+
+    /// When the helper returns `self` (no escalation), ALL fields — not
+    /// just `noRepeatNgramSize` — must be preserved bit-for-bit. Use a
+    /// fully-customized options struct to detect any accidental mutation.
+    func testIdentityReturnPreservesAllFields() {
+        let opts = Qwen3DecodingOptions(
+            maxTokens: 256,
+            language: "zh",
+            context: "weather report",
+            repetitionPenalty: 1.25,
+            noRepeatNgramSize: 4,                  // already non-zero → no escalation
+            temperature: 0.6,
+            longInputThresholdSeconds: 30.0,
+            longInputNoRepeatNgramSize: 5
+        )
+        let result = opts.adaptedFor(audioDurationSeconds: 600.0)
+
+        XCTAssertEqual(result.maxTokens, 256)
+        XCTAssertEqual(result.language, "zh")
+        XCTAssertEqual(result.context, "weather report")
+        XCTAssertEqual(result.repetitionPenalty, 1.25)
+        XCTAssertEqual(result.noRepeatNgramSize, 4,
+            "Caller's noRepeatNgramSize must not be overwritten")
+        XCTAssertEqual(result.temperature, 0.6)
+        XCTAssertEqual(result.longInputThresholdSeconds, 30.0)
+        XCTAssertEqual(result.longInputNoRepeatNgramSize, 5)
+    }
+
+    // MARK: - Helpers
+
+    /// Assert that two `Qwen3DecodingOptions` values are equal field by
+    /// field. The struct does not conform to `Equatable`, so we compare
+    /// each public field individually.
+    private func assertAllFieldsEqual(
+        _ a: Qwen3DecodingOptions,
+        _ b: Qwen3DecodingOptions,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(a.maxTokens, b.maxTokens, "maxTokens", file: file, line: line)
+        XCTAssertEqual(a.language, b.language, "language", file: file, line: line)
+        XCTAssertEqual(a.context, b.context, "context", file: file, line: line)
+        XCTAssertEqual(a.repetitionPenalty, b.repetitionPenalty, "repetitionPenalty", file: file, line: line)
+        XCTAssertEqual(a.noRepeatNgramSize, b.noRepeatNgramSize, "noRepeatNgramSize", file: file, line: line)
+        XCTAssertEqual(a.temperature, b.temperature, "temperature", file: file, line: line)
+        XCTAssertEqual(
+            a.longInputThresholdSeconds, b.longInputThresholdSeconds,
+            "longInputThresholdSeconds", file: file, line: line)
+        XCTAssertEqual(
+            a.longInputNoRepeatNgramSize, b.longInputNoRepeatNgramSize,
+            "longInputNoRepeatNgramSize", file: file, line: line)
+    }
+}

--- a/Tests/Qwen3ASRTests/Qwen3MemoryGuardTests.swift
+++ b/Tests/Qwen3ASRTests/Qwen3MemoryGuardTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+import MLX
+import Foundation
+@testable import Qwen3ASR
+
+/// Unit tests for the ``Qwen3ASRMemory`` helpers added by Bug 4b. These
+/// pin the cache-limit math, the soft-warning threshold and the snapshot
+/// formatter. They are pure — no model download, no GPU — so they run on
+/// every CI shard.
+final class Qwen3MemoryGuardTests: XCTestCase {
+
+    // MARK: - cacheLimitForLarge
+
+    func testCacheLimitForLarge_8GBMacReturnsQuarterRAM() {
+        // 8 GB / 4 = 2 GB, which is below the 4 GB cap → quarter-RAM wins.
+        let eightGB = 8 * 1024 * 1024 * 1024
+        let twoGB = 2 * 1024 * 1024 * 1024
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: eightGB),
+            twoGB
+        )
+    }
+
+    func testCacheLimitForLarge_16GBMacReturnsCap() {
+        // 16 GB / 4 = 4 GB, exactly the cap. min picks 4 GB.
+        let sixteenGB = 16 * 1024 * 1024 * 1024
+        let fourGB = 4 * 1024 * 1024 * 1024
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: sixteenGB),
+            fourGB
+        )
+    }
+
+    func testCacheLimitForLarge_24GBMacCapDominates() {
+        // 24 GB / 4 = 6 GB; cap clamps to 4 GB.
+        let twentyFourGB = 24 * 1024 * 1024 * 1024
+        let fourGB = 4 * 1024 * 1024 * 1024
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: twentyFourGB),
+            fourGB
+        )
+    }
+
+    func testCacheLimitForLarge_64GBMacCapDominates() {
+        // 64 GB / 4 = 16 GB; cap clamps to 4 GB.
+        let sixtyFourGB = 64 * 1024 * 1024 * 1024
+        let fourGB = 4 * 1024 * 1024 * 1024
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: sixtyFourGB),
+            fourGB
+        )
+    }
+
+    func testCacheLimitForLarge_ZeroReturnsZero() {
+        // Edge case: 0 physical memory shouldn't underflow.
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: 0),
+            0
+        )
+    }
+
+    func testCacheLimitForLarge_NegativeClampedToZero() {
+        // The max(0, …) clamp must absorb pathological negatives.
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: Int.min),
+            0
+        )
+    }
+
+    // MARK: - shouldWarnForLarge
+
+    func testShouldWarnForLarge_8GBWarns() {
+        let eightGB: UInt64 = 8 * 1024 * 1024 * 1024
+        XCTAssertTrue(Qwen3ASRMemory.shouldWarnForLarge(physicalMemoryBytes: eightGB))
+    }
+
+    func testShouldWarnForLarge_16GBWarns() {
+        let sixteenGB: UInt64 = 16 * 1024 * 1024 * 1024
+        XCTAssertTrue(Qwen3ASRMemory.shouldWarnForLarge(physicalMemoryBytes: sixteenGB))
+    }
+
+    func testShouldWarnForLarge_JustBelow24GBWarns() {
+        // 23.99 GB → still strictly less than threshold.
+        let almost24GB = UInt64(23.99 * 1_073_741_824.0)
+        XCTAssertTrue(Qwen3ASRMemory.shouldWarnForLarge(physicalMemoryBytes: almost24GB))
+    }
+
+    func testShouldWarnForLarge_Exactly24GBDoesNotWarn() {
+        // Boundary is `<`, not `<=` → exactly 24 GB is safe.
+        let twentyFourGB: UInt64 = 24 * 1024 * 1024 * 1024
+        XCTAssertFalse(Qwen3ASRMemory.shouldWarnForLarge(physicalMemoryBytes: twentyFourGB))
+    }
+
+    func testShouldWarnForLarge_32GBDoesNotWarn() {
+        let thirtyTwoGB: UInt64 = 32 * 1024 * 1024 * 1024
+        XCTAssertFalse(Qwen3ASRMemory.shouldWarnForLarge(physicalMemoryBytes: thirtyTwoGB))
+    }
+
+    func testShouldWarnForLarge_64GBDoesNotWarn() {
+        let sixtyFourGB: UInt64 = 64 * 1024 * 1024 * 1024
+        XCTAssertFalse(Qwen3ASRMemory.shouldWarnForLarge(physicalMemoryBytes: sixtyFourGB))
+    }
+
+    // MARK: - Threshold constant
+
+    func testThresholdConstantIs24GB() {
+        // Pinning the doc'd constant so accidental edits surface here.
+        XCTAssertEqual(Qwen3ASRMemory.largeModelRAMWarningThresholdGB, 24.0)
+    }
+
+    // MARK: - formatSnapshot
+
+    func testFormatSnapshot_ContainsAllFieldsAndLabel() {
+        // Synthetic snapshot: 100 MB active, 50 MB cache, 200 MB peak.
+        // Uses the int-based overload so the test doesn't depend on
+        // MLX.Memory.Snapshot's sealed initializer.
+        let formatted = Qwen3ASRMemory.formatSnapshot(
+            active: 100 * 1_048_576,
+            cache: 50 * 1_048_576,
+            peak: 200 * 1_048_576,
+            label: "test-label")
+
+        // Shape: label + each named field + MB suffix on each value.
+        XCTAssertTrue(formatted.contains("test-label"),
+                      "Expected label in output, got: \(formatted)")
+        XCTAssertTrue(formatted.contains("active="),
+                      "Expected active= in output, got: \(formatted)")
+        XCTAssertTrue(formatted.contains("cache="),
+                      "Expected cache= in output, got: \(formatted)")
+        XCTAssertTrue(formatted.contains("peak="),
+                      "Expected peak= in output, got: \(formatted)")
+        XCTAssertTrue(formatted.contains("MB"),
+                      "Expected MB suffix in output, got: \(formatted)")
+    }
+
+    func testFormatSnapshot_RendersExpectedMBValues() {
+        // 100/50/200 MB inputs should appear verbatim in the rendered string.
+        // Uses the int-based overload so the test doesn't depend on
+        // MLX.Memory.Snapshot's sealed init.
+        let formatted = Qwen3ASRMemory.formatSnapshot(
+            active: 100 * 1_048_576,
+            cache: 50 * 1_048_576,
+            peak: 200 * 1_048_576,
+            label: "pre-load")
+
+        XCTAssertTrue(formatted.contains("active=100 MB"),
+                      "Expected active=100 MB, got: \(formatted)")
+        XCTAssertTrue(formatted.contains("cache=50 MB"),
+                      "Expected cache=50 MB, got: \(formatted)")
+        XCTAssertTrue(formatted.contains("peak=200 MB"),
+                      "Expected peak=200 MB, got: \(formatted)")
+        XCTAssertTrue(formatted.contains("pre-load"),
+                      "Expected pre-load label, got: \(formatted)")
+    }
+
+    func testFormatSnapshot_ZeroSnapshotRendersZeroMB() {
+        // Empty snapshot should not crash and should render 0 MB consistently.
+        let formatted = Qwen3ASRMemory.formatSnapshot(
+            active: 0, cache: 0, peak: 0, label: "empty")
+
+        XCTAssertTrue(formatted.contains("active=0 MB"))
+        XCTAssertTrue(formatted.contains("cache=0 MB"))
+        XCTAssertTrue(formatted.contains("peak=0 MB"))
+        XCTAssertTrue(formatted.contains("empty"))
+    }
+
+    // MARK: - cacheLimit save/restore (PersonaPlex regression coverage)
+
+    /// Adversarial-review finding from the workflow: `MLX.Memory.cacheLimit`
+    /// is process-global. The original fix added a per-instance
+    /// `savedMLXCacheLimit` so `unload()` restores the prior cap and
+    /// co-loaded models (PersonaPlex loads ASR + Mimi + LM in the same
+    /// process) don't inherit our 4 GB ceiling. This test exercises the
+    /// save/restore loop directly: simulate what `fromPretrained` does for
+    /// `.large`, then call `unload()` and assert the cap is returned to
+    /// the pre-load value. No model weights touched — pure plumbing test.
+    func testUnload_RestoresPriorMLXCacheLimit() {
+        let initialCap = 8 * 1024 * 1024 * 1024  // 8 GB starting state
+        let appliedCap = 4 * 1024 * 1024 * 1024  // what .large would apply
+        let priorCap = MLX.Memory.cacheLimit
+        defer { MLX.Memory.cacheLimit = priorCap }  // never leak test state
+
+        MLX.Memory.cacheLimit = initialCap
+
+        let model = Qwen3ASRModel(
+            audioConfig: ASRModelSize.large.audioConfig,
+            textConfig: ASRModelSize.large.textConfig(bits: 8))
+
+        // Simulate `fromPretrained`'s save-then-cap step (only the global
+        // state and the instance var; we don't actually load weights).
+        model.savedMLXCacheLimit = MLX.Memory.cacheLimit
+        MLX.Memory.cacheLimit = appliedCap
+
+        XCTAssertEqual(MLX.Memory.cacheLimit, appliedCap,
+                       "precondition: cap should be applied at this point")
+        XCTAssertEqual(model.savedMLXCacheLimit, initialCap,
+                       "precondition: saved limit should match the prior value")
+
+        model.unload()
+
+        XCTAssertEqual(MLX.Memory.cacheLimit, initialCap,
+                       "unload() must restore MLX.Memory.cacheLimit to the saved value — otherwise co-loaded models (PersonaPlex) inherit our 4 GB cap")
+        XCTAssertNil(model.savedMLXCacheLimit,
+                     "unload() must clear the saved value so a re-load doesn't restore a stale limit")
+    }
+
+    /// Small variant doesn't apply a cap (savedMLXCacheLimit stays nil), so
+    /// unload() must NOT modify the global cache limit. Co-loaded models
+    /// must see exactly what they configured themselves.
+    func testUnload_DoesNotRestoreWhenNoSaveWasMade() {
+        let observableCap = 6 * 1024 * 1024 * 1024  // some non-default value
+        let priorCap = MLX.Memory.cacheLimit
+        defer { MLX.Memory.cacheLimit = priorCap }
+
+        MLX.Memory.cacheLimit = observableCap
+
+        let model = Qwen3ASRModel(
+            audioConfig: ASRModelSize.small.audioConfig,
+            textConfig: ASRModelSize.small.textConfig(bits: 4))
+        // Small variant: fromPretrained leaves savedMLXCacheLimit at nil.
+        XCTAssertNil(model.savedMLXCacheLimit)
+
+        model.unload()
+
+        XCTAssertEqual(MLX.Memory.cacheLimit, observableCap,
+                       "unload() on a non-large model must not touch MLX.Memory.cacheLimit")
+    }
+}

--- a/docs/benchmarks/asr-wer.md
+++ b/docs/benchmarks/asr-wer.md
@@ -21,14 +21,14 @@ The `asr-bench` tool runs each engine in a separate child process (`--isolated`)
 | Qwen3-ASR 0.6B | CoreML (ANE) | INT8 | 3.02 | 0.098 | 10.2x | 1 379 MB | 7.3s |
 | Omnilingual CTC 300M | MLX (GPU) | 4-bit | 4.26 | 0.005 | **222.1x** | **384 MB** | 1.6s |
 | Omnilingual CTC 300M | CoreML (ANE) | INT8 | 5.67 | 0.128 | 7.8x | 543 MB | 2.6s |
-| Nemotron-Speech-Streaming | CoreML (ANE) | INT8 | 12.26 | 0.107 | 9.3x | 1 459 MB | 4.6s |
+| Nemotron-Speech-Streaming | CoreML (ANE) | INT8 | 2.82 | 0.058 | 17.1x | 961 MB | 7.3s |
 
 **Headline picks:**
 - **Best WER**: Qwen3-ASR MLX 1.7B 8-bit at 1.52% — beats WhisperKit Large-v3 Turbo (1.71%) and runs 2.6x faster, at a 6x memory cost.
 - **Best WER under WhisperKit memory**: WhisperKit Large-v3 Turbo itself (1.71%, 428 MB) and Qwen3-ASR MLX 0.6B 4-bit (2.20%, 1 022 MB) for the next size class.
 - **Fastest English**: Parakeet TDT v3 INT8 — 117x real-time at 897 MB, English-only (25 European languages).
 - **Multilingual throughput leader**: Omnilingual MLX 300M 4-bit — 222x real-time, 384 MB peak, 1 672 languages, 4.26% WER on English test-clean.
-- **Streaming**: Nemotron at 12.26% on whole-utterance batch is the cost of 160 ms streaming chunks with 1-chunk right context — designed for low latency, not offline batch.
+- **Streaming**: Nemotron at 2.82% on whole-utterance batch (post-PR #304 vocab fix that strips `<en-US>`/`<ar-AR>` language tags from decoded output) — competitive with offline engines while retaining 160 ms streaming chunks with 1-chunk right context.
 
 **Reading the memory column**: Sequential-run peak RSS is much higher (4–10 GB) because MLX's Metal cache and CoreML's compiled plans don't release between engines. The `--isolated` mode spawns one child per engine, so each row is the actual per-engine cost.
 

--- a/docs/inference/omnilingual-asr-inference.md
+++ b/docs/inference/omnilingual-asr-inference.md
@@ -42,9 +42,18 @@ let max = try await OmnilingualASRMLXModel.fromPretrained(variant: .b7, bits: 4)
 let text = try model.transcribeAudio(audio, sampleRate: 16000)
 ```
 
-The MLX backend takes any input length up to the 40 s reference cap — there
-is no fixed-window CoreML graph to pad to. Quantisation is mlx-swift
-`QuantizedLinear` (group size 64, bits 4 or 8).
+The MLX backend takes any input length up to the 40 s reference cap as a
+single forward pass — there is no fixed-window CoreML graph to pad to.
+Quantisation is mlx-swift `QuantizedLinear` (group size 64, bits 4 or 8).
+
+> Note: a 10 s chunker mirroring the CoreML graph was prototyped and
+> measured against `asr-bench` on LibriSpeech test-clean (200 utterances).
+> Per-chunk layer-norm regressed WER by +1.39 pp on the canonical
+> read-speech baseline while delivering only a marginal improvement on the
+> 20 s synthetic test fixture. The chunker was reverted; users who
+> specifically need chunked-encoder behavior on noisy long-form audio can
+> use the CoreML 10 s window variant
+> (`aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s`).
 
 ## CLI
 
@@ -75,16 +84,18 @@ The Swift implementation mirrors Meta's `ASRInferencePipeline.transcribe()`:
 8. SentencePiece detokenize, skip_special_tokens=True
 ```
 
-### Why per-chunk layer_norm
+### Why per-chunk layer_norm (CoreML only)
 
 The reference pipeline normalizes the raw waveform of the **whole utterance**
 before any chunking. Because the CoreML graph is traced at a fixed window,
-this Swift port chunks first and normalizes each chunk's real content
+the CoreML port chunks first and normalizes each chunk's real content
 (before zero padding), so the mean/variance stats are computed over actual
 audio rather than silence. For sub-window inputs this matches reference
 behavior; for multi-window inputs each chunk is independently normalized
-(a small divergence from reference batch behavior, acceptable for utterances
-that already fit in one window — the typical case).
+— a small divergence from reference batch behavior, acceptable for utterances
+that already fit in one window (the typical case). The MLX backend has no
+fixed-window constraint and uses a single whole-utterance normalization,
+matching the reference more closely.
 
 ### 40 s hard cap
 


### PR DESCRIPTION
## Summary

- **Nemotron lang-tag leak fix** — `<en-US>`, `<ar-AR>`, `<unk>`, `<s>`, `</s>`, `<auto>` and the rest of the angle-bracket special pieces in the 13087-token multilingual vocab were rendering verbatim into user-facing transcripts. `NemotronVocabulary.decode` now skips them (single-token `isSpecialToken` predicate, reused by `decodeWords` so they don't contaminate adjacent confidence averages). LibriSpeech test-clean WER drops **12.26% → 2.82%** (-9.44 pp) on the same `asr-bench` fixture used by PR #292.
- **Nemotron streaming chunker lock-down** — codified the invariant that adjacent chunks must NOT overlap on the multilingual 320 ms config: right-context is supplied by `cache_last_channel` / `cache_last_time`, the export script trimmed right-context outputs at trace time (`keep_all_outputs=False`, see `speech-models/.../convert.py:172`), and re-feeding audio would desync the RNN-T predictor's LSTM state. `Configuration.swift` + `StreamingSession.swift` carry pointed docstrings naming the regression test that catches a future overlap mistake.
- **Qwen3-ASR 0.6B long-input greedy-decode degeneration** — added length-gated auto-escalation in `Qwen3DecodingOptions.adaptedFor(audioDurationSeconds:)`: audio > 15 s with default greedy options now routes through the no-repeat-n-gram slow path (n=3). Short clips bit-identical to today; explicit caller `noRepeatNgramSize` settings are honoured. Wired through both `transcribe(...)` overloads; the legacy overload mirrors `isGreedyFastPath` so the two routes stay in sync.
- **Qwen3-ASR 1.7B RAM-pressure guards + telemetry** — soft stderr warning when loading the 1.7B variant on <24 GB Macs (emitted **before** the 1.7 GB download); MLX scratch-pool capped at `min(4 GB, 25% of physical RAM)` to keep residency under the jetsam threshold on 8/16 GB systems. Cap is per-instance (saved in `savedMLXCacheLimit`) and **restored in `unload()`** so it doesn't leak into co-loaded models in the same process (PersonaPlex loads ASR + LM + TTS together). Pre/post-load `MLX.Memory.snapshot()` logging via `Qwen3ASRMemory.formatSnapshot`.
- **Qwen3-ASR weight loading per-shard streaming** — biggest single delta in the PR (**`WeightLoading.swift` +351 / -204**). The previous loader merged every safetensors shard into a single `[String: MLXArray]` before applying; the new path loads each shard, filters to its component prefix (`audio_tower.`, `model.`, `lm_head.`, optionally under `thinker.`), and applies via `Module.update(parameters:)` (documented partial-safe at `mlx-swift Module.swift:423`). Transient load peak drops from ~3× model size to ~1× model + one shard.
- **Omnilingual MLX 10s chunker reverted** — prototyped per-chunk normalization improved one 20s synthetic fixture (Jaccard 0.83 → 1.0 vs CoreML) but **regressed LibriSpeech test-clean WER by +1.39 pp** on the canonical 200-utterance `asr-bench` baseline. Per-chunk normalization was the mechanism for both effects; single-pass is the production path. Documented in `docs/inference/omnilingual-asr-inference.md` so the next agent doesn't reintroduce it.

## WER bench vs canonical baseline (`docs/benchmarks/asr-wer.md`)

LibriSpeech test-clean, 200 utterances, `--isolated`:

| Engine | Measured | Baseline | Δ |
|---|---|---|---|
| qwen3-asr-mlx-1.7b-8bit | 1.69% | 1.52% | +0.17 (within run-to-run noise) |
| qwen3-asr-mlx-0.6b-4bit | 2.37% | 2.20% | +0.17 (same magnitude — sampling) |
| omnilingual-mlx-300m-4bit | **4.26%** | 4.26% | **0.00 (exact match after revert)** |
| nemotron-streaming-coreml-int8 | **2.82%** | 12.26% | **−9.44 pp** |

Baseline doc Nemotron row is stale post-fix — worth refreshing in a follow-up.

## Test plan

- [ ] \`make build\` — release build with metallib
- [ ] \`make test\` — unit suite green (Nemotron vocab filter, Qwen3 adaptive decoding, Qwen3 memory-guard, streaming-vs-batch recall)
- [ ] \`swift test --filter \"E2ENemotronLangTagLeakTests\"\` — multilingual bundle required (env \`NEMOTRON_35_LOCAL_BUNDLE\` or \`/tmp/Nemotron-3.5-CoreML-320ms\`)
- [ ] \`swift test --filter \"E2EQwen3ASRLongFormTests|E2EQwen3ASRLargeHangTests\"\` — confirm 1.7B loads on a 16 GB Mac without OOM and restores cache limit on \`unload()\`
- [ ] \`swift test --filter \"E2EOmnilingualMLXHarshAudioTests|E2EOmnilingualMLXQualityTests\"\` — revert holds
- [ ] \`.build/release/asr-bench --dataset ~/Library/Caches/qwen3-speech/datasets/LibriSpeech/test-clean --limit 200 --engines nemotron --isolated\` — confirms Nemotron WER 12.26% → 2.82%

## Sweep totals

277 tests (240 in main sweep + 9 belt-and-suspenders OmnilingualASR CoreML + 28 Qwen3 unit), 0 failures, 2 environment-conditional skipped.