### PR TITLE
ci(release): stop bumping soniqo/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,36 +42,3 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/speech-macos-arm64.tar.gz
-
-      # Mint a short-lived installation token for soniqo/homebrew-tap via the
-      # `soniqo-release-bot` GitHub App. The token is auto-revoked when the job
-      # ends and is scoped to Contents: write on the tap only. App credentials
-      # live as repo secrets (RELEASE_BOT_APP_ID, RELEASE_BOT_PRIVATE_KEY).
-      - name: Mint Homebrew tap token
-        id: tap-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-          owner: soniqo
-          repositories: homebrew-tap
-
-      - name: Update Homebrew tap
-        env:
-          HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}
-        run: |
-          SHA=$(shasum -a 256 dist/speech-macos-arm64.tar.gz | awk '{print $1}')
-          TAG="${GITHUB_REF_NAME}"
-          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/speech-macos-arm64.tar.gz"
-
-          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/soniqo/homebrew-tap.git" /tmp/homebrew-tap
-          cd /tmp/homebrew-tap
-
-          sed -i '' "s|url \".*\"|url \"${URL}\"|" Formula/speech.rb
-          sed -i '' "s|sha256 \".*\"|sha256 \"${SHA}\"|" Formula/speech.rb
-
-          git config user.name "soniqo-release-bot[bot]"
-          git config user.email "soniqo-release-bot[bot]@users.noreply.github.com"
-          git add Formula/speech.rb
-          git diff --cached --quiet || git commit -m "speech: update to ${TAG}"
-          git push origin main


### PR DESCRIPTION
## Summary

Drop the \`Mint Homebrew tap token\` + \`Update Homebrew tap\` steps from \`.github/workflows/release.yml\` (lines 46-77 inclusive, plus the blank separator at 45).

speech moved to Homebrew Core in #301; the tap formula at \`soniqo/homebrew-tap\` is being deprecated in [soniqo/homebrew-tap#1](https://github.com/soniqo/homebrew-tap/pull/1) (yellow \`deprecate!\` warning + a frozen formula).

The deleted steps had a long-standing bug: the inline \`sed\` rewrote the \`url\` and \`sha256\` of the tap formula on every release, but never the \`version "..."\` literal — so \`brew info soniqo/tap/speech\` reported \`v0.0.17\` while actually downloading the \`v0.0.20\` tarball. That surfaced as #298. Rather than patch the sed, dropping the tap-update steps is the cleaner end-state because the tap is now retired.

## After this lands

- The release workflow still: checks out main, builds the release binary + metallib, packages the tarball, uploads the \`speech-macos-arm64.tar.gz\` asset to the GitHub Release.
- No outbound writes to \`soniqo/homebrew-tap\` from this repo's CI.
- Repo secrets \`RELEASE_BOT_APP_ID\` and \`RELEASE_BOT_PRIVATE_KEY\` are no longer used by any workflow — safe to delete from repository settings.

## Test plan

- [ ] Workflow YAML is syntactically valid
- [ ] \`grep -rE 'RELEASE_BOT_APP_ID|RELEASE_BOT_PRIVATE_KEY|HOMEBREW_TAP_TOKEN|homebrew-tap' .github/\` returns nothing
- [ ] Next \`vX.X.X\` tag push triggers the release workflow, builds + uploads the tarball, and does NOT write to \`soniqo/homebrew-tap\`