### PR TITLE
chore(tts): point CustomVoice at the new bf16 bundle (int4 fully decommissioned)

### DIFF
--- a/Sources/Qwen3TTS/Configuration.swift
+++ b/Sources/Qwen3TTS/Configuration.swift
@@ -278,9 +278,7 @@ public enum TTSModelVariant: String, CaseIterable, Sendable {
     case base = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     case base17B8bit = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit"
     case base17Bbf16 = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"
-    // TODO(int4-decommission): CustomVoice ships only as int4 — no 8bit/bf16
-    // bundle exists yet. Repoint once a non-int4 CustomVoice bundle is produced.
-    case customVoice = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit"
+    case customVoice = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16"
 }
 
 // MARK: - Combined TTS Config
@@ -306,9 +304,9 @@ public struct Qwen3TTSConfig: Codable, Sendable {
 
     /// Build config for a given model size and quantization. `bits == 0` selects bf16.
     ///
-    /// int4 is no longer a shipped TTS default, but the loader must still construct a
-    /// 4-bit config for the one surviving int4 TTS bundle (the 0.6B CustomVoice model),
-    /// so this respects any `bits` rather than routing int4 away.
+    /// int4 is no longer shipped for any TTS model. This still respects any `bits` —
+    /// the loader builds the config for whatever precision the model id reports — so a
+    /// 4-bit bundle (none ship today) would still load rather than being routed away.
     public static func config(for size: TTSModelSize, bits: Int) -> Qwen3TTSConfig {
         var talker: TalkerConfig = (size == .large) ? .large : TalkerConfig()
         var codePredictor: CodePredictorConfig = (size == .large) ? .large : CodePredictorConfig()

--- a/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
+++ b/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
@@ -195,8 +195,7 @@ final class Qwen3TTSConfigTests: XCTestCase {
         XCTAssertEqual(TTSModelVariant.base.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit")
         XCTAssertEqual(TTSModelVariant.base17B8bit.rawValue, "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit")
         XCTAssertEqual(TTSModelVariant.base17Bbf16.rawValue, "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16")
-        // CustomVoice ships only as int4 (no non-int4 bundle exists yet — tracked TODO).
-        XCTAssertEqual(TTSModelVariant.customVoice.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit")
+        XCTAssertEqual(TTSModelVariant.customVoice.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16")
     }
 
     func testUpsampleRateProduct() {
@@ -283,7 +282,7 @@ final class SpeakerConfigTests: XCTestCase {
 
     func testTTSModelVariant() {
         XCTAssertEqual(TTSModelVariant.base.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit")
-        XCTAssertEqual(TTSModelVariant.customVoice.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit")
+        XCTAssertEqual(TTSModelVariant.customVoice.rawValue, "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16")
     }
 
     func testAvailableSpeakersEmptyByDefault() {
@@ -383,7 +382,7 @@ final class E2EInstructTokenTests: XCTestCase {
 /// Requires CustomVoice model weights (~1 GB download).
 final class E2ECustomVoiceInstructTests: XCTestCase {
 
-    static let customVoiceModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit"
+    static let customVoiceModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     static let asrModelId = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
     private static var _sharedTTSModel: Qwen3TTSModel?
@@ -637,7 +636,7 @@ final class E2ECustomVoiceInstructTests: XCTestCase {
 /// Regression test for #105: speaker token must come BEFORE pad+bos.
 final class E2ESpeakerTokenPositionTests: XCTestCase {
 
-    static let customVoiceModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-4bit"
+    static let customVoiceModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     private static var _sharedModel: Qwen3TTSModel?
 


### PR DESCRIPTION
Closes the last int4 hole from #333. CustomVoice was the only TTS model still on int4 (no non-int4 bundle existed). I produced one — `aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16` (fp16, converted from the official `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` source via the same convert.py pipeline as the Base bundles, using the source's own `custom_voice` config minus quantization) — and repoint `TTSModelVariant.customVoice` at it.

**Validated before upload:** loaded the bundle offline in speech-swift and synthesized a clean 5.6s clip with baked speaker `ryan` (maxAmp 0.18); 402 tensor names match the source exactly. Drops the tracked TODO and the int4-specific note in the config ladder (no int4 TTS bundles ship now). Variant unit tests updated; `Qwen3TTSConfigTests` 18/18.