### PR TITLE
feat(sortformer): preload(), computeUnits, balanced variant

### DIFF
--- a/Sources/AudioCLILib/DiarizeCommand.swift
+++ b/Sources/AudioCLILib/DiarizeCommand.swift
@@ -2,6 +2,9 @@ import Foundation
 import ArgumentParser
 import SpeechVAD
 import AudioCommon
+#if canImport(CoreML)
+import CoreML
+#endif
 
 public struct DiarizeCommand: ParsableCommand {
     public static let configuration = CommandConfiguration(
@@ -18,8 +21,11 @@ public struct DiarizeCommand: ParsableCommand {
     @Option(name: .long, help: "Diarization engine: pyannote (default) or sortformer")
     public var engine: String = "pyannote"
 
-    @Option(name: .long, help: "Sortformer variant: default (offline, ~125x RTF) or streaming (low-latency)")
+    @Option(name: .long, help: "Sortformer variant: default (offline, ~125x RTF), balanced (faster first-load, ~hundreds-x RTF), or streaming (low-latency)")
     public var sortformerVariant: String = "default"
+
+    @Option(name: .long, help: "Sortformer CoreML compute units: ane (default, ANE+CPU), cpu (instant first-load, ~20x RTF), gpu (cpu+gpu), all (every backend; rarely needed)")
+    public var sortformerComputeUnits: String = "ane"
 
     @Option(name: .long, help: "Speaker embedding engine: mlx (default) or coreml")
     public var embeddingEngine: String = "mlx"
@@ -79,14 +85,32 @@ public struct DiarizeCommand: ParsableCommand {
         let sortformerConfig: SortformerConfig
         switch sortformerVariant.lowercased() {
         case "default":   sortformerConfig = .default
+        case "balanced":  sortformerConfig = .balanced
         case "streaming": sortformerConfig = .streaming
         default:
-            print("Error: unknown sortformer variant '\(sortformerVariant)'. Use 'default' or 'streaming'.")
+            print("Error: unknown sortformer variant '\(sortformerVariant)'. Use 'default', 'balanced', or 'streaming'.")
             return
         }
-        print("Loading Sortformer model (variant: \(sortformerVariant.lowercased()), chunk=\(sortformerConfig.coreMLInputFrames) mel frames)...")
+
+        let computeUnits: MLComputeUnits
+        switch sortformerComputeUnits.lowercased() {
+        case "ane", "cpuandneuralengine", "neuralengine":
+            computeUnits = .cpuAndNeuralEngine
+        case "cpu", "cpuonly":
+            computeUnits = .cpuOnly
+        case "gpu", "cpuandgpu":
+            computeUnits = .cpuAndGPU
+        case "all":
+            computeUnits = .all
+        default:
+            print("Error: unknown sortformer compute units '\(sortformerComputeUnits)'. Use 'ane', 'cpu', 'gpu', or 'all'.")
+            return
+        }
+
+        print("Loading Sortformer model (variant: \(sortformerVariant.lowercased()), chunk=\(sortformerConfig.coreMLInputFrames) mel frames, compute units: \(sortformerComputeUnits.lowercased()))...")
         let diarizer = try await SortformerDiarizer.fromPretrained(
             config: sortformerConfig,
+            computeUnits: computeUnits,
             progressHandler: reportProgress
         )
 

--- a/Sources/SpeechVAD/SortformerConfig.swift
+++ b/Sources/SpeechVAD/SortformerConfig.swift
@@ -128,9 +128,9 @@ public struct SortformerConfig: Sendable {
     /// Default configuration — high-throughput offline diarization.
     /// `chunk_len=340` encoder frames → ~30 s of audio per CoreML call,
     /// measured ~125–750× RTF on M-series ANE depending on input length.
-    /// This is what every Swift API and the `speech diarize` CLI use today;
-    /// the small-chunk streaming preset below is held in reserve for a
-    /// future realtime API.
+    /// First-load BNNS codegen on a cold device cache can take minutes
+    /// because the compiled ANE graph is large; use `.balanced` if that
+    /// matters more than peak RTF.
     public static let `default` = SortformerConfig(
         nMels: 128,
         nFFT: 400,
@@ -150,6 +150,33 @@ public struct SortformerConfig: Sendable {
         minSilenceDuration: 0.15,
         spkcacheUpdatePeriod: 188,
         variantName: ""
+    )
+
+    /// Balanced configuration — same checkpoint, ~3× smaller attention
+    /// cost in the compiled graph (188+40+121 vs 188+40+381 tokens).
+    /// First-load BNNS codegen is correspondingly faster, while RTF stays
+    /// in the hundreds of × on M-series ANE. Use this when first-launch
+    /// UX matters more than peak throughput (iOS apps amortizing the
+    /// compile cost during onboarding).
+    public static let balanced = SortformerConfig(
+        nMels: 128,
+        nFFT: 400,
+        hopLength: 160,
+        sampleRate: 16000,
+        chunkLenSeconds: 100.0,
+        leftContextSeconds: 1.0,
+        rightContextSeconds: 20.0,
+        subsamplingFactor: 8,
+        spkcacheLen: 188,
+        fifoLen: 40,
+        fcDModel: 512,
+        maxSpeakers: 4,
+        onset: 0.5,
+        offset: 0.3,
+        minSpeechDuration: 0.3,
+        minSilenceDuration: 0.15,
+        spkcacheUpdatePeriod: 100,
+        variantName: "balanced"
     )
 
     /// Streaming / low-latency configuration. `chunk_len=6` encoder frames

--- a/Sources/SpeechVAD/SortformerDiarizer.swift
+++ b/Sources/SpeechVAD/SortformerDiarizer.swift
@@ -56,6 +56,15 @@ public final class SortformerDiarizer {
     ///
     /// - Parameters:
     ///   - modelId: HuggingFace model ID
+    ///   - cacheDir: optional override for the local cache directory
+    ///   - offlineMode: if true, only consult the local cache
+    ///   - config: chunk-shape preset (`.default`, `.balanced`, `.streaming`)
+    ///   - computeUnits: which CoreML backends to enable. Defaults to
+    ///     `.cpuAndNeuralEngine` (ANE-only, no GPU/MPSGraph validation).
+    ///     Set to `.cpuOnly` for instant first-load at the cost of ~10–50×
+    ///     RTF instead of ~125–750× (useful during onboarding / on
+    ///     simulator / on weak devices). `SPEECH_COREML_COMPUTE_UNITS` env
+    ///     var overrides this when set.
     ///   - progressHandler: callback for download progress
     /// - Returns: ready-to-use diarizer
     public static func fromPretrained(
@@ -63,6 +72,7 @@ public final class SortformerDiarizer {
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         config: SortformerConfig = .default,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> SortformerDiarizer {
         progressHandler?(0.0, "Downloading Sortformer model...")
@@ -91,17 +101,10 @@ public final class SortformerDiarizer {
 
         let mlConfig = MLModelConfiguration()
         // `.cpuAndNeuralEngine` skips the GPU/MPSGraph backend during model
-        // load validation. `.all` is ~12% faster on some configurations but
-        // forces CoreML to validate the pipeline against MPSGraph as well,
-        // and that validation fails on chip+OS combos where MPSGraph rejects
-        // ops our pipeline emits (reported on M5 Max with macOS 26 in #319:
-        // "Espresso compiled without MPSGraph enabled"). Matches the default
-        // every other VAD loader in this package uses (Silero, FireRed,
-        // WeSpeaker, CAM++).
-        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
-        // Hint only honored when the runtime actually schedules GPU work
-        // (e.g. user opts back in with SPEECH_COREML_COMPUTE_UNITS=all). No
-        // effect on the default ANE-only path.
+        // load validation — see #319 (M5 Max + macOS 26) and #328. The
+        // caller can override via the `computeUnits` parameter or by
+        // setting SPEECH_COREML_COMPUTE_UNITS in the environment.
+        mlConfig.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
         mlConfig.allowLowPrecisionAccumulationOnGPU = true
 
         let mlModel: MLModel
@@ -118,6 +121,46 @@ public final class SortformerDiarizer {
 
         progressHandler?(1.0, "Ready")
         return SortformerDiarizer(model: coremlModel, config: config)
+    }
+
+    /// Prime the on-device CoreML cache without holding a diarizer instance.
+    ///
+    /// The first time a Sortformer `.mlmodelc` loads on a given device,
+    /// CoreML compiles its MIL into ANE bytecode via the BNNS compiler.
+    /// For `.default` (chunk_len=340) this can take minutes on cold cache;
+    /// subsequent loads pull from `~/Library/Caches/com.apple.modelcompiler/`
+    /// in seconds. Call this from a background task at app launch (or any
+    /// non-interactive moment) so the user pays the compile cost during
+    /// onboarding instead of on the first diarize call.
+    ///
+    /// The compiled artifact persists in the system cache after this
+    /// returns; the temporary `MLModel` instance is discarded.
+    ///
+    /// - Parameters:
+    ///   - modelId: HuggingFace model ID
+    ///   - cacheDir: optional override for the local cache directory
+    ///   - offlineMode: if true, only consult the local cache
+    ///   - config: chunk-shape preset to warm
+    ///   - computeUnits: backends to compile for (defaults to `.cpuAndNeuralEngine`)
+    ///   - progressHandler: callback for download + load progress
+    public static func preload(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        config: SortformerConfig = .default,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws {
+        // Reuses fromPretrained so the load path is identical to what the
+        // app would later hit; the diarizer is allowed to deallocate as
+        // soon as this function returns — the BNNS compile cache survives.
+        _ = try await fromPretrained(
+            modelId: modelId,
+            cacheDir: cacheDir,
+            offlineMode: offlineMode,
+            config: config,
+            computeUnits: computeUnits,
+            progressHandler: progressHandler)
     }
 
     // MARK: - Diarization


### PR DESCRIPTION
## Summary

Four load-time optimizations for Sortformer diarization, driven by the M4 Pro report on #319 (minutes-long first-load).

**(a) `SortformerDiarizer.preload(...)`.** Static fire-and-forget warm path so apps can amortize the ANE BNNS codegen during onboarding instead of on the first diarize call. Loads + drops; the compiled artifact stays in CoreML's per-device cache.

**(b) `computeUnits` parameter on `fromPretrained` / `preload`.** Defaults to `.cpuAndNeuralEngine` (no behavior change). Apps that prefer instant first-load over peak RTF can opt into `.cpuOnly` — ~20× RTF instead of ~125–750×, but no minutes-long BNNS compile. The existing `SPEECH_COREML_COMPUTE_UNITS` env override still wins when set.

**(c) FP16 pre-encoder** (companion change in soniqo/speech-models#48). The new default `.mlmodelc` on `aufklarer/Sortformer-Diarization-CoreML` uses `compute_precision=FLOAT16` for the pre-encoder. Identical speaker outputs, ~15% faster warm RTF.

**(d) `SortformerConfig.balanced`** preset for the new HF variant `Sortformer_balanced.mlmodelc` (`chunk_len=100`, ~8 s per CoreML call). Compiled graph is ~3× smaller than `default`, so first-load wall-clock drops from 14.4 s to 9.0 s on M5 Pro (–37%). RTF stays in the hundreds of × on M-series ANE.

## CLI

```bash
# unchanged default
speech diarize meeting.wav --engine sortformer

# new balanced variant — fast first-load, hundreds-of-x RTF
speech diarize meeting.wav --engine sortformer --sortformer-variant balanced

# instant first-load, ~20x RTF
speech diarize meeting.wav --engine sortformer --sortformer-compute-units cpu
```

## Benchmarks (M5 Pro, release build)

| Fixture | OLD default | NEW default (FP16 pre-enc) | NEW balanced |
|---------|-------------|----------------------------|--------------|
| 76 s 2-spk alternation | 0.42 s (181×), 2 spk ✓ | **0.35 s (217×)**, 2 spk ✓ | 0.38 s (200×), 2 spk ✓ |
| 240 s | 1.19 s (201×) | **1.03 s (233×)** | 1.17 s (205×) |
| 68 s 4-spk round-robin | — | 4 distinct speakers ✓ | 4 distinct speakers ✓ |
| 76 s cold first-load wall-clock | — | 14.4 s | **9.0 s (-37%)** |

Speaker assignments and segment timestamps match within ±0.5 s across all variants. No quality regression.

## Test plan

- [x] Build clean (`swift build -c release`)
- [x] Full SpeechVAD test suite: 52 tests, 0 failures (DERScoring 10/10, DiarizationHelpers 33/33, DiarizationPipeline 5/5, E2EDiarizationPipeline 3/3, Sortformer 11/11)
- [x] `testE2EWithRealModel` passes against the new default `.mlmodelc` on HF
- [x] CLI smoke: all 3 variants × 3 fixtures on M5 Pro (table above)
- [ ] Reporter on M4 Pro to confirm `--sortformer-variant balanced` gives a usable first-launch experience