### PR TITLE
feat(qwen3-tts): ship 1.7B bf16, drop degrading 1.7B int4

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -51,7 +51,7 @@ public struct SpeakCommand: ParsableCommand {
     @Option(name: .long, help: "Sidon variant for --clean-reference: fp16 (default) or int8")
     public var cleanReferenceVariant: String = "fp16"
 
-    @Option(name: .long, help: "[qwen3] Model variant: base (default), base-8bit, 1.7b, 1.7b-8bit, customVoice, or full HF model ID. Note: --speaker requires customVoice.")
+    @Option(name: .long, help: "[qwen3] Model variant: base (default), base-8bit, 1.7b (bf16), 1.7b-8bit, customVoice, or full HF model ID. Note: --speaker requires customVoice.")
     public var model: String = "base"
 
     @Flag(name: .long, help: "[qwen3] List available speakers and exit")
@@ -512,8 +512,8 @@ public struct SpeakCommand: ParsableCommand {
                 resolvedModelId = TTSModelVariant.base.rawValue
             case "base-8bit", "base8bit":
                 resolvedModelId = TTSModelVariant.base8bit.rawValue
-            case "1.7b", "large":
-                resolvedModelId = TTSModelVariant.base17B.rawValue
+            case "1.7b", "large", "1.7b-bf16", "large-bf16":
+                resolvedModelId = TTSModelVariant.base17Bbf16.rawValue
             case "1.7b-8bit", "large-8bit":
                 resolvedModelId = TTSModelVariant.base17B8bit.rawValue
             case "customvoice", "custom_voice", "custom-voice":

--- a/Sources/Qwen3TTS/Configuration.swift
+++ b/Sources/Qwen3TTS/Configuration.swift
@@ -281,8 +281,8 @@ public enum TTSModelVariant: String, CaseIterable, Sendable {
     case base = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
     case base8bit = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     case customVoice = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit"
-    case base17B = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit"
     case base17B8bit = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit"
+    case base17Bbf16 = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"
 }
 
 // MARK: - Combined TTS Config

--- a/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
+++ b/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
@@ -100,7 +100,7 @@ final class Qwen3TTSConfigTests: XCTestCase {
 
     func testTTSModelSizeDetection() {
         XCTAssertEqual(TTSModelSize.detect(from: "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"), .small)
-        XCTAssertEqual(TTSModelSize.detect(from: "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit"), .large)
+        XCTAssertEqual(TTSModelSize.detect(from: "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"), .large)
         XCTAssertEqual(TTSModelSize.detect(from: "some/custom-1.7b-model"), .large)
         XCTAssertEqual(TTSModelSize.detect(from: "some/custom-model"), .small)
     }
@@ -191,8 +191,8 @@ final class Qwen3TTSConfigTests: XCTestCase {
     func testTTSModelVariants() {
         XCTAssertEqual(TTSModelVariant.base.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit")
         XCTAssertEqual(TTSModelVariant.base8bit.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit")
-        XCTAssertEqual(TTSModelVariant.base17B.rawValue, "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit")
         XCTAssertEqual(TTSModelVariant.base17B8bit.rawValue, "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit")
+        XCTAssertEqual(TTSModelVariant.base17Bbf16.rawValue, "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16")
         XCTAssertEqual(TTSModelVariant.customVoice.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit")
     }
 
@@ -1124,17 +1124,17 @@ final class E2ETTS8bitTests: XCTestCase {
 
 final class E2ETTS17BTests: XCTestCase {
 
-    static let ttsModelId4bit = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit"
+    static let ttsModelIdBf16 = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"
     static let ttsModelId8bit = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     static let asrModelId = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
-    private static var _shared4bitModel: Qwen3TTSModel?
+    private static var _sharedBf16Model: Qwen3TTSModel?
     private static var _shared8bitModel: Qwen3TTSModel?
     private static var _sharedASRModel: Qwen3ASRModel?
 
-    /// 1.7B 4-bit: model loads with correct config
-    func testModelLoading17B4bit() async throws {
-        let model = try await load4bitModel()
+    /// 1.7B bf16: model loads with correct config
+    func testModelLoading17BBf16() async throws {
+        let model = try await loadBf16Model()
         XCTAssertEqual(model.config.talker.bits, 4, "Should load as 4-bit model")
         XCTAssertEqual(model.config.talker.hiddenSize, 2048, "Should be 1.7B (hidden=2048)")
         XCTAssertEqual(model.config.talker.intermediateSize, 6144, "1.7B intermediate size")
@@ -1147,17 +1147,17 @@ final class E2ETTS17BTests: XCTestCase {
         XCTAssertEqual(model.config.talker.hiddenSize, 2048, "Should be 1.7B (hidden=2048)")
     }
 
-    /// 1.7B 4-bit -> ASR round-trip
-    func testRoundTrip17B4bit() async throws {
-        let ttsModel = try await load4bitModel()
+    /// 1.7B bf16 -> ASR round-trip
+    func testRoundTrip17BBf16() async throws {
+        let ttsModel = try await loadBf16Model()
         let asrModel = try await loadASRModel()
 
         let inputText = "Hello world, this is a test."
         let samples = ttsModel.synthesize(text: inputText, language: "english")
         let transcription = asrModel.transcribe(audio: samples, sampleRate: 24000)
 
-        print("1.7B 4-bit Input:  \"\(inputText)\"")
-        print("1.7B 4-bit Output: \"\(transcription)\"")
+        print("1.7B bf16 Input:  \"\(inputText)\"")
+        print("1.7B bf16 Output: \"\(transcription)\"")
 
         let lowerTranscription = transcription.lowercased()
         let expectedWords = ["hello", "world", "test"]
@@ -1187,16 +1187,16 @@ final class E2ETTS17BTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func load4bitModel() async throws -> Qwen3TTSModel {
-        if let model = Self._shared4bitModel { return model }
-        print("Loading 1.7B 4-bit TTS model...")
+    private func loadBf16Model() async throws -> Qwen3TTSModel {
+        if let model = Self._sharedBf16Model { return model }
+        print("Loading 1.7B bf16 TTS model...")
         let model = try await Qwen3TTSModel.fromPretrained(
-            modelId: Self.ttsModelId4bit,
+            modelId: Self.ttsModelIdBf16,
             tokenizerModelId: Self.ttsTokenizerModelId
         ) { progress, status in
-            print("[TTS-1.7B-4bit \(Int(progress * 100))%] \(status)")
+            print("[TTS-1.7B-bf16 \(Int(progress * 100))%] \(status)")
         }
-        Self._shared4bitModel = model
+        Self._sharedBf16Model = model
         return model
     }
 

--- a/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
+++ b/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
@@ -1135,7 +1135,7 @@ final class E2ETTS17BTests: XCTestCase {
     /// 1.7B bf16: model loads with correct config
     func testModelLoading17BBf16() async throws {
         let model = try await loadBf16Model()
-        XCTAssertEqual(model.config.talker.bits, 4, "Should load as 4-bit model")
+        XCTAssertEqual(model.config.talker.bits, 0, "Should load as bf16 (no quantization)")
         XCTAssertEqual(model.config.talker.hiddenSize, 2048, "Should be 1.7B (hidden=2048)")
         XCTAssertEqual(model.config.talker.intermediateSize, 6144, "1.7B intermediate size")
     }

--- a/docs/models/tts-model.md
+++ b/docs/models/tts-model.md
@@ -161,14 +161,14 @@ Audio (24kHz) -> SeanetEncoder (Conv1d downsampling, residual blocks)
 
 ## Model Variants
 
-Qwen3-TTS ships in two variants with identical architecture (Talker + Code Predictor + Speech Tokenizer). The difference is fine-tuning and how speaker identity is provided. Both variants are available in 4-bit and 8-bit quantization, and in 0.6B and 1.7B sizes.
+Qwen3-TTS ships in two variants with identical architecture (Talker + Code Predictor + Speech Tokenizer). The difference is fine-tuning and how speaker identity is provided. Both variants come in 0.6B and 1.7B sizes. The 0.6B ships 4-bit and 8-bit; the 1.7B ships **8-bit and bf16** — its 4-bit was dropped because it degraded badly (silent or garbled output on some inputs).
 
 | Variant | Size | Quantization | HuggingFace ID | Speaker Selection |
 |---------|------|--------------|----------------|-------------------|
 | **Base** | 0.6B | 4-bit | `aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit` | None (single default voice) |
 | **Base** | 0.6B | 8-bit | `aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit` | None (single default voice) |
-| **Base** | 1.7B | 4-bit | `aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-4bit` | None (single default voice) |
 | **Base** | 1.7B | 8-bit | `aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit` | None (single default voice) |
+| **Base** | 1.7B | bf16 | `aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16` | None (single default voice) |
 | **CustomVoice** | 0.6B | 4-bit | `aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit` | 9 preset voices + instruction control |
 
 ### CustomVoice Speakers


### PR DESCRIPTION
## Summary

The 1.7B 4-bit Qwen3-TTS variant degrades badly — on some inputs the talker rambles to the token-safety limit and the decoder emits ~5 s of silence plus a short garbled tail (reproduced). Replace it with a **bf16** (non-quantized) variant. The runtime already supports the no-quant path (`detectBits` → 0, `largeBf16` configs from #272), so this is a variant swap, not a runtime change.

## What changed

- `TTSModelVariant`: `base17B` (1.7B-4bit) → `base17Bbf16` (1.7B-bf16).
- CLI `--model 1.7b` / `large` now resolves to **bf16**; added explicit `1.7b-bf16`; `1.7b-8bit` unchanged. No 4-bit 1.7B path remains.
- Tests: `testTTSModelVariants` + the 1.7B E2E suite switched int4 → bf16.
- Docs: `tts-model.md` variant table updated, with a note on why int4 was dropped.

## Validation

- `swift build` and `swift build --build-tests` green.
- bf16 1.7B verified end-to-end out of band: loads (480 weights, fp16), synthesizes at **RTF ≈ 0.48**, 15-sentence round-trip with 0 failures. SEEI (sibilance) shows int4 adds *noticeable* harsh sibilance vs bf16, and 4-bit produced a silent render on one sentence.

## Note

The `aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16` bundle is published separately; CI here only checks the variant string (E2E download tests are gated).
