### PR TITLE
chore(tts): decommission int4 for TTS models (defaults → bf16/int8)

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -83,8 +83,8 @@ public struct SpeakCommand: ParsableCommand {
     @Option(name: .long, help: "[cosyvoice] HuggingFace model ID. Set explicitly to bypass --cosyvoice-variant resolution.")
     public var modelId: String?
 
-    @Option(name: .long, help: "[cosyvoice] Quantization variant: 4bit (default), 8bit, 8bit-full, bf16. Resolves to aufklarer/CosyVoice3-0.5B-MLX-<variant>. Ignored when --model-id is set.")
-    public var cosyvoiceVariant: String = "4bit"
+    @Option(name: .long, help: "[cosyvoice] Quantization variant: bf16 (default), 8bit, 8bit-full (int4 was decommissioned). Resolves to aufklarer/CosyVoice3-0.5B-MLX-<variant>. Ignored when --model-id is set.")
+    public var cosyvoiceVariant: String = "bf16"
 
     @Option(name: .long, help: "[cosyvoice] Speaker mapping: s1=alice.wav,s2=bob.wav")
     public var speakers: String?
@@ -112,7 +112,7 @@ public struct SpeakCommand: ParsableCommand {
 
     // MARK: - VoxCPM2-specific options
 
-    @Option(name: .long, help: "[voxcpm2] Quantization variant: bf16 (default), int8, int4. Resolves to aufklarer/VoxCPM2-MLX-<variant>.")
+    @Option(name: .long, help: "[voxcpm2] Quantization variant: bf16 (default), int8 (int4 was decommissioned). Resolves to aufklarer/VoxCPM2-MLX-<variant>.")
     public var voxcpm2Variant: String = "bf16"
 
     @Option(name: .long, help: "[voxcpm2] Style instruction")
@@ -147,8 +147,8 @@ public struct SpeakCommand: ParsableCommand {
 
     // MARK: - Magpie-specific options
 
-    @Option(name: .long, help: "[magpie] Quantization variant: int4 (default) or int8. Resolves to aufklarer/Magpie-TTS-Multilingual-357M-MLX-<variant>.")
-    public var magpieVariant: String = "int4"
+    @Option(name: .long, help: "[magpie] Quantization variant: int8 (int4 was decommissioned). Resolves to aufklarer/Magpie-TTS-Multilingual-357M-MLX-int8.")
+    public var magpieVariant: String = "int8"
 
     @Option(name: .long, help: "[magpie] Baked speaker: sofia (default), aria, jason, leo, john. No voice cloning.")
     public var magpieSpeaker: String = "sofia"
@@ -203,8 +203,8 @@ public struct SpeakCommand: ParsableCommand {
             if MagpieSpeaker(named: magpieSpeaker) == nil {
                 throw ValidationError("--magpie-speaker must be one of sofia, aria, jason, leo, john (got '\(magpieSpeaker)')")
             }
-            guard magpieVariant.lowercased() == "int4" || magpieVariant.lowercased() == "int8" else {
-                throw ValidationError("--magpie-variant must be int4 or int8 (got '\(magpieVariant)')")
+            guard magpieVariant.lowercased() == "int8" else {
+                throw ValidationError("--magpie-variant must be int8 (int4 was decommissioned) (got '\(magpieVariant)')")
             }
             // magpie-coreml validation: nothing extra needed beyond the
             // shared --magpie-* flag checks above. --stream is supported
@@ -325,8 +325,7 @@ public struct SpeakCommand: ParsableCommand {
                 print("Error: invalid Magpie speaker '\(magpieSpeaker)'")
                 throw ExitCode(1)
             }
-            let variant: MagpieTTSVariant =
-                (magpieVariant.lowercased() == "int8") ? .int8 : .int4
+            let variant: MagpieTTSVariant = .int8
             let language: MagpieLanguage =
                 MagpieLanguage(code: effectiveLanguage) ?? .english
 
@@ -402,8 +401,7 @@ public struct SpeakCommand: ParsableCommand {
             if mlxLang == .japanese {
                 FileHandle.standardError.write(Data(
                     "[magpie-coreml] --language ja not supported by the CoreML bundle; using MLX backend.\n".utf8))
-                let variant: MagpieTTSVariant =
-                    (magpieVariant.lowercased() == "int8") ? .int8 : .int4
+                let variant: MagpieTTSVariant = .int8
                 let model = try await MagpieTTS.fromPretrained(
                     variant: variant,
                     progressHandler: { reportProgress($0, "Downloading MLX fallback") })
@@ -508,10 +506,8 @@ public struct SpeakCommand: ParsableCommand {
             // Resolve model ID
             let resolvedModelId: String
             switch model.lowercased() {
-            case "base":
+            case "base", "base-8bit", "base8bit":
                 resolvedModelId = TTSModelVariant.base.rawValue
-            case "base-8bit", "base8bit":
-                resolvedModelId = TTSModelVariant.base8bit.rawValue
             case "1.7b", "large", "1.7b-bf16", "large-bf16":
                 resolvedModelId = TTSModelVariant.base17Bbf16.rawValue
             case "1.7b-8bit", "large-8bit":
@@ -730,10 +726,8 @@ public struct SpeakCommand: ParsableCommand {
             return "aufklarer/VoxCPM2-MLX-bf16"
         case "int8":
             return "aufklarer/VoxCPM2-MLX-int8"
-        case "int4":
-            return "aufklarer/VoxCPM2-MLX-int4"
         default:
-            throw ValidationError("--voxcpm2-variant must be bf16, int8, or int4 (got '\(voxcpm2Variant)')")
+            throw ValidationError("--voxcpm2-variant must be bf16 or int8 (int4 was decommissioned) (got '\(voxcpm2Variant)')")
         }
     }
 
@@ -828,13 +822,12 @@ public struct SpeakCommand: ParsableCommand {
     private func resolvedCosyVoiceModelId() throws -> String {
         if let explicit = modelId, !explicit.isEmpty { return explicit }
         switch cosyvoiceVariant.lowercased() {
-        case "4bit":      return "aufklarer/CosyVoice3-0.5B-MLX-4bit"
         case "8bit":      return "aufklarer/CosyVoice3-0.5B-MLX-8bit"
         case "8bit-full": return "aufklarer/CosyVoice3-0.5B-MLX-8bit-full"
         case "bf16":      return "aufklarer/CosyVoice3-0.5B-MLX-bf16"
         default:
             throw ValidationError(
-                "--cosyvoice-variant must be 4bit, 8bit, 8bit-full, or bf16 (got '\(cosyvoiceVariant)')")
+                "--cosyvoice-variant must be 8bit, 8bit-full, or bf16 (int4 was decommissioned) (got '\(cosyvoiceVariant)')")
         }
     }
 

--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -534,7 +534,7 @@ final class ModelState: RealtimeModelLoading, @unchecked Sendable {
 
     /// Back-compat shim — default Qwen3-TTS bundle.
     func loadTTS() async throws -> Qwen3TTSModel {
-        try await loadQwen3TTS(modelId: "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit")
+        try await loadQwen3TTS(modelId: Qwen3TTSModel.defaultModelId)
     }
 
     func loadCosyVoice(modelId: String) async throws -> CosyVoiceTTSModel {
@@ -547,7 +547,7 @@ final class ModelState: RealtimeModelLoading, @unchecked Sendable {
 
     /// Back-compat shim — default CosyVoice bundle for HTTP routes.
     func loadCosyVoice() async throws -> CosyVoiceTTSModel {
-        try await loadCosyVoice(modelId: "aufklarer/CosyVoice3-0.5B-MLX-4bit")
+        try await loadCosyVoice(modelId: CosyVoiceTTSModel.defaultModelId)
     }
 
     func loadKokoro(modelId: String) async throws -> KokoroTTSModel {

--- a/Sources/AudioServer/ModelRegistry.swift
+++ b/Sources/AudioServer/ModelRegistry.swift
@@ -139,20 +139,20 @@ public let MODEL_REGISTRY: [ModelVariant] = [
           modelId: VoxCPM2TTSModel.int8ModelId,
           aliases: ["voxcpm2-int8"],
           kind: .tts),
-    .init(name: "qwen3-tts-0.6b-mlx-int4",
+    .init(name: "qwen3-tts-1.7b-mlx-bf16",
           engine: "qwen3-tts",
           modelId: Qwen3TTSModel.defaultModelId,
           // "qwen3" is shared with the ASR variant — bare "qwen3" lands in
           // both slots so naming the family pairs ASR + TTS in one update.
-          aliases: ["qwen3", "qwen3-tts", "qwen3-speech", "qwen3-tts-0.6b"],
+          aliases: ["qwen3", "qwen3-tts", "qwen3-speech", "qwen3-tts-1.7b"],
           kind: .tts),
-    // Magpie ships as a fixed bundle today (the `MagpieTTSVariant.int4`
-    // default). Listing it here keeps it selectable via the protocol; the
-    // dispatch site ignores the modelId because MagpieTTS.fromPretrained
-    // builds the model from its own variant enum, not an HF slug.
-    .init(name: "magpie-tts-multilingual-mlx-int4",
+    // Magpie ships as a fixed bundle today (the `MagpieTTSVariant.int8`
+    // default; int4 was decommissioned). Listing it here keeps it selectable
+    // via the protocol; the dispatch site ignores the modelId because
+    // MagpieTTS.fromPretrained builds the model from its own variant enum.
+    .init(name: "magpie-tts-multilingual-mlx-int8",
           engine: "magpie",
-          modelId: "aufklarer/Magpie-TTS-Multilingual-MLX-4bit",
+          modelId: MagpieTTSVariant.int8.huggingFaceRepoId,
           aliases: ["magpie", "magpie-tts"],
           kind: .tts),
     .init(name: "magpie-tts-multilingual-357m-coreml-int8",

--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -30,9 +30,9 @@ public enum CosyVoiceTTSError: Error, LocalizedError {
 ///
 /// - Warning: This class is not thread-safe. Create separate instances for concurrent use.
 public final class CosyVoiceTTSModel {
-    /// Default HuggingFace model identifier — the 0.5B 4-bit MLX bundle.
-    /// Single SSOT for the registry and other call sites.
-    public static let defaultModelId = "aufklarer/CosyVoice3-0.5B-MLX-4bit"
+    /// Default HuggingFace model identifier — the 0.5B bf16 MLX bundle (int4 was
+    /// decommissioned for TTS). Single SSOT for the registry and other call sites.
+    public static let defaultModelId = "aufklarer/CosyVoice3-0.5B-MLX-bf16"
 
     public let config: CosyVoiceConfig
 
@@ -58,7 +58,7 @@ public final class CosyVoiceTTSModel {
     /// Downloads three safetensors files: llm.safetensors, flow.safetensors, hifigan.safetensors
     /// Caches to ~/Library/Caches/qwen3-speech/
     public static func fromPretrained(
-        modelId: String = "aufklarer/CosyVoice3-0.5B-MLX-4bit",
+        modelId: String = CosyVoiceTTSModel.defaultModelId,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil

--- a/Sources/MagpieTTS/Configuration.swift
+++ b/Sources/MagpieTTS/Configuration.swift
@@ -1,22 +1,19 @@
 import Foundation
 
-/// Magpie-TTS Multilingual 357M variant. Both bundles share the architecture;
-/// only the on-disk storage quantisation differs (INT4 vs INT8). Weights are
-/// dequantised to FP at load time — runtime is FP32 everywhere.
+/// Magpie-TTS Multilingual 357M variant. Weights are dequantised to FP at load
+/// time — runtime is FP32 everywhere. int4 was decommissioned for TTS (too much
+/// quality loss); INT8 is the floor (no bf16 bundle exists for Magpie).
 public enum MagpieTTSVariant: String, Sendable, CaseIterable {
-    case int4
     case int8
 
     public var huggingFaceRepoId: String {
         switch self {
-        case .int4: return "aufklarer/Magpie-TTS-Multilingual-357M-MLX-4bit"
         case .int8: return "aufklarer/Magpie-TTS-Multilingual-357M-MLX-8bit"
         }
     }
 
     public var bits: Int {
         switch self {
-        case .int4: return 4
         case .int8: return 8
         }
     }

--- a/Sources/MagpieTTS/Downloader.swift
+++ b/Sources/MagpieTTS/Downloader.swift
@@ -15,7 +15,7 @@ public enum MagpieTTSDownloader {
     }
 
     public static func ensureDownloaded(
-        variant: MagpieTTSVariant = .int4,
+        variant: MagpieTTSVariant = .int8,
         progressHandler: ((Double) -> Void)? = nil
     ) async throws -> Paths {
         let repoId = variant.huggingFaceRepoId

--- a/Sources/MagpieTTS/MagpieTTS.swift
+++ b/Sources/MagpieTTS/MagpieTTS.swift
@@ -52,7 +52,7 @@ public final class MagpieTTS {
     // MARK: - Loading
 
     public static func fromPretrained(
-        variant: MagpieTTSVariant = .int4,
+        variant: MagpieTTSVariant = .int8,
         progressHandler: ((Double) -> Void)? = nil
     ) async throws -> MagpieTTS {
         let paths = try await MagpieTTSDownloader.ensureDownloaded(

--- a/Sources/MagpieTTSCoreML/Downloader.swift
+++ b/Sources/MagpieTTSCoreML/Downloader.swift
@@ -75,7 +75,9 @@ public enum MagpieCoreMLDownloader {
                 })
         }
 
-        let mlxRepoId = "aufklarer/Magpie-TTS-Multilingual-357M-MLX-4bit"
+        // int4 decommissioned for TTS — the CoreML path sources tokenizer assets
+        // from the surviving 8-bit MLX bundle.
+        let mlxRepoId = "aufklarer/Magpie-TTS-Multilingual-357M-MLX-8bit"
         let mlxDir = try HuggingFaceDownloader.getCacheDirectory(for: mlxRepoId)
         let mlxCached = filesPresent(in: mlxDir, relativePaths: mlxTokenizerFiles)
         if !mlxCached {

--- a/Sources/MagpieTTSCoreML/MagpieTTSCoreML.swift
+++ b/Sources/MagpieTTSCoreML/MagpieTTSCoreML.swift
@@ -134,7 +134,7 @@ public final class MagpieTTSCoreML {
         } else {
             tick("cache MISS", tCache)
             let tMLX = CFAbsoluteTimeGetCurrent()
-            let mlxModel = try await MagpieTTS.fromPretrained(variant: .int4)
+            let mlxModel = try await MagpieTTS.fromPretrained(variant: .int8)
             tick("MLX MagpieTTS load", tMLX)
             let tExtract = CFAbsoluteTimeGetCurrent()
             (ltWeights, audioEmbeds) = try MagpieCoreMLWeightExtractor.extract(from: mlxModel)

--- a/Sources/Qwen3TTS/Configuration.swift
+++ b/Sources/Qwen3TTS/Configuration.swift
@@ -45,11 +45,13 @@ public struct TalkerConfig: Codable, Sendable {
     public var textHiddenSize: Int = 2048
     public var codecVocabSize: Int = 3072
     public var groupSize: Int = 64
-    public var bits: Int = 4
+    // int4 was decommissioned for TTS (too much quality loss); 8-bit is the floor
+    // for the 0.6B (no bf16 bundle exists), bf16 for the 1.7B.
+    public var bits: Int = 8
 
     public init() {}
 
-    /// 0.6B, 4-bit (default)
+    /// 0.6B, 8-bit (the smallest shipped 0.6B precision; no 0.6B bf16 bundle exists).
     public static var base06B: TalkerConfig { TalkerConfig() }
 
     /// 0.6B, 8-bit
@@ -59,8 +61,8 @@ public struct TalkerConfig: Codable, Sendable {
         return config
     }
 
-    /// 1.7B, 4-bit
-    public static var large4bit: TalkerConfig {
+    /// 1.7B base dims; precision set by the derived configs (bf16 floor).
+    public static var large: TalkerConfig {
         var config = TalkerConfig()
         config.hiddenSize = 2048
         config.numHeads = 16
@@ -68,13 +70,13 @@ public struct TalkerConfig: Codable, Sendable {
         config.headDim = 128
         config.intermediateSize = 6144
         config.textHiddenSize = 2048
-        config.bits = 4
+        config.bits = 0
         return config
     }
 
     /// 1.7B, 8-bit
     public static var large8bit: TalkerConfig {
-        var config = large4bit
+        var config = large
         config.bits = 8
         return config
     }
@@ -86,12 +88,8 @@ public struct TalkerConfig: Codable, Sendable {
         return config
     }
 
-    /// 1.7B, bf16 (no quantization).
-    public static var largeBf16: TalkerConfig {
-        var config = large4bit
-        config.bits = 0
-        return config
-    }
+    /// 1.7B, bf16 (no quantization) — the production floor.
+    public static var largeBf16: TalkerConfig { large }
 }
 
 // MARK: - Code Predictor Config
@@ -110,7 +108,8 @@ public struct CodePredictorConfig: Codable, Sendable {
     public var vocabSize: Int = 2048
     public var numCodeGroups: Int = 16
     public var groupSize: Int = 64
-    public var bits: Int = 4
+    // int4 decommissioned for TTS; 8-bit floor (0.6B), bf16 (1.7B).
+    public var bits: Int = 8
 
     /// Whether a projection from embeddingDim → hiddenSize is needed
     public var needsProjection: Bool { embeddingDim != hiddenSize }
@@ -124,17 +123,17 @@ public struct CodePredictorConfig: Codable, Sendable {
         return config
     }
 
-    /// 1.7B, 4-bit — embeddings are 2048-dim with projection to 1024
-    public static var large4bit: CodePredictorConfig {
+    /// 1.7B base dims (embeddings 2048-dim with projection to 1024); precision set by derived configs.
+    public static var large: CodePredictorConfig {
         var config = CodePredictorConfig()
         config.embeddingDim = 2048
-        config.bits = 4
+        config.bits = 0
         return config
     }
 
     /// 1.7B, 8-bit
     public static var large8bit: CodePredictorConfig {
-        var config = large4bit
+        var config = large
         config.bits = 8
         return config
     }
@@ -146,12 +145,8 @@ public struct CodePredictorConfig: Codable, Sendable {
         return config
     }
 
-    /// 1.7B, bf16 (no quantization).
-    public static var largeBf16: CodePredictorConfig {
-        var config = large4bit
-        config.bits = 0
-        return config
-    }
+    /// 1.7B, bf16 (no quantization) — the production floor.
+    public static var largeBf16: CodePredictorConfig { large }
 }
 
 // MARK: - Speech Tokenizer Decoder Config
@@ -278,11 +273,14 @@ public struct StreamingConfig: Sendable {
 
 /// Well-known TTS model variants
 public enum TTSModelVariant: String, CaseIterable, Sendable {
-    case base = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
-    case base8bit = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
-    case customVoice = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit"
+    // int4 decommissioned for TTS. The 0.6B has no bf16 bundle, so 8-bit is its
+    // floor; the 1.7B production model is bf16.
+    case base = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     case base17B8bit = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit"
     case base17Bbf16 = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"
+    // TODO(int4-decommission): CustomVoice ships only as int4 — no 8bit/bf16
+    // bundle exists yet. Repoint once a non-int4 CustomVoice bundle is produced.
+    case customVoice = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit"
 }
 
 // MARK: - Combined TTS Config
@@ -306,22 +304,16 @@ public struct Qwen3TTSConfig: Codable, Sendable {
         Qwen3TTSConfig()
     }
 
-    /// Build config for a given model size and quantization.
-    /// `bits == 0` selects the bf16 (no-quantization) path.
+    /// Build config for a given model size and quantization. `bits == 0` selects bf16.
+    ///
+    /// int4 is no longer a shipped TTS default, but the loader must still construct a
+    /// 4-bit config for the one surviving int4 TTS bundle (the 0.6B CustomVoice model),
+    /// so this respects any `bits` rather than routing int4 away.
     public static func config(for size: TTSModelSize, bits: Int) -> Qwen3TTSConfig {
-        switch (size, bits) {
-        case (.small, 0):
-            return Qwen3TTSConfig(talker: .smallBf16, codePredictor: .smallBf16)
-        case (.large, 0):
-            return Qwen3TTSConfig(talker: .largeBf16, codePredictor: .largeBf16)
-        case (.small, 8):
-            return Qwen3TTSConfig(talker: .small8bit, codePredictor: .small8bit)
-        case (.large, 8):
-            return Qwen3TTSConfig(talker: .large8bit, codePredictor: .large8bit)
-        case (.large, _):
-            return Qwen3TTSConfig(talker: .large4bit, codePredictor: .large4bit)
-        default:
-            return Qwen3TTSConfig()  // small 4-bit
-        }
+        var talker: TalkerConfig = (size == .large) ? .large : TalkerConfig()
+        var codePredictor: CodePredictorConfig = (size == .large) ? .large : CodePredictorConfig()
+        talker.bits = bits
+        codePredictor.bits = bits
+        return Qwen3TTSConfig(talker: talker, codePredictor: codePredictor)
     }
 }

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -24,9 +24,10 @@ public enum TTSError: Error, LocalizedError {
 ///
 /// - Warning: This class is not thread-safe. Create separate instances for concurrent use.
 public class Qwen3TTSModel {
-    /// Default HuggingFace model identifier — the 12 Hz 0.6B Base 4-bit MLX
-    /// bundle. Single SSOT for the registry and other call sites.
-    public static let defaultModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
+    /// Default HuggingFace model identifier — the 12 Hz 1.7B Base bf16 MLX bundle
+    /// (the production model; int4 was decommissioned for TTS). Single SSOT for the
+    /// registry and other call sites.
+    public static let defaultModelId = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"
 
     /// Default instruct text applied automatically for CustomVoice models when no explicit
     /// `--instruct` is provided. Prevents rambling output for short texts.
@@ -1598,7 +1599,7 @@ public class Qwen3TTSModel {
 public extension Qwen3TTSModel {
     /// Load model from HuggingFace hub
     static func fromPretrained(
-        modelId: String = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit",
+        modelId: String = Qwen3TTSModel.defaultModelId,
         tokenizerModelId: String = "Qwen/Qwen3-TTS-Tokenizer-12Hz",
         cacheDir: URL? = nil,
         offlineMode: Bool = false,

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -348,9 +348,10 @@ final class SpeakCommandTests: XCTestCase {
         let cmd = try AudioCLI.parseAsRoot(["speak", "Hello"])
         let speak = try XCTUnwrap(cmd as? SpeakCommand)
         // --model-id is now opt-in; the runtime resolves the default through
-        // --cosyvoice-variant (4bit by default → aufklarer/CosyVoice3-0.5B-MLX-4bit).
+        // --cosyvoice-variant (bf16 by default → aufklarer/CosyVoice3-0.5B-MLX-bf16;
+        // int4 was decommissioned).
         XCTAssertNil(speak.modelId)
-        XCTAssertEqual(speak.cosyvoiceVariant, "4bit")
+        XCTAssertEqual(speak.cosyvoiceVariant, "bf16")
     }
 
     func testCosyVoiceVariantBf16() throws {

--- a/Tests/AudioServerTests/RealtimeAPITests.swift
+++ b/Tests/AudioServerTests/RealtimeAPITests.swift
@@ -91,7 +91,7 @@ final class RealtimeAPITests: XCTestCase {
         // the TTS slot. ASR slot stays at the default.
         XCTAssertEqual(session?["engine"] as? String, "qwen3")
         XCTAssertEqual(session?["tts_engine"] as? String, "qwen3-tts")
-        XCTAssertEqual(session?["tts_model"] as? String, "qwen3-tts-0.6b-mlx-int4")
+        XCTAssertEqual(session?["tts_model"] as? String, "qwen3-tts-1.7b-mlx-bf16")
         XCTAssertEqual(session?["asr_engine"] as? String, "parakeet")
         XCTAssertEqual(session?["language"] as? String, "chinese")
         XCTAssertEqual(session?["input_audio_format"] as? String, "pcm16")

--- a/Tests/CosyVoiceTTSTests/CosyVoiceTTSTests.swift
+++ b/Tests/CosyVoiceTTSTests/CosyVoiceTTSTests.swift
@@ -132,7 +132,7 @@ final class CosyVoiceTTSConfigTests: XCTestCase {
 //      on first run.
 // CI's `--skip E2E` filter excludes these classes via the E2E prefix.
 private enum CosyVoiceTestWeights {
-    static let modelId = "aufklarer/CosyVoice3-0.5B-MLX-4bit"
+    static let modelId = "aufklarer/CosyVoice3-0.5B-MLX-bf16"
     static let files = [
         "llm.safetensors", "flow.safetensors", "hifigan.safetensors",
         "vocab.json", "merges.txt", "tokenizer_config.json", "config.json",

--- a/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
+++ b/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
@@ -161,7 +161,7 @@ final class VoiceCloningTests: XCTestCase {
             ?? "This is a reference audio recording used for voice cloning."
 
         let modelId = ProcessInfo.processInfo.environment["COSY_TEST_MODEL_ID"]
-            ?? "aufklarer/CosyVoice3-0.5B-MLX-4bit"
+            ?? "aufklarer/CosyVoice3-0.5B-MLX-bf16"
         let model = try await CosyVoiceTTSModel.fromPretrained(modelId: modelId)
 
         // Locate speech_tokenizer.safetensors — the test prefers an explicit

--- a/Tests/MagpieTTSTests/E2EMagpieTests.swift
+++ b/Tests/MagpieTTSTests/E2EMagpieTests.swift
@@ -12,8 +12,8 @@ final class E2EMagpieSynthesisTests: XCTestCase {
     /// Round-trip sanity test: load INT4 bundle → synthesize a short phrase →
     /// verify shape, dtype, non-silence, and that greedy decoding terminates
     /// well below the max-frame cap.
-    func testInt4LoadAndSynthesizeHello() async throws {
-        let model = try await MagpieTTS.fromPretrained(variant: .int4)
+    func testInt8LoadAndSynthesizeHello() async throws {
+        let model = try await MagpieTTS.fromPretrained(variant: .int8)
 
         let start = Date()
         // Greedy decoding (temperature=0) makes the test deterministic and
@@ -57,7 +57,7 @@ final class E2EMagpieSynthesisTests: XCTestCase {
     /// dedup-ordering, weight-loading key paths, attention masks or the FSQ
     /// inverse — all of which are bugs we've already hit once.
     func testFirstFrameMatchesPythonReference() async throws {
-        let model = try await MagpieTTS.fromPretrained(variant: .int4)
+        let model = try await MagpieTTS.fromPretrained(variant: .int8)
 
         // Magpie's English vocab has duplicates after `<pad>`/`<oov>`. The
         // Python reference (and now our tokeniser) uses the first
@@ -82,7 +82,7 @@ final class E2EMagpieSynthesisTests: XCTestCase {
     /// "Hello, World from Magpie Text to Speech." — Swift must match.
     func testSynthesizedAudioTranscribesToInput() async throws {
 #if canImport(CoreML)
-        let tts = try await MagpieTTS.fromPretrained(variant: .int4)
+        let tts = try await MagpieTTS.fromPretrained(variant: .int8)
         let asr = try await CoreMLASRModel.fromPretrained()
 
         let prompt = "Hello world from Magpie text to speech."
@@ -225,7 +225,7 @@ final class E2EMagpieSynthesisTests: XCTestCase {
                  temperature: 0.6, topK: 80, maxSteps: 300, seed: 42),
         ]
 
-        let tts = try await MagpieTTS.fromPretrained(variant: .int4)
+        let tts = try await MagpieTTS.fromPretrained(variant: .int8)
         let asr = try await CoreMLASRModel.fromPretrained()
 
         var failures: [String] = []
@@ -270,7 +270,7 @@ final class E2EMagpieSynthesisTests: XCTestCase {
     /// concatenated stream matches what batch synthesis would have produced
     /// for the same seed.
     func testStreamingEmitsMultipleChunks() async throws {
-        let model = try await MagpieTTS.fromPretrained(variant: .int4)
+        let model = try await MagpieTTS.fromPretrained(variant: .int8)
         let stream = model.synthesizeStream(
             text: "test",
             speaker: .aria,

--- a/Tests/MagpieTTSTests/MagpieConfigTests.swift
+++ b/Tests/MagpieTTSTests/MagpieConfigTests.swift
@@ -3,12 +3,11 @@ import XCTest
 
 final class MagpieConfigTests: XCTestCase {
     func testVariantHFIDs() {
-        XCTAssertEqual(MagpieTTSVariant.int4.huggingFaceRepoId,
-                       "aufklarer/Magpie-TTS-Multilingual-357M-MLX-4bit")
+        // int4 was decommissioned for TTS; int8 is the sole surviving Magpie variant.
         XCTAssertEqual(MagpieTTSVariant.int8.huggingFaceRepoId,
                        "aufklarer/Magpie-TTS-Multilingual-357M-MLX-8bit")
-        XCTAssertEqual(MagpieTTSVariant.int4.bits, 4)
         XCTAssertEqual(MagpieTTSVariant.int8.bits, 8)
+        XCTAssertEqual(MagpieTTSVariant.allCases, [.int8])
     }
 
     func testSpeakerNames() {

--- a/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
+++ b/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
@@ -122,12 +122,13 @@ final class Qwen3TTSConfigTests: XCTestCase {
         XCTAssertEqual(config.numLayers, 28)
     }
 
-    func testTalkerLarge4bit() {
-        let config = TalkerConfig.large4bit
+    func testTalkerLarge() {
+        // 1.7B base dims; int4 decommissioned, so the base precision is bf16 (bits 0).
+        let config = TalkerConfig.large
         XCTAssertEqual(config.hiddenSize, 2048)
         XCTAssertEqual(config.intermediateSize, 6144)
         XCTAssertEqual(config.textHiddenSize, 2048)
-        XCTAssertEqual(config.bits, 4)
+        XCTAssertEqual(config.bits, 0)
         XCTAssertEqual(config.numLayers, 28)
     }
 
@@ -144,12 +145,13 @@ final class Qwen3TTSConfigTests: XCTestCase {
         XCTAssertEqual(config.bits, 8)
     }
 
-    func testCodePredictorLarge4bit() {
-        let config = CodePredictorConfig.large4bit
+    func testCodePredictorLarge() {
+        // 1.7B base dims; bf16 (bits 0) after int4 decommission.
+        let config = CodePredictorConfig.large
         XCTAssertEqual(config.hiddenSize, 1024)
         XCTAssertEqual(config.embeddingDim, 2048)
         XCTAssertTrue(config.needsProjection)
-        XCTAssertEqual(config.bits, 4)
+        XCTAssertEqual(config.bits, 0)
     }
 
     func testCodePredictorLarge8bit() {
@@ -189,10 +191,11 @@ final class Qwen3TTSConfigTests: XCTestCase {
     // MARK: - Model Variants
 
     func testTTSModelVariants() {
-        XCTAssertEqual(TTSModelVariant.base.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit")
-        XCTAssertEqual(TTSModelVariant.base8bit.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit")
+        // int4 decommissioned: the 0.6B Base floor is 8bit (no bf16 bundle); 1.7B is bf16.
+        XCTAssertEqual(TTSModelVariant.base.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit")
         XCTAssertEqual(TTSModelVariant.base17B8bit.rawValue, "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit")
         XCTAssertEqual(TTSModelVariant.base17Bbf16.rawValue, "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16")
+        // CustomVoice ships only as int4 (no non-int4 bundle exists yet — tracked TODO).
         XCTAssertEqual(TTSModelVariant.customVoice.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit")
     }
 
@@ -279,7 +282,7 @@ final class SpeakerConfigTests: XCTestCase {
     }
 
     func testTTSModelVariant() {
-        XCTAssertEqual(TTSModelVariant.base.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit")
+        XCTAssertEqual(TTSModelVariant.base.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit")
         XCTAssertEqual(TTSModelVariant.customVoice.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit")
     }
 
@@ -299,7 +302,7 @@ final class SpeakerConfigTests: XCTestCase {
 
 final class E2EInstructTokenTests: XCTestCase {
 
-    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
+    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     private static var _sharedModel: Qwen3TTSModel?
 
     /// Verify instruct token format: <|im_start|>user\n{text}<|im_end|>\n
@@ -741,7 +744,7 @@ final class E2ESpeakerTokenPositionTests: XCTestCase {
 /// Requires TTS model weights (~1.7 GB). Tests are grouped by language.
 final class E2ETTSTests: XCTestCase {
 
-    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
+    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     static let asrModelId = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
     private static var _sharedTTSModel: Qwen3TTSModel?
@@ -1234,7 +1237,7 @@ final class E2ETTSLongTextTests: XCTestCase {
     /// Before the chunkedDecode eval fix, this peaked at 17+ GB and crashed on 16 GB Macs.
     func testLongTextDoesNotOOM() async throws {
         let model = try await Qwen3TTSModel.fromPretrained(
-            modelId: "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
+            modelId: "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
         ) { _, _ in }
 
         let longText = "In the beginning of a new era of artificial intelligence, " +
@@ -1257,7 +1260,7 @@ final class E2ETTSLongTextTests: XCTestCase {
 
 final class E2ETTSBatchTests: XCTestCase {
 
-    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
+    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     static let asrModelId = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
     private static var _sharedTTSModel: Qwen3TTSModel?
@@ -1454,7 +1457,7 @@ final class E2ETTSBatchTests: XCTestCase {
 /// Requires TTS model weights (~1.7 GB).
 final class E2ETTSStreamingTests: XCTestCase {
 
-    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-4bit"
+    static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     static let asrModelId = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
     private static var _sharedTTSModel: Qwen3TTSModel?

--- a/Tests/VoxCPM2TTSTests/VoxCPM2TTSTests.swift
+++ b/Tests/VoxCPM2TTSTests/VoxCPM2TTSTests.swift
@@ -406,7 +406,7 @@ final class E2EVoxCPM2TTSTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         // Free the previous variant's MLX buffers before the next test loads
-        // its model — otherwise running bf16 + int8 + int4 in one process
+        // its model — otherwise running bf16 + int8 in one process
         // blows past the GPU memory budget.
         Memory.clearCache()
     }
@@ -437,8 +437,5 @@ final class E2EVoxCPM2TTSTests: XCTestCase {
     func testBasicSynthesisInt8() async throws {
         try await runBasicSynthesis(modelId: "aufklarer/VoxCPM2-MLX-int8")
     }
-
-    func testBasicSynthesisInt4() async throws {
-        try await runBasicSynthesis(modelId: "aufklarer/VoxCPM2-MLX-int4")
-    }
+    // testBasicSynthesisInt4 removed — int4 was decommissioned for TTS.
 }


### PR DESCRIPTION
## Summary

int4 quantization degrades TTS quality too much, so it's being removed as a shipped option for the **TTS models**. This repoints every int4 TTS default to the best available non-int4 variant — **bf16 where it exists, int8 where it doesn't** (verified against the actual `aufklarer/` HF bundles). Non-TTS int4 (ASR, chat, translation, music, super-res, PersonaPlex) is untouched.

## Per-model mapping

| Model | int4 → replacement |
|---|---|
| Qwen3-TTS (default) | **1.7B-bf16** (production model) |
| Qwen3-TTS 0.6B `.base` | **0.6B-8bit** (no 0.6B bf16 bundle exists) |
| CosyVoice3 0.5B | **bf16** |
| VoxCPM2 | **bf16** (was already the default; dropped the selectable int4 variant) |
| Magpie-TTS 357M | **int8** (no bf16 bundle exists) |
| Qwen3-TTS **CustomVoice** | ⚠️ stays **int4** — no non-int4 bundle exists yet |

## What changed

- **Qwen3-TTS**: SSOT `defaultModelId` → 1.7B-bf16; `fromPretrained` defaults reference the SSOT. Dropped the redundant `.base8bit` enum case (`.base` is now 0.6B-8bit). Renamed the int4 `large4bit` Talker/CodePredictor configs to a precision-neutral `large` base (bf16 floor); **the config ladder now respects any `bits`** so the loader can still construct a 4-bit config (needed for CustomVoice). Struct `bits` defaults 4 → 8.
- **CosyVoice3**: default → 0.5B-bf16; dropped the `4bit` CLI variant.
- **Magpie-TTS**: removed the `.int4` enum case (int8 floor); CoreML weight-extraction + tokenizer assets now source the 8-bit MLX bundle.
- **VoxCPM2**: dropped the selectable `int4` CLI variant (already bf16 by default).
- **AudioServer** back-compat shims + **ModelRegistry** entries → the new defaults.
- **Tests** repointed to surviving variants; int4-specific tests removed; the `detectBits`/`detect` parser tests keep their `-4bit` fixtures (they test the parser, not a shipped model).

## CustomVoice exception

Qwen3-TTS CustomVoice ships **only** as int4 — there's no 8bit/bf16 bundle on HF. It stays on int4 behind a tracked `TODO`, and the loader retains the ability to build a 4-bit config for it. Fully decommissioning it needs a non-int4 CustomVoice bundle produced + uploaded.

## Test plan

- Sources + full test target build clean.
- Affected unit suites pass: `Qwen3TTSConfigTests` 18/18, `MagpieConfigTests` 7/7, `AudioCLITests` 105/105, `RealtimeAPITests` 34/34.
- (E2E classes are skipped in CI; their fixtures were repointed to surviving variants.)

## Follow-up (not in this PR)

The multilingual README catalog tables still list int4 for the TTS rows — a separate doc pass. speech-models (convert/upload/benchmarks) and speech-studio doc cleanup are tracked as their own PRs.