### PR TITLE
fix(sortformer): default to ANE-only compute units (#319)

### DIFF
--- a/Sources/SpeechVAD/SortformerDiarizer.swift
+++ b/Sources/SpeechVAD/SortformerDiarizer.swift
@@ -90,12 +90,18 @@ public final class SortformerDiarizer {
         }
 
         let mlConfig = MLModelConfiguration()
-        // Match FluidAudio reference: `.all` lets CoreML schedule across
-        // ANE+GPU+CPU as it sees fit and `allowLowPrecisionAccumulationOnGPU`
-        // permits fp16 accumulators on the GPU paths that share work with
-        // ANE-resident layers. Measured ~12% RTF improvement on M5 Pro vs
-        // pinning to .cpuAndNeuralEngine.
-        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .all)
+        // `.cpuAndNeuralEngine` skips the GPU/MPSGraph backend during model
+        // load validation. `.all` is ~12% faster on some configurations but
+        // forces CoreML to validate the pipeline against MPSGraph as well,
+        // and that validation fails on chip+OS combos where MPSGraph rejects
+        // ops our pipeline emits (reported on M5 Max with macOS 26 in #319:
+        // "Espresso compiled without MPSGraph enabled"). Matches the default
+        // every other VAD loader in this package uses (Silero, FireRed,
+        // WeSpeaker, CAM++).
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
+        // Hint only honored when the runtime actually schedules GPU work
+        // (e.g. user opts back in with SPEECH_COREML_COMPUTE_UNITS=all). No
+        // effect on the default ANE-only path.
         mlConfig.allowLowPrecisionAccumulationOnGPU = true
 
         let mlModel: MLModel


### PR DESCRIPTION
## Summary

Sortformer was the only CoreML loader in this repo defaulting to `MLComputeUnits.all`. Every other VAD loader (Silero, FireRed, WeSpeaker, CAM++) uses `.cpuAndNeuralEngine`. This PR brings Sortformer in line.

## Why

Reported in #319 on M5 Max + macOS 26 after the #326 fix:

```
EXC_BAD_ACCESS
E5RT encountered an STL exception. msg = Espresso exception: "Invalid state":
MpsGraph backend validation on incompatible OS.
[Espresso::handle_ex_] exception=Espresso compiled without MPSGraph enabled
```

`.all` tells CoreML it may schedule across ANE + GPU + CPU, which makes CoreML AOT-validate the model for the GPU/MPSGraph backend at load time — not just the ANE backend it will actually use. MPSGraph's op validation differs by chip family + macOS point release, so the same `.mlpackage` can pass on one M-series machine and crash the loader on another.

`.cpuAndNeuralEngine` skips the GPU/MPSGraph validation entirely. The model still runs on ANE just like before.

## Trade-off

`.all` was a measured ~12% RTF win on my M5 Pro vs `.cpuAndNeuralEngine`. We lose that on configurations where `.all` would have worked, but the default offline preset still runs ~125-750× RTF on M-series. Users who want the GPU path back can opt in with:

```
SPEECH_COREML_COMPUTE_UNITS=all speech diarize ...
```

via the existing `CoreMLComputeUnitsResolver` env override.

## Test plan

- [x] `swift test --filter "Sortformer|Diarization"` — 49/49 pass (incl. `testE2EWithRealModel` which loads the actual CoreML model)
- [x] CLI smoke: `speech diarize test_audio.wav --engine sortformer` — 20s audio in 0.15s (133× RTF), no MPSGraph error on M5 Pro
- [ ] Reporter on M5 Max to verify the load error is gone

Fixes #319