### PR TITLE
skill(benchmark): /benchmark asr now reports WER + peakRSS + throughput

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: benchmark
-description: Run performance benchmarks. Arguments: asr, tts, vad, diarize (with optional --num-files N).
+description: Run performance + quality benchmarks. ASR reports WER, RTF, peak RSS, and throughput across engines/variants. Arguments include asr, tts, vad, diarize, asr-quick.
 disable-model-invocation: false
-argument-hint: [asr|tts|vad|diarize]
+argument-hint: [asr|asr-quick|tts|vad|diarize] [extra args]
 allowed-tools: Bash
 ---
 
@@ -12,17 +12,56 @@ Run benchmarks using the release build. Build first with `/build`.
 
 ## Usage
 
-- `/benchmark asr` — transcribe test audio, report RTF
+- `/benchmark asr` — full WER + RTF + peakRSS + throughput on a labeled
+  dataset (LibriSpeech-style dir or `.tsv` manifest). Extra args pass
+  through to `asr-bench`. **Requires** `BENCH_DATASET` env var or
+  `--dataset <path>` in the trailing args.
+- `/benchmark asr-quick` — single-file RTF smoke test (no WER, no dataset
+  required). Equivalent to the old `asr` behavior.
 - `/benchmark tts` — synthesize test text, report RTF
 - `/benchmark vad` — VAD on VoxConverse (all engines)
 - `/benchmark diarize` — DER on VoxConverse (requires downloaded test set)
 
+### Examples
+
+Compare our MLX quantizations on LibriSpeech test-clean (WER + RTF + peakRSS,
+each engine isolated in its own process so RSS reflects per-engine cost):
+
 ```bash
-module="$ARGUMENTS"
+BENCH_DATASET=$HOME/datasets/LibriSpeech/test-clean /benchmark asr \
+  --engines qwen3-mlx-0.6b-4bit qwen3-mlx-0.6b-8bit \
+  --isolated --limit 50
+```
+
+Default engine set (qwen3-coreml + parakeet + whisperkit) on a TSV manifest:
+
+```bash
+/benchmark asr --dataset bench.tsv --limit 100 --output /tmp/run.json
+```
+
+```bash
+module="$1"
+shift || true
 cli=".build/release/speech"
+bench=".build/release/asr-bench"
 
 case "$module" in
   asr)
+    if [ ! -x "$bench" ]; then
+      echo "asr-bench binary missing — run /build first (release)." >&2
+      exit 1
+    fi
+    # Honor BENCH_DATASET if --dataset isn't already in the trailing args.
+    has_dataset=0
+    for a in "$@"; do
+      if [ "$a" = "--dataset" ]; then has_dataset=1; break; fi
+    done
+    if [ "$has_dataset" = "0" ] && [ -n "$BENCH_DATASET" ]; then
+      set -- --dataset "$BENCH_DATASET" "$@"
+    fi
+    "$bench" "$@" 2>&1
+    ;;
+  asr-quick)
     $cli transcribe Tests/Qwen3ASRTests/Resources/test_audio.wav 2>&1
     ;;
   tts)
@@ -35,16 +74,41 @@ case "$module" in
     python3 scripts/benchmark_diarization.py --num-files 5 2>&1
     ;;
   *)
-    echo "Usage: /benchmark [asr|tts|vad|diarize]"
+    echo "Usage: /benchmark [asr|asr-quick|tts|vad|diarize] [args...]"
+    echo "  asr       — full WER + RTF + peakRSS via asr-bench (needs dataset)"
+    echo "  asr-quick — single-file RTF smoke test (no dataset)"
     ;;
 esac
 ```
+
+## What `/benchmark asr` reports
+
+Per engine, in the printed table and the JSON output:
+
+| Metric | Source |
+|--------|--------|
+| `WER%` | substitutions + insertions + deletions over normalized reference words (`AsrBenchmark/WER.swift`) |
+| `RTF` | mean transcribe-elapsed / audio-duration per utterance |
+| `xRT` | throughput = 1 / RTF |
+| `peakRSS` | high-water resident-set size via `mach_task_basic_info` |
+| `RSSΔ` | RSS gained from pre-load to peak (engine cost vs. baseline) |
+| `loadSec` | model load + warmup wall time |
+
+Use `--isolated` to run each engine in a child process — peakRSS then
+reflects each engine's true memory cost instead of the cumulative
+high-water mark of a single sequential run.
+
+## Available engines
+
+`qwen3-coreml`, `qwen3-mlx-{0.6b,1.7b}-{4bit,8bit}`, `parakeet`,
+`nemotron`, `omnilingual`, `omnilingual-mlx-{300m,1b,3b,7b}-4bit`,
+`whisperkit-{large-v3-turbo,large-v3,distil-large-v3}`.
 
 ## Performance targets (M2 Max)
 
 | Module | Metric | Target |
 |--------|--------|--------|
-| ASR (Qwen3) | RTF | ~0.06 |
+| ASR (Qwen3 MLX) | RTF | ~0.06 |
 | ASR (Parakeet) | RTF | ~0.025 |
 | TTS | RTF | ~0.7 |
 | VAD (Silero) | RTF | >20x real-time |


### PR DESCRIPTION
## Summary

Re-points the `/benchmark asr` skill at the existing `asr-bench` binary so it reports the metrics that already exist in `AsrBenchmark/`: **WER%, RTF, throughput (xRT), peakRSS, RSSΔ, loadSec** — instead of just RTF on a single test file.

## Why

The old skill ran `speech transcribe Tests/Qwen3ASRTests/Resources/test_audio.wav` and reported RTF. That's not enough to compare ASR variants (e.g. 4-bit vs 8-bit MLX) on quality OR memory cost. Meanwhile `asr-bench` has had WER + peakRSS support for a while — the skill just wasn't using it.

## What changed

- `.claude/skills/benchmark/SKILL.md` only.
- `/benchmark asr` → invokes `asr-bench` with passthrough args. Needs `BENCH_DATASET` env var (or `--dataset <path>`).
- `/benchmark asr-quick` → preserves the old single-file RTF smoke test for when you don't have a labeled set handy.
- Documents the metric → source mapping and the list of available engines.

## Example

```bash
BENCH_DATASET=$HOME/datasets/LibriSpeech/test-clean /benchmark asr \\
  --engines qwen3-mlx-0.6b-4bit qwen3-mlx-0.6b-8bit \\
  --isolated --limit 50
```

`--isolated` runs each engine in a child process, so `peakRSS` reflects each engine's true memory cost.

## Tests

- `swift build --product asr-bench` clean.
- Skill is a markdown change; no Swift code touched.

## Follow-up

5-bit engine cases (`qwen3-mlx-0.6b-5bit`, `qwen3-mlx-1.7b-5bit`) will land in a trivial follow-up once #262 merges — they're 4 lines in `Engine.swift`.