### PR TITLE
fix(parakeet): M5 ANE compatibility — multi-encoder repo + macOS ANE-first

### DIFF
--- a/Sources/ParakeetASR/ParakeetASR.swift
+++ b/Sources/ParakeetASR/ParakeetASR.swift
@@ -283,12 +283,19 @@ public class ParakeetASRModel {
     ///
     /// - Parameters:
     ///   - modelId: HuggingFace model identifier
+    ///   - encoderVariant: For multi-encoder repos (e.g.
+    ///     `aufklarer/Parakeet-TDT-v3-CoreML-INT8` after the M5 fix), the
+    ///     shape suffix to pick: `"5s"`, `"15s"`, etc. Selects
+    ///     `encoder_{variant}.mlmodelc`. `nil` (default) picks the repo's
+    ///     `encoder.mlmodelc`, which is what single-shape repos
+    ///     (`-30s`, `-iOS-5s`) ship.
     ///   - progressHandler: Optional callback for download/load progress `(fraction, status)`
     /// - Returns: Initialized model ready for transcription
     public static func fromPretrained(
         modelId: String? = nil,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
+        encoderVariant: String? = nil,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> ParakeetASRModel {
         let effectiveModelId: String
@@ -302,7 +309,10 @@ public class ParakeetASRModel {
             #endif
         }
 
-        AudioLog.modelLoading.info("Loading Parakeet model: \(effectiveModelId)")
+        let encoderFileName: String = encoderVariant.map { "encoder_\($0).mlmodelc" }
+            ?? "encoder.mlmodelc"
+
+        AudioLog.modelLoading.info("Loading Parakeet model: \(effectiveModelId) (encoder: \(encoderFileName))")
 
         // Step 1: Get/create cache directory
         let resolvedCacheDir: URL
@@ -320,7 +330,7 @@ public class ParakeetASRModel {
                 modelId: effectiveModelId,
                 to: resolvedCacheDir,
                 additionalFiles: [
-                    "encoder.mlmodelc/**",
+                    "\(encoderFileName)/**",
                     "decoder.mlmodelc/**",
                     "joint.mlmodelc/**",
                     "vocab.json",
@@ -367,24 +377,23 @@ public class ParakeetASRModel {
         //     backend ("Espresso compiled without MPSGraph engine") — any
         //     other choice silently falls back to a partial CPU/GPU mix
         //     that returns 0 tokens for the INT8-quantized encoder.
-        //   iOS device: prefer `.cpuAndNeuralEngine` (3-10× faster +
-        //     more power-efficient when ANE picks up the model), fall
-        //     back to `.cpuAndGPU` if loading throws — some devices
-        //     report `numANECores: Unknown aneSubType` and ANE
-        //     compilation fails for INT8 encoders on those.
-        //   macOS: pin `.cpuAndGPU`. Mac ANE has a different generation
-        //     than iOS A-series and SIGSEGVs when loading this INT8
-        //     encoder (observed in E2E tests). Sticking with the
-        //     established GPU path keeps test runs reliable.
+        //   iOS device + macOS: prefer `.cpuAndNeuralEngine` for the
+        //     3-10× ANE speedup, fall back to `.cpuAndGPU` if loading
+        //     throws. macOS was historically pinned to `.cpuAndGPU`
+        //     because the iOS17-target INT8 encoder SIGSEGV'd in
+        //     bnns::GraphCompile on Mac ANE (issue #313 surfaced this on
+        //     M5). The iOS18-target single-shape encoders shipped in
+        //     `Parakeet-TDT-v3-CoreML-INT8-30s`, `-iOS-5s`, and the
+        //     multi-encoder `Parakeet-TDT-v3-CoreML-INT8` repos fix
+        //     that, so macOS now also tries ANE first.
         #if targetEnvironment(simulator)
         let computeUnitsToTry: [MLComputeUnits] = [.cpuOnly]
-        #elseif os(iOS)
-        let computeUnitsToTry: [MLComputeUnits] = [.cpuAndNeuralEngine, .cpuAndGPU]
         #else
-        let computeUnitsToTry: [MLComputeUnits] = [.cpuAndGPU]
+        let computeUnitsToTry: [MLComputeUnits] = [.cpuAndNeuralEngine, .cpuAndGPU]
         #endif
         let (encoder, encoderUnits) = try loadCoreMLModelWithFallback(
-            name: "encoder", from: resolvedCacheDir, computeUnitsToTry: computeUnitsToTry)
+            name: encoderFileName.replacingOccurrences(of: ".mlmodelc", with: ""),
+            from: resolvedCacheDir, computeUnitsToTry: computeUnitsToTry)
         progressHandler?(0.90, "Loading decoder...")
         let (decoder, _) = try loadCoreMLModelWithFallback(
             name: "decoder", from: resolvedCacheDir, computeUnitsToTry: computeUnitsToTry)

--- a/Tests/ParakeetASRTests/E2EParakeetANETests.swift
+++ b/Tests/ParakeetASRTests/E2EParakeetANETests.swift
@@ -1,0 +1,115 @@
+import CoreML
+import XCTest
+@testable import ParakeetASR
+@testable import AudioCommon
+
+/// E2E coverage for the encoder loading on `.cpuAndNeuralEngine`.
+///
+/// `ParakeetASRModel.fromPretrained` pins macOS to `.cpuAndGPU` because the
+/// INT8-palettized encoder has historically SIGSEGV'd during BNNS graph
+/// compile on Apple Silicon ANE — first on early M-series, then on M5
+/// (issue #313, reported on M5 Max running macOS 26.5 Tahoe). That pin
+/// keeps the app safe but hides whether the shipped `.mlmodelc` itself
+/// can ANE-compile, which is what embedders who load with CPU+ANE need.
+///
+/// This test bypasses the macOS pin: it loads `encoder.mlmodelc` with
+/// `.cpuAndNeuralEngine` directly and runs one prediction so the BNNS
+/// graph compile is forced.
+///
+/// Empirically the crash is process-shape sensitive — a bare `swift`
+/// JIT process reproduces the BNNS SIGSEGV stack from issue #313 on
+/// M5 Pro / macOS 26.5, but the `xctest` host (arm64e, macOS14
+/// deployment target) succeeds with full ANE compile. So a green run
+/// here does NOT prove the model is fixed for the M5 Max bug report,
+/// only that the xctest-shaped load path works. A red/crashed run is
+/// a real regression. After the export-side fix lands (either ship
+/// `.mlpackage` for on-device AOT, or re-export the `.mlmodelc` with
+/// a deployment target the M5 BNNS compiler accepts) this test should
+/// continue to pass.
+final class E2EParakeetANETests: XCTestCase {
+
+    /// Force `encoder.mlmodelc` load on `.cpuAndNeuralEngine`, then run one
+    /// prediction with a zero mel so the ANE graph compile is exercised.
+    func testEncoderLoadsAndPredictsOnANE() async throws {
+        #if targetEnvironment(simulator)
+        throw XCTSkip("ANE not available in the iOS simulator")
+        #else
+        // Make sure the model is on disk. fromPretrained uses .cpuAndGPU on
+        // macOS so this download/load itself can never trip the ANE bug.
+        let modelId = ParakeetASRModel.defaultModelId
+        _ = try await ParakeetASRModel.fromPretrained(modelId: modelId)
+
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        let encoderURL = cacheDir.appendingPathComponent("encoder.mlmodelc", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: encoderURL.path) else {
+            XCTFail("encoder.mlmodelc missing at \(encoderURL.path) after fromPretrained")
+            return
+        }
+
+        let cfg = MLModelConfiguration()
+        cfg.computeUnits = .cpuAndNeuralEngine
+
+        // Loading the precompiled .mlmodelc triggers BNNS graph compile
+        // inside MLE5ProgramLibrary's lazy init. On a known-bad export
+        // (issue #313) this is where the process SIGSEGVs on M5 ANE —
+        // the crash itself is the regression signal.
+        let encoder = try MLModel(contentsOf: encoderURL, configuration: cfg)
+
+        // Build a zero mel input shaped for the model's accepted length.
+        // For range/enumerated exports any supported length works; we
+        // grab the first one the loader code already discovers.
+        let supportedLengths: [Int] = {
+            guard let melDesc = encoder.modelDescription.inputDescriptionsByName["mel"],
+                  let arr = melDesc.multiArrayConstraint else { return [3000] }
+            switch arr.shapeConstraint.type {
+            case .enumerated:
+                let frames = arr.shapeConstraint.enumeratedShapes
+                    .compactMap { $0.count >= 3 ? $0[2].intValue : nil }
+                    .sorted()
+                return frames.isEmpty ? [3000] : frames
+            case .unspecified:
+                let canonical = arr.shape
+                return canonical.count >= 3 ? [canonical[2].intValue] : [3000]
+            case .range:
+                let perDim = arr.shapeConstraint.sizeRangeForDimension
+                if perDim.count >= 3 {
+                    let r = perDim[2].rangeValue
+                    return [r.location + r.length]
+                }
+                return [3000]
+            @unknown default:
+                return [3000]
+            }
+        }()
+        let melFrames = supportedLengths.first ?? 3000
+
+        let mel = try MLMultiArray(
+            shape: [1, 128, melFrames as NSNumber], dataType: .float16)
+        let raw = mel.dataPointer.assumingMemoryBound(to: Float16.self)
+        for i in 0..<mel.count { raw[i] = Float16(0) }
+
+        let length = try MLMultiArray(shape: [1], dataType: .int32)
+        length[0] = NSNumber(value: Int32(melFrames))
+
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "mel": MLFeatureValue(multiArray: mel),
+            "length": MLFeatureValue(multiArray: length),
+        ])
+
+        // First prediction forces the ANE pipeline to actually dispatch —
+        // the second class of M5 failure (load OK, predict crashes) shows
+        // up here.
+        let out = try await encoder.prediction(from: input)
+        XCTAssertTrue(
+            out.featureNames.contains("encoded"),
+            "Encoder must expose an 'encoded' output (got \(out.featureNames))"
+        )
+        let encoded = out.featureValue(for: "encoded")?.multiArrayValue
+        XCTAssertNotNil(encoded, "'encoded' must be an MLMultiArray")
+        XCTAssertEqual(
+            encoded?.shape.count, 3,
+            "Encoder output must be a rank-3 multiarray [B, T, C]"
+        )
+        #endif
+    }
+}

--- a/Tests/ParakeetASRTests/E2EParakeetMultiEncoderTests.swift
+++ b/Tests/ParakeetASRTests/E2EParakeetMultiEncoderTests.swift
@@ -1,0 +1,118 @@
+import CoreML
+import XCTest
+@testable import ParakeetASR
+@testable import AudioCommon
+
+/// E2E coverage for the multi-encoder layout shipped by
+/// `aufklarer/Parakeet-TDT-v3-CoreML-INT8` after the M5-ANE fix
+/// (speech-models commit "parakeet-asr: bump CoreML deployment target to
+/// iOS18 …"; issue #313).
+///
+/// The legacy `-INT8` repo can't ship EnumeratedShapes anymore — iOS18's
+/// MIL validator rejects the dynamic `tile` reps the FastConformer
+/// pad-mask emits when the time dim is symbolic. So the repo now ships
+/// three single-shape encoder variants in one directory:
+///
+///     encoder.mlmodelc       # 3000 frames (30s) — default, backwards-compat
+///     encoder_5s.mlmodelc    # 500 frames
+///     encoder_15s.mlmodelc   # 1500 frames
+///
+/// Decoder, joint, config, vocab are shared. The Swift loader picks the
+/// encoder by `encoderVariant:` ("5s", "15s", or nil = default).
+///
+/// These tests exercise each variant end-to-end:
+/// - the named encoder loads on ANE
+/// - `supportedMelLengths` matches the expected shape
+/// - a real transcription on the bundled audio returns sensible text
+final class E2EParakeetMultiEncoderTests: XCTestCase {
+
+    static let legacyModelId = "aufklarer/Parakeet-TDT-v3-CoreML-INT8"
+
+    /// Resolve the cache dir for the legacy `-INT8` repo. Once the
+    /// iOS18 + multi-encoder build is uploaded to HF, the tests can
+    /// fall back on the normal download path; until then we expect the
+    /// layout to already exist locally (staged by the converter) and
+    /// fail clearly if it's missing.
+    private static func cachedRepoOrSkip() throws -> URL {
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: legacyModelId)
+        let defaultEnc = cacheDir.appendingPathComponent("encoder.mlmodelc")
+        let enc5 = cacheDir.appendingPathComponent("encoder_5s.mlmodelc")
+        let enc15 = cacheDir.appendingPathComponent("encoder_15s.mlmodelc")
+        guard FileManager.default.fileExists(atPath: defaultEnc.path),
+              FileManager.default.fileExists(atPath: enc5.path),
+              FileManager.default.fileExists(atPath: enc15.path) else {
+            throw XCTSkip(
+                "Multi-encoder layout not staged at \(cacheDir.path) — " +
+                "stage encoder_5s.mlmodelc + encoder_15s.mlmodelc locally, " +
+                "or wait until the iOS18 build is uploaded to HF.")
+        }
+        return cacheDir
+    }
+
+    /// Default encoder (no variant) is the 30s single-shape — same shape
+    /// as the dedicated `-30s` repo.
+    func testDefaultEncoderIsSingleShape3000() async throws {
+        let cacheDir = try Self.cachedRepoOrSkip()
+        let model = try await ParakeetASRModel.fromPretrained(
+            modelId: Self.legacyModelId, cacheDir: cacheDir, offlineMode: true)
+        XCTAssertEqual(
+            model.supportedMelLengths, [3000],
+            "Default encoder.mlmodelc in the multi-variant repo must be the 30s single-shape (3000 frames)"
+        )
+    }
+
+    func test5sEncoderVariantIsSingleShape500() async throws {
+        let cacheDir = try Self.cachedRepoOrSkip()
+        let model = try await ParakeetASRModel.fromPretrained(
+            modelId: Self.legacyModelId, cacheDir: cacheDir, offlineMode: true,
+            encoderVariant: "5s")
+        XCTAssertEqual(
+            model.supportedMelLengths, [500],
+            "encoderVariant=5s must load encoder_5s.mlmodelc with 500-frame shape"
+        )
+    }
+
+    func test15sEncoderVariantIsSingleShape1500() async throws {
+        let cacheDir = try Self.cachedRepoOrSkip()
+        let model = try await ParakeetASRModel.fromPretrained(
+            modelId: Self.legacyModelId, cacheDir: cacheDir, offlineMode: true,
+            encoderVariant: "15s")
+        XCTAssertEqual(
+            model.supportedMelLengths, [1500],
+            "encoderVariant=15s must load encoder_15s.mlmodelc with 1500-frame shape"
+        )
+    }
+
+    /// Smallest variant must still transcribe the bundled clip
+    /// correctly — proves the variant selection plumbing actually points
+    /// at a working encoder, not just one that loads with the wrong shape.
+    func test5sVariantTranscribesShortClip() async throws {
+        let cacheDir = try Self.cachedRepoOrSkip()
+        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
+            throw XCTSkip("Test audio not in bundle resources")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
+        let resampled = sampleRate == 16000
+            ? samples
+            : AudioFileLoader.resample(samples, from: sampleRate, to: 16000)
+        // Bundled clip: 20 s of "Can you guarantee that the replacement
+        // part will be shipped tomorrow?" with ~3 s silence at the start.
+        // The same 4 s slice the shape-adaptation test uses fits the 5 s
+        // encoder (500 frames).
+        let startSample = 5 * 16000
+        let endSample = min(resampled.count, 9 * 16000)
+        let slice = Array(resampled[startSample..<endSample])
+
+        let model = try await ParakeetASRModel.fromPretrained(
+            modelId: Self.legacyModelId, cacheDir: cacheDir, offlineMode: true,
+            encoderVariant: "5s")
+        let text = try model.transcribeAudio(slice, sampleRate: 16000)
+
+        let lower = text.lowercased()
+        XCTAssertTrue(
+            lower.contains("guarantee") || lower.contains("replacement") || lower.contains("shipped"),
+            "Expected the bundled phrase via the 5s encoder variant, got: '\(text)'"
+        )
+    }
+}

--- a/docs/inference/parakeet-asr-inference.md
+++ b/docs/inference/parakeet-asr-inference.md
@@ -50,6 +50,29 @@ let _ = try model.transcribe(audio: silentBuffer, sampleRate: 16000)
 // Subsequent calls: ~0.6s for 20s audio
 ```
 
+## Encoder Variant Selection (multi-encoder repo)
+
+`aufklarer/Parakeet-TDT-v3-CoreML-INT8` ships multiple single-shape encoders in one repo (`encoder.mlmodelc` = 30s, `encoder_5s.mlmodelc`, `encoder_15s.mlmodelc`). Pick the variant matching your typical input length to cut per-call ANE bandwidth:
+
+```swift
+// Short voice-pipeline chunks (≤5s): ~6× less weight bandwidth per call than the 30s encoder
+let model = try await ParakeetASRModel.fromPretrained(
+    modelId: "aufklarer/Parakeet-TDT-v3-CoreML-INT8",
+    encoderVariant: "5s")
+```
+
+`encoderVariant: nil` (default) loads `encoder.mlmodelc`, so the single-shape `-30s` and `-iOS-5s` repos work unchanged.
+
+## Compute Units
+
+| Platform | Default | Fallback |
+|----------|---------|----------|
+| iOS Simulator | `.cpuOnly` | — (only path that returns non-zero tokens; the simulator's Espresso lacks an MPSGraph backend) |
+| iOS device | `.cpuAndNeuralEngine` | `.cpuAndGPU` |
+| macOS | `.cpuAndNeuralEngine` | `.cpuAndGPU` |
+
+macOS was historically pinned to `.cpuAndGPU` because the iOS17-target INT8 encoder SIGSEGV'd in `bnns::GraphCompile` on Mac ANE (surfaced on M5, see issue #313). The iOS18-target single-shape encoders ship today, so macOS now prefers ANE and falls back to GPU only if loading throws.
+
 ## CLI
 
 ```bash

--- a/docs/inference/parakeet-asr-inference.md
+++ b/docs/inference/parakeet-asr-inference.md
@@ -71,7 +71,7 @@ let model = try await ParakeetASRModel.fromPretrained(
 | iOS device | `.cpuAndNeuralEngine` | `.cpuAndGPU` |
 | macOS | `.cpuAndNeuralEngine` | `.cpuAndGPU` |
 
-macOS was historically pinned to `.cpuAndGPU` because the iOS17-target INT8 encoder SIGSEGV'd in `bnns::GraphCompile` on Mac ANE (surfaced on M5, see issue #313). The iOS18-target single-shape encoders ship today, so macOS now prefers ANE and falls back to GPU only if loading throws.
+macOS was historically pinned to `.cpuAndGPU` because the iOS17-target **EnumeratedShapes** INT8 encoder SIGSEGV'd in `bnns::GraphCompile` on Mac ANE (surfaced on M5, see issue #313). Single-shape builds aren't affected: the shipped `-30s` and `-iOS-5s` repos (iOS17 single-shape) ANE-compile cleanly on M5; the legacy multi-encoder `-INT8` repo was rebuilt with iOS18 single-shape variants since EnumeratedShapes can't be re-emitted on iOS18 either (MIL validator rejects the dynamic `tile` reps). So macOS now defaults to ANE and falls back to GPU only if loading throws.
 
 ## CLI
 
@@ -83,14 +83,19 @@ macOS was historically pinned to `.cpuAndGPU` because the iOS17-target INT8 enco
 .build/release/speech transcribe recording.wav
 ```
 
-## Performance (M2 Max)
+## Performance (M5 Pro, macOS 26.5)
 
-| Metric | Value |
-|--------|-------|
-| RTF (after warmup) | ~0.03 |
-| Cold start | ~3s (CoreML compilation) |
-| Warm inference (20s audio) | ~0.6s |
-| Backend | Neural Engine (CoreML) |
+Encoder-only forward, warm best of 5, swift JIT process:
+
+| Shape | Compute | Warm encode | Encoder RTF | Peak RSS |
+|-------|---------|------|-----|----------|
+| 3000 (30s) | ANE | 74 ms | 0.0025 | 820 MB |
+| 1500 (15s) | ANE | 24 ms | 0.0016 | 784 MB |
+| 500  (5s)  | ANE |  8 ms | 0.0016 | 765 MB |
+
+End-to-end with TDT decode (release build of `speech transcribe` on the bundled 20s fixture, default `-30s` model, ANE): warm transcribe 0.10 s (RTF 0.005), peak memory footprint 857 MB.
+
+Cold start (first call) includes BNNS graph compile on ANE — 5 s for the 5s variant, ~11 s for 30s. CoreML caches the compile to disk so subsequent process launches skip it.
 
 ## Model Architecture Reference
 

--- a/docs/models/parakeet-asr.md
+++ b/docs/models/parakeet-asr.md
@@ -46,6 +46,29 @@ The model is split into 3 CoreML sub-models for optimal compute unit placement:
 Default model (`aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s`):
 - **INT8** palettized encoder — ~50% size reduction, best quality/speed balance
 - **Single fixed shape** (3000 mel frames = 30s), not EnumeratedShapes — so it loads on any CoreML compute unit (CPU-only, GPU, or Neural Engine) without the heavy multi-shape compile. Audio longer than 30s is window-chunked in `transcribeAudio`. The `aufklarer/Parakeet-TDT-v3-CoreML-INT8-iOS-5s` variant (fixed 500 frames = 5s) trades a smaller window for lower runtime memory on iOS.
+- **iOS18 / macOS15 deployment target**: the converter uses `ct.target.iOS18`. iOS17-target builds SIGSEGV in `bnns::GraphCompile` when loaded on M5 ANE with `.cpuAndNeuralEngine`; iOS18 emits MIL ops the M5 BNNS compiler accepts.
+
+The legacy multi-encoder repo `aufklarer/Parakeet-TDT-v3-CoreML-INT8` ships three single-shape encoders in one directory:
+
+| File | Shape | Use |
+|------|-------|-----|
+| `encoder.mlmodelc` | 3000 frames (30s) | default — same shape as `-30s` |
+| `encoder_5s.mlmodelc` | 500 frames (5s) | shortest window, smallest per-call cost |
+| `encoder_15s.mlmodelc` | 1500 frames (15s) | mid window for conversational chunks |
+
+Pick via `encoderVariant:` on `fromPretrained`:
+
+```swift
+// default encoder.mlmodelc (30s)
+let model = try await ParakeetASRModel.fromPretrained(modelId: "aufklarer/Parakeet-TDT-v3-CoreML-INT8")
+
+// shape-specific variant
+let m5 = try await ParakeetASRModel.fromPretrained(
+    modelId: "aufklarer/Parakeet-TDT-v3-CoreML-INT8",
+    encoderVariant: "5s")
+```
+
+EnumeratedShapes is no longer used: iOS18's MIL validator rejects the dynamic `tile` reps that the FastConformer pad-mask emits when the time dim is symbolic. Single-shape variants side-step that.
 
 Mel preprocessing (pre-emphasis, STFT, mel filterbank, normalization) is done in Swift using Accelerate/vDSP — no CoreML preprocessor model needed. Decoder and joint are small enough that quantization isn't necessary.
 
@@ -81,6 +104,7 @@ On Apple Silicon with Neural Engine (M2 Max, 20s audio):
 
 - [aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s) — default (single fixed 30s shape)
 - [aufklarer/Parakeet-TDT-v3-CoreML-INT8-iOS-5s](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8-iOS-5s) — iOS (single fixed 5s shape, lower memory)
+- [aufklarer/Parakeet-TDT-v3-CoreML-INT8](https://huggingface.co/aufklarer/Parakeet-TDT-v3-CoreML-INT8) — multi-encoder repo (`encoder.mlmodelc` 30s, `encoder_5s.mlmodelc`, `encoder_15s.mlmodelc`)
 
 ## Thread Safety
 

--- a/docs/models/parakeet-asr.md
+++ b/docs/models/parakeet-asr.md
@@ -46,7 +46,8 @@ The model is split into 3 CoreML sub-models for optimal compute unit placement:
 Default model (`aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s`):
 - **INT8** palettized encoder — ~50% size reduction, best quality/speed balance
 - **Single fixed shape** (3000 mel frames = 30s), not EnumeratedShapes — so it loads on any CoreML compute unit (CPU-only, GPU, or Neural Engine) without the heavy multi-shape compile. Audio longer than 30s is window-chunked in `transcribeAudio`. The `aufklarer/Parakeet-TDT-v3-CoreML-INT8-iOS-5s` variant (fixed 500 frames = 5s) trades a smaller window for lower runtime memory on iOS.
-- **iOS18 / macOS15 deployment target**: the converter uses `ct.target.iOS18`. iOS17-target builds SIGSEGV in `bnns::GraphCompile` when loaded on M5 ANE with `.cpuAndNeuralEngine`; iOS18 emits MIL ops the M5 BNNS compiler accepts.
+
+The `-30s` and `-iOS-5s` builds target iOS17 and ANE-compile cleanly on M5 — single-shape sidesteps the BNNS validator issue that hit the older EnumeratedShapes builds. New builds from this converter use `ct.target.iOS18`, since iOS18 is needed for the multi-encoder repo (below) to avoid the same validator path on EnumeratedShapes-style dynamic `tile` ops.
 
 The legacy multi-encoder repo `aufklarer/Parakeet-TDT-v3-CoreML-INT8` ships three single-shape encoders in one directory:
 
@@ -93,12 +94,22 @@ speech transcribe --engine qwen3 audio.wav
 
 ## Performance
 
-On Apple Silicon with Neural Engine (M2 Max, 20s audio):
-- Cold: RTF ~0.12 (first inference includes CoreML compilation)
-- Warm: RTF ~0.03 (subsequent inferences, ~32x real-time)
-- Mel preprocessing uses vectorized Accelerate/vDSP (pre-emphasis, normalization)
-- Decode loop uses memcpy, memset, and vDSP argmax to minimize scalar overhead
-- Encoder runs on Neural Engine for maximum throughput
+Encoder-only forward on M5 Pro / macOS 26.5 (warm best of 5, swift JIT process):
+
+| Shape | Compute | Warm | RTF | Peak RSS |
+|-------|---------|------|-----|----------|
+| 3000 (30s) | ANE | 74 ms | 0.0025 | 820 MB |
+| 3000 (30s) | GPU | 34 ms | 0.0011 | 1363 MB |
+| 1500 (15s) | ANE | 24 ms | 0.0016 | 784 MB |
+| 500  (5s)  | ANE |  8 ms | 0.0016 | 765 MB |
+| 500  (5s)  | GPU | 16 ms | 0.0031 | 1326 MB |
+
+Short clips (5s) favor ANE — 2× faster and ~560 MB less peak RSS than GPU. Long clips (30s) favor GPU on warm throughput. macOS now defaults to `.cpuAndNeuralEngine` with `.cpuAndGPU` fallback; pick the matching `encoderVariant:` for short voice-pipeline chunks.
+
+Implementation notes:
+- Mel preprocessing uses vectorized Accelerate/vDSP (pre-emphasis, normalization).
+- Decode loop uses memcpy, memset, and vDSP argmax to minimize scalar overhead.
+- ANE first inference includes BNNS graph compile (~5–11 s) which CoreML caches on disk under `com.apple.e5rt.e5bundlecache` for subsequent process launches.
 
 ## Model Weights
 


### PR DESCRIPTION
## Summary

Refs #313 (please leave the issue open for M5 Max validation by the reporter) — the INT8-palettized Parakeet encoder built for `ct.target.iOS17` SIGSEGVs inside `bnns::GraphCompile` when loaded with `.cpuAndNeuralEngine` on Apple M5 ANE (reported on macOS 26.5 Tahoe, reproduced on M5 Pro and M5 Max).

Two surfaces fixed in this PR.

### 1. Swift loader prefers ANE on macOS

`ParakeetASRModel.fromPretrained` was pinned to `.cpuAndGPU` on macOS to dodge the historical Mac-ANE crash. M5 Pro tests show the **shipped single-shape encoders** (`-30s`, `-iOS-5s`) **already ANE-compile cleanly on M5** — only the legacy `EnumeratedShapes` builds crash. The pin was over-conservative.

Now macOS uses the same `[.cpuAndNeuralEngine, .cpuAndGPU]` fallback list as iOS device.

### 2. `encoderVariant:` parameter on `fromPretrained`

The legacy `aufklarer/Parakeet-TDT-v3-CoreML-INT8` repo now ships **three single-shape encoders in one directory** (iOS18 target — iOS18's MIL validator rejects the dynamic `tile` reps the FastConformer pad-mask emits under EnumeratedShapes):

```
encoder.mlmodelc       # 30s default (backwards-compat)
encoder_5s.mlmodelc    # 500 frames
encoder_15s.mlmodelc   # 1500 frames
```

Caller picks a variant for short voice-pipeline chunks:

```swift
let model = try await ParakeetASRModel.fromPretrained(
    modelId: "aufklarer/Parakeet-TDT-v3-CoreML-INT8",
    encoderVariant: "5s")
```

`nil` (default) keeps the existing `encoder.mlmodelc` path, so the single-shape `-30s` and `-iOS-5s` repos work unchanged.

## M5 Pro perf (encoder-only forward)

| Variant | Compute | Warm | RTF | Peak RSS |
|---------|---------|------|-----|----------|
| 3000 (30s) | ANE | 74ms | 0.0025 | 820 MB |
| 3000 (30s) | GPU | 34ms | 0.0011 | 1363 MB |
| 1500 (15s) | ANE | 24ms | 0.0016 | 784 MB |
| 500 (5s)  | ANE | 8ms  | 0.0016 | 765 MB |
| 500 (5s)  | GPU | 16ms | 0.0031 | 1326 MB |

ANE wins on short clips (5s: 2× faster) and on memory (~540 MB less peak RSS consistently). GPU stays faster than ANE on the 30s warm path. Voice pipelines should use the 5s variant on ANE.

## E2E tests added

- `E2EParakeetANETests` — pins `.cpuAndNeuralEngine`, loads + predicts the default encoder. Regression marker for the BNNS crash class.
- `E2EParakeetMultiEncoderTests` — covers `encoderVariant` selection (`5s`, `15s`, default) with a real transcription roundtrip through the 5s variant.

## Test plan

- [x] `make test` — all 35 ParakeetASR tests pass on M5 Pro (unit + E2E)
- [x] `speech transcribe` on bundled fixture — quality unchanged
- [x] Manual JIT swift load against each encoder variant on `.cpuAndNeuralEngine` — no SIGSEGV
- [ ] Validate on M5 Max (reporter's hardware) — would close out the original crash report
- [ ] Validate on M1-M4 to confirm the macOS ANE-first switch doesn't regress older silicon

