### PR TITLE
Disable Hummingbird auto-ping on realtime websocket

### DIFF
--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -52,7 +52,7 @@ public struct AudioServer {
     public func run() async throws {
         let router = buildRouter()
         let realtimeState = self.realtimeState
-        let wsConfig = WebSocketServerConfiguration(maxFrameSize: 1 << 24)  // 16 MB max frame
+        let wsConfig = realtimeWebSocketServerConfiguration()
         let wsServer: HTTPServerBuilder = .http1WebSocketUpgrade(configuration: wsConfig) { head, _, _ in
             let path = head.path ?? ""
             guard path == "/v1/realtime" else { return .dontUpgrade }
@@ -329,6 +329,15 @@ public struct AudioServer {
 
         return router
     }
+}
+
+func realtimeWebSocketServerConfiguration() -> WebSocketServerConfiguration {
+    // Long-running model work emits application-level keepalive events. Hummingbird's
+    // automatic ping watchdog expects a matching control-frame pong, which URLSession
+    // does not reliably surface while a receive is pending.
+    WebSocketServerConfiguration(
+        maxFrameSize: 1 << 24,
+        autoPing: .disabled)
 }
 
 // MARK: - Lazy Model State
@@ -1342,7 +1351,6 @@ private func withRealtimeKeepalive<T: Sendable>(
                 try await outbound.write(.text(formatJSON([
                     "type": realtimeKeepaliveEvent
                 ])))
-                try await outbound.write(.pong)
             } catch {
                 return
             }

--- a/Tests/AudioServerTests/RealtimeAPIErrorHandlingTests.swift
+++ b/Tests/AudioServerTests/RealtimeAPIErrorHandlingTests.swift
@@ -101,7 +101,7 @@ final class RealtimeAPIKeepaliveTests: XCTestCase {
                 host: "127.0.0.1",
                 port: port,
                 realtimeState: FailingRealtimeModelLoading(
-                    beforeFailure: { Thread.sleep(forTimeInterval: 16) }))
+                    beforeFailure: { Thread.sleep(forTimeInterval: 61) }))
             try await server.run()
         }
         Thread.sleep(forTimeInterval: 1.5)
@@ -149,10 +149,19 @@ final class RealtimeAPIKeepaliveTests: XCTestCase {
         let created = try await receiveJSON(ws)
         XCTAssertEqual(created["type"] as? String, "response.created")
 
-        let keepalive = try await receiveJSON(ws)
-        XCTAssertEqual(keepalive["type"] as? String, "realtime.keepalive")
-
-        let failure = try await receiveJSON(ws)
-        XCTAssertEqual(failure["type"] as? String, "error")
+        var keepaliveCount = 0
+        while true {
+            let message = try await receiveJSON(ws)
+            switch message["type"] as? String {
+            case "realtime.keepalive":
+                keepaliveCount += 1
+            case "error":
+                XCTAssertGreaterThanOrEqual(keepaliveCount, 4)
+                return
+            default:
+                XCTFail("Unexpected realtime message: \(message)")
+                return
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Disable Hummingbird's automatic ping watchdog on the realtime endpoint; keep the application-level `realtime.keepalive` event
- Remove the unsolicited `.pong` write (can't satisfy the payload-matching protocol ping anyway)

## Why
PR #320 detached model work from the websocket event loop so app-level keepalives could flush. Nightly on the merged commit still dropped Hibiki at 71s and PersonaPlex at 60s on `audio-infra`. Tracing the 60s cadence pinpointed the cause: Hummingbird's default `autoPing` (30s interval) closes the connection when `URLSessionWebSocketTask` doesn't return a payload-matching pong control frame — which it can't reliably do while a receive is pending behind blocking inference. Disabling the watchdog keeps the transport open; visible keepalive text frames still tell the client the server is alive.

## Verification
- New regression test runs a 61s blocking model load (past the former 60s close window) and asserts the client receives 4+ keepalives before the expected error event
- Realtime unit subset: 36 tests pass (`RealtimeAPITests | RealtimeAPIErrorHandlingTests | RealtimeAPIKeepaliveTests`)
- Three affected E2E engines pass locally on the metallib debug build:
  - `testDefaultKokoroTTSSynthesizes`: 14.5s
  - `testS2SHibikiTranslatesAudio`: 23.8s
  - `testS2SPersonaPlexProducesAudio`: 52.0s
  Total 90.4s, no disconnects.

## Test plan
- [ ] PR `build-and-test` green
- [ ] Nightly E2E `audio-infra` green on the merged SHA