### PR TITLE
fix(download): survive flaky networks during first-run model fetch

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -41,6 +41,10 @@ jobs:
     # the ANE (env unset -> each loader's normal default).
     env:
       SPEECH_COREML_COMPUTE_UNITS: cpuOnly
+      # The library default stall timeout is end-user tuned (300 s — see
+      # HuggingFaceDownloader.downloadStallTimeoutSeconds). CI wants to fail
+      # fast on a wedged HF download instead of eating the shard timeout.
+      HF_DOWNLOAD_STALL_TIMEOUT: "90"
     strategy:
       fail-fast: false
       matrix:

--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -25,7 +25,11 @@ public enum DownloadError: Error, LocalizedError {
 /// HuggingFace model downloader — shared between ASR, TTS, VAD, etc.
 ///
 /// Uses `HubApi` from the swift-transformers `Hub` module for downloads,
-/// which provides HF token auth, metadata tracking, and resume support.
+/// which provides HF token auth and metadata tracking. Files that finished
+/// downloading are skipped on retry (etag/commit-hash check), but a file
+/// interrupted mid-transfer restarts from byte 0 — there is no usable
+/// mid-file resume in the current Hub stack, which is why the stall guard
+/// and retry ladder below favor patience over fast abort.
 public enum HuggingFaceDownloader {
 
     // MARK: - Cache Directory
@@ -95,6 +99,7 @@ public enum HuggingFaceDownloader {
         to directory: URL,
         additionalFiles: [String] = [],
         offlineMode: Bool = false,
+        retryDelaysSeconds: [Int]? = nil,
         progressHandler: ((Double) -> Void)? = nil
     ) async throws {
         // Skip network requests when weights are already cached
@@ -128,14 +133,19 @@ public enum HuggingFaceDownloader {
         let hub = makeHubApi(for: modelId, repoDir: directory, offlineMode: offlineMode)
         let repo = Hub.Repo(id: modelId)
 
-        // Retry with exponential backoff — HuggingFace can timeout on
-        // slow connections or rate-limit. 3 attempts: 0s, 5s, 15s delays.
-        // Each attempt is wrapped in a progress-stall guard so a wedged
-        // mid-transfer (which `hub.snapshot` won't surface on its own)
-        // aborts and retries instead of hanging until the CI job is killed.
-        let maxRetries = 3
+        // Retry with capped backoff — HuggingFace can timeout on slow
+        // connections or rate-limit, and flaky networks (hotspots, captive
+        // portals) drop out for minutes at a time. Each attempt is wrapped
+        // in a progress-stall guard so a wedged mid-transfer (which
+        // `hub.snapshot` won't surface on its own) aborts and retries
+        // instead of hanging until the CI job is killed.
+        //
+        // No retries in offline mode: the failure is a deterministic local
+        // cache miss, and 110 s of backoff can't change what's on disk.
+        let delays = offlineMode ? [] : (retryDelaysSeconds ?? downloadRetryDelaysSeconds)
+        let maxAttempts = delays.count + 1
         var lastError: Error?
-        for attempt in 1...maxRetries {
+        for attempt in 1...maxAttempts {
             do {
                 try await withDownloadStallGuard(modelId: modelId) { reportProgress in
                     try await hub.snapshot(from: repo, matching: globs) { progress in
@@ -146,13 +156,15 @@ public enum HuggingFaceDownloader {
                 return  // Success
             } catch {
                 lastError = error
-                if attempt < maxRetries {
-                    let delay = attempt == 1 ? 5 : 15
-                    try await Task.sleep(for: .seconds(delay))
+                if attempt < maxAttempts {
+                    try await Task.sleep(for: .seconds(delays[attempt - 1]))
                 }
             }
         }
-        throw DownloadError.failedToDownload("\(modelId): \(lastError?.localizedDescription ?? "unknown")")
+        throw DownloadError.failedToDownload(
+            "\(modelId) after \(maxAttempts) attempt\(maxAttempts == 1 ? "" : "s") "
+                + "(target: \(directory.path)): "
+                + (lastError?.localizedDescription ?? "unknown"))
     }
 
     /// Download an explicit list of files from HuggingFace without adding any
@@ -163,6 +175,7 @@ public enum HuggingFaceDownloader {
         to directory: URL,
         files: [String],
         offlineMode: Bool = false,
+        retryDelaysSeconds: [Int]? = nil,
         progressHandler: ((Double) -> Void)? = nil
     ) async throws {
         if files.isEmpty {
@@ -174,9 +187,12 @@ public enum HuggingFaceDownloader {
         let repo = Hub.Repo(id: modelId)
 
         let globs = files.map { $0 }
-        let maxRetries = 3
+        // Same retry semantics as downloadWeights, including the offline
+        // no-retry rule — keep the two loops in lockstep.
+        let delays = offlineMode ? [] : (retryDelaysSeconds ?? downloadRetryDelaysSeconds)
+        let maxAttempts = delays.count + 1
         var lastError: Error?
-        for attempt in 1...maxRetries {
+        for attempt in 1...maxAttempts {
             do {
                 try await withDownloadStallGuard(modelId: modelId) { reportProgress in
                     try await hub.snapshot(from: repo, matching: globs) { progress in
@@ -187,14 +203,30 @@ public enum HuggingFaceDownloader {
                 return
             } catch {
                 lastError = error
-                if attempt < maxRetries {
-                    let delay = attempt == 1 ? 5 : 15
-                    try await Task.sleep(for: .seconds(delay))
+                if attempt < maxAttempts {
+                    try await Task.sleep(for: .seconds(delays[attempt - 1]))
                 }
             }
         }
-        throw DownloadError.failedToDownload("\(modelId): \(lastError?.localizedDescription ?? "unknown")")
+        throw DownloadError.failedToDownload(
+            "\(modelId) after \(maxAttempts) attempt\(maxAttempts == 1 ? "" : "s") "
+                + "(target: \(directory.path)): "
+                + (lastError?.localizedDescription ?? "unknown"))
     }
+
+    // MARK: - Retry ladder
+
+    /// Delays between download attempts. One more attempt than entries:
+    /// 5 attempts with 5/15/30/60 s pauses (~110 s of backoff on top of the
+    /// per-attempt stall patience). Generous on purpose — abandoned attempts
+    /// restart files from byte 0 with the current Hub stack, so the cheap
+    /// resource here is wall-clock, not bytes. A network that's down for a
+    /// couple of minutes (AP roam, hotspot sleep, captive-portal re-auth)
+    /// should not kill a 2.75 GB first-run download.
+    static let downloadRetryDelaysSeconds = [5, 15, 30, 60]
+
+    /// Total attempts per download (retries + the initial try).
+    static var downloadMaxAttempts: Int { downloadRetryDelaysSeconds.count + 1 }
 
     // MARK: - Download stall guard
 
@@ -202,14 +234,22 @@ public enum HuggingFaceDownloader {
     /// considered wedged and aborted. `hub.snapshot` reports
     /// `fractionCompleted` continuously while bytes flow, so a healthy
     /// (even slow) transfer keeps resetting the clock; only a genuinely
-    /// stalled connection trips this. Overridable via
-    /// `HF_DOWNLOAD_STALL_TIMEOUT` for CI tuning.
+    /// stalled connection trips this.
+    ///
+    /// The default is tuned for end users, not CI: aborted attempts restart
+    /// each file from byte 0 (the Hub stack's mid-file resume never engages
+    /// on a fresh download), so firing the guard on a connection that would
+    /// have recovered throws away every byte of that attempt. Flaky networks
+    /// — AP roams, captive-portal re-auth, hotspot sleep — routinely stall
+    /// for 1–3 minutes and then recover, hence 300 s. CI pins
+    /// `HF_DOWNLOAD_STALL_TIMEOUT=90` to keep failing fast (app users can't
+    /// set env vars; CI can).
     static var downloadStallTimeoutSeconds: Int {
         if let raw = ProcessInfo.processInfo.environment["HF_DOWNLOAD_STALL_TIMEOUT"],
            let v = Int(raw), v > 0 {
             return v
         }
-        return 90
+        return 300
     }
 
     /// Thread-safe last-progress timestamp. `hub.snapshot`'s progress

--- a/Sources/VoxCPM2TTS/VoxCPM2TTS.swift
+++ b/Sources/VoxCPM2TTS/VoxCPM2TTS.swift
@@ -191,10 +191,18 @@ public final class VoxCPM2TTSModel: Module {
                     progressHandler?(fraction * 0.8, "Refreshing tokenizer snapshot...")
                 }
             } catch {
+                // A refresh failure is only survivable when a usable snapshot
+                // is already on disk. Without one, swallowing here just defers
+                // the failure to loadTokenizer, which throws a confusing
+                // tokenizer error instead of the actionable DownloadError.
+                let fm = FileManager.default
+                let hasUsableSnapshot = fm.fileExists(
+                    atPath: tokenizerCacheDir.appendingPathComponent("tokenizer.json").path)
+                    && fm.fileExists(
+                        atPath: tokenizerCacheDir.appendingPathComponent("tokenizer_config.json").path)
+                guard hasUsableSnapshot else { throw error }
                 let warning = "VoxCPM2 tokenizer refresh failed, continuing with cached snapshot: \(error)"
-                if let data = "[VoxCPM2] \(warning)\n".data(using: .utf8) {
-                    FileHandle.standardOutput.write(data)
-                }
+                logToStderr("[VoxCPM2] \(warning)")
             }
         }
 
@@ -215,7 +223,7 @@ public final class VoxCPM2TTSModel: Module {
         if ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_WLOAD"] == "1" {
             let q = model.base_lm.layers[0].selfAttn.qProj.weight
             let mAbs = q.abs().mean().item(Float.self)
-            print("[VoxCPM2 WLOAD pre-promote] base_lm L0 q_proj mean_abs=\(mAbs) dtype=\(q.dtype)")
+            logToStderr("[VoxCPM2 WLOAD pre-promote] base_lm L0 q_proj mean_abs=\(mAbs) dtype=\(q.dtype)")
         }
         // Upstream promotes low-precision VoxCPM2 runtime dtypes to float32 on
         // Apple Silicon because bf16/fp16 can glitch the diffusion loop.
@@ -227,7 +235,7 @@ public final class VoxCPM2TTSModel: Module {
         if ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_WLOAD"] == "1" {
             let q = model.base_lm.layers[0].selfAttn.qProj.weight
             let mAbs = q.abs().mean().item(Float.self)
-            print("[VoxCPM2 WLOAD post-promote] base_lm L0 q_proj mean_abs=\(mAbs) dtype=\(q.dtype)")
+            logToStderr("[VoxCPM2 WLOAD post-promote] base_lm L0 q_proj mean_abs=\(mAbs) dtype=\(q.dtype)")
         }
 
         progressHandler?(0.98, "Evaluating parameters...")
@@ -338,12 +346,18 @@ public final class VoxCPM2TTSModel: Module {
             )
         } catch {
             if ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1" {
-                let message = "[VoxCPM2] tokenizer compatibility load failed, falling back to default loader: \(error)\n"
-                if let data = message.data(using: .utf8) {
-                    FileHandle.standardOutput.write(data)
-                }
+                logToStderr("[VoxCPM2] tokenizer compatibility load failed, falling back to default loader: \(error)")
             }
             return try await AutoTokenizer.from(modelFolder: directory, strict: false)
+        }
+    }
+
+    /// Diagnostics must NEVER go to stdout: consumers like the Speech Studio
+    /// sidecar use stdout as an NDJSON protocol channel, and a stray line
+    /// there fails the in-flight request and desyncs every one after it.
+    private static func logToStderr(_ message: String) {
+        if let data = (message + "\n").data(using: .utf8) {
+            FileHandle.standardError.write(data)
         }
     }
 

--- a/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
+++ b/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
@@ -57,12 +57,15 @@ final class HuggingFaceDownloaderTests: XCTestCase {
         let fakeWeights = tmpDir.appendingPathComponent("model.safetensors")
         try? Data([0x00]).write(to: fakeWeights)
 
-        // offlineMode=false should attempt network (and fail for fake model)
+        // offlineMode=false should attempt network (and fail for fake model).
+        // No retry delays: a 404 is a 404 — the test only cares that the
+        // network path was attempted, not the production backoff ladder.
         do {
             try await HuggingFaceDownloader.downloadWeights(
                 modelId: "nonexistent/model-that-does-not-exist",
                 to: tmpDir,
-                offlineMode: false
+                offlineMode: false,
+                retryDelaysSeconds: []
             )
             XCTFail("Should have thrown for nonexistent model with offlineMode=false")
         } catch {
@@ -294,5 +297,30 @@ final class HuggingFaceDownloaderTests: XCTestCase {
                 reportProgress(Double(i) / 8.0)
             }
         }
+    }
+
+    /// The shipped stall default is end-user tuned: aborted attempts restart
+    /// files from byte 0, so the guard must out-wait flaky-network recovery
+    /// (AP roams, hotspot sleep), not fail fast like CI. Locks the default
+    /// so a refactor doesn't silently regress it to a CI-tuned value.
+    /// Skipped when HF_DOWNLOAD_STALL_TIMEOUT is set (the override IS the
+    /// behavior under test elsewhere; here we want the bare default).
+    func testStallTimeoutDefaultIsEndUserTuned() throws {
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["HF_DOWNLOAD_STALL_TIMEOUT"] != nil,
+            "HF_DOWNLOAD_STALL_TIMEOUT override active; default not observable")
+        XCTAssertEqual(HuggingFaceDownloader.downloadStallTimeoutSeconds, 300)
+    }
+
+    /// Retry ladder sanity: attempts = delays + 1, delays strictly grow,
+    /// and total backoff stays bounded (≲2 min) so a hard failure still
+    /// terminates in reasonable time.
+    func testRetryLadderShape() {
+        let delays = HuggingFaceDownloader.downloadRetryDelaysSeconds
+        XCTAssertEqual(HuggingFaceDownloader.downloadMaxAttempts, delays.count + 1)
+        XCTAssertTrue(zip(delays, delays.dropFirst()).allSatisfy { $0 < $1 },
+                      "backoff should strictly grow")
+        XCTAssertLessThanOrEqual(delays.reduce(0, +), 120,
+                                 "total backoff should stay bounded")
     }
 }


### PR DESCRIPTION
## Summary

A Speech Studio user on library WiFi hit `Download stalled for aufklarer/VoxCPM2-MLX-int8: no progress in 90s` and the app gave up after ~30 s of total backoff (soniqo/speech-studio#15). The downloader's defaults were CI-tuned, not user-tuned — and aborting is expensive because the Hub stack has no usable mid-file resume (the `.incomplete` blob is deleted before each fresh attempt, so every abort restarts the file from byte 0).

## What changed

- **Stall default 90 s → 300 s** (`HF_DOWNLOAD_STALL_TIMEOUT` override unchanged). Flaky networks routinely stall 1–3 min and recover; firing the guard early discards every byte of the attempt. CI keeps failing fast — `nightly-e2e.yml` now pins the env var to 90.
- **Retry ladder 3 → 5 attempts** with 5/15/30/60 s capped backoff, shared constants between `downloadWeights` and `downloadFiles`. **No retries in offline mode** — a local cache miss is deterministic (this also returns the two offline unit tests to ~3 s).
- **Terminal error now names the attempt count and the on-disk target directory**, so manual file placement is discoverable from the failure itself.
- **Tokenizer download failures rethrow when no usable cached snapshot exists** instead of being swallowed and resurfacing later as a confusing tokenizer-load error.
- **Library diagnostics now go to stderr.** The Studio sidecar uses stdout as an NDJSON protocol channel; the tokenizer-refresh warning landing there failed the in-flight request and desynced the channel.

## Test plan

- `swift test --filter HuggingFaceDownloaderTests` — 17 tests, includes two new ones (default = 300 locked in, ladder shape strictly-growing and bounded ≤ 120 s backoff).
- `swift test --filter VoxCPM2TTSTests` — 17 tests green.
- Full `swift build` green; downstream speech-studio sidecar builds against this branch via the path dependency.
- Verified `testStallTimeoutDefaultIsEndUserTuned` skips (not fails) under `HF_DOWNLOAD_STALL_TIMEOUT=90`, so the nightly-e2e audio-infra shard stays green.