### PR TITLE
feat(cosyvoice): honor style instructions on cloned voices via instruct2

### DIFF
--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -410,10 +410,31 @@ public final class CosyVoiceTTSModel {
     /// for it — otherwise the model treats the instruction as content to speak.
     static let assistantPrefix = "You are a helpful assistant."
 
-    /// Whether a voice profile with a reference transcript needs the upstream
-    /// `instruct2` layout. Default instructions stay on the transcript-led
-    /// zero-shot path; custom style instructions need the dedicated layout or
-    /// are otherwise ignored by the clone path.
+    /// Single source of truth for "is a style instruction present?".
+    /// `instruction` defaults to `assistantPrefix`, so anything trimmed-equal to
+    /// that (or empty) means "no style". This is the one place that knows the
+    /// default sentinel — both the clone dispatch and the LLM framing defer to
+    /// it instead of re-comparing the magic string.
+    static func hasCustomStyleInstruction(_ instruction: String) -> Bool {
+        let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && trimmed != assistantPrefix
+    }
+
+    /// Frame an instruction for the LLM. CosyVoice3 was trained with the
+    /// `"You are a helpful assistant. {style}"` system frame; a bare style is
+    /// read aloud as content, so a custom style is prefixed with the frame while
+    /// the default/empty case collapses to the frame alone.
+    static func framedInstruction(_ instruction: String) -> String {
+        guard hasCustomStyleInstruction(instruction) else { return assistantPrefix }
+        let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix(assistantPrefix) ? trimmed : "\(assistantPrefix) \(trimmed)"
+    }
+
+    /// Whether a cloned voice (one carrying a reference transcript) should use
+    /// CosyVoice's `instruct2` layout instead of the transcript-led zero-shot
+    /// path: only when a reference transcript is present *and* a custom style
+    /// instruction was supplied. Otherwise the higher-fidelity transcript-led
+    /// path is kept.
     static func usesInstructionConditionedClone(
         promptText: String?,
         instruction: String
@@ -421,32 +442,19 @@ public final class CosyVoiceTTSModel {
         guard let promptText, !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
-        let trimmedInstruction = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !trimmedInstruction.isEmpty && trimmedInstruction != assistantPrefix
+        return hasCustomStyleInstruction(instruction)
     }
 
-    /// Format and tokenize text for CosyVoice3 LLM.
-    ///
-    /// Upstream training format: `"You are a helpful assistant. {style}<|endofprompt|>{text}"`.
-    /// Stripping the assistant prefix pushes the model out of distribution and it
-    /// reads the style instruction aloud instead of using it as conditioning.
+    /// Format and tokenize text for CosyVoice3 LLM: framed instruction, the
+    /// `<|endofprompt|>` boundary, then the content tokens. Framing keeps the
+    /// model in distribution — stripping the assistant prefix makes it read the
+    /// style aloud instead of using it as conditioning.
     func tokenizeText(
         _ text: String, language: String,
         instruction: String = "You are a helpful assistant."
     ) -> [Int32] {
-        let framedInstruction: String
-        let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty || trimmed == Self.assistantPrefix {
-            framedInstruction = Self.assistantPrefix
-        } else if trimmed.hasPrefix(Self.assistantPrefix) {
-            framedInstruction = trimmed
-        } else {
-            framedInstruction = "\(Self.assistantPrefix) \(trimmed)"
-        }
-
-        let instructionTokens = tokenizer.encode(framedInstruction).map { Int32($0) }
+        let instructionTokens = tokenizer.encode(Self.framedInstruction(instruction)).map { Int32($0) }
         let textTokens = tokenizer.encode(text).map { Int32($0) }
-
         return instructionTokens + [Self.endOfPromptToken] + textTokens
     }
 }

--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -238,15 +238,24 @@ public final class CosyVoiceTTSModel {
         //    instruction. Upstream: `min_len = (text_len - prompt_text_len) * ratio`.
         let contentTokens = tokenizer.encode(text).map { Int32($0) }
 
-        // For zero-shot voice cloning, upstream's text input is literally
+        // For an unstyled zero-shot clone, upstream's text input is literally
         //   concat(transcript_tokens + [<|endofprompt|>], content_tokens)
-        // with NO "You are a helpful assistant. " system frame. Adding the
-        // system frame puts the LLM off the training distribution and it
-        // reads back the tail of the transcript instead of synthesising the
-        // user text. So when promptText is set we bypass tokenizeText entirely
-        // and build the sequence directly.
+        // with the reference speech tokens included in the LLM prefix. This
+        // is the highest-fidelity identity path.
+        //
+        // A non-default instruction selects CosyVoice's `instruct2` layout:
+        // the framed instruction becomes the LLM text prefix and the reference
+        // speech tokens are withheld from the LLM. The Flow model still gets
+        // promptToken + promptFeat, retaining the cloned-voice anchor while
+        // allowing the LLM to follow the requested emotion or style.
+        let useInstructionConditionedClone = Self.usesInstructionConditionedClone(
+            promptText: promptText,
+            instruction: instruction
+        )
         let textTokens: [Int32]
-        if let pt = promptText, !pt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if useInstructionConditionedClone {
+            textTokens = tokenizeText(text, language: language, instruction: instruction)
+        } else if let pt = promptText, !pt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let promptTextTokens = tokenizer.encode(pt).map { Int32($0) }
             textTokens = promptTextTokens + [Self.endOfPromptToken] + contentTokens
         } else {
@@ -260,9 +269,11 @@ public final class CosyVoiceTTSModel {
         //    the LLM emits "neutral default voice" tokens that conflict with
         //    the flow's prompt_token + prompt_feat anchors and the cloned
         //    output drifts to a different voice (see PR #247).
-        let promptSpeechTokensArr: [Int32]? = promptToken.map { pt in
-            pt.reshaped(-1).asArray(Int32.self)
-        }
+        let promptSpeechTokensArr: [Int32]? = useInstructionConditionedClone
+            ? nil
+            : promptToken.map { pt in
+                pt.reshaped(-1).asArray(Int32.self)
+            }
         // Cap maxTokens proportionally to the content length. With prompt
         // conditioning the LLM is biased to "keep speaking" — a fixed cap of
         // 500 lets a 5-word phrase generate 20 s of repeats. Scale to 10×
@@ -398,6 +409,21 @@ public final class CosyVoiceTTSModel {
     /// Custom style instructions are *appended* to this frame, not substituted
     /// for it — otherwise the model treats the instruction as content to speak.
     static let assistantPrefix = "You are a helpful assistant."
+
+    /// Whether a voice profile with a reference transcript needs the upstream
+    /// `instruct2` layout. Default instructions stay on the transcript-led
+    /// zero-shot path; custom style instructions need the dedicated layout or
+    /// are otherwise ignored by the clone path.
+    static func usesInstructionConditionedClone(
+        promptText: String?,
+        instruction: String
+    ) -> Bool {
+        guard let promptText, !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+        let trimmedInstruction = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmedInstruction.isEmpty && trimmedInstruction != assistantPrefix
+    }
 
     /// Format and tokenize text for CosyVoice3 LLM.
     ///

--- a/Sources/CosyVoiceTTS/VoiceCloning.swift
+++ b/Sources/CosyVoiceTTS/VoiceCloning.swift
@@ -21,7 +21,10 @@ import AudioCommon
 ///     content-incorrect speech (in the right voice).
 ///
 /// Build once per reference clip with `CosyVoiceTTSModel.extractVoiceProfile`
-/// and reuse across as many `synthesize(...)` calls as you need.
+/// and reuse across as many `synthesize(...)` calls as you need. A
+/// non-default instruction selects CosyVoice's `instruct2` clone layout:
+/// the LLM follows the instruction while `promptToken` and `promptFeat`
+/// continue to anchor the Flow model to the reference voice.
 public struct CosyVoiceVoiceProfile: Sendable {
     public let speakerEmbedding: [Float]?
     public let promptToken: MLXArray?

--- a/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
+++ b/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
@@ -65,6 +65,24 @@ final class VoiceCloningTests: XCTestCase {
         ))
     }
 
+    func testInstructionFramingAndStyleDetection() {
+        // hasCustomStyleInstruction is the single dispatch predicate.
+        XCTAssertFalse(CosyVoiceTTSModel.hasCustomStyleInstruction(""))
+        XCTAssertFalse(CosyVoiceTTSModel.hasCustomStyleInstruction("You are a helpful assistant."))
+        XCTAssertFalse(CosyVoiceTTSModel.hasCustomStyleInstruction("  You are a helpful assistant.  "))
+        XCTAssertTrue(CosyVoiceTTSModel.hasCustomStyleInstruction("Speak excitedly."))
+
+        // framedInstruction: default collapses to the frame; a custom style is
+        // prefixed with it; an already-framed style is left unchanged.
+        XCTAssertEqual(CosyVoiceTTSModel.framedInstruction(""), "You are a helpful assistant.")
+        XCTAssertEqual(CosyVoiceTTSModel.framedInstruction("You are a helpful assistant."),
+                       "You are a helpful assistant.")
+        XCTAssertEqual(CosyVoiceTTSModel.framedInstruction("Speak excitedly."),
+                       "You are a helpful assistant. Speak excitedly.")
+        XCTAssertEqual(CosyVoiceTTSModel.framedInstruction("You are a helpful assistant. Speak excitedly."),
+                       "You are a helpful assistant. Speak excitedly.")
+    }
+
     /// Helper: load a `CosyVoiceTTSModel` so we have a tokenizer available.
     /// Falls back to skipping the test if HF is unreachable.
     private func loadModel() async throws -> CosyVoiceTTSModel {

--- a/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
+++ b/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
@@ -46,6 +46,25 @@ final class VoiceCloningTests: XCTestCase {
 
     // MARK: - tokenizeText: system-frame rules
 
+    func testStyleInstructionSelectsInstruct2CloneLayout() {
+        XCTAssertTrue(CosyVoiceTTSModel.usesInstructionConditionedClone(
+            promptText: "A reference transcript.",
+            instruction: "Speak excitedly and quickly."
+        ))
+        XCTAssertFalse(CosyVoiceTTSModel.usesInstructionConditionedClone(
+            promptText: "A reference transcript.",
+            instruction: "You are a helpful assistant."
+        ))
+        XCTAssertFalse(CosyVoiceTTSModel.usesInstructionConditionedClone(
+            promptText: "A reference transcript.",
+            instruction: "  You are a helpful assistant.  "
+        ))
+        XCTAssertFalse(CosyVoiceTTSModel.usesInstructionConditionedClone(
+            promptText: nil,
+            instruction: "Speak excitedly and quickly."
+        ))
+    }
+
     /// Helper: load a `CosyVoiceTTSModel` so we have a tokenizer available.
     /// Falls back to skipping the test if HF is unreachable.
     private func loadModel() async throws -> CosyVoiceTTSModel {
@@ -123,7 +142,9 @@ final class VoiceCloningTests: XCTestCase {
         let transcript = ProcessInfo.processInfo.environment["COSY_TEST_VOICE_TRANSCRIPT"]
             ?? "This is a reference audio recording used for voice cloning."
 
-        let model = try await CosyVoiceTTSModel.fromPretrained()
+        let modelId = ProcessInfo.processInfo.environment["COSY_TEST_MODEL_ID"]
+            ?? "aufklarer/CosyVoice3-0.5B-MLX-4bit"
+        let model = try await CosyVoiceTTSModel.fromPretrained(modelId: modelId)
 
         // Locate speech_tokenizer.safetensors — the test prefers an explicit
         // override, otherwise tries the same cache directory the model used.
@@ -167,5 +188,22 @@ final class VoiceCloningTests: XCTestCase {
         let peak = samples.map { abs($0) }.max() ?? 0
         XCTAssertGreaterThan(peak, 0.01, "Cloned output must not be silence")
         XCTAssertLessThan(peak, 1.0001, "Cloned output must not overflow")
+
+        // A style instruction selects the instruct2 clone layout. It must
+        // still produce a valid, bounded render while preserving the Flow
+        // model's reference-audio anchor.
+        let styledSamples = model.synthesize(
+            text: "Welcome to the demo.",
+            voiceProfile: profile,
+            language: "english",
+            instruction: "Speak warmly with restrained excitement."
+        )
+        XCTAssertFalse(styledSamples.isEmpty, "Instructed clone must produce audio")
+        let styledDuration = Double(styledSamples.count) / 24_000.0
+        XCTAssertGreaterThan(styledDuration, 0.4, "Instructed clone should be > 0.4 s")
+        XCTAssertLessThan(styledDuration, 12.0, "Instructed clone should not run on for >12 s")
+        let styledPeak = styledSamples.map { abs($0) }.max() ?? 0
+        XCTAssertGreaterThan(styledPeak, 0.01, "Instructed clone must not be silence")
+        XCTAssertLessThan(styledPeak, 1.0001, "Instructed clone must not overflow")
     }
 }

--- a/docs/models/cosyvoice-tts.md
+++ b/docs/models/cosyvoice-tts.md
@@ -48,6 +48,11 @@ Three-stage pipeline: LLM → DiT Flow Matching → HiFi-GAN Vocoder → 24kHz a
 - Unknown tags pass through as freeform instructions: `(Speak like a pirate)`
 - `--cosy-instruct` sets the global default instruction (replaces "You are a helpful assistant.")
 - Text format: `{instruction}<|endofprompt|>(token 151646){text_to_synthesize}`
+- For zero-shot cloning, a non-default instruction uses CosyVoice's `instruct2`
+  layout: the LLM receives the framed instruction and target text, while the
+  reference audio remains attached to the Flow model as the voice anchor. The
+  unstyled path continues to use the reference transcript plus speech-token
+  context for maximum speaker fidelity.
 
 ## Streaming
 - Chunk-aware causal masking in DiT


### PR DESCRIPTION
## Summary

A zero-shot CosyVoice clone conditions the LLM on the reference transcript and the reference speech tokens for maximum speaker fidelity. In that mode there was no slot for a style/emotion instruction — any `instruction` passed alongside a cloned voice was silently ignored, so emotion/style markers had no effect on cloned voices.

## What changed

Route a **non-default** instruction through CosyVoice's upstream `instruct2` clone layout:

- The framed instruction becomes the LLM text prefix (`tokenizeText(text, instruction:)`).
- The reference speech tokens are **withheld** from the LLM (`promptSpeechTokens = nil`).
- The Flow model still receives `promptToken` + `promptFeat`, so the cloned-voice identity is preserved while the LLM follows the requested style.

Unstyled clones (no instruction, or the default `"You are a helpful assistant."`) keep the transcript-led, highest-fidelity path **unchanged** — both the text-token construction and the prompt-speech-token branches fall through to the existing code, so an ordinary clone is byte-for-byte identical to before.

Gated by `usesInstructionConditionedClone(promptText:instruction:)`: true only when a reference transcript is present *and* the instruction is non-empty and not the assistant default.

## Test plan

- **Unit** (`CosyVoiceTTSTests`, 69 tests, 0 failures): adds `testStyleInstructionSelectsInstruct2CloneLayout` covering the routing predicate (styled → instruct2; default / whitespace-only / no-transcript → transcript-led).
- **E2E** (`VoiceCloningTests/testE2ECloneProducesAudio`, real bf16 inference): extended to synthesize both the default clone and an instructed clone from the same reference profile, asserting each produces non-silent, bounded, non-overflowing audio. Passed against `aufklarer/CosyVoice3-0.5B-MLX-bf16`.

> Note: automated tests verify routing + output validity (non-silent, bounded duration, no overflow). Perceptual emotion strength still warrants a listening A/B and is not asserted here.

## Docs

`docs/models/cosyvoice-tts.md` updated to describe the `instruct2` clone layout.
