### PR TITLE
fix(asr): per-component compute units in CoreMLASRModel + StreamingASR docs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -475,7 +475,7 @@ let package = Package(
         ),
         .testTarget(
             name: "Qwen3ASRTests",
-            dependencies: ["Qwen3ASR", "SpeechVAD", "AudioCommon"],
+            dependencies: ["Qwen3ASR", "SpeechVAD", "AudioCommon", "KokoroTTS"],
             resources: [
                 .copy("Resources/test_audio.wav")
             ]

--- a/Sources/Qwen3ASR/CoreMLASRModel.swift
+++ b/Sources/Qwen3ASR/CoreMLASRModel.swift
@@ -24,11 +24,22 @@ public class CoreMLASRModel {
     /// Load full CoreML ASR from HuggingFace.
     ///
     /// Downloads encoder and decoder models from `aufklarer/Qwen3-ASR-CoreML`.
+    ///
+    /// Compute units are split per-component because the encoder and decoder
+    /// have different optimal backends: the encoder defaults to `.all` (the
+    /// 30 s fixed-shape graph runs well on GPU on most Macs), while the
+    /// decoder defaults to `.cpuAndNeuralEngine` (the autoregressive
+    /// MLState path is ANE-friendly and ~7× faster there than GPU per the
+    /// rebuilt-encoder PR). A single `computeUnits` parameter that
+    /// propagated into both calls silently overrode the decoder's stated
+    /// `.cpuAndNeuralEngine` default with `.all`, costing real ANE
+    /// throughput on the full-pipeline path.
     public static func fromPretrained(
         encoderModelId: String = CoreMLASREncoder.defaultModelId,
         decoderModelId: String = CoreMLASREncoder.defaultModelId,
         tokenizerModelId: String = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit",
-        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all),
+        encoderComputeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all),
+        decoderComputeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine),
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil
@@ -37,7 +48,7 @@ public class CoreMLASRModel {
         progressHandler?(0.0, "Loading CoreML encoder...")
         let enc = try await CoreMLASREncoder.fromPretrained(
             modelId: encoderModelId,
-            computeUnits: computeUnits,
+            computeUnits: encoderComputeUnits,
             cacheDir: cacheDir,
             offlineMode: offlineMode
         ) { p, msg in
@@ -48,7 +59,7 @@ public class CoreMLASRModel {
         progressHandler?(0.3, "Loading CoreML decoder...")
         let dec = try await CoreMLTextDecoder.fromPretrained(
             modelId: decoderModelId,
-            computeUnits: computeUnits,
+            computeUnits: decoderComputeUnits,
             cacheDir: cacheDir,
             offlineMode: offlineMode
         ) { p, msg in

--- a/docs/inference/qwen3-asr-inference.md
+++ b/docs/inference/qwen3-asr-inference.md
@@ -115,7 +115,7 @@ M5 Pro, 48 GB; LibriSpeech test-clean n=200; isolated per-engine. See [docs/benc
 
 Qwen3-ASR operates in batch mode only. The entire audio input is processed in a single forward pass — there is no streaming or partial transcription support. The audio encoder uses block attention over the full mel spectrogram, and the text decoder generates tokens autoregressively conditioned on the complete encoder output.
 
-For real-time transcription use cases where partial results are needed, consider chunking the audio externally and running separate inference passes on each chunk.
+For long-form audio (> 15 s) and real-time transcription use cases, use [`StreamingASR.transcribeStream(...)`](https://github.com/soniqo/speech-swift/blob/main/Sources/Qwen3ASR/StreamingASR.swift) — it VAD-segments the input at silence boundaries with a `maxSegmentDuration` force-split safety net (default 10 s), so each segment hits the greedy fast path instead of the slow-path escalation that batch `transcribe(...)` engages on inputs over `longInputThresholdSeconds` (default 15 s). Streaming also avoids the per-segment encoder peak that long batch inputs incur on memory-constrained devices.
 
 ## Language Detection
 


### PR DESCRIPTION
## Summary

Follow-up to #304 — three small fixes uncovered during a post-merge reanalysis sweep:

- **`CoreMLASRModel.fromPretrained` compute-unit override** — the wrapper took a single `computeUnits` parameter (default `.all`) and propagated it into both `CoreMLASREncoder.fromPretrained(computeUnits:)` and `CoreMLTextDecoder.fromPretrained(computeUnits:)`. The decoder's stated default is `.cpuAndNeuralEngine` (~7× faster than GPU on ANE per the rebuilt-encoder PR), but the full-pipeline path silently demoted it to `.all`. Split into `encoderComputeUnits` (default `.all`) + `decoderComputeUnits` (default `.cpuAndNeuralEngine`) so each component gets its preferred backend. All 6 in-tree callers (`EngineQwen3CoreML`, `TranscribeCommand`, 4 test sites) use defaults — non-breaking at the call site.
- **`Qwen3ASRTests` Package.swift gap** — `E2EQwen3ASRHarshAudioTests.swift` (added in #304) imports `KokoroTTS`, but the test target's dependency list doesn't declare it. The previous regression sweep on PR #304 passed only because of transitive build cache; a clean-cache rebuild surfaces the missing-module error. Added `KokoroTTS` to the target deps.
- **Long-form batch docs pointer** — `docs/inference/qwen3-asr-inference.md` now points users with >15 s inputs at `StreamingASR.transcribeStream(...)`, which VAD-segments + force-splits so each segment hits the greedy fast path. Without this, batch `transcribe(...)` engages PR #304's Bug 3a slow-path escalation (correct, but slower than necessary when silence-based segmentation is available).

## Why this matters

The override bug was a real latent defect: every full-pipeline CoreML user has been running the decoder on `.all` rather than `.cpuAndNeuralEngine` since `CoreMLASRModel` shipped, masked by an editorial-not-measured "(ANE)" label in `docs/benchmarks/asr-wer.md`. Throughput on the decoder side may be materially higher on devices where ANE wasn't the OS-resolved default under `.all`.

## Test plan

- [ ] `swift build --target Qwen3ASRTests` succeeds from a clean cache (validates the KokoroTTS dep)
- [ ] `swift test --filter E2ECoreMLASRTests` passes — the only test exercising the full-pipeline path
- [ ] Documentation render preview confirms the StreamingASR pointer is in the "Streaming / Partial Transcription" section

## Not in scope

The deeper Bug 4c reanalysis ("default CoreML encoder to `.cpuAndNeuralEngine` with Parakeet-style fallback") was held back pending a multi-Mac probe to confirm the encoder's actual current backend resolution under `.all`. The Parakeet comment at `ParakeetASR.swift:375-378` documents a Mac ANE SIGSEGV on INT8 encoders that we haven't ruled out for Qwen3-ASR's encoder.