### PR TITLE
FunctionGemma: render full developer/declaration block via FunctionGemmaPrompt

### DIFF
--- a/Sources/FunctionGemma/FunctionGemma.swift
+++ b/Sources/FunctionGemma/FunctionGemma.swift
@@ -8,8 +8,10 @@ import Tokenizers
 /// `aufklarer/FunctionGemma-270M-CoreML-Palettize8` (or `-CoreML` fp16).
 ///
 /// Pipeline:
-///   1. Tokenize a prompt formatted with ``FunctionGemmaPrompt.formatUserTurn``
-///      via the chat template at `chat_template.jinja`.
+///   1. Tokenize a prompt formatted with
+///      ``FunctionGemmaPrompt.formatToolCallPrompt``, which mirrors the exact
+///      developer / user / model-prefix layout the model was trained on
+///      (including the `<start_function_declaration>` block).
 ///   2. Right-pad to ``cacheSeqLen`` (128), build prefill inputs, prefill once
 ///      against an `MLState` cache.
 ///   3. Decode greedily one token per step; each step writes to a one-hot
@@ -125,8 +127,7 @@ public final class FunctionGemma: @unchecked Sendable {
     public func generate(prompt: String,
                           tools: [FunctionDeclaration],
                           maxNewTokens: Int = 64) async throws -> String {
-        let userTurn = FunctionGemmaPrompt.formatUserTurn(tools: tools, userText: prompt)
-        let fullPrompt = try renderChatTemplate(userMessage: userTurn)
+        let fullPrompt = FunctionGemmaPrompt.formatToolCallPrompt(tools: tools, userText: prompt)
         let promptIds = try tokenize(fullPrompt)
         return try await generateFromTokens(promptIds: promptIds, maxNewTokens: maxNewTokens)
     }
@@ -180,14 +181,7 @@ public final class FunctionGemma: @unchecked Sendable {
         return (text, FunctionGemmaParser.parseFunctionCalls(text))
     }
 
-    // MARK: - Chat template + tokenize
-
-    private func renderChatTemplate(userMessage: String) throws -> String {
-        // The model's chat_template.jinja boils down to this — there is no
-        // multi-turn assistant history to fold in for a single tool call, so
-        // we use the fixed string instead of running the Jinja engine.
-        return "<start_of_turn>user\n\(userMessage)<end_of_turn>\n<start_of_turn>model\n"
-    }
+    // MARK: - Tokenize
 
     private func tokenize(_ text: String) throws -> [Int] {
         let ids = tokenizer.encode(text: text)

--- a/Sources/FunctionGemma/FunctionGemmaPrompt.swift
+++ b/Sources/FunctionGemma/FunctionGemmaPrompt.swift
@@ -2,12 +2,13 @@ import Foundation
 
 /// Mirrors `function_calls.format_tool_call_prompt` from the Python export
 /// repo so Swift-side prompts hit the same grammar FunctionGemma was trained
-/// on. Output is plain text — wrap it with the model's chat template before
-/// tokenizing.
+/// on. Output is the fully-formed prompt — feed it straight to the tokenizer
+/// without any additional chat-template wrapping.
 enum FunctionGemmaPrompt {
 
-    static let functionDeclarationsStart = "<start_function_declarations>"
-    static let functionDeclarationsEnd   = "<end_function_declarations>"
+    static let startOfTurn               = "<start_of_turn>"
+    static let endOfTurn                 = "<end_of_turn>"
+    static let developerPrompt           = "You are a model that can do function calling with the following functions"
     static let functionDeclarationStart  = "<start_function_declaration>"
     static let functionDeclarationEnd    = "<end_function_declaration>"
     static let functionCallStart         = "<start_function_call>"
@@ -16,41 +17,63 @@ enum FunctionGemmaPrompt {
     static let functionResponseEnd       = "<end_function_response>"
     static let escape                    = "<escape>"
 
-    /// Serialise the tool list in the FunctionGemma grammar, e.g.:
+    /// Serialise a single tool declaration in the FunctionGemma grammar, e.g.:
     /// ```
-    /// <start_function_declarations>
-    /// <start_function_declaration>
-    /// name:get_weather,description:<escape>Get current weather<escape>,parameters:{type:<escape>object<escape>,properties:{location:{type:<escape>string<escape>}}}
-    /// <end_function_declaration>
-    /// <end_function_declarations>
+    /// <start_function_declaration>declaration:get_weather{description:<escape>Get current weather<escape>,parameters:{type:<escape>object<escape>,properties:{location:{type:<escape>string<escape>}}}}<end_function_declaration>
     /// ```
-    static func formatDeclarations(_ tools: [FunctionDeclaration]) -> String {
-        var out = "\(functionDeclarationsStart)\n"
-        for tool in tools {
-            out += "\(functionDeclarationStart)\n"
-            out += "name:\(tool.name),description:\(escape)\(tool.description)\(escape),parameters:"
-            out += formatValue(tool.parameters)
-            out += "\n\(functionDeclarationEnd)\n"
-        }
-        out += functionDeclarationsEnd
-        return out
+    static func formatFunctionDeclaration(_ tool: FunctionDeclaration) -> String {
+        // Mirror Python: body = {"description": ..., "parameters": ...}
+        let body = "{description:\(escape)\(tool.description)\(escape),parameters:\(formatStructuredValue(tool.parameters))}"
+        return "\(functionDeclarationStart)declaration:\(tool.name)\(body)\(functionDeclarationEnd)"
     }
 
-    /// Format a tool-call prompt as a plain user message — the chat template
-    /// wraps it with `<start_of_turn>user … <end_of_turn><start_of_turn>model`.
-    static func formatUserTurn(tools: [FunctionDeclaration], userText: String) -> String {
-        let declarations = formatDeclarations(tools)
-        return "\(declarations)\n\(userText)"
+    /// Format the developer turn that introduces the tool list:
+    /// `<start_of_turn>developer\n{prompt}{declarations}<end_of_turn>`.
+    static func formatDeveloperTurn(_ tools: [FunctionDeclaration]) -> String {
+        let declarations = tools.map(formatFunctionDeclaration).joined()
+        return "\(startOfTurn)developer\n\(developerPrompt)\(declarations)\(endOfTurn)"
+    }
+
+    /// Format a user turn: `<start_of_turn>user\nTEXT<end_of_turn>`.
+    static func formatUserTurn(_ text: String) -> String {
+        return "\(startOfTurn)user\n\(text)\(endOfTurn)"
+    }
+
+    /// Format the trailing model-turn prefix used before generation:
+    /// `<start_of_turn>model\n`.
+    static func formatModelTurnPrefix() -> String {
+        return "\(startOfTurn)model\n"
+    }
+
+    /// Build the full first-pass tool-call prompt:
+    /// `developer_turn\nuser_turn\nmodel_prefix`. The result is byte-identical
+    /// to `function_calls.format_tool_call_prompt` in the Python export, so
+    /// the model sees the same grammar it was trained on.
+    static func formatToolCallPrompt(tools: [FunctionDeclaration], userText: String) -> String {
+        return "\(formatDeveloperTurn(tools))\n\(formatUserTurn(userText))\n\(formatModelTurnPrefix())"
+    }
+
+    /// Encode the result of executing a tool back into the FunctionGemma
+    /// response format for the second forward pass.
+    static func formatResponse(name: String, response: [String: Any]) -> String {
+        return "\(functionResponseStart)response:\(name)\(formatStructuredValue(response))\(functionResponseEnd)"
     }
 
     // MARK: - JSON-like serialiser
 
-    private static func formatValue(_ value: Any) -> String {
+    /// Recursive serialiser that mirrors Python's ``_format_structured_value``.
+    /// Strings are wrapped in `<escape>...<escape>`, bools/null are lowercase,
+    /// dicts become `{k:v,...}`, lists become `[v,...]`. Dict keys are emitted
+    /// in a stable order — Python relies on dict insertion order, which Swift
+    /// `[String: Any]` does not preserve, so we apply a preferred ordering
+    /// that matches the canonical layout (`type, description, properties,
+    /// required, items, enum`) and fall back to alphabetical for unknown keys.
+    private static func formatStructuredValue(_ value: Any) -> String {
         if let dict = value as? [String: Any] {
             return formatObject(dict)
         }
         if let arr = value as? [Any] {
-            let items = arr.map(formatValue).joined(separator: ",")
+            let items = arr.map(formatStructuredValue).joined(separator: ",")
             return "[\(items)]"
         }
         if let s = value as? String {
@@ -60,21 +83,12 @@ enum FunctionGemmaPrompt {
             return b ? "true" : "false"
         }
         if let n = value as? NSNumber {
-            // `NSNumber` covers Int, Double, etc. The serialiser distinguishes
-            // them based on objCType: 'i'/'q' = integer, 'd'/'f' = float.
-            let type = String(cString: n.objCType)
-            if type == "i" || type == "q" || type == "l" || type == "s" || type == "c" {
-                return n.stringValue
-            }
             return n.stringValue
         }
         return "null"
     }
 
     private static func formatObject(_ dict: [String: Any]) -> String {
-        // Preserve "type" first then "properties" if both exist — that's the
-        // order the Python tokenisation script emits, which matters because
-        // FunctionGemma was trained on that exact field ordering.
         let preferred = ["type", "description", "properties", "required", "items", "enum"]
         var keys = Array(dict.keys)
         keys.sort { a, b in
@@ -84,15 +98,8 @@ enum FunctionGemmaPrompt {
             return a < b
         }
         let pairs = keys.map { key -> String in
-            "\(key):\(formatValue(dict[key] as Any))"
+            "\(key):\(formatStructuredValue(dict[key] as Any))"
         }
         return "{\(pairs.joined(separator: ","))}"
-    }
-
-    /// Encode the result of executing a tool back into the FunctionGemma
-    /// response format for the second forward pass.
-    static func formatResponse(name: String, response: [String: Any]) -> String {
-        let body = formatObject(response)
-        return "\(functionResponseStart)response:\(name)\(body)\(functionResponseEnd)"
     }
 }

--- a/Tests/FunctionGemmaTests/FunctionGemmaPromptTests.swift
+++ b/Tests/FunctionGemmaTests/FunctionGemmaPromptTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import FunctionGemma
+
+final class FunctionGemmaPromptTests: XCTestCase {
+
+    /// The rendered first-pass prompt must contain the full developer block
+    /// with `<start_function_declaration>` entries — that's the grammar
+    /// FunctionGemma was trained on, and the previous simplified template
+    /// omitted it, causing garbage `<start_function_call>` repetition at
+    /// inference time.
+    func testFormatToolCallPromptIncludesDeveloperAndDeclarationBlocks() {
+        let tool = FunctionDeclaration(
+            name: "get_exchange_rate",
+            description: "Get the exchange rate between two currencies.",
+            parameters: [
+                "type": "object",
+                "properties": [
+                    "amount": ["type": "number"],
+                    "from_currency": ["type": "string"],
+                    "to_currency": ["type": "string"],
+                ],
+                "required": ["amount", "from_currency", "to_currency"],
+            ]
+        )
+        let userText = "Convert 23 USD to EUR"
+
+        let prompt = FunctionGemmaPrompt.formatToolCallPrompt(
+            tools: [tool],
+            userText: userText
+        )
+
+        // Developer turn (the bug fix: this block was missing before).
+        XCTAssertTrue(prompt.contains("<start_of_turn>developer"),
+                      "missing developer turn in prompt:\n\(prompt)")
+        XCTAssertTrue(prompt.contains("<start_function_declaration>"),
+                      "missing <start_function_declaration> in prompt:\n\(prompt)")
+        XCTAssertTrue(prompt.contains("get_exchange_rate"),
+                      "missing tool name in prompt:\n\(prompt)")
+        XCTAssertTrue(prompt.contains("<end_function_declaration>"),
+                      "missing <end_function_declaration> in prompt:\n\(prompt)")
+        XCTAssertTrue(prompt.contains("<end_of_turn>"),
+                      "missing <end_of_turn> in prompt:\n\(prompt)")
+
+        // User turn.
+        XCTAssertTrue(prompt.contains("<start_of_turn>user"),
+                      "missing user turn in prompt:\n\(prompt)")
+        XCTAssertTrue(prompt.contains(userText),
+                      "missing user text in prompt:\n\(prompt)")
+
+        // Model-turn prefix (asserted as the contiguous end-of-user →
+        // start-of-model transition that wraps the generation slot).
+        XCTAssertTrue(prompt.contains("<end_of_turn>\n<start_of_turn>model"),
+                      "missing user→model transition in prompt:\n\(prompt)")
+    }
+
+    /// The declaration body must use `declaration:NAME{description:...,parameters:...}`
+    /// with `<escape>`-wrapped strings — mirrors the Python reference exactly.
+    func testFormatFunctionDeclarationMatchesPythonGrammar() {
+        let tool = FunctionDeclaration(
+            name: "set_timer",
+            description: "Start a countdown timer.",
+            parameters: [
+                "type": "object",
+                "properties": ["seconds": ["type": "integer"]],
+            ]
+        )
+
+        let rendered = FunctionGemmaPrompt.formatFunctionDeclaration(tool)
+
+        XCTAssertTrue(rendered.hasPrefix("<start_function_declaration>declaration:set_timer{"),
+                      "unexpected declaration prefix: \(rendered)")
+        XCTAssertTrue(rendered.hasSuffix("<end_function_declaration>"),
+                      "unexpected declaration suffix: \(rendered)")
+        XCTAssertTrue(rendered.contains("description:<escape>Start a countdown timer.<escape>"),
+                      "description not wrapped in <escape>: \(rendered)")
+        XCTAssertTrue(rendered.contains("parameters:{type:<escape>object<escape>"),
+                      "parameters block missing or mis-ordered: \(rendered)")
+    }
+
+    /// Multiple tools must concatenate without a separator and both end up in
+    /// the developer turn body.
+    func testFormatDeveloperTurnConcatenatesTools() {
+        let a = FunctionDeclaration(name: "turn_on", description: "On",
+                                    parameters: ["type": "object"])
+        let b = FunctionDeclaration(name: "turn_off", description: "Off",
+                                    parameters: ["type": "object"])
+
+        let turn = FunctionGemmaPrompt.formatDeveloperTurn([a, b])
+
+        XCTAssertTrue(turn.hasPrefix("<start_of_turn>developer\n"))
+        XCTAssertTrue(turn.hasSuffix("<end_of_turn>"))
+        XCTAssertTrue(turn.contains("declaration:turn_on"))
+        XCTAssertTrue(turn.contains("declaration:turn_off"))
+        // Back-to-back: end of one declaration must touch the start of the next.
+        XCTAssertTrue(turn.contains("<end_function_declaration><start_function_declaration>"),
+                      "declarations should concatenate without separator: \(turn)")
+    }
+}


### PR DESCRIPTION
## Summary
- The simplified single-turn template in `FunctionGemma.swift` omitted the
  `<start_of_turn>developer` block with `<start_function_declaration>` entries.
  This caused the model to emit `<start_function_call>` repetition instead
  of a clean `call:NAME{args}` response.
- Route the prompt through `FunctionGemmaPrompt.formatToolCallPrompt(tools:userText:)`,
  which now mirrors `function_calls.format_tool_call_prompt` from the Python
  export 1:1 — developer turn with the canonical prompt + concatenated
  `<start_function_declaration>declaration:NAME{...}<end_function_declaration>`
  entries, then `<start_of_turn>user`, then `<start_of_turn>model`.
- Add `Tests/FunctionGemmaTests/FunctionGemmaPromptTests.swift` that asserts
  the rendered prompt contains the developer block, the function-declaration
  block, and the standard `<start_of_turn>user` / `<end_of_turn><start_of_turn>model`
  wrapper, plus checks the declaration body grammar and multi-tool concatenation.

## Test plan
- [x] `swift test --filter FunctionGemmaTests` passes (9 tests, 0 failures —
      6 pre-existing parser tests + 3 new prompt tests).
- [ ] Manual tool-call smoke against the published Palettize-8 CoreML model
      emits a proper `<start_function_call>call:NAME{...}<end_function_call>`
      response instead of empty repetition.