### PR TITLE
fix(function-gemma): route loadFromHub through HF_ENDPOINT mirror

### DIFF
--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -264,7 +264,11 @@ public enum HuggingFaceDownloader {
     /// when the variable is unset, blank, or not a valid `http(s)://host` URL.
     /// The validation mirrors `HubApi`'s own guard so a malformed value falls
     /// back to the default instead of breaking downloads.
-    static func resolvedEndpoint() -> String? {
+    ///
+    /// Public so modules that construct `HubApi` directly (e.g.
+    /// `FunctionGemma.loadFromHub`, which calls `snapshot(from:)` instead of
+    /// going through `downloadWeights`) can still honor the mirror.
+    public static func resolvedEndpoint() -> String? {
         guard let raw = ProcessInfo.processInfo.environment["HF_ENDPOINT"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
               !raw.isEmpty,

--- a/Sources/FunctionGemma/FunctionGemma.swift
+++ b/Sources/FunctionGemma/FunctionGemma.swift
@@ -1,3 +1,4 @@
+import AudioCommon
 import CoreML
 import Foundation
 import Hub
@@ -89,9 +90,13 @@ public final class FunctionGemma: @unchecked Sendable {
 
     /// Download the published HuggingFace repo into a local Hub cache and
     /// load it. Defaults to ``defaultModelId``.
+    ///
+    /// Honors the `HF_ENDPOINT` env var (China mirror support) via
+    /// `HuggingFaceDownloader.resolvedEndpoint()` — keeps this loader in sync
+    /// with every other `fromPretrained` path in the package.
     public static func loadFromHub(_ repoId: String = defaultModelId,
                                    computeUnits: MLComputeUnits = .cpuAndNeuralEngine) async throws -> FunctionGemma {
-        let hub = HubApi()
+        let hub = HubApi(endpoint: HuggingFaceDownloader.resolvedEndpoint())
         let folder = try await hub.snapshot(from: repoId)
         return try await load(from: folder, computeUnits: computeUnits)
     }


### PR DESCRIPTION
## What

Follow-up to #331. `FunctionGemma.loadFromHub` built `HubApi()` directly and never went through the shared downloader, so it stayed pinned to `huggingface.co` even when `HF_ENDPOINT` was set. Routes it through the same `HuggingFaceDownloader.resolvedEndpoint()` helper #331 introduced.

## How

- `HuggingFaceDownloader.resolvedEndpoint()` → `public` (was internal). Documented why.
- `FunctionGemma.loadFromHub` now calls `HubApi(endpoint: HuggingFaceDownloader.resolvedEndpoint())`. When the env var is unset, this is a literal no-op (the param defaults to `nil`).

11 lines, 2 files. Unset → identical behavior. Set → fetches from the mirror like every other `fromPretrained` path.

## Tests

`HuggingFaceDownloaderTests` (23) + `AudioCommonTests` (136) pass. `FunctionGemma` target builds clean. No E2E run — change is config-only and the unset path is identical to before.