### PR TITLE
ci(release): restore tap auto-bump with version-literal sed fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,42 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/speech-macos-arm64.tar.gz
+
+      # Mint a short-lived installation token for soniqo/homebrew-tap via the
+      # `soniqo-release-bot` GitHub App. The token is auto-revoked when the job
+      # ends and is scoped to Contents: write on the tap only. App credentials
+      # live as repo secrets (RELEASE_BOT_APP_ID, RELEASE_BOT_PRIVATE_KEY).
+      - name: Mint Homebrew tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: soniqo
+          repositories: homebrew-tap
+
+      - name: Update Homebrew tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}
+        run: |
+          SHA=$(shasum -a 256 dist/speech-macos-arm64.tar.gz | awk '{print $1}')
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/speech-macos-arm64.tar.gz"
+
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/soniqo/homebrew-tap.git" /tmp/homebrew-tap
+          cd /tmp/homebrew-tap
+
+          # All three sed rewrites must stay in sync — previously only `url`
+          # and `sha256` were rewritten while `version` drifted, producing
+          # tap formulas that downloaded the new tarball but reported the
+          # old version (see soniqo/speech-swift#298).
+          sed -i '' "s|url \".*\"|url \"${URL}\"|" Formula/speech.rb
+          sed -i '' "s|sha256 \".*\"|sha256 \"${SHA}\"|" Formula/speech.rb
+          sed -i '' "s|version \".*\"|version \"${VERSION}\"|" Formula/speech.rb
+
+          git config user.name "soniqo-release-bot[bot]"
+          git config user.email "soniqo-release-bot[bot]@users.noreply.github.com"
+          git add Formula/speech.rb
+          git diff --cached --quiet || git commit -m "speech: update to ${TAG}"
+          git push origin main


### PR DESCRIPTION
## Summary

Reverts #307 — the tap (\`soniqo/homebrew-tap\`) stays as a parallel stable channel alongside Homebrew Core. Power users / fast-track installs (\`brew install soniqo/tap/speech\`) get new versions immediately on every release without waiting for Homebrew Core review.

The corresponding revert of the tap-side deprecation is at [soniqo/homebrew-tap#2](https://github.com/soniqo/homebrew-tap/pull/2) — they should land together so users don't see the deprecation warning on a re-enabled tap.

## Why the original sed bug surfaced (#298)

The previous \`Update Homebrew tap\` step rewrote the \`url\` and \`sha256\` of the tap formula on every release but **never the \`version "..."\` literal**. Result: \`brew info soniqo/tap/speech\` reported the old version even though the tarball it downloaded was the new one. That's why @ernestyao saw \`v0.0.17\` after \`brew upgrade\`.

## What this PR does

\`\`\`diff
   SHA=\$(shasum -a 256 dist/speech-macos-arm64.tar.gz | awk '{print \$1}')
   TAG="\${GITHUB_REF_NAME}"
+  VERSION="\${TAG#v}"
   URL="https://github.com/\${{ github.repository }}/releases/download/\${TAG}/speech-macos-arm64.tar.gz"

   git clone "...soniqo/homebrew-tap.git" /tmp/homebrew-tap
   cd /tmp/homebrew-tap

+  # All three sed rewrites must stay in sync — previously only \`url\`
+  # and \`sha256\` were rewritten while \`version\` drifted, producing
+  # tap formulas that downloaded the new tarball but reported the
+  # old version (see soniqo/speech-swift#298).
   sed -i '' "s|url \\".*\\"|url \\"\${URL}\\"|" Formula/speech.rb
   sed -i '' "s|sha256 \\".*\\"|sha256 \\"\${SHA}\\"|" Formula/speech.rb
+  sed -i '' "s|version \\".*\\"|version \\"\${VERSION}\\"|" Formula/speech.rb
\`\`\`

\`\${TAG#v}\` strips the leading \`v\` so the tap formula's version literal matches Homebrew's convention (\`v0.0.20\` → \`0.0.20\`).

## Test plan

- [ ] YAML syntactically valid (verified: \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml').read())"\` returns clean)
- [ ] Next release tag (when published) bumps all three fields in lockstep on the tap formula
- [ ] \`brew info soniqo/tap/speech\` reports the new version after upgrade