### PR TITLE
sortformer: high-throughput offline variant + proper streaming state (#319)

### DIFF
--- a/Sources/AudioCLILib/DiarizeCommand.swift
+++ b/Sources/AudioCLILib/DiarizeCommand.swift
@@ -18,6 +18,9 @@ public struct DiarizeCommand: ParsableCommand {
     @Option(name: .long, help: "Diarization engine: pyannote (default) or sortformer")
     public var engine: String = "pyannote"
 
+    @Option(name: .long, help: "Sortformer variant: default (offline, ~125x RTF) or streaming (low-latency)")
+    public var sortformerVariant: String = "default"
+
     @Option(name: .long, help: "Speaker embedding engine: mlx (default) or coreml")
     public var embeddingEngine: String = "mlx"
 
@@ -73,8 +76,17 @@ public struct DiarizeCommand: ParsableCommand {
             print("Warning: --target-speaker is not supported with Sortformer (no speaker embeddings). Ignoring.")
         }
 
-        print("Loading Sortformer model...")
+        let sortformerConfig: SortformerConfig
+        switch sortformerVariant.lowercased() {
+        case "default":   sortformerConfig = .default
+        case "streaming": sortformerConfig = .streaming
+        default:
+            print("Error: unknown sortformer variant '\(sortformerVariant)'. Use 'default' or 'streaming'.")
+            return
+        }
+        print("Loading Sortformer model (variant: \(sortformerVariant.lowercased()), chunk=\(sortformerConfig.coreMLInputFrames) mel frames)...")
         let diarizer = try await SortformerDiarizer.fromPretrained(
+            config: sortformerConfig,
             progressHandler: reportProgress
         )
 

--- a/Sources/SpeechVAD/SortformerConfig.swift
+++ b/Sources/SpeechVAD/SortformerConfig.swift
@@ -54,10 +54,110 @@ public struct SortformerConfig: Sendable {
     /// Minimum silence gap to split segments, in seconds
     public var minSilenceDuration: Float
 
+    // MARK: - Variant identity
+
+    /// Identifies which exported `.mlmodelc` to load from the HF repo. Empty
+    /// is the legacy filename (`Sortformer.mlmodelc`); other variants get a
+    /// suffixed name (`Sortformer_high.mlmodelc`). Lets the same HF repo host
+    /// multiple shape-specific exports of the same NeMo checkpoint.
+    public var variantName: String
+
+    // MARK: - Streaming State Updater
+
+    /// How often (in encoder frames) the spkcache rotates / gets compressed.
+    public var spkcacheUpdatePeriod: Int
+
+    /// Reserved slots per speaker in spkcache filled with the running silence
+    /// profile after compression. Models "what does no-one-speaking look like
+    /// for this acoustic environment" so the compression keeps a baseline.
+    public var spkcacheSilFramesPerSpk: Int
+
+    /// Frames whose summed speaker probability is below this are treated as
+    /// silence and folded into `meanSilenceEmbedding`.
+    public var silenceThreshold: Float
+
+    /// Lower clamp on probabilities going into the log-score computation —
+    /// prevents log(0) blow-up while keeping the relative ordering intact.
+    public var predScoreThreshold: Float
+
+    /// Boost added to scores from the most recent (post-spkcacheCapacity)
+    /// frames so that newer evidence outweighs equally-confident older
+    /// evidence during compression.
+    public var scoresBoostLatest: Float
+
+    /// Fraction of per-speaker spkcache slots that get the strong boost
+    /// (factor 2.0). Highest-scoring frames per speaker.
+    public var strongBoostRate: Float
+
+    /// Fraction of per-speaker spkcache slots that get the weak boost
+    /// (factor 1.0). Picks up moderately-confident frames once the
+    /// strong-boost set is full.
+    public var weakBoostRate: Float
+
+    /// Fraction of per-speaker spkcache slots that must have positive
+    /// scores before non-positive ones are disabled. Stops compression
+    /// from prematurely throwing away "weak but still positive" frames
+    /// when the speaker has very few confident frames.
+    public var minPosScoresRate: Float
+
+    /// Sentinel used as a top-k placeholder for disabled / silent slots.
+    /// Must be larger than any real frame index in a chunk.
+    public var maxIndex: Int
+
+    // MARK: - Derived dimensions
+
+    /// Total mel frames per CoreML call. The model has a fixed input shape
+    /// `[1, coreMLInputFrames, nMels]`, so this is the encoder window
+    /// expressed in mel frames: `(left + core + right) × subsamplingFactor`.
+    /// The fields are still named `*Seconds` for legacy reasons, but their
+    /// values are encoder-frame counts.
+    public var coreMLInputFrames: Int {
+        (Int(leftContextSeconds) + Int(chunkLenSeconds) + Int(rightContextSeconds))
+            * subsamplingFactor
+    }
+
+    /// Filename of the `.mlmodelc` directory inside the HF repo for this
+    /// variant. Default variant keeps the legacy `Sortformer.mlmodelc` so
+    /// existing caches keep working without re-download.
+    public var coreMLModelFileName: String {
+        variantName.isEmpty ? "Sortformer.mlmodelc" : "Sortformer_\(variantName).mlmodelc"
+    }
+
     // MARK: - Presets
 
-    /// Default streaming configuration matching the NeMo checkpoint.
+    /// Default configuration — high-throughput offline diarization.
+    /// `chunk_len=340` encoder frames → ~30 s of audio per CoreML call,
+    /// measured ~125–750× RTF on M-series ANE depending on input length.
+    /// This is what every Swift API and the `speech diarize` CLI use today;
+    /// the small-chunk streaming preset below is held in reserve for a
+    /// future realtime API.
     public static let `default` = SortformerConfig(
+        nMels: 128,
+        nFFT: 400,
+        hopLength: 160,
+        sampleRate: 16000,
+        chunkLenSeconds: 340.0,
+        leftContextSeconds: 1.0,
+        rightContextSeconds: 40.0,
+        subsamplingFactor: 8,
+        spkcacheLen: 188,
+        fifoLen: 40,
+        fcDModel: 512,
+        maxSpeakers: 4,
+        onset: 0.5,
+        offset: 0.3,
+        minSpeechDuration: 0.3,
+        minSilenceDuration: 0.15,
+        spkcacheUpdatePeriod: 188,
+        variantName: ""
+    )
+
+    /// Streaming / low-latency configuration. `chunk_len=6` encoder frames
+    /// (~480 ms of audio per CoreML call) — useful when first output is
+    /// needed before 30 s of audio is buffered. RTF is roughly an order of
+    /// magnitude lower than `.default`; only pick this if you actually need
+    /// the latency.
+    public static let streaming = SortformerConfig(
         nMels: 128,
         nFFT: 400,
         hopLength: 160,
@@ -73,7 +173,9 @@ public struct SortformerConfig: Sendable {
         onset: 0.5,
         offset: 0.3,
         minSpeechDuration: 0.3,
-        minSilenceDuration: 0.15
+        minSilenceDuration: 0.15,
+        spkcacheUpdatePeriod: 32,
+        variantName: "streaming"
     )
 
     public init(
@@ -92,7 +194,17 @@ public struct SortformerConfig: Sendable {
         onset: Float = 0.5,
         offset: Float = 0.3,
         minSpeechDuration: Float = 0.3,
-        minSilenceDuration: Float = 0.15
+        minSilenceDuration: Float = 0.15,
+        spkcacheUpdatePeriod: Int = 32,
+        spkcacheSilFramesPerSpk: Int = 3,
+        silenceThreshold: Float = 0.2,
+        predScoreThreshold: Float = 0.25,
+        scoresBoostLatest: Float = 0.05,
+        strongBoostRate: Float = 0.75,
+        weakBoostRate: Float = 1.5,
+        minPosScoresRate: Float = 0.5,
+        maxIndex: Int = 99_999,
+        variantName: String = ""
     ) {
         self.nMels = nMels
         self.nFFT = nFFT
@@ -110,5 +222,15 @@ public struct SortformerConfig: Sendable {
         self.offset = offset
         self.minSpeechDuration = minSpeechDuration
         self.minSilenceDuration = minSilenceDuration
+        self.spkcacheUpdatePeriod = spkcacheUpdatePeriod
+        self.spkcacheSilFramesPerSpk = spkcacheSilFramesPerSpk
+        self.silenceThreshold = silenceThreshold
+        self.predScoreThreshold = predScoreThreshold
+        self.scoresBoostLatest = scoresBoostLatest
+        self.strongBoostRate = strongBoostRate
+        self.weakBoostRate = weakBoostRate
+        self.minPosScoresRate = minPosScoresRate
+        self.maxIndex = maxIndex
+        self.variantName = variantName
     }
 }

--- a/Sources/SpeechVAD/SortformerDiarizer.swift
+++ b/Sources/SpeechVAD/SortformerDiarizer.swift
@@ -6,8 +6,12 @@ import AudioCommon
 /// End-to-end neural speaker diarization using NVIDIA Sortformer (CoreML).
 ///
 /// Sortformer directly predicts per-frame speaker activity for up to 4 speakers
-/// without requiring separate embedding extraction or clustering. Runs on
-/// Neural Engine at ~120x real-time.
+/// without requiring separate embedding extraction or clustering. The default
+/// preset (`SortformerConfig.default`) runs on the Neural Engine at ~125–750×
+/// RTF on M-series silicon (warm, depending on input length) — single CoreML
+/// dispatch handles up to 30 s of audio per call. A small-chunk
+/// `.streaming` preset is available for future realtime / low-latency
+/// consumers but is significantly slower per-second-of-audio.
 ///
 /// ```swift
 /// let diarizer = try await SortformerDiarizer.fromPretrained()
@@ -30,28 +34,20 @@ public final class SortformerDiarizer {
 
     // MARK: - Streaming State
 
-    /// Speaker cache buffer, flat `[spkcacheLen * fcDModel]`
-    private var spkcache: [Float]
-    /// Number of valid frames in speaker cache
-    private var spkcacheLength: Int = 0
-    /// FIFO buffer, flat `[fifoLen * fcDModel]`
-    private var fifo: [Float]
-    /// Number of valid frames in FIFO
-    private var fifoLength: Int = 0
+    private var state: SortformerStreamingState
+    private let updater: SortformerStateUpdater
+
     init(model: SortformerCoreMLModel, config: SortformerConfig = .default) {
         self.model = model
         self.config = config
         self.melExtractor = SortformerMelExtractor(config: config)
-        self.spkcache = [Float](repeating: 0, count: config.spkcacheLen * config.fcDModel)
-        self.fifo = [Float](repeating: 0, count: config.fifoLen * config.fcDModel)
+        self.state = SortformerStreamingState(config: config)
+        self.updater = SortformerStateUpdater(config: config)
     }
 
     /// Reset streaming state between different audio files.
     public func resetState() {
-        spkcache = [Float](repeating: 0, count: config.spkcacheLen * config.fcDModel)
-        spkcacheLength = 0
-        fifo = [Float](repeating: 0, count: config.fifoLen * config.fcDModel)
-        fifoLength = 0
+        state.reset()
     }
 
     // MARK: - Loading
@@ -66,16 +62,18 @@ public final class SortformerDiarizer {
         modelId: String = defaultModelId,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
+        config: SortformerConfig = .default,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> SortformerDiarizer {
         progressHandler?(0.0, "Downloading Sortformer model...")
 
         let cacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
 
+        let modelFileName = config.coreMLModelFileName
         try await HuggingFaceDownloader.downloadWeights(
             modelId: modelId,
             to: cacheDir,
-            additionalFiles: ["Sortformer.mlmodelc/**", "config.json"],
+            additionalFiles: ["\(modelFileName)/**", "config.json"],
             offlineMode: offlineMode,
             progressHandler: { progress in
                 progressHandler?(progress * 0.8, "Downloading Sortformer model...")
@@ -84,7 +82,7 @@ public final class SortformerDiarizer {
 
         progressHandler?(0.8, "Loading CoreML model...")
 
-        let modelURL = cacheDir.appendingPathComponent("Sortformer.mlmodelc", isDirectory: true)
+        let modelURL = cacheDir.appendingPathComponent(modelFileName, isDirectory: true)
         guard FileManager.default.fileExists(atPath: modelURL.path) else {
             throw AudioModelError.modelLoadFailed(
                 modelId: modelId,
@@ -92,7 +90,13 @@ public final class SortformerDiarizer {
         }
 
         let mlConfig = MLModelConfiguration()
-        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
+        // Match FluidAudio reference: `.all` lets CoreML schedule across
+        // ANE+GPU+CPU as it sees fit and `allowLowPrecisionAccumulationOnGPU`
+        // permits fp16 accumulators on the GPU paths that share work with
+        // ANE-resident layers. Measured ~12% RTF improvement on M5 Pro vs
+        // pinning to .cpuAndNeuralEngine.
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .all)
+        mlConfig.allowLowPrecisionAccumulationOnGPU = true
 
         let mlModel: MLModel
         do {
@@ -104,7 +108,6 @@ public final class SortformerDiarizer {
                 underlying: error)
         }
 
-        let config = SortformerConfig.default
         let coremlModel = SortformerCoreMLModel(model: mlModel, config: config)
 
         progressHandler?(1.0, "Ready")
@@ -168,19 +171,20 @@ public final class SortformerDiarizer {
 
         // Streaming chunking parameters (matching NeMo)
         let subFactor = self.config.subsamplingFactor
-        let chunkLen = Int(self.config.chunkLenSeconds)  // 6 encoder output frames
-        let leftCtx = Int(self.config.leftContextSeconds)  // 1
-        let rightCtx = Int(self.config.rightContextSeconds) // 7
-        let coreMelFrames = chunkLen * subFactor  // 48 mel frames per core chunk
-        let coreMLInputFrames = 112  // Fixed CoreML input size
+        let chunkLen = Int(self.config.chunkLenSeconds)
+        let leftCtx = Int(self.config.leftContextSeconds)
+        let rightCtx = Int(self.config.rightContextSeconds)
+        let coreMelFrames = chunkLen * subFactor
+        let coreMLInputFrames = self.config.coreMLInputFrames
         let nMels = self.config.nMels
         let numSpeakers = self.config.maxSpeakers
+        let dim = self.config.fcDModel
+        let spkcacheCapacity = self.config.spkcacheLen
+        let fifoCapacity = self.config.fifoLen
 
-        // Collect core predictions from each chunk
-        var allChunkProbs = [[Float]]()  // Each entry: [coreFrames * numSpeakers]
+        var allChunkProbs = [[Float]]()
         let emptyResult = DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
 
-        // Calculate total chunks for progress reporting
         let totalChunks = max(1, (totalMelFrames + coreMelFrames - 1) / coreMelFrames)
         var chunkIndex = 0
 
@@ -203,47 +207,49 @@ public final class SortformerDiarizer {
             // Build padded mel chunk [coreMLInputFrames, nMels]
             var chunkMel = [Float](repeating: 0, count: coreMLInputFrames * nMels)
             let framesToCopy = min(actualLen, coreMLInputFrames)
-            for fi in 0..<framesToCopy {
-                let srcBase = (chunkStart + fi) * nMels
-                let dstBase = fi * nMels
-                for di in 0..<nMels {
-                    chunkMel[dstBase + di] = melSpec[srcBase + di]
+            if framesToCopy > 0 {
+                let elements = framesToCopy * nMels
+                let srcStart = chunkStart * nMels
+                chunkMel.withUnsafeMutableBufferPointer { dst in
+                    melSpec.withUnsafeBufferPointer { src in
+                        memcpy(dst.baseAddress!, src.baseAddress! + srcStart,
+                               elements * MemoryLayout<Float>.stride)
+                    }
                 }
             }
+
+            // The CoreML inputs require fixed shapes — pad the dynamic state
+            // arrays up to capacity for this call. The model fills the
+            // unused tail with zeros via its internal length inputs.
+            var paddedSpkcache = state.spkcache
+            paddedSpkcache.append(contentsOf:
+                [Float](repeating: 0,
+                        count: spkcacheCapacity * dim - paddedSpkcache.count))
+            var paddedFifo = state.fifo
+            paddedFifo.append(contentsOf:
+                [Float](repeating: 0,
+                        count: fifoCapacity * dim - paddedFifo.count))
 
             do {
                 let output = try model.predict(
                     chunk: chunkMel,
                     chunkLength: actualLen,
-                    spkcache: spkcache,
-                    spkcacheLength: spkcacheLength,
-                    fifo: fifo,
-                    fifoLength: fifoLength
+                    spkcache: paddedSpkcache,
+                    spkcacheLength: state.spkcacheLength,
+                    fifo: paddedFifo,
+                    fifoLength: state.fifoLength
                 )
 
-                // Extract core predictions (skip spkcache + fifo + left context,
-                // trim right context)
-                let validEmbs: Int = output.validEmbFrames
-                let lcFrames: Int = Int(Float(leftOffset) / Float(subFactor) + 0.5)
-                let rcFrames: Int = Int(ceil(Float(rightOffset) / Float(subFactor)))
-                let coreLen: Int = validEmbs - lcFrames - rcFrames
-                let corePredLen = coreLen > 0 ? coreLen : 0
+                let lcFrames = Int(Float(leftOffset) / Float(subFactor) + 0.5)
+                let rcFrames = Int(ceil(Float(rightOffset) / Float(subFactor)))
 
-                let predOffset = spkcacheLength + fifoLength + lcFrames
-                let totalPredFrames = output.predsFrames
-
-                var chunkProbs = [Float]()
-                for f in 0..<corePredLen {
-                    let predFrame = predOffset + f
-                    guard predFrame < totalPredFrames else { break }
-                    for s in 0..<numSpeakers {
-                        chunkProbs.append(output.pred(frame: predFrame, speaker: s))
-                    }
-                }
-                allChunkProbs.append(chunkProbs)
-
-                // Update streaming state (FIFO overflow → spkcache)
-                updateState(from: output)
+                let result = updater.update(
+                    state: &state,
+                    chunkEmbs: output.encoderEmbs,
+                    preds: output.speakerPreds,
+                    leftContext: lcFrames,
+                    rightContext: rcFrames)
+                allChunkProbs.append(result.confirmed)
             } catch {
                 print("Warning: Sortformer inference failed on chunk at mel frame \(sttFeat): \(error)")
             }
@@ -273,90 +279,6 @@ public final class SortformerDiarizer {
             numSpeakers: usedSpeakers.count,
             speakerEmbeddings: []  // End-to-end model, no separate embeddings
         )
-    }
-
-    // MARK: - State Management (NeMo FIFO→spkcache pattern)
-
-    /// Update spkcache and fifo buffers from encoder embeddings.
-    ///
-    /// Follows NeMo's streaming_update: new embeddings go into FIFO.
-    /// When FIFO overflows, oldest frames move to spkcache.
-    private func updateState(from output: SortformerOutput) {
-        let validFrames = output.validEmbFrames
-        guard validFrames > 0 else { return }
-        let dim = config.fcDModel
-        let fifoCapacity = config.fifoLen
-        let cacheCapacity = config.spkcacheLen
-
-        if fifoLength + validFrames <= fifoCapacity {
-            // FIFO has room — just append
-            for f in 0..<validFrames {
-                let srcBase = f * dim
-                let dstBase = (fifoLength + f) * dim
-                for d in 0..<dim {
-                    fifo[dstBase + d] = output.encoderEmbs[srcBase + d]
-                }
-            }
-            fifoLength += validFrames
-        } else {
-            // FIFO overflow: move oldest frames to spkcache
-            let overflow = fifoLength + validFrames - fifoCapacity
-
-            // Move overflow frames from front of FIFO to spkcache
-            if spkcacheLength + overflow <= cacheCapacity {
-                // Append to spkcache
-                for f in 0..<overflow {
-                    let srcBase = f * dim
-                    let dstBase = (spkcacheLength + f) * dim
-                    for d in 0..<dim {
-                        spkcache[dstBase + d] = fifo[srcBase + d]
-                    }
-                }
-                spkcacheLength += overflow
-            } else {
-                // Spkcache also overflows — shift left and append
-                let cacheOverflow = spkcacheLength + overflow - cacheCapacity
-                let keep = spkcacheLength - cacheOverflow
-                if keep > 0 {
-                    for f in 0..<keep {
-                        let srcBase = (f + cacheOverflow) * dim
-                        let dstBase = f * dim
-                        for d in 0..<dim {
-                            spkcache[dstBase + d] = spkcache[srcBase + d]
-                        }
-                    }
-                }
-                for f in 0..<overflow {
-                    let srcBase = f * dim
-                    let dstBase = (keep + f) * dim
-                    for d in 0..<dim {
-                        spkcache[dstBase + d] = fifo[srcBase + d]
-                    }
-                }
-                spkcacheLength = min(cacheCapacity, keep + overflow)
-            }
-
-            // Shift FIFO left by overflow, then append new frames
-            let remaining = fifoLength - overflow
-            if remaining > 0 {
-                for f in 0..<remaining {
-                    let srcBase = (f + overflow) * dim
-                    let dstBase = f * dim
-                    for d in 0..<dim {
-                        fifo[dstBase + d] = fifo[srcBase + d]
-                    }
-                }
-            }
-            fifoLength = remaining
-            for f in 0..<validFrames {
-                let srcBase = f * dim
-                let dstBase = (fifoLength + f) * dim
-                for d in 0..<dim {
-                    fifo[dstBase + d] = output.encoderEmbs[srcBase + d]
-                }
-            }
-            fifoLength += validFrames
-        }
     }
 
     // MARK: - Binarization

--- a/Sources/SpeechVAD/SortformerModel.swift
+++ b/Sources/SpeechVAD/SortformerModel.swift
@@ -13,9 +13,10 @@ final class SortformerCoreMLModel {
     private let model: MLModel
     let config: SortformerConfig
 
-    /// Input shape constants derived from the CoreML model.
-    /// chunk: [1, 112, 128], spkcache: [1, 188, 512], fifo: [1, 40, 512]
-    private let chunkFrames: Int = 112
+    /// Input shape constants derived from the CoreML model. `chunkFrames` is
+    /// the model's fixed mel-frame input dimension — varies by variant.
+    /// chunk: `[1, chunkFrames, 128]`, spkcache: `[1, 188, 512]`, fifo: `[1, fifoLen, 512]`.
+    private let chunkFrames: Int
     private let spkcacheFrames: Int
     private let fifoFrames: Int
     private let featureDim: Int
@@ -23,6 +24,7 @@ final class SortformerCoreMLModel {
     init(model: MLModel, config: SortformerConfig = .default) {
         self.model = model
         self.config = config
+        self.chunkFrames = config.coreMLInputFrames
         self.spkcacheFrames = config.spkcacheLen
         self.fifoFrames = config.fifoLen
         self.featureDim = config.fcDModel

--- a/Sources/SpeechVAD/SortformerStateUpdater.swift
+++ b/Sources/SpeechVAD/SortformerStateUpdater.swift
@@ -1,0 +1,532 @@
+import Accelerate
+import Foundation
+
+/// Streaming state carried across Sortformer chunks.
+///
+/// The model is autoregressive in speaker identity: each chunk's predictions
+/// depend on `spkcache` (long-term speaker memory) and `fifo` (recent context)
+/// from prior chunks. To keep identities stable across chunks we have to
+/// maintain those buffers *and* their predictions in sync with what the model
+/// expects on the next call.
+public struct SortformerStreamingState: Sendable {
+    /// Flat `[length, fcDModel]` embeddings — long-term speaker memory.
+    public var spkcache: [Float]
+    public var spkcacheLength: Int
+    /// Flat `[length, numSpeakers]` predictions tracked alongside `spkcache`.
+    /// Used during compression to keep the highest-confidence frames per
+    /// speaker. Lazily created the first time spkcache overflows.
+    public var spkcachePreds: [Float]?
+
+    /// Flat `[length, fcDModel]` embeddings — recent context being collected
+    /// before it spills into `spkcache`.
+    public var fifo: [Float]
+    public var fifoLength: Int
+    /// Flat `[length, numSpeakers]` predictions tracked alongside `fifo`.
+    public var fifoPreds: [Float]?
+
+    /// Running mean embedding for silence frames. Filled with the
+    /// `[spkcacheSilFramesPerSpk × numSpeakers]` placeholder slots during
+    /// spkcache compression so the model has a stable "no one is talking"
+    /// anchor for the current acoustic environment.
+    public var meanSilenceEmbedding: [Float]
+    public var silenceFrameCount: Int
+
+    public init(config: SortformerConfig) {
+        self.spkcache = []
+        self.spkcacheLength = 0
+        self.spkcachePreds = nil
+
+        self.fifo = []
+        self.fifoLength = 0
+        self.fifoPreds = nil
+
+        let dim = config.fcDModel
+        self.fifo.reserveCapacity(
+            (config.fifoLen + Int(config.chunkLenSeconds)) * dim)
+        self.spkcache.reserveCapacity(
+            (config.spkcacheLen + config.spkcacheUpdatePeriod) * dim)
+        self.meanSilenceEmbedding = [Float](repeating: 0, count: dim)
+        self.silenceFrameCount = 0
+    }
+
+    public mutating func reset() {
+        spkcache.removeAll(keepingCapacity: true)
+        spkcacheLength = 0
+        spkcachePreds = nil
+        fifo.removeAll(keepingCapacity: true)
+        fifoLength = 0
+        fifoPreds = nil
+        meanSilenceEmbedding = [Float](
+            repeating: 0, count: meanSilenceEmbedding.count)
+        silenceFrameCount = 0
+    }
+}
+
+/// Streaming state manager for Sortformer. Ports NeMo's `streaming_update`
+/// (Python) / FluidAudio's `SortformerStateUpdater` (Swift) so multi-chunk
+/// runs of the High variant keep speaker identity stable.
+///
+/// Why this exists: each model call returns per-frame predictions for
+/// `spkcache + fifo + chunk` frames plus encoder embeddings for the chunk
+/// itself. The naive "discard oldest when overflow" approach drops the
+/// speaker-identifying frames the model needs to keep speakers consistent
+/// across chunks. The reference algorithm instead:
+///   1. Tracks predictions alongside embeddings.
+///   2. Folds silence frames into a running mean (acoustic anchor).
+///   3. Compresses the spkcache via log-score top-K so the most distinctive
+///      frame per speaker survives, not the most recent one.
+struct SortformerStateUpdater {
+    let config: SortformerConfig
+
+    init(config: SortformerConfig) {
+        self.config = config
+    }
+
+    /// Result of one streaming update — the per-chunk predictions in the
+    /// "confirmed" region (core frames) and the "tentative" region
+    /// (right-context frames whose interpretation may change once the next
+    /// chunk lands).
+    struct Update {
+        let confirmed: [Float]  // [coreFrames * numSpeakers]
+        let tentative: [Float]  // [rightCtx * numSpeakers]
+    }
+
+    /// Apply one chunk to the streaming state.
+    ///
+    /// - Parameters:
+    ///   - state: streaming state, mutated in place
+    ///   - chunkEmbs: per-frame encoder embeddings for the chunk, flat
+    ///     `[chunkLeft + chunkCore + chunkRight, fcDModel]`
+    ///   - preds: per-frame predictions for the full output region, flat
+    ///     `[spkcacheLength + fifoLength + chunkFrames, numSpeakers]`
+    ///   - leftContext: number of left-context encoder frames in this chunk
+    ///     (varies between the first chunk and later ones)
+    ///   - rightContext: number of right-context encoder frames in this chunk
+    func update(
+        state: inout SortformerStreamingState,
+        chunkEmbs: [Float],
+        preds: [Float],
+        leftContext: Int,
+        rightContext: Int
+    ) -> Update {
+        let dim = config.fcDModel
+        let numSpeakers = config.maxSpeakers
+        let fifoCapacity = config.fifoLen
+        let spkcacheCapacity = config.spkcacheLen
+
+        let prevSpkcacheLen = state.spkcacheLength
+        let prevFifoLen = state.fifoLength
+
+        // Capture FIFO predictions before we slice the new chunk in.
+        if prevFifoLen > 0 {
+            let start = prevSpkcacheLen * numSpeakers
+            let end = (prevSpkcacheLen + prevFifoLen) * numSpeakers
+            if end <= preds.count {
+                state.fifoPreds = Array(preds[start..<end])
+            }
+        }
+
+        // Slice out the CORE frames from the chunk embeddings (no context).
+        let chunkTotalFrames = chunkEmbs.count / dim
+        let coreFrames = max(0, chunkTotalFrames - leftContext - rightContext)
+        let coreStart = leftContext * dim
+        let coreEnd = (leftContext + coreFrames) * dim
+        let coreEmbs = (coreEnd <= chunkEmbs.count)
+            ? Array(chunkEmbs[coreStart..<coreEnd])
+            : []
+
+        // Per-chunk predictions live at:
+        //   spkcache (prevSpkcacheLen) | fifo (prevFifoLen) | chunk (chunkTotalFrames)
+        // Core slice: skip left context, take coreFrames.
+        let chunkStart = prevSpkcacheLen + prevFifoLen + leftContext
+        let chunkEnd = chunkStart + coreFrames
+        let tentEnd = chunkEnd + rightContext
+        let confirmed: [Float] = {
+            let s = chunkStart * numSpeakers
+            let e = chunkEnd * numSpeakers
+            guard e <= preds.count else { return [] }
+            return Array(preds[s..<e])
+        }()
+        let tentative: [Float] = {
+            let s = chunkEnd * numSpeakers
+            let e = tentEnd * numSpeakers
+            guard e <= preds.count else { return [] }
+            return Array(preds[s..<e])
+        }()
+
+        // Append core embeddings and predictions to FIFO.
+        state.fifo.append(contentsOf: coreEmbs)
+        state.fifoLength += coreFrames
+        if state.fifoPreds != nil {
+            state.fifoPreds!.append(contentsOf: confirmed)
+        } else {
+            state.fifoPreds = confirmed
+        }
+
+        // Flush oldest FIFO frames into spkcache when FIFO overflows.
+        let context = coreFrames + prevFifoLen
+        if context > fifoCapacity {
+            guard let currentFifoPreds = state.fifoPreds else {
+                return Update(confirmed: confirmed, tentative: tentative)
+            }
+
+            var popOut = config.spkcacheUpdatePeriod
+            popOut = max(popOut, context - fifoCapacity)
+            popOut = min(popOut, context)
+
+            let popEmbs = Array(state.fifo.prefix(popOut * dim))
+            let popPreds = Array(currentFifoPreds.prefix(popOut * numSpeakers))
+
+            updateSilenceProfile(
+                state: &state, embs: popEmbs, preds: popPreds,
+                frameCount: popOut)
+
+            state.fifo.removeFirst(popOut * dim)
+            state.fifoLength -= popOut
+            state.fifoPreds?.removeFirst(popOut * numSpeakers)
+
+            state.spkcache.append(contentsOf: popEmbs)
+            state.spkcacheLength += popOut
+            if state.spkcachePreds != nil {
+                state.spkcachePreds!.append(contentsOf: popPreds)
+            }
+
+            // Compress spkcache the first time AND every time it overflows.
+            if state.spkcacheLength > spkcacheCapacity {
+                if state.spkcachePreds == nil {
+                    // First overflow — backfill predictions for the frames
+                    // we already had before popOut arrived.
+                    if prevSpkcacheLen > 0 {
+                        let prefix = preds.prefix(prevSpkcacheLen * numSpeakers)
+                        state.spkcachePreds = Array(prefix) + popPreds
+                    } else {
+                        state.spkcachePreds = popPreds
+                    }
+                }
+                compressSpkcache(state: &state)
+            }
+        }
+
+        return Update(confirmed: confirmed, tentative: tentative)
+    }
+
+    // MARK: - Silence profile
+
+    private func updateSilenceProfile(
+        state: inout SortformerStreamingState,
+        embs: [Float],
+        preds: [Float],
+        frameCount: Int
+    ) {
+        let dim = config.fcDModel
+        let numSpeakers = config.maxSpeakers
+        let silenceThreshold = config.silenceThreshold
+
+        for frame in 0..<frameCount {
+            var probSum: Float = 0
+            for spk in 0..<numSpeakers {
+                let idx = frame * numSpeakers + spk
+                if idx < preds.count { probSum += preds[idx] }
+            }
+            guard probSum < silenceThreshold else { continue }
+
+            let n = Float(state.silenceFrameCount)
+            let newN = n + 1
+            for d in 0..<dim {
+                let i = frame * dim + d
+                guard i < embs.count else { continue }
+                let old = state.meanSilenceEmbedding[d]
+                state.meanSilenceEmbedding[d] = (old * n + embs[i]) / newN
+            }
+            state.silenceFrameCount += 1
+        }
+    }
+
+    // MARK: - Spkcache compression
+
+    /// Compress spkcache from `state.spkcacheLength` rows down to
+    /// `config.spkcacheLen` by keeping the most distinctive frame per speaker.
+    /// Mirrors NeMo's `_compress_spkcache`.
+    private func compressSpkcache(state: inout SortformerStreamingState) {
+        guard let spkcachePreds = state.spkcachePreds else { return }
+
+        let dim = config.fcDModel
+        let numSpeakers = config.maxSpeakers
+        let spkcacheCapacity = config.spkcacheLen
+        let silPerSpk = config.spkcacheSilFramesPerSpk
+        let currentLen = state.spkcacheLength
+
+        // Per-speaker budget after silence reservations.
+        let perSpk = spkcacheCapacity / numSpeakers - silPerSpk
+        let strongPerSpk = Int(Float(perSpk) * config.strongBoostRate)
+        let weakPerSpk = Int(Float(perSpk) * config.weakBoostRate)
+        let minPosPerSpk = Int(Float(perSpk) * config.minPosScoresRate)
+
+        var scores = logPredScores(preds: spkcachePreds, frameCount: currentLen)
+        scores = disableLowScores(
+            preds: spkcachePreds, scores: scores,
+            frameCount: currentLen, minPos: minPosPerSpk)
+
+        // Latest frames (past the capacity threshold) get a small bonus —
+        // breaks ties in favor of recency.
+        if currentLen > spkcacheCapacity {
+            for frame in spkcacheCapacity..<currentLen {
+                for spk in 0..<numSpeakers {
+                    scores[frame * numSpeakers + spk] += config.scoresBoostLatest
+                }
+            }
+        }
+
+        scores = boostTopK(
+            scores: scores, frameCount: currentLen,
+            k: strongPerSpk, scale: 2.0)
+        scores = boostTopK(
+            scores: scores, frameCount: currentLen,
+            k: weakPerSpk, scale: 1.0)
+
+        // Reserve `silPerSpk × numSpeakers` slots with +∞ score so they
+        // always make the top-k cut and we can fill them with silence embeds.
+        let totalFrames = currentLen + silPerSpk
+        for _ in 0..<(silPerSpk * numSpeakers) {
+            scores.append(.infinity)
+        }
+
+        let (indices, disabled) = topKIndices(
+            scores: scores, frameCount: totalFrames, k: spkcacheCapacity)
+
+        var newSpkcache = [Float](repeating: 0, count: spkcacheCapacity * dim)
+        var newPreds = [Float](repeating: 0, count: spkcacheCapacity * numSpeakers)
+
+        for (i, frameIdx) in indices.enumerated() {
+            if disabled[i] {
+                // Fill with running silence profile.
+                for d in 0..<dim {
+                    newSpkcache[i * dim + d] = state.meanSilenceEmbedding[d]
+                }
+                // Predictions left at zero.
+            } else if frameIdx < currentLen {
+                for d in 0..<dim {
+                    let src = frameIdx * dim + d
+                    if src < state.spkcache.count {
+                        newSpkcache[i * dim + d] = state.spkcache[src]
+                    }
+                }
+                for s in 0..<numSpeakers {
+                    let src = frameIdx * numSpeakers + s
+                    if src < spkcachePreds.count {
+                        newPreds[i * numSpeakers + s] = spkcachePreds[src]
+                    }
+                }
+            }
+        }
+
+        state.spkcache = newSpkcache
+        state.spkcacheLength = spkcacheCapacity
+        state.spkcachePreds = newPreds
+    }
+
+    // MARK: - Score computation
+
+    /// log(p/(1-p)) + Σ_{j≠i} log(1-p_j) - log(0.5)
+    private func logPredScores(preds: [Float], frameCount: Int) -> [Float] {
+        let numSpeakers = config.maxSpeakers
+        let threshold = config.predScoreThreshold
+        var scores = [Float](repeating: 0, count: frameCount * numSpeakers)
+
+        var tmp = [Float](repeating: 0, count: preds.count)
+        var log1mP = [Float](repeating: 0, count: preds.count)
+
+        vDSP.clip(preds, to: threshold...Float.greatestFiniteMagnitude, result: &tmp)
+        vForce.log(tmp, result: &scores)
+
+        vDSP.clip(preds, to: 0...(1 - threshold), result: &tmp)
+        vDSP.negative(tmp, result: &tmp)
+        vForce.log1p(tmp, result: &log1mP)
+        vDSP.subtract(scores, log1mP, result: &scores)
+        vDSP.add(logf(2), scores, result: &scores)
+
+        scores.withUnsafeMutableBufferPointer { sBuf in
+            log1mP.withUnsafeBufferPointer { lBuf in
+                guard let s = sBuf.baseAddress, let l = lBuf.baseAddress else { return }
+                let S = numSpeakers
+                for frame in 0..<frameCount {
+                    let base = frame &* S
+                    var sum: Float = 0
+                    for spk in 0..<S { sum += l[base + spk] }
+                    for spk in 0..<S { s[base + spk] += sum }
+                }
+            }
+        }
+        return scores
+    }
+
+    /// Mark scores `-∞` for non-speech frames and for frames whose speaker
+    /// already has enough positive scores.
+    private func disableLowScores(
+        preds: [Float],
+        scores: [Float],
+        frameCount: Int,
+        minPos: Int
+    ) -> [Float] {
+        let numSpeakers = config.maxSpeakers
+        var result = scores
+
+        var posCounts = [Int](repeating: 0, count: numSpeakers)
+        for frame in 0..<frameCount {
+            for spk in 0..<numSpeakers {
+                let idx = frame * numSpeakers + spk
+                if preds[idx] > 0.5 && scores[idx] > 0 {
+                    posCounts[spk] += 1
+                }
+            }
+        }
+        for spk in 0..<numSpeakers {
+            for frame in 0..<frameCount {
+                let idx = frame * numSpeakers + spk
+                let p = preds[idx]
+                if p <= 0.5 {
+                    result[idx] = -.infinity
+                    continue
+                }
+                if result[idx] <= 0 && posCounts[spk] >= minPos {
+                    result[idx] = -.infinity
+                }
+            }
+        }
+        return result
+    }
+
+    /// Boost the top-k scores per speaker by `-scale * log(0.5)`.
+    private func boostTopK(
+        scores: [Float],
+        frameCount: Int,
+        k: Int,
+        scale: Float
+    ) -> [Float] {
+        let S = config.maxSpeakers
+        guard frameCount > 0, S > 0, k > 0 else { return scores }
+        let boost: Float = -scale * logf(0.5)
+        var result = scores
+        let kEff = min(k, frameCount)
+
+        result.withUnsafeMutableBufferPointer { resBuf in
+            guard let base = resBuf.baseAddress else { return }
+            for spk in 0..<S {
+                // Insertion sort: arrays kept DESC by score.
+                var topFrames = [Int](repeating: 0, count: kEff)
+                var topScores = [Float](
+                    repeating: -.greatestFiniteMagnitude, count: kEff)
+                var count = 0
+                for frame in 0..<frameCount {
+                    let idx = frame &* S &+ spk
+                    let v = base[idx]
+                    if v == -.infinity { continue }
+                    if count < kEff {
+                        var pos = count
+                        while pos > 0 && v > topScores[pos - 1] {
+                            topScores[pos] = topScores[pos - 1]
+                            topFrames[pos] = topFrames[pos - 1]
+                            pos -= 1
+                        }
+                        topScores[pos] = v
+                        topFrames[pos] = frame
+                        count += 1
+                    } else {
+                        if v <= topScores[count - 1] { continue }
+                        var pos = count - 1
+                        while pos > 0 && v > topScores[pos - 1] {
+                            topScores[pos] = topScores[pos - 1]
+                            topFrames[pos] = topFrames[pos - 1]
+                            pos -= 1
+                        }
+                        topScores[pos] = v
+                        topFrames[pos] = frame
+                    }
+                }
+                for i in 0..<count {
+                    base[topFrames[i] &* S &+ spk] += boost
+                }
+            }
+        }
+        return result
+    }
+
+    /// Top-k frame indices over the (numSpeakers × frameCount) flattened
+    /// scores. Matches NeMo's `_get_topk_indices` exactly: permutes to
+    /// `[speaker, frame]` order, takes the top k, sorts ascending, then
+    /// converts back to frame indices via `% frameCount`. Frames past the
+    /// real content (`frameCount - silFramesPerSpk`) are marked disabled
+    /// so the caller fills them with the silence profile.
+    private func topKIndices(
+        scores: [Float],
+        frameCount: Int,
+        k: Int
+    ) -> (indices: [Int], disabled: [Bool]) {
+        let S = config.maxSpeakers
+        let silPerSpk = config.spkcacheSilFramesPerSpk
+        let realFrames = frameCount - silPerSpk
+        let maxIndex = config.maxIndex
+        let N = frameCount * S
+        guard k > 0 else { return ([], []) }
+
+        let kEff = min(k, N)
+        var bestIdx = [Int](repeating: 0, count: kEff)
+        var bestVal = [Float](repeating: -.infinity, count: kEff)
+        var count = 0
+
+        for spk in 0..<S {
+            for frame in 0..<frameCount {
+                let permuted = spk * frameCount + frame
+                let v = scores[frame * S + spk]
+                if count < kEff {
+                    var pos = count
+                    while pos > 0 {
+                        let pv = bestVal[pos - 1]
+                        let pi = bestIdx[pos - 1]
+                        if v > pv || (v == pv && permuted < pi) {
+                            bestVal[pos] = pv
+                            bestIdx[pos] = pi
+                            pos -= 1
+                        } else { break }
+                    }
+                    bestVal[pos] = v
+                    bestIdx[pos] = permuted
+                    count += 1
+                } else {
+                    let worstV = bestVal[kEff - 1]
+                    let worstI = bestIdx[kEff - 1]
+                    if v < worstV || (v == worstV && permuted >= worstI) { continue }
+                    var pos = kEff - 1
+                    while pos > 0 {
+                        let pv = bestVal[pos - 1]
+                        let pi = bestIdx[pos - 1]
+                        if v > pv || (v == pv && permuted < pi) {
+                            bestVal[pos] = pv
+                            bestIdx[pos] = pi
+                            pos -= 1
+                        } else { break }
+                    }
+                    bestVal[pos] = v
+                    bestIdx[pos] = permuted
+                }
+            }
+        }
+
+        var indices = [Int](repeating: maxIndex, count: k)
+        for i in 0..<kEff {
+            indices[i] = (bestVal[i] == -.infinity) ? maxIndex : bestIdx[i]
+        }
+        indices.sort()
+
+        var disabled = [Bool](repeating: false, count: k)
+        for i in 0..<k where indices[i] == maxIndex { disabled[i] = true }
+        for i in 0..<k where !disabled[i] {
+            indices[i] = indices[i] % frameCount
+        }
+        for i in 0..<k where !disabled[i] {
+            if indices[i] >= realFrames { disabled[i] = true }
+        }
+        for i in 0..<k where disabled[i] { indices[i] = 0 }
+        return (indices, disabled)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix issue #319 (Sortformer slow and inaccurate): ship a high-throughput offline variant of the model and port NeMo's streaming state-update so multi-chunk runs keep speaker identity stable
- New `SortformerConfig.default` = chunk_len=340 (~30 s of audio per CoreML call) — measured 125-750× RTF on M5 Pro depending on input length
- Old streaming-shape variant kept under `SortformerConfig.streaming` for a future low-latency consumer
- Both variants published to `aufklarer/Sortformer-Diarization-CoreML`

References issue #319 — does not auto-close (leaving it open for the reporter to confirm on their setup).

## Diagnosis
Two root causes, both fixed here.

**Speed.** The `.mlmodelc` we shipped was a streaming export with `chunk_len=6` (~480 ms of audio per CoreML call). Each ANE dispatch has fixed overhead, so the small chunk left most of the budget paying for dispatch rather than real inference. Switching to a `chunk_len=340` export (~30 s per call) amortizes the fixed cost to near-zero.

**Accuracy.** Our previous `updateState` was a naive "discard oldest on overflow", which threw away the speaker-identifying frames the model relies on to keep speakers stable across chunks. Default was hit hardest (6-frame chunks rely heavily on long-term spkcache history). The multi-chunk High path inherited the same bug at a different scale.

Both now go through the ported NeMo streaming_update logic in `SortformerStateUpdater`:
- Tracks predictions alongside embeddings
- Folds silence frames into a running acoustic profile
- Compresses spkcache via log-pred scoring + top-K selection so the most distinctive frame per speaker survives, not the most recent one

## Changes
| File | Change |
|------|--------|
| `Sources/SpeechVAD/SortformerStateUpdater.swift` | **NEW** — port of NeMo `streaming_update` (silence profile, log-pred scoring, top-K spkcache compression) |
| `Sources/SpeechVAD/SortformerConfig.swift` | Added 9 streaming-updater knobs, `.streaming` preset, `variantName` + derived `coreMLModelFileName` |
| `Sources/SpeechVAD/SortformerDiarizer.swift` | Uses new state + updater; loader picks `.mlmodelc` filename from config |
| `Sources/SpeechVAD/SortformerModel.swift` | Chunk shape now config-driven (was hardcoded 112) |
| `Sources/AudioCLILib/DiarizeCommand.swift` | `--sortformer-variant default\|streaming` flag |

## Verification
**M5 Pro (release build, warm runs)** across locally-built multi-speaker fixtures:

| Fixture | Length | Before | Default now | Pyannote (reference) |
|---------|--------|--------|-------------|----------------------|
| 1 speaker simple | 20 s | 16× | 125× ✅ 1 spk | — |
| 3-source mix | 45 s | 18× | 252× ✅ 2 spk | — |
| 2-spk alt Q↔DE × 3 | 76 s | 21× | **362× ✅ perfect alternation** | perfect alternation |
| 4-spk round-robin | 68 s | 21× | **324× ✅ all 4 spk distinct** | 4 spk |
| 240 s same × 12 | 240 s | 20× | **750× ✅ 1 spk** | — |
| 360 s same × 18 | 360 s | 20× | **837× ✅ 1 spk** | — |

**Test suite:** 144/144 SpeechVAD tests pass (SortformerTests, DiarizationHelpersTests, DiarizationPipelineTests, E2EDiarizationPipelineTests, FireRedVADTests, SileroVADTests, SpeechVADTests, WeSpeakerTests).

## Backwards compat
`SortformerDiarizer.fromPretrained()` with no arguments still downloads `Sortformer.mlmodelc` from `aufklarer/Sortformer-Diarization-CoreML` (same model id, same filename) — but the file content is now the chunk_len=340 export. Existing caches will refresh via HF on first download.

API additions are all optional defaults; no consumer changes required.

## Test plan
- [ ] PR `build-and-test` green
- [ ] One reviewer confirms the variant rename intent (`.default` is the offline path now, not the streaming one)

## Notes
- The earlier docstring claim of "120× real-time" was copied from upstream docs and never independently measured. We now hit that number for real with the default variant.