### PR TITLE
Keep realtime inference off websocket event loops

### DIFF
--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -362,12 +362,18 @@ struct RealtimeModelLoadingFailure: Error, CustomStringConvertible {
 
 final class FailingRealtimeModelLoading: RealtimeModelLoading, @unchecked Sendable {
     let error: Error
+    let beforeFailure: (@Sendable () -> Void)?
 
-    init(error: Error = RealtimeModelLoadingFailure()) {
+    init(
+        error: Error = RealtimeModelLoadingFailure(),
+        beforeFailure: (@Sendable () -> Void)? = nil
+    ) {
         self.error = error
+        self.beforeFailure = beforeFailure
     }
 
     private func fail<T>() async throws -> T {
+        beforeFailure?()
         throw error
     }
 
@@ -1323,11 +1329,12 @@ private func sendRealtimeError(
 private let realtimeKeepaliveIntervalNanoseconds: UInt64 = 15_000_000_000
 private let realtimeKeepaliveEvent = "realtime.keepalive"
 
-private func withRealtimeKeepalive<T>(
+private func withRealtimeKeepalive<T: Sendable>(
     outbound: WebSocketOutboundWriter,
-    operation: () async throws -> T
+    operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
-    let keepalive = Task {
+    let operationTask = Task.detached(operation: operation)
+    let keepalive = Task.detached {
         while !Task.isCancelled {
             do {
                 try await Task.sleep(nanoseconds: realtimeKeepaliveIntervalNanoseconds)
@@ -1343,11 +1350,12 @@ private func withRealtimeKeepalive<T>(
     }
 
     do {
-        let value = try await operation()
+        let value = try await operationTask.value
         keepalive.cancel()
         await keepalive.value
         return value
     } catch {
+        operationTask.cancel()
         keepalive.cancel()
         await keepalive.value
         throw error

--- a/Tests/AudioServerTests/RealtimeAPIErrorHandlingTests.swift
+++ b/Tests/AudioServerTests/RealtimeAPIErrorHandlingTests.swift
@@ -89,3 +89,70 @@ final class RealtimeAPIErrorHandlingTests: XCTestCase {
         XCTAssertEqual(cleared["type"] as? String, "input_audio_buffer.cleared")
     }
 }
+
+final class RealtimeAPIKeepaliveTests: XCTestCase {
+    static var serverTask: Task<Void, Error>?
+    static let port = 19388
+
+    override class func setUp() {
+        super.setUp()
+        serverTask = Task {
+            let server = AudioServer(
+                host: "127.0.0.1",
+                port: port,
+                realtimeState: FailingRealtimeModelLoading(
+                    beforeFailure: { Thread.sleep(forTimeInterval: 16) }))
+            try await server.run()
+        }
+        Thread.sleep(forTimeInterval: 1.5)
+    }
+
+    override class func tearDown() {
+        serverTask?.cancel()
+        Thread.sleep(forTimeInterval: 0.5)
+        super.tearDown()
+    }
+
+    private func connect() async throws -> URLSessionWebSocketTask {
+        let url = URL(string: "ws://127.0.0.1:\(Self.port)/v1/realtime")!
+        let ws = URLSession.shared.webSocketTask(with: url)
+        ws.resume()
+        return ws
+    }
+
+    private func receiveJSON(_ ws: URLSessionWebSocketTask) async throws -> [String: Any] {
+        let msg = try await ws.receive()
+        guard case .string(let text) = msg,
+              let data = text.data(using: .utf8),
+              let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Expected JSON text message")
+            return [:]
+        }
+        return json
+    }
+
+    private func sendJSON(_ ws: URLSessionWebSocketTask, _ dict: [String: Any]) async throws {
+        let data = try JSONSerialization.data(withJSONObject: dict)
+        try await ws.send(.string(String(data: data, encoding: .utf8)!))
+    }
+
+    func testBlockingModelLoadEmitsKeepaliveBeforeFailure() async throws {
+        let ws = try await connect()
+        defer { ws.cancel(with: .normalClosure, reason: nil) }
+
+        _ = try await receiveJSON(ws)
+        try await sendJSON(ws, [
+            "type": "response.create",
+            "response": ["instructions": "Hello"]
+        ] as [String: Any])
+
+        let created = try await receiveJSON(ws)
+        XCTAssertEqual(created["type"] as? String, "response.created")
+
+        let keepalive = try await receiveJSON(ws)
+        XCTAssertEqual(keepalive["type"] as? String, "realtime.keepalive")
+
+        let failure = try await receiveJSON(ws)
+        XCTAssertEqual(failure["type"] as? String, "error")
+    }
+}


### PR DESCRIPTION
## Summary
- run guarded realtime model loads and generation off the WebSocket handler executor
- allow keepalive frames to flush while blocking inference is in progress
- add a regression test for a blocking model load

## Root cause
The first keepalive implementation emitted frames from a separate task, but the guarded model operation still ran on the NIO WebSocket handler task. Synchronous loads and generation could block the handler long enough for URLSession to close the idle socket before the keepalive write was serviced.

## Verification
- `swift test --filter "RealtimeAPITests|RealtimeAPIErrorHandlingTests|RealtimeAPIKeepaliveTests"`
- `./scripts/build_mlx_metallib.sh debug`
- `swift test --skip-build --filter "E2ERealtimeAPIEnginesTests/testDefaultKokoroTTSSynthesizes|E2ERealtimeAPIEnginesTests/testS2SHibikiTranslatesAudio|E2ERealtimeAPIEnginesTests/testS2SPersonaPlexProducesAudio"`