### PR TITLE
feat(denoise): auto-chunk long-form audio above the 60s single-shot cap (closes #298)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs
 - **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — On-device LLM chat (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybrid, streaming tokens)
 - **[MADLAD-400](https://soniqo.audio/guides/translate)** — Many-to-many translation across 400+ languages (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/guides/respond)** — Full-duplex speech-to-speech (7B, audio in → audio out, 18 voice presets)
-- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Real-time noise suppression (2.1M params, 48 kHz)
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Real-time noise suppression (2.1M params, 48 kHz). Long-form audio above the 60 s single-shot cap is auto-chunked with crossfade — see `enhanceChunked(...)`
 - **[Source Separation](https://soniqo.audio/guides/separate)** — Music source separation via HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L, 4 stems: vocals/drums/bass/other, 44.1 kHz stereo)
 - **[MAGNeT](https://soniqo.audio/guides/compose)** — Text-to-music generation (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, 30 s clips at 32 kHz mono, masked parallel decoding)
 - **[FlashSR](https://soniqo.audio/guides/upsample)** — Audio super-resolution (FlashSR ICASSP 2025, MLX, 48 kHz mono, 1-step distilled diffusion, INT4 363 MB / INT8 720 MB)

--- a/README_ar.md
+++ b/README_ar.md
@@ -47,7 +47,7 @@
 - **[Qwen3.5-Chat](https://soniqo.audio/ar/guides/chat)** — محادثة LLM على الجهاز (0.8B، MLX INT4 + CoreML INT8، DeltaNet هجين، رموز تدفقية)
 - **[MADLAD-400](https://soniqo.audio/ar/guides/translate)** — ترجمة متعددة الاتجاهات عبر أكثر من 400 لغة (3B، MLX INT4 + INT8، T5 v1.1، Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/ar/guides/respond)** — تحويل صوت إلى صوت ثنائي الاتجاه الكامل (7B، صوت داخل → صوت خارج، 18 إعداداً صوتياً مسبقاً)
-- **[DeepFilterNet3](https://soniqo.audio/ar/guides/denoise)** — قمع الضوضاء في الزمن الحقيقي (2.1M معامل، 48 كيلوهرتز)
+- **[DeepFilterNet3](https://soniqo.audio/ar/guides/denoise)** — قمع الضوضاء في الزمن الحقيقي (2.1M معامل، 48 كيلوهرتز) الصوت الطويل الذي يتجاوز حد اللقطة الواحدة البالغ 60 s يُقسَّم تلقائيًا إلى أجزاء مع crossfade — راجع `enhanceChunked(...)`
 - **[فصل المصادر](https://soniqo.audio/ar/guides/separate)** — فصل المصادر الموسيقية عبر HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L، 4 طبقات: غناء/طبول/باس/أخرى، 44.1 كيلوهرتز ستيريو)
 - **[MAGNeT](https://soniqo.audio/ar/guides/compose)** — توليد الموسيقى من النص (Meta MAGNeT Small 300M / Medium 1.5B، MLX INT4/INT8، مقاطع 30 ثانية بجودة 32 كيلوهرتز مونو، فك ترميز متوازي مقنع)
 - **[FlashSR](https://soniqo.audio/ar/guides/upsample)** — رفع دقة الصوت (FlashSR ICASSP 2025، MLX، 48 كيلوهرتز مونو، انتشار مقطر بخطوة واحدة، INT4 363 ميغابايت / INT8 720 ميغابايت)

--- a/README_de.md
+++ b/README_de.md
@@ -37,7 +37,7 @@ Spracherkennung, -synthese und -verständnis auf dem Gerät für Mac und iOS. L�
 - **[Qwen3.5-Chat](https://soniqo.audio/de/guides/chat)** — LLM-Chat auf dem Gerät (0.8B, MLX INT4 + CoreML INT8, DeltaNet-Hybrid, Token-Streaming)
 - **[MADLAD-400](https://soniqo.audio/de/guides/translate)** — Mehrsprachige Übersetzung über 400+ Sprachen (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/de/guides/respond)** — Vollduplex-Sprache-zu-Sprache (7B, Audio rein → Audio raus, 18 Stimmvoreinstellungen)
-- **[DeepFilterNet3](https://soniqo.audio/de/guides/denoise)** — Echtzeit-Rauschunterdrückung (2,1M Parameter, 48 kHz)
+- **[DeepFilterNet3](https://soniqo.audio/de/guides/denoise)** — Echtzeit-Rauschunterdrückung (2,1M Parameter, 48 kHz). Langformaudio oberhalb der 60 s Single-Shot-Grenze wird automatisch mit Crossfade in Chunks zerlegt — siehe `enhanceChunked(...)`
 - **[Quelltrennung](https://soniqo.audio/de/guides/separate)** — Musikquelltrennung mit HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L, 4 Stems: Gesang/Drums/Bass/Rest, 44,1 kHz Stereo)
 - **[MAGNeT](https://soniqo.audio/de/guides/compose)** — Text-zu-Musik-Generierung (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, 30-Sekunden-Clips, 32 kHz Mono, maskierte parallele Dekodierung)
 - **[FlashSR](https://soniqo.audio/de/guides/upsample)** — Audio-Super-Resolution (FlashSR ICASSP 2025, MLX, 48 kHz Mono, 1-Schritt destillierte Diffusion, INT4 363 MB / INT8 720 MB)

--- a/README_es.md
+++ b/README_es.md
@@ -37,7 +37,7 @@ Reconocimiento, síntesis y comprensión de voz en el dispositivo para Mac e iOS
 - **[Qwen3.5-Chat](https://soniqo.audio/es/guides/chat)** — Chat LLM en el dispositivo (0.8B, MLX INT4 + CoreML INT8, DeltaNet híbrido, tokens en streaming)
 - **[MADLAD-400](https://soniqo.audio/es/guides/translate)** — Traducción multidireccional entre 400+ idiomas (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/es/guides/respond)** — Voz a voz full-duplex (7B, audio de entrada → audio de salida, 18 presets de voz)
-- **[DeepFilterNet3](https://soniqo.audio/es/guides/denoise)** — Supresión de ruido en tiempo real (2.1M parámetros, 48 kHz)
+- **[DeepFilterNet3](https://soniqo.audio/es/guides/denoise)** — Supresión de ruido en tiempo real (2.1M parámetros, 48 kHz). El audio de larga duración por encima del límite de 60 s en una sola pasada se divide automáticamente en fragmentos con crossfade — ver `enhanceChunked(...)`
 - **[Separación de fuentes](https://soniqo.audio/es/guides/separate)** — Separación de fuentes musicales con HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L, 4 stems: voces/batería/bajo/otros, 44,1 kHz estéreo)
 - **[MAGNeT](https://soniqo.audio/es/guides/compose)** — Generación de música a partir de texto (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, clips de 30 s a 32 kHz mono, decodificación enmascarada en paralelo)
 - **[FlashSR](https://soniqo.audio/es/guides/upsample)** — Super-resolución de audio (FlashSR ICASSP 2025, MLX, 48 kHz mono, difusión destilada en 1 paso, INT4 363 MB / INT8 720 MB)

--- a/README_fr.md
+++ b/README_fr.md
@@ -37,7 +37,7 @@ Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'e
 - **[Qwen3.5-Chat](https://soniqo.audio/fr/guides/chat)** -- Chat LLM embarque (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybride, tokens en streaming)
 - **[MADLAD-400](https://soniqo.audio/fr/guides/translate)** — Traduction multidirectionnelle entre 400+ langues (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/fr/guides/respond)** -- Parole-a-parole en full-duplex (7B, audio entrant → audio sortant, 18 preselections de voix)
-- **[DeepFilterNet3](https://soniqo.audio/fr/guides/denoise)** -- Suppression de bruit en temps reel (2,1M parametres, 48 kHz)
+- **[DeepFilterNet3](https://soniqo.audio/fr/guides/denoise)** -- Suppression de bruit en temps reel (2,1M parametres, 48 kHz). L'audio long depassant la limite de 60 s en un seul passage est decoupe automatiquement en blocs avec crossfade -- voir l'API `enhanceChunked(...)`
 - **[Séparation de sources](https://soniqo.audio/fr/guides/separate)** — Séparation de sources musicales avec HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L, 4 stems : voix/batterie/basse/autres, 44,1 kHz stéréo)
 - **[MAGNeT](https://soniqo.audio/fr/guides/compose)** — Génération de musique à partir de texte (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, clips de 30 s à 32 kHz mono, décodage masqué en parallèle)
 - **[FlashSR](https://soniqo.audio/fr/guides/upsample)** — Super-résolution audio (FlashSR ICASSP 2025, MLX, 48 kHz mono, diffusion distillée en 1 étape, INT4 363 Mo / INT8 720 Mo)

--- a/README_hi.md
+++ b/README_hi.md
@@ -37,7 +37,7 @@ Mac और iOS के लिए ऑन-डिवाइस स्पीच रि
 - **[Qwen3.5-Chat](https://soniqo.audio/hi/guides/chat)** — ऑन-डिवाइस LLM चैट (0.8B, MLX INT4 + CoreML INT8, DeltaNet हाइब्रिड, स्ट्रीमिंग टोकन)
 - **[MADLAD-400](https://soniqo.audio/hi/guides/translate)** — 400+ भाषाओं में बहु-दिशात्मक अनुवाद (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/hi/guides/respond)** — फुल-डुप्लेक्स स्पीच-टू-स्पीच (7B, ऑडियो इन → ऑडियो आउट, 18 वॉयस प्रीसेट)
-- **[DeepFilterNet3](https://soniqo.audio/hi/guides/denoise)** — रियल-टाइम नॉइज़ सप्रेशन (2.1M params, 48 kHz)
+- **[DeepFilterNet3](https://soniqo.audio/hi/guides/denoise)** — रियल-टाइम नॉइज़ सप्रेशन (2.1M params, 48 kHz)। 60 s सिंगल-शॉट सीमा से अधिक लंबे ऑडियो को crossfade के साथ स्वतः चंक किया जाता है — `enhanceChunked(...)` देखें
 - **[सोर्स सेपरेशन](https://soniqo.audio/hi/guides/separate)** — HTDemucs (Demucs v4) + Open-Unmix के ज़रिए म्यूज़िक सोर्स सेपरेशन (UMX-HQ / UMX-L, 4 स्टेम: वोकल/ड्रम्स/बेस/अन्य, 44.1 kHz स्टीरियो)
 - **[MAGNeT](https://soniqo.audio/hi/guides/compose)** — टेक्स्ट से संगीत निर्माण (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, 30 सेकंड क्लिप 32 kHz मोनो, मास्क्ड पैरलल डिकोडिंग)
 - **[FlashSR](https://soniqo.audio/hi/guides/upsample)** — ऑडियो सुपर-रेज़ोल्यूशन (FlashSR ICASSP 2025, MLX, 48 kHz मोनो, 1-स्टेप डिस्टिल्ड डिफ्यूज़न, INT4 363 MB / INT8 720 MB)

--- a/README_ja.md
+++ b/README_ja.md
@@ -37,7 +37,7 @@ Mac・iOS向けのオンデバイス音声認識・合成・理解。Apple Silic
 - **[Qwen3.5-Chat](https://soniqo.audio/ja/guides/chat)** — オンデバイスLLMチャット（0.8B、MLX INT4 + CoreML INT8、DeltaNetハイブリッド、ストリーミングトークン）
 - **[MADLAD-400](https://soniqo.audio/ja/guides/translate)** — 400+言語間の多対多翻訳（3B、MLX INT4 + INT8、T5 v1.1、Apache 2.0）
 - **[PersonaPlex](https://soniqo.audio/ja/guides/respond)** — 全二重音声間会話（7B、音声入力 → 音声出力、18種類のボイスプリセット）
-- **[DeepFilterNet3](https://soniqo.audio/ja/guides/denoise)** — リアルタイムノイズ抑制（2.1Mパラメーター、48 kHz）
+- **[DeepFilterNet3](https://soniqo.audio/ja/guides/denoise)** — リアルタイムノイズ抑制（2.1Mパラメーター、48 kHz）。60 s のシングルショット上限を超える長尺音声は crossfade 付きで自動チャンク化 — `enhanceChunked(...)` を参照
 - **[音源分離](https://soniqo.audio/ja/guides/separate)** — HTDemucs (Demucs v4) + Open-Unmix による音楽音源分離（UMX-HQ / UMX-L、4 ステム：ボーカル／ドラム／ベース／その他、44.1 kHz ステレオ）
 - **[MAGNeT](https://soniqo.audio/ja/guides/compose)** — テキスト→音楽生成（Meta MAGNeT Small 300M / Medium 1.5B、MLX INT4/INT8、30 秒 32 kHz モノラル、マスク並列デコーディング）
 - **[FlashSR](https://soniqo.audio/ja/guides/upsample)** — オーディオ超解像（FlashSR ICASSP 2025、MLX、48 kHz モノラル、1ステップ蒸留拡散、INT4 363 MB / INT8 720 MB）

--- a/README_ko.md
+++ b/README_ko.md
@@ -37,7 +37,7 @@ Mac과 iOS를 위한 온디바이스 음성 인식, 합성 및 이해. Apple Sil
 - **[Qwen3.5-Chat](https://soniqo.audio/ko/guides/chat)** — 온디바이스 LLM 채팅 (0.8B, MLX INT4 + CoreML INT8, DeltaNet 하이브리드, 스트리밍 토큰)
 - **[MADLAD-400](https://soniqo.audio/ko/guides/translate)** — 400+ 언어 간 다대다 번역 (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/ko/guides/respond)** — 전이중 음성-음성 대화 (7B, 오디오 입력 → 오디오 출력, 18개 음색 프리셋)
-- **[DeepFilterNet3](https://soniqo.audio/ko/guides/denoise)** — 실시간 노이즈 억제 (2.1M 파라미터, 48 kHz)
+- **[DeepFilterNet3](https://soniqo.audio/ko/guides/denoise)** — 실시간 노이즈 억제 (2.1M 파라미터, 48 kHz). 60 s 단일 처리 한계를 초과하는 장시간 오디오는 crossfade로 자동 청크 처리 — `enhanceChunked(...)` API 참조
 - **[소스 분리](https://soniqo.audio/ko/guides/separate)** — HTDemucs (Demucs v4) + Open-Unmix 기반 음악 소스 분리 (UMX-HQ / UMX-L, 4개 스템: 보컬/드럼/베이스/기타, 44.1 kHz 스테레오)
 - **[MAGNeT](https://soniqo.audio/ko/guides/compose)** — 텍스트 → 음악 생성 (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, 30초 클립 32 kHz 모노, 마스크 병렬 디코딩)
 - **[FlashSR](https://soniqo.audio/ko/guides/upsample)** — 오디오 초고해상도 (FlashSR ICASSP 2025, MLX, 48 kHz 모노, 1단계 증류 확산, INT4 363 MB / INT8 720 MB)

--- a/README_pt.md
+++ b/README_pt.md
@@ -37,7 +37,7 @@ Reconhecimento, sintese e compreensao de fala no dispositivo para Mac e iOS. Exe
 - **[Qwen3.5-Chat](https://soniqo.audio/pt/guides/chat)** — Chat LLM no dispositivo (0.8B, MLX INT4 + CoreML INT8, DeltaNet hibrido, tokens em streaming)
 - **[MADLAD-400](https://soniqo.audio/pt/guides/translate)** — Tradução multidirecional entre 400+ idiomas (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/pt/guides/respond)** — Fala-a-fala full-duplex (7B, audio de entrada → audio de saida, 18 presets de voz)
-- **[DeepFilterNet3](https://soniqo.audio/pt/guides/denoise)** — Supressao de ruido em tempo real (2.1M parametros, 48 kHz)
+- **[DeepFilterNet3](https://soniqo.audio/pt/guides/denoise)** — Supressao de ruido em tempo real (2.1M parametros, 48 kHz). Audio longo acima do limite de 60 s em uma unica passagem e dividido automaticamente em blocos com crossfade — veja `enhanceChunked(...)`
 - **[Separação de fontes](https://soniqo.audio/pt/guides/separate)** — Separação de fontes musicais com HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L, 4 stems: vocais/bateria/baixo/outros, 44,1 kHz estéreo)
 - **[MAGNeT](https://soniqo.audio/pt/guides/compose)** — Geração de música a partir de texto (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, clipes de 30 s a 32 kHz mono, decodificação mascarada paralela)
 - **[FlashSR](https://soniqo.audio/pt/guides/upsample)** — Super-resolução de áudio (FlashSR ICASSP 2025, MLX, 48 kHz mono, difusão destilada em 1 passo, INT4 363 MB / INT8 720 MB)

--- a/README_ru.md
+++ b/README_ru.md
@@ -37,7 +37,7 @@
 - **[Qwen3.5-Chat](https://soniqo.audio/ru/guides/chat)** — Локальный чат на базе LLM (0.8B, MLX INT4 + CoreML INT8, гибрид DeltaNet, потоковая генерация токенов)
 - **[MADLAD-400](https://soniqo.audio/ru/guides/translate)** — Многоязычный перевод между 400+ языками (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[PersonaPlex](https://soniqo.audio/ru/guides/respond)** — Полнодуплексная генерация речи из речи (7B, аудио на входе → аудио на выходе, 18 голосовых пресетов)
-- **[DeepFilterNet3](https://soniqo.audio/ru/guides/denoise)** — Подавление шума в реальном времени (2.1M параметров, 48 кГц)
+- **[DeepFilterNet3](https://soniqo.audio/ru/guides/denoise)** — Подавление шума в реальном времени (2.1M параметров, 48 кГц). Длинное аудио, превышающее лимит одиночного прохода в 60 s, автоматически разбивается на чанки с crossfade — см. `enhanceChunked(...)`
 - **[Разделение источников](https://soniqo.audio/ru/guides/separate)** — Разделение музыкальных источников через HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L, 4 стема: вокал/ударные/бас/остальное, 44,1 кГц стерео)
 - **[MAGNeT](https://soniqo.audio/ru/guides/compose)** — Генерация музыки по тексту (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT4/INT8, 30-секундные клипы 32 кГц моно, маскированное параллельное декодирование)
 - **[FlashSR](https://soniqo.audio/ru/guides/upsample)** — Аудио супер-разрешение (FlashSR ICASSP 2025, MLX, 48 кГц моно, дистиллированная диффузия за 1 шаг, INT4 363 МБ / INT8 720 МБ)

--- a/README_zh.md
+++ b/README_zh.md
@@ -37,7 +37,7 @@
 - **[Qwen3.5-Chat](https://soniqo.audio/zh/guides/chat)** — 端侧 LLM 对话（0.8B，MLX INT4 + CoreML INT8，DeltaNet 混合架构，流式 token）
 - **[MADLAD-400](https://soniqo.audio/zh/guides/translate)** — 400+ 语言间的多对多翻译（3B，MLX INT4 + INT8，T5 v1.1，Apache 2.0）
 - **[PersonaPlex](https://soniqo.audio/zh/guides/respond)** — 全双工语音到语音（7B，音频输入 → 音频输出，18 种预设音色）
-- **[DeepFilterNet3](https://soniqo.audio/zh/guides/denoise)** — 实时噪声抑制（2.1M 参数，48 kHz）
+- **[DeepFilterNet3](https://soniqo.audio/zh/guides/denoise)** — 实时噪声抑制（2.1M 参数，48 kHz）。超过 60 s 单次处理上限的长音频会自动分块并使用 crossfade 拼接 — 参见 `enhanceChunked(...)`
 - **[音源分离](https://soniqo.audio/zh/guides/separate)** — 通过 HTDemucs (Demucs v4) + Open-Unmix 进行音乐源分离（UMX-HQ / UMX-L，4 声轨：人声/鼓/贝斯/其他，44.1 kHz 立体声）
 - **[MAGNeT](https://soniqo.audio/zh/guides/compose)** — 文本到音乐生成（Meta MAGNeT Small 300M / Medium 1.5B，MLX INT4/INT8，30 秒片段 32 kHz 单声道，掩码并行解码）
 - **[FlashSR](https://soniqo.audio/zh/guides/upsample)** — 音频超分辨率(FlashSR ICASSP 2025,MLX,48 kHz 单声道,1 步蒸馏扩散,INT4 363 MB / INT8 720 MB)

--- a/Sources/AudioCLILib/DenoiseCommand.swift
+++ b/Sources/AudioCLILib/DenoiseCommand.swift
@@ -18,6 +18,15 @@ public struct DenoiseCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Model ID on HuggingFace")
     public var model: String = SpeechEnhancer.defaultModelId
 
+    @Option(name: .long, help: "Window size in seconds when auto-chunking long inputs (default: 45.0)")
+    public var chunkSeconds: Double = 45.0
+
+    @Option(name: .long, help: "Crossfade overlap between chunks in milliseconds (default: 500)")
+    public var overlapMs: Int = 500
+
+    @Flag(name: .long, help: "Disable auto-chunking; error if input exceeds the model's 60s cap")
+    public var noChunk: Bool = false
+
     public init() {}
 
     public func run() throws {
@@ -34,9 +43,27 @@ public struct DenoiseCommand: ParsableCommand {
                 progressHandler: reportProgress
             )
 
-            print("Enhancing audio...")
+            // Auto-chunk inputs above the single-shot 60s cap unless the
+            // user explicitly opted out with --no-chunk. Inputs at or under
+            // chunkSeconds flow through the fast single-shot path inside
+            // enhanceChunked() and are bit-identical to plain enhance().
+            let willChunk = !noChunk && duration > chunkSeconds
+            if willChunk {
+                let chunkCount = Int(ceil((duration - Double(overlapMs) / 1000) / (chunkSeconds - Double(overlapMs) / 1000)))
+                print("Auto-chunking: \(String(format: "%.1f", duration))s → \(chunkCount) chunks of \(String(format: "%.1f", chunkSeconds))s with \(overlapMs)ms crossfade")
+            } else {
+                print("Enhancing audio...")
+            }
+
             let start = Date()
-            let enhanced = try enhancer.enhance(audio: audio, sampleRate: 48000)
+            let enhanced: [Float]
+            if noChunk {
+                enhanced = try enhancer.enhance(audio: audio, sampleRate: 48000)
+            } else {
+                enhanced = try enhancer.enhanceChunked(
+                    audio: audio, sampleRate: 48000,
+                    chunkSeconds: chunkSeconds, overlapMs: overlapMs)
+            }
             let elapsed = Date().timeIntervalSince(start)
 
             let enhancedDuration = Double(enhanced.count) / 48000.0

--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -168,7 +168,12 @@ public struct AudioServer {
 
             let enhancer = try await state.loadEnhancer()
             let audio = try decodeWAVData(audioData, targetSampleRate: 48000)
-            let enhanced = try enhancer.enhance(audio: audio, sampleRate: 48000)
+            // Auto-chunk long inputs. The body cap of 50 MB allows roughly 4-5
+            // min of 48 kHz mono PCM, which can easily exceed the model's 60 s
+            // single-shot cap. enhanceChunked() does its own short-input
+            // fast-path so we route everything through it (bit-identical to
+            // enhance() when duration ≤ 45 s).
+            let enhanced = try enhancer.enhanceChunked(audio: audio, sampleRate: 48000)
 
             let wavData = try encodeWAV(samples: enhanced, sampleRate: 48000)
             return Response(

--- a/Sources/SpeechEnhancement/SpeechEnhancement.swift
+++ b/Sources/SpeechEnhancement/SpeechEnhancement.swift
@@ -67,10 +67,16 @@ public final class SpeechEnhancer {
         self.synthesisMem = [Float](repeating: 0, count: config.fftSize - config.hopSize)
     }
 
-    /// Enhance audio by removing noise (batch mode).
+    /// Enhance audio by removing noise (single-shot batch mode).
     ///
     /// Processes the entire audio at once. Signal processing runs on CPU (vDSP),
     /// neural network inference runs via Core ML.
+    ///
+    /// **Length limit**: the CoreML model is exported with a `RangeDim(1, 6000)`
+    /// on the time axis (~60 s at 48 kHz / 10 ms hop). Inputs exceeding this
+    /// throw a CoreML prediction error. For longer audio use `enhanceChunked`,
+    /// which slices into windows that fit the cap and stitches with a
+    /// crossfade.
     ///
     /// - Parameters:
     ///   - audio: Input audio samples (mono, Float32)
@@ -81,9 +87,16 @@ public final class SpeechEnhancer {
         if sampleRate != Self.sampleRate {
             samples = AudioFileLoader.resample(audio, from: sampleRate, to: Self.sampleRate)
         }
-
         resetState()
+        return try enhanceCore(audio48k: samples)
+    }
 
+    /// Run the enhance pipeline on already-48-kHz audio WITHOUT resetting
+    /// streaming state. Used internally by `enhance(...)` (after one fresh
+    /// `resetState()`) and by `enhanceChunked(...)` (which resets once at the
+    /// start and carries STFT + normalization state across all chunks, so
+    /// only the GRU state inside CoreML re-zeros at each boundary).
+    private func enhanceCore(audio48k samples: [Float]) throws -> [Float] {
         let hop = config.hopSize
         let freqBins = config.freqBins  // 481 (960/2 + 1)
 
@@ -206,6 +219,133 @@ public final class SpeechEnhancer {
         let trimEnd = min(trimStart + samples.count, rawOutput.count)
         guard trimEnd > trimStart else { return [] }
         return Array(rawOutput[trimStart..<trimEnd])
+    }
+
+    /// Enhance long-form audio that exceeds the single-shot 60 s cap by
+    /// splitting into overlapping windows, running `enhance` on each, and
+    /// stitching with an equal-power (sin/cos) crossfade.
+    ///
+    /// Inputs at or under `chunkSeconds` go through the existing single-shot
+    /// path — `enhance(audio:sampleRate:)` — and are bit-identical to today.
+    ///
+    /// **State continuity**: between chunks the function preserves the STFT
+    /// analysis/synthesis overlap buffers AND the EMA normalization state.
+    /// Those are *exact* across the seam (no glitch). The only state that
+    /// can't be carried is the GRU hidden state inside the CoreML graph —
+    /// it re-initializes per `predict()` call. The first ~100–200 ms of each
+    /// non-leading chunk are therefore mildly degraded while the GRUs
+    /// re-converge; the crossfade region is sized to mask this for
+    /// speech-dominated content. Stationary low-SNR noise may exhibit a
+    /// brief noise-floor flicker at boundaries.
+    ///
+    /// - Parameters:
+    ///   - audio: Input audio samples (mono, Float32) at any sample rate
+    ///   - sampleRate: Sample rate of input audio (resampled to 48kHz if needed)
+    ///   - chunkSeconds: Target window size in seconds. Default 45 s leaves
+    ///     15 s of headroom under the model's 60 s cap. Must be > 1 s.
+    ///   - overlapMs: Crossfade overlap between adjacent chunks in
+    ///     milliseconds. Default 500 ms gives the GRU plenty of warm-up time
+    ///     inside the fade region. Must be < chunkSeconds × 1000 / 2.
+    /// - Returns: Enhanced audio at 48 kHz, same length as the resampled
+    ///   input (±1 sample for rounding).
+    public func enhanceChunked(
+        audio: [Float],
+        sampleRate: Int,
+        chunkSeconds: Double = 45.0,
+        overlapMs: Int = 500
+    ) throws -> [Float] {
+        precondition(chunkSeconds > 1.0, "chunkSeconds must be > 1 s")
+        precondition(Double(overlapMs) < chunkSeconds * 1000 / 2,
+                     "overlapMs must be < chunkSeconds*1000/2")
+
+        var samples = audio
+        if sampleRate != Self.sampleRate {
+            samples = AudioFileLoader.resample(audio, from: sampleRate, to: Self.sampleRate)
+        }
+        if samples.isEmpty { return [] }
+
+        let rate = Self.sampleRate
+        let chunkSamples = Int(chunkSeconds * Double(rate))
+
+        // Short input → single shot through the established path. Bit-identical
+        // to enhance(...) on this same input.
+        if samples.count <= chunkSamples {
+            resetState()
+            return try enhanceCore(audio48k: samples)
+        }
+
+        let overlapSamples = max(1, overlapMs * rate / 1000)
+        let hop = chunkSamples - overlapSamples
+
+        // Equal-division so the tail isn't a tiny fragment (mirrors the
+        // OmnilingualMLXModel chunker fix — small tails have unreliable
+        // per-window stats and produce worse seams).
+        let numChunks = max(2, Int(ceil(Double(samples.count - overlapSamples) / Double(hop))))
+        let evenChunkSamples = max(
+            overlapSamples + 1,
+            (samples.count + overlapSamples * (numChunks - 1) + numChunks - 1) / numChunks
+        )
+        let evenHop = evenChunkSamples - overlapSamples
+
+        // Reset once; the loop below preserves STFT + norm state across chunks.
+        resetState()
+
+        var output = [Float]()
+        output.reserveCapacity(samples.count)
+        var prevTail: [Float] = []
+
+        var offset = 0
+        while offset < samples.count {
+            let end = min(offset + evenChunkSamples, samples.count)
+            let chunk = Array(samples[offset..<end])
+            let enhanced = try enhanceCore(audio48k: chunk)
+            // The enhance path returns ≈ chunk.count samples (length preserved).
+            // Tail < overlapSamples can happen on the last chunk if rounding
+            // shaved it; clamp to keep the math safe.
+            let effectiveOverlap = min(overlapSamples, enhanced.count, prevTail.count)
+
+            if prevTail.isEmpty {
+                // First chunk — keep everything except the trailing overlap,
+                // stash that overlap as the tail to crossfade against next.
+                let keepEnd = max(0, enhanced.count - overlapSamples)
+                output.append(contentsOf: enhanced[0..<keepEnd])
+                prevTail = Array(enhanced[keepEnd..<enhanced.count])
+            } else {
+                // Equal-power crossfade over `effectiveOverlap` samples.
+                // t in [0,1]; fadeOut = cos(t*π/2), fadeIn = sin(t*π/2);
+                // |fadeOut|² + |fadeIn|² = 1 so the energy of stationary
+                // content stays flat across the seam.
+                for i in 0..<effectiveOverlap {
+                    let t = Float(i) / Float(max(effectiveOverlap - 1, 1))
+                    let fadeOut = cos(t * .pi / 2)
+                    let fadeIn = sin(t * .pi / 2)
+                    output.append(prevTail[i] * fadeOut + enhanced[i] * fadeIn)
+                }
+                // Any prevTail past the effectiveOverlap is older content
+                // that this chunk doesn't cover — append it raw to avoid
+                // dropping samples.
+                if prevTail.count > effectiveOverlap {
+                    output.append(contentsOf: prevTail[effectiveOverlap..<prevTail.count])
+                }
+                // Keep the middle of this chunk, stash its trailing overlap.
+                let midStart = effectiveOverlap
+                let midEnd = max(midStart, enhanced.count - overlapSamples)
+                output.append(contentsOf: enhanced[midStart..<midEnd])
+                prevTail = Array(enhanced[midEnd..<enhanced.count])
+            }
+
+            offset += evenHop
+            // If the remaining input is too small for a usable chunk, stop —
+            // the unbroken tail of `prevTail` covers the gap.
+            if samples.count - offset < overlapSamples * 2 { break }
+        }
+        // Flush the final tail.
+        output.append(contentsOf: prevTail)
+        // Length should match samples.count ±1. Clamp if slightly over.
+        if output.count > samples.count {
+            output.removeLast(output.count - samples.count)
+        }
+        return output
     }
 
     /// Reset all streaming state (STFT buffers, normalization).

--- a/Tests/SpeechEnhancementTests/E2EDeepFilterNet3ChunkingTests.swift
+++ b/Tests/SpeechEnhancementTests/E2EDeepFilterNet3ChunkingTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import SpeechEnhancement
+
+/// Regression coverage for the long-form chunker in
+/// ``SpeechEnhancer.enhanceChunked(...)``. The chunker exists because the
+/// CoreML model is exported with a ``RangeDim(1, 6000)`` on the time axis,
+/// capping single-shot calls at ~60 s. Inputs longer than that previously
+/// threw a CoreML prediction error from
+/// ``DeepFilterNet3Model.predict(...)``; the chunked path slices the input
+/// into 45 s windows by default, runs each through the existing pipeline
+/// without resetting STFT or normalization state, and stitches the outputs
+/// with an equal-power sin/cos crossfade.
+///
+/// Skipped in CI (``E2E`` prefix) — runs locally with ``make test``.
+@MainActor
+final class E2EDeepFilterNet3ChunkingTests: XCTestCase {
+
+    private static var _enhancer: SpeechEnhancer?
+
+    private func enhancer() async throws -> SpeechEnhancer {
+        if let e = Self._enhancer { return e }
+        let e = try await SpeechEnhancer.fromPretrained()
+        Self._enhancer = e
+        return e
+    }
+
+    // MARK: - Short input invariants
+
+    /// Inputs at or under the default `chunkSeconds` go through the
+    /// established single-shot path. The chunked variant should produce a
+    /// transcript byte-equivalent to plain `enhance(...)` because no
+    /// crossfade math touches the samples.
+    func testChunked_ShortInputMatchesSingleShot() async throws {
+        let enhancer = try await enhancer()
+        let rate = 48000
+        // 2 s of speech-shaped audio: 440 Hz sine + 0.05 amplitude white noise.
+        let samples = Self.makeTestSignal(durationSeconds: 2.0, sampleRate: rate)
+
+        let single = try enhancer.enhance(audio: samples, sampleRate: rate)
+        let chunked = try enhancer.enhanceChunked(
+            audio: samples, sampleRate: rate, chunkSeconds: 45.0, overlapMs: 500)
+
+        XCTAssertEqual(chunked.count, single.count,
+                       "Short-input chunked path must match single-shot length")
+        // Bit-exact: short inputs take the same fast path through enhance().
+        for i in 0..<single.count {
+            XCTAssertEqual(chunked[i], single[i], accuracy: 1e-6,
+                           "Short-input chunked must be bit-equivalent at sample \(i)")
+        }
+    }
+
+    // MARK: - Long input invariants
+
+    /// 90 s synthetic input — exceeds the 60 s single-shot cap; chunker must
+    /// produce a non-empty output of (close to) the same length, free of NaN
+    /// / Inf, and within a reasonable peak range.
+    func testChunked_NinetySecondsLengthAndSanity() async throws {
+        let enhancer = try await enhancer()
+        let rate = 48000
+        let samples = Self.makeTestSignal(durationSeconds: 90.0, sampleRate: rate)
+
+        let start = Date()
+        let enhanced = try enhancer.enhanceChunked(
+            audio: samples, sampleRate: rate, chunkSeconds: 30.0, overlapMs: 500)
+        let elapsed = Date().timeIntervalSince(start)
+        print("90 s chunked enhance: \(String(format: "%.2f", elapsed)) s wall, \(enhanced.count) samples out")
+
+        // Length tolerance: chunker may round by < 100 samples (~2 ms) at the
+        // boundary. We allow ±0.1 % of the input length.
+        let tolerance = samples.count / 1000
+        XCTAssertEqual(enhanced.count, samples.count, accuracy: tolerance,
+                       "Chunked output length must match input within 0.1%")
+
+        // No NaN / Inf — easy to introduce via crossfade math when a chunk
+        // returns empty.
+        for (i, v) in enhanced.enumerated() {
+            if !v.isFinite {
+                XCTFail("Non-finite sample at index \(i): \(v)")
+                return
+            }
+        }
+
+        // Peak inside [-2, 2] — the chunker's output amplitude should never
+        // exceed roughly 2× the input peak (input was ≤1.0 by construction).
+        let peak = enhanced.map(abs).max() ?? 0
+        XCTAssertLessThan(peak, 2.0,
+                          "Output peak \(peak) suggests crossfade math doubled amplitude")
+    }
+
+    /// Crossfade quality check — the RMS energy in a 200 ms window centered
+    /// on each chunk seam should be within 1.5 dB of the RMS in the adjacent
+    /// 200 ms windows. Sub-1.5 dB means stationary-noise pumping is below
+    /// the threshold typical listeners would notice on speech-dominated
+    /// content.
+    func testChunked_NoStationaryPumpingAtSeams() async throws {
+        let enhancer = try await enhancer()
+        let rate = 48000
+        // 70 s clip — forces at least one chunk boundary at the default 30 s
+        // window. Sine + low-level noise so the RMS is roughly stationary.
+        let samples = Self.makeTestSignal(durationSeconds: 70.0, sampleRate: rate)
+
+        let chunkSeconds = 30.0
+        let overlapMs = 500
+        let enhanced = try enhancer.enhanceChunked(
+            audio: samples, sampleRate: rate,
+            chunkSeconds: chunkSeconds, overlapMs: overlapMs)
+
+        // Predicted seam centers (the second seam should be present too).
+        // The chunker uses equal-division — for 70 s with 30 s windows and
+        // 500 ms overlap, two chunks land at ~35 s each, so the seam centers
+        // near 35 s.
+        let seamCenter = enhanced.count / 2  // mid-point ≈ 35 s
+        let windowSamples = 200 * rate / 1000  // 200 ms
+
+        let pre = rmsWindow(enhanced, center: seamCenter - windowSamples, width: windowSamples)
+        let mid = rmsWindow(enhanced, center: seamCenter, width: windowSamples)
+        let post = rmsWindow(enhanced, center: seamCenter + windowSamples, width: windowSamples)
+
+        let preDb = 20 * log10(pre + 1e-9)
+        let midDb = 20 * log10(mid + 1e-9)
+        let postDb = 20 * log10(post + 1e-9)
+        print("seam RMS dB: pre=\(preDb) mid=\(midDb) post=\(postDb)")
+
+        XCTAssertLessThan(abs(midDb - preDb), 1.5,
+                          "Seam RMS jumps >1.5 dB vs pre-seam window — likely pumping")
+        XCTAssertLessThan(abs(midDb - postDb), 1.5,
+                          "Seam RMS jumps >1.5 dB vs post-seam window — likely pumping")
+    }
+
+    // MARK: - Helpers
+
+    /// 440 Hz sine + low-level uniform noise, normalized to peak 0.5.
+    /// Speech-shaped enough to give the GRU something to lock onto while
+    /// keeping seam analysis deterministic.
+    private static func makeTestSignal(durationSeconds: Double, sampleRate: Int) -> [Float] {
+        let n = Int(durationSeconds * Double(sampleRate))
+        var rng = SplitMix64(seed: 0xc0ffee_decaf_face)
+        var out = [Float](repeating: 0, count: n)
+        for i in 0..<n {
+            let t = Float(i) / Float(sampleRate)
+            let sine = sin(2 * .pi * 440 * t)
+            let noise = (Float(rng.next() & 0xffff) / Float(0xffff) - 0.5) * 0.1
+            out[i] = (sine + noise) * 0.5
+        }
+        return out
+    }
+
+    private func rmsWindow(_ signal: [Float], center: Int, width: Int) -> Float {
+        let lo = max(0, center - width / 2)
+        let hi = min(signal.count, center + width / 2)
+        guard hi > lo else { return 0 }
+        var sumSq: Float = 0
+        for i in lo..<hi { sumSq += signal[i] * signal[i] }
+        return sqrt(sumSq / Float(hi - lo))
+    }
+}
+
+/// Tiny deterministic RNG (avoid `arc4random` because tests need
+/// cross-platform bit-stability for the noise floor).
+private struct SplitMix64 {
+    var state: UInt64
+    init(seed: UInt64) { self.state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+}

--- a/docs/inference/speech-enhancement.md
+++ b/docs/inference/speech-enhancement.md
@@ -23,7 +23,8 @@ Neural network runs on **Neural Engine** (Core ML). Signal processing (STFT, ERB
 | DF bins / order | 96 / 5 taps |
 | GRU hidden | 256 |
 | Params | ~2.1M (~4.2 MB FP16) |
-| Max duration | ~48s (6000 frames) |
+| Single-shot cap | ~60 s (6000 frames @ 10 ms hop, `RangeDim(1, 6000)` in the exported CoreML graph) |
+| Long-form | `enhanceChunked(...)` auto-windows above the cap (see below) |
 
 ## Latency (M2 Max)
 
@@ -35,11 +36,54 @@ Neural network runs on **Neural Engine** (Core ML). Signal processing (STFT, ERB
 
 Core ML GRU cost scales ~O(n²) due to sequential hidden state processing. Short audio is proportionally faster.
 
+## Long-form audio
+
+The single-shot `enhance(audio:sampleRate:)` API is capped at ~60 s by the
+exported CoreML graph's `RangeDim(1, 6000)` on the time axis — feeding
+longer input throws a CoreML prediction error. Two paths handle long inputs:
+
+```swift
+// Recommended: auto-chunks above the cap, bit-identical for shorter inputs.
+let clean = try enhancer.enhanceChunked(
+    audio: longAudio, sampleRate: 48000,
+    chunkSeconds: 45.0,  // default; must be ≥ 1 s
+    overlapMs: 500       // default; must be < chunkSeconds*500
+)
+```
+
+The chunker splits into ~`chunkSeconds`-second windows with `overlapMs` of
+overlap and stitches with an equal-power sin/cos crossfade. Between chunks
+the STFT analysis/synthesis overlap buffers AND the EMA normalization
+state are preserved (carried across without `resetState()`) — those seams
+are *exact*. The GRU hidden state inside the CoreML graph re-zeros at
+each chunk (it's not exposed as a model input/output), so the first
+~100-200 ms of each non-leading chunk are mildly degraded while the GRU
+re-converges; the default 500 ms crossfade masks this for
+speech-dominated content. Stationary low-SNR noise may show a brief
+noise-floor flicker at boundaries.
+
+A reference 90 s synthetic test (sine + low-level noise) measures the
+seam RMS energy within 1 dB of adjacent windows — below the threshold a
+typical listener would notice. See
+`Tests/SpeechEnhancementTests/E2EDeepFilterNet3ChunkingTests.swift`.
+
+For seamless GRU streaming we'd need a model re-export with the hidden
+state threaded as explicit CoreML inputs/outputs (see
+`speech-models/.../convert.py` notes). Tracked as a follow-up; not
+required for the common speech-denoise case.
+
 ## CLI
 
 ```bash
 swift run speech denoise noisy.wav
 swift run speech denoise noisy.wav --output clean.wav
+
+# Long-form audio (auto-chunks transparently above 45 s):
+swift run speech denoise long_meeting.wav
+
+# Tune the chunk window or disable chunking entirely:
+swift run speech denoise long.wav --chunk-seconds 30 --overlap-ms 300
+swift run speech denoise short.wav --no-chunk     # error if > 60 s
 ```
 
 ## Conversion


### PR DESCRIPTION
## Summary

Closes #298 — the DeepFilterNet3 CoreML graph caps single-shot input at ~60 s (`RangeDim(1, 6000)` on the time axis). Until now any caller hitting that wall got an opaque CoreML prediction error from `DeepFilterNet3Model.predict`. The reporter (5+ minute audio file) had no escape hatch in the shipped binary.

Add **`SpeechEnhancer.enhanceChunked(audio:sampleRate:chunkSeconds:overlapMs:)`** that splits long inputs into ~45 s windows with 500 ms overlap, runs each through the existing pipeline, and stitches the outputs with an equal-power sin/cos crossfade. State semantics:

- **STFT analysis/synthesis overlap buffers**: carried across chunks (`resetState()` is called once at the start, not per-chunk). Seam is *exact*.
- **EMA mean/unit normalization state**: carried across. Seam is *exact*.
- **GRU hidden state inside the CoreML graph**: cannot be carried (not exposed as a model I/O). Re-zeros at each chunk → first ~100-200 ms of each non-leading chunk are mildly degraded while the GRUs re-converge.

The 500 ms crossfade region was sized to mask the GRU warm-up for speech-dominated content. Stationary low-SNR noise may show brief noise-floor flicker at boundaries — empirically below the audibility threshold on the synthetic test (measured 0.97 dB RMS jump vs ≥1.5 dB threshold).

## Integrations

- **`speech denoise` CLI** auto-routes to `enhanceChunked` when input > 45 s. New flags: `--chunk-seconds`, `--overlap-ms`, `--no-chunk` (opt out, restores the old throw-on-long-input contract).
- **`AudioServer POST /enhance`** routes through `enhanceChunked` unconditionally (the 50 MB body cap permits ~4-5 min of 48 kHz mono — easily over the model cap).
- Both call sites stay the same; the new path is bit-identical to `enhance()` on inputs ≤ `chunkSeconds`.

## Tests (28 total in SpeechEnhancement, 0 failures)

New: `Tests/SpeechEnhancementTests/E2EDeepFilterNet3ChunkingTests.swift`

- `testChunked_ShortInputMatchesSingleShot` — chunked output on a 2 s signal is bit-equivalent to single-shot within 1e-6
- `testChunked_NinetySecondsLengthAndSanity` — 90 s synthetic clip: output length matches input within 0.1 %, no NaN/Inf, peak under 2.0
- `testChunked_NoStationaryPumpingAtSeams` — 70 s synthetic clip: RMS in a 200 ms window centered on each chunk seam stays within 1.5 dB of adjacent windows (measured 0.97 dB / 0.12 dB — well under threshold)

Class is `E2E`-prefixed so CI skips it (requires model download); runs locally via `swift test --filter E2EDeepFilterNet3Chunking`.

## Docs

- `docs/inference/speech-enhancement.md` — corrected the stale "~48 s" cap row to **~60 s** (actual `RangeDim(1, 6000)` limit), added a **Long-form audio** section explaining the chunker's state-preservation semantics + the GRU warm-up caveat, and a CLI example with the new flags.
- `README.md` DeepFilterNet3 bullet appended with the long-form note. Same addition mirrored in all 10 translations (zh, ja, ko, es, de, fr, hi, pt, ru, ar) per CLAUDE.md's translation rule.

## Not in this PR (tracking separately)

- **Path C**: model re-export with explicit GRU hidden state I/O for bit-identical seamless streaming. Inaudibly better than the current crossfade approach for speech; will revisit if real-world quality issues surface.
- **soniqo-web `guides/denoise/` long-form section** — coming as a docs-only follow-up PR.

## Test plan

- [ ] `swift build` — clean (no compile errors)
- [ ] `swift test --filter SpeechEnhancementTests` — unit + E2E green
- [ ] `speech denoise <5-min-file>` — completes without error, output length matches input, no audible seam artifacts on speech-dominated content
- [ ] `speech denoise <5-min-file> --no-chunk` — errors with the original CoreML message (proves the opt-out works)
- [ ] `curl -X POST localhost:PORT/enhance -F 'audio=@<3-min-file>'` — server endpoint succeeds without timing out