### PR TITLE
fix(qwen3-icl): reimplement the Mimi codec encoder so voice clone is target-only

### DIFF
--- a/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
@@ -189,23 +189,22 @@ extension Qwen3TTSModel {
         // Step 7: Optionally trim the reference echo from the start of the waveform.
         // The model is conditioned on [ref_text + target_text] and produces codec
         // for both, so the raw decoded waveform begins with a regeneration of the
-        // reference. Trim by the text-token ratio (refTokens / totalTokens) — this
-        // is more robust than trimming by raw reference-audio sample count, because
-        // the model often reproduces the reference at a different speech rate
-        // than the original recording (slower → reference leaks into target).
+        // reference. Trim by the reference's known codec-frame count: the model
+        // re-speaks the reference at ~its own encoded length (refCodes.dim(2)
+        // frames), which we know exactly — far more reliable than the old token-
+        // ratio estimate, whose generous floor clamped the trim and leaked seconds
+        // of reference echo.
         let trimmedWaveform: [Float]
         if trimReference {
-            let refTokenCount = tokenizer.encode(referenceText).count
             let targetTokenCount = tokenizer.encode(text).count
-            trimmedWaveform = Qwen3TTSModel.trimICLReferenceByTokenRatio(
+            let refFrames = refCodes.dim(2)
+            trimmedWaveform = Qwen3TTSModel.trimICLReferenceByFrames(
                 waveform,
-                referenceTokenCount: refTokenCount,
-                targetTokenCount: targetTokenCount,
-                referenceAudio: referenceAudio,
-                referenceSampleRate: referenceSampleRate)
+                referenceFrames: refFrames,
+                targetTokenCount: targetTokenCount)
             let removed = waveform.count - trimmedWaveform.count
             if removed > 0 {
-                iclLog("  ICL: trimmed \(removed) reference samples (~\(String(format: "%.2f", Double(removed)/24000.0))s, refTok=\(refTokenCount) tgtTok=\(targetTokenCount)) from output start")
+                iclLog("  ICL: trimmed \(removed) reference samples (~\(String(format: "%.2f", Double(removed)/24000.0))s, refFrames=\(refFrames) tgtTok=\(targetTokenCount)) from output start")
             }
         } else {
             trimmedWaveform = waveform
@@ -226,67 +225,44 @@ extension Qwen3TTSModel {
 
     // MARK: - Reference echo trim
 
-    /// Drop the first ~refDuration samples from an ICL-synthesized waveform.
+    /// Trim the reference reproduction by its known codec-frame count.
     ///
-    /// The Qwen3-TTS ICL path produces codec for `[reference_text + target_text]`, so the
-    /// raw output begins with the model's regeneration of the reference audio. This helper
-    /// removes that prefix, assuming the regeneration roughly matches the reference duration
-    /// at 24 kHz. The estimate is heuristic — the model may regenerate the reference at a
-    /// slightly different speech rate than the source — so a short tail can remain.
+    /// ICL output is `[reference reproduction + target]`. The model re-speaks the
+    /// reference transcript at ~its original rate, so the reproduction occupies
+    /// about `referenceFrames` codec frames (1920 samples each at 24 kHz) — the
+    /// same length as the encoded reference, which we know exactly. That makes the
+    /// frame count a far better trim point than the old token-ratio estimate,
+    /// whose over-generous `6 frames/token` target floor clamped the trim and left
+    /// seconds of reference echo (the seed-ladder leak that failed the grader's
+    /// prefix check).
     ///
-    /// Returns `waveform` unchanged if the computed trim would empty it.
-    static func trimICLReferenceFromWaveform(
+    /// The reproduction length still varies run-to-run, so the trim is a best
+    /// estimate, not exact: a longer-than-encoded reproduction leaves a short tail
+    /// (a leading word or two), a shorter one risks clipping the target's first
+    /// word. Both are caught by the caller's ASR grader + seed ladder.
+    static func trimICLReferenceByFrames(
         _ waveform: [Float],
-        referenceAudio: [Float],
-        referenceSampleRate: Int
+        referenceFrames: Int,
+        targetTokenCount: Int
     ) -> [Float] {
-        let refSampleCount24k: Int = referenceSampleRate == 24000
-            ? referenceAudio.count
-            : Int((Double(referenceAudio.count) / Double(referenceSampleRate)) * 24000.0)
-        guard refSampleCount24k > 0, refSampleCount24k < waveform.count else {
-            return waveform
-        }
-        return Array(waveform.dropFirst(refSampleCount24k))
-    }
-
-    /// Trim the reference reproduction by text-token proportion.
-    ///
-    /// The model generates [ref_reproduction + target] for `numFrames` codec frames
-    /// totalling `waveform.count` samples. Token-count ratio approximates the
-    /// time-domain split: the ref portion is `refTokens / (refTokens + targetTokens)`
-    /// of the output. We add a small safety margin (1 codec frame = 1920 samples
-    /// at 24 kHz = 80 ms) to account for the model's transition between ref and
-    /// target. Falls back to the audio-sample-based heuristic if token counts
-    /// are unavailable (zero or nonsensical).
-    static func trimICLReferenceByTokenRatio(
-        _ waveform: [Float],
-        referenceTokenCount: Int,
-        targetTokenCount: Int,
-        referenceAudio: [Float],
-        referenceSampleRate: Int
-    ) -> [Float] {
-        let total = referenceTokenCount + targetTokenCount
-        guard referenceTokenCount > 0, targetTokenCount > 0, total > 0 else {
-            return trimICLReferenceFromWaveform(waveform,
-                referenceAudio: referenceAudio,
-                referenceSampleRate: referenceSampleRate)
-        }
-        // Token-proportion estimate of where the target audio begins.
-        let proportional = waveform.count * referenceTokenCount / total
-        // Safety margin: 10 codec frames (~800 ms) catches the trailing word
-        // of the reference reproduction (e.g. "Ruddering.", "of fellows.").
-        let margin = 1920 * 10
-        let estimate = proportional + margin
-
-        // Floor on the target audio that survives the trim: rough estimate of
-        // how much audio a `targetTokenCount`-long sentence should produce —
-        // 6 codec frames per BPE token at 12.5 fps ≈ 0.48 s per token. With
-        // the floor we never trim INTO the target, even when MLX-Metal jitter
-        // makes the model produce an unusually short output and the
-        // proportional estimate over-shoots.
-        let minTargetSamples = max(1920 * 6, targetTokenCount * 6 * 1920)
-        let maxTrim = waveform.count - minTargetSamples
-        let trim = min(estimate, max(0, maxTrim))
+        guard referenceFrames > 0 else { return waveform }
+        let samplesPerFrame = 1920
+        // ~ the reproduction length + 1 frame for the ref→target boundary word.
+        let estimate = (referenceFrames + 1) * samplesPerFrame
+        // Safety floor against pathological over-trim: if the reproduction came out
+        // much shorter than its encoded length, `estimate` would eat into the
+        // target, so cap the trim to keep at least this many target samples. The
+        // cap only binds when the reproduction is well under `referenceFrames`; in
+        // the normal regime the exact frame `estimate` governs. Keep it loose
+        // (~2 frames/token) so it stays a last-resort net and doesn't displace the
+        // known-frame estimate with a coarser token-length guess (a higher floor
+        // would bind in the common case and re-introduce reference-echo leak).
+        let minTarget = max(samplesPerFrame * 4, targetTokenCount * 2 * samplesPerFrame)
+        // When the whole take is shorter than the floor (a degenerate/repetitive
+        // generation), `trim` collapses to 0 and the untrimmed waveform — reference
+        // echo included — is returned for the grader to reject and the seed ladder
+        // to retry.
+        let trim = min(estimate, max(0, waveform.count - minTarget))
         guard trim > 0, trim < waveform.count else { return waveform }
         return Array(waveform.dropFirst(trim))
     }
@@ -349,12 +325,34 @@ extension Qwen3TTSModel {
         let codecEmbedICL = concatenated([codecBosEmbed, refCodecEmbed], axis: 1)  // [1, T_ref+1, D]
         let codecLens = codecEmbedICL.dim(1)
 
-        // 5. Non-streaming overlay: all text + codec_pad, then all codec + tts_pad
-        let codecPadEmbed = talker.embedCodec(
-            MLXArray([Int32(CodecTokens.codecPad)]).expandedDimensions(axis: 0))
-        let textWithCodecPad = textEmbedWithEos + broadcast(codecPadEmbed, to: [1, textLens, hiddenSize])
-        let codecWithTextPad = codecEmbedICL + broadcast(ttsPadEmbed, to: [1, codecLens, hiddenSize])
-        let iclInputEmbed = concatenated([textWithCodecPad, codecWithTextPad], axis: 1)
+        // 5. Streaming overlay — matches the qwen-tts reference default
+        // (generate_icl_prompt, non_streaming_mode=False). Align the text with the
+        // reference codec ELEMENT-WISE (sum) instead of concatenating them, and feed
+        // any text beyond the codec length as trailing.
+        //
+        // The model still re-speaks the reference before the target (the trim below
+        // is still required), but with this overlay the reproduction is ~ the
+        // reference's own frame count and far more consistent run-to-run, instead of
+        // the longer, highly variable reproduction the non-streaming layout (text
+        // block, then codec block) produced. That variability is what defeated the
+        // token-ratio trim and leaked seconds of reference echo into the output
+        // (failing the grader's prefix check → seed-ladder retries). With the
+        // overlay + frame-based trim, takes come out clean often enough that the
+        // seed ladder reliably lands a clean one, and ~30-40% fewer frames are
+        // generated per take.
+        let iclInputEmbed: MLXArray
+        let iclTrailing: MLXArray
+        if textLens > codecLens {
+            iclInputEmbed = textEmbedWithEos[0..., 0..<codecLens, 0...] + codecEmbedICL
+            iclTrailing = textEmbedWithEos[0..., codecLens..., 0...]
+        } else {
+            let padLen = codecLens - textLens
+            let paddedText = padLen > 0
+                ? concatenated([textEmbedWithEos, broadcast(ttsPadEmbed, to: [1, padLen, hiddenSize])], axis: 1)
+                : textEmbedWithEos
+            iclInputEmbed = paddedText + codecEmbedICL
+            iclTrailing = ttsPadEmbed
+        }
 
         // 6. Codec prefix. Two layouts (reference parity):
         //   With language id: [codec_think, codec_think_bos, lang_id, codec_think_eos, pad, bos]
@@ -413,7 +411,8 @@ extension Qwen3TTSModel {
         let inputEmbeds = concatenated(
             [roleEmbed, combinedPrefixOverlay, iclInputEmbed], axis: 1)
 
-        // Trailing text: tts_pad (single token, generation will stream text via codec overlay)
-        return (inputEmbeds, ttsPadEmbed, ttsPadEmbed)
+        // Trailing text: leftover target text (streaming) or tts_pad. The generation
+        // loop feeds this one token per step so the model produces the target codec.
+        return (inputEmbeds, iclTrailing, ttsPadEmbed)
     }
 }

--- a/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
@@ -35,12 +35,16 @@ extension Qwen3TTSModel {
         let tts = try await Qwen3TTSModel.fromPretrained(
             modelId: modelId, cacheDir: cacheDir, offlineMode: offlineMode, progressHandler: progressHandler)
 
-        let weightsDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        // The codec encoder (Mimi) lives in the speech-tokenizer bundle, NOT the
+        // talker bundle — the talker bundle has no `encoder.*`/`decoder.*` keys.
+        // `fromPretrained` already downloaded the tokenizer (same dir the decoder
+        // loads from), so just resolve its cache dir.
+        let tokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
+        let tokenizerDir = try HuggingFaceDownloader.getCacheDirectory(for: tokenizerModelId)
 
-        // Build encoder with same config as decoder
         let encoderConfig = tts.config.speechTokenizerDecoder
         let encoder = SpeechTokenizerEncoder(config: encoderConfig)
-        try TTSWeightLoader.loadSpeechTokenizerEncoderWeights(into: encoder, from: weightsDir)
+        try TTSWeightLoader.loadSpeechTokenizerEncoderWeights(into: encoder, from: tokenizerDir)
 
         return (tts, encoder)
     }
@@ -51,11 +55,11 @@ extension Qwen3TTSModel {
     /// into codec tokens and prepends them with their transcript into the autoregressive
     /// context. This produces correct EOS and higher voice fidelity.
     ///
-    /// Because the model is conditioned on `[reference_text + target_text]` and trained to
-    /// produce codec for the entire text sequence, the raw decoded waveform contains a
-    /// regeneration of the reference audio followed by the target. By default this method
-    /// returns only the target portion; pass `trimReference: false` to receive the full
-    /// waveform (useful for debugging the model's reference reproduction).
+    /// The reference codec (from the encoder) is supplied as in-context conditioning, so
+    /// the model generates the TARGET codec only. For decoding, the reference codec is
+    /// prepended (the causal Mimi decoder needs left context) and then cut back off by the
+    /// exact `refFrames / totalFrames` audio ratio — leaving clean target audio. Pass
+    /// `trimReference: false` to receive the full decoded waveform (reference + target).
     ///
     /// - Parameters:
     ///   - text: Target text to synthesize
@@ -65,10 +69,9 @@ extension Qwen3TTSModel {
     ///   - language: Language hint (e.g. "english", "german")
     ///   - sampling: Sampling config
     ///   - codecEncoder: SpeechTokenizerEncoder from fromPretrainedWithEncoder()
-    ///   - trimReference: When `true` (default), strip the reference-text portion from the
-    ///                    start of the output, returning only the target audio. The trim
-    ///                    point is estimated from the reference duration (codec runs at
-    ///                    12.5 fps, 1920 samples per frame at 24 kHz). Set `false` to
+    ///   - trimReference: When `true` (default), prepend the reference codec for the decode
+    ///                    and cut the reference portion (`refFrames / totalFrames` of the
+    ///                    audio) off the front, returning only the target audio. Set `false` to
     ///                    receive the raw decoded waveform.
     public func synthesizeWithVoiceCloneICL(
         text: String,
@@ -154,17 +157,13 @@ extension Qwen3TTSModel {
         if iclSampling.temperature > 0 && iclSampling.repetitionPenalty < 1.5 {
             iclSampling.repetitionPenalty = 1.5
         }
-        // Cap maxTokens so under-EOS runaway outputs can't exhaust GPU memory.
-        // ICL generates [ref reproduction + target], so the budget must cover
-        // BOTH: ref-codec-frames (from the encoded reference) plus a per-target-
-        // text allowance. 6 codec frames per text token is a loose upper bound
-        // on natural speech rate (~12.5 fps / ~2 tok/s). Extra 1.5× safety
-        // margin on the reference portion handles model speech-rate variance.
-        let refCodecFrames = refCodes.dim(2)
+        // Cap maxTokens so an under-EOS runaway can't exhaust GPU memory. The
+        // model generates the TARGET codec only (the reference is provided as
+        // context, not regenerated), so the budget is purely a per-target-text
+        // allowance: 8 codec frames per BPE token is a loose upper bound on
+        // natural speech rate (~12.5 fps), with a floor for very short lines.
         let targetTokenCount = tokenizer.encode(text).count
-        let refBudget = refCodecFrames + refCodecFrames / 2  // 1.5x of ref frames
-        let targetBudget = max(75, targetTokenCount * 6)
-        let textDerivedCap = refBudget + targetBudget
+        let textDerivedCap = max(96, targetTokenCount * 8)
         iclSampling.maxTokens = min(iclSampling.maxTokens, textDerivedCap)
         let (allCodebooks, numFrames) = generateWithCodePredictor(
             prefillEmbeds: prefillEmbeds,
@@ -180,34 +179,32 @@ extension Qwen3TTSModel {
             return []
         }
 
-        // Step 6: Decode codec tokens → waveform
-        let outputSamples = numFrames * 1920
-        iclLog("  ICL: decoding \(numFrames) frames → \(outputSamples) samples...")
-        let waveform = codecDecoder.decode(codes: allCodebooks)
+        // Step 6+7: Decode, prepending the reference codec, then cut the reference
+        // portion off the front (matches the qwen-tts reference decode path).
+        //
+        // The talker now generates the TARGET codec only (the encoder produces the
+        // correct reference codec, so the model continues past it instead of re-
+        // speaking it). The Mimi decoder is causal and needs left context, so we
+        // prepend the exact reference codec for the decode and then cut the leading
+        // `refFrames / totalFrames` fraction of audio — the part the reference
+        // codec produced — leaving clean target audio with no echo and no clipping.
+        let refFrames = refCodes.dim(2)
+        let codesForDecode = trimReference
+            ? concatenated([refCodes, allCodebooks], axis: 2)   // [1, 16, refFrames + numFrames]
+            : allCodebooks
+        let totalFrames = codesForDecode.dim(2)
+        iclLog("  ICL: decoding \(numFrames) target frames (+ \(trimReference ? refFrames : 0) ref ctx) → \(totalFrames) frames...")
+        let fullWaveform = codecDecoder.decode(codes: codesForDecode)
         let t3 = CFAbsoluteTimeGetCurrent()
 
-        // Step 7: Optionally trim the reference echo from the start of the waveform.
-        // The model is conditioned on [ref_text + target_text] and produces codec
-        // for both, so the raw decoded waveform begins with a regeneration of the
-        // reference. Trim by the reference's known codec-frame count: the model
-        // re-speaks the reference at ~its own encoded length (refCodes.dim(2)
-        // frames), which we know exactly — far more reliable than the old token-
-        // ratio estimate, whose generous floor clamped the trim and leaked seconds
-        // of reference echo.
         let trimmedWaveform: [Float]
-        if trimReference {
-            let targetTokenCount = tokenizer.encode(text).count
-            let refFrames = refCodes.dim(2)
-            trimmedWaveform = Qwen3TTSModel.trimICLReferenceByFrames(
-                waveform,
-                referenceFrames: refFrames,
-                targetTokenCount: targetTokenCount)
-            let removed = waveform.count - trimmedWaveform.count
-            if removed > 0 {
-                iclLog("  ICL: trimmed \(removed) reference samples (~\(String(format: "%.2f", Double(removed)/24000.0))s, refFrames=\(refFrames) tgtTok=\(targetTokenCount)) from output start")
-            }
+        if trimReference && totalFrames > 0 {
+            let cut = refFrames * fullWaveform.count / totalFrames
+            trimmedWaveform = (cut > 0 && cut < fullWaveform.count)
+                ? Array(fullWaveform.dropFirst(cut)) : fullWaveform
+            iclLog("  ICL: cut \(cut) reference samples (~\(String(format: "%.2f", Double(cut)/24000.0))s, \(refFrames)/\(totalFrames) frames) from output start")
         } else {
-            trimmedWaveform = waveform
+            trimmedWaveform = fullWaveform
         }
 
         let audioDur = Double(trimmedWaveform.count) / 24000.0
@@ -221,50 +218,6 @@ extension Qwen3TTSModel {
         iclLog("  ICL timing: encode=\(encTime)s | generate=\(genTime)s (\(numFrames) steps, \(msPerStep)ms/step) | decode=\(decTime)s | total=\(totTime)s | audio=\(audDur)s | RTF=\(rtf)")
 
         return trimmedWaveform
-    }
-
-    // MARK: - Reference echo trim
-
-    /// Trim the reference reproduction by its known codec-frame count.
-    ///
-    /// ICL output is `[reference reproduction + target]`. The model re-speaks the
-    /// reference transcript at ~its original rate, so the reproduction occupies
-    /// about `referenceFrames` codec frames (1920 samples each at 24 kHz) — the
-    /// same length as the encoded reference, which we know exactly. That makes the
-    /// frame count a far better trim point than the old token-ratio estimate,
-    /// whose over-generous `6 frames/token` target floor clamped the trim and left
-    /// seconds of reference echo (the seed-ladder leak that failed the grader's
-    /// prefix check).
-    ///
-    /// The reproduction length still varies run-to-run, so the trim is a best
-    /// estimate, not exact: a longer-than-encoded reproduction leaves a short tail
-    /// (a leading word or two), a shorter one risks clipping the target's first
-    /// word. Both are caught by the caller's ASR grader + seed ladder.
-    static func trimICLReferenceByFrames(
-        _ waveform: [Float],
-        referenceFrames: Int,
-        targetTokenCount: Int
-    ) -> [Float] {
-        guard referenceFrames > 0 else { return waveform }
-        let samplesPerFrame = 1920
-        // ~ the reproduction length + 1 frame for the ref→target boundary word.
-        let estimate = (referenceFrames + 1) * samplesPerFrame
-        // Safety floor against pathological over-trim: if the reproduction came out
-        // much shorter than its encoded length, `estimate` would eat into the
-        // target, so cap the trim to keep at least this many target samples. The
-        // cap only binds when the reproduction is well under `referenceFrames`; in
-        // the normal regime the exact frame `estimate` governs. Keep it loose
-        // (~2 frames/token) so it stays a last-resort net and doesn't displace the
-        // known-frame estimate with a coarser token-length guess (a higher floor
-        // would bind in the common case and re-introduce reference-echo leak).
-        let minTarget = max(samplesPerFrame * 4, targetTokenCount * 2 * samplesPerFrame)
-        // When the whole take is shorter than the floor (a degenerate/repetitive
-        // generation), `trim` collapses to 0 and the untrimmed waveform — reference
-        // echo included — is returned for the grader to reject and the seed ladder
-        // to retry.
-        let trim = min(estimate, max(0, waveform.count - minTarget))
-        guard trim > 0, trim < waveform.count else { return waveform }
-        return Array(waveform.dropFirst(trim))
     }
 
     // MARK: - ICL Prefill Construction

--- a/Sources/Qwen3TTS/SpeechTokenizerEncoder.swift
+++ b/Sources/Qwen3TTS/SpeechTokenizerEncoder.swift
@@ -5,246 +5,365 @@ import MLXFast
 import MLXCommon
 import AudioCommon
 
-// MARK: - Encoder Residual Unit
+// MARK: - Mimi codec encoder (Qwen3-TTS 12 Hz speech tokenizer)
+//
+// The Qwen3-TTS reference encoder is HuggingFace `MimiModel`
+// (`class Qwen3TTSTokenizerV2Encoder(MimiModel)`). The encode path is:
+//
+//   xs = seanet_encoder(xs)          # conv stack, 24 kHz → 80 frames @ 512ch
+//   xs = encoder_transformer(xs)     # 8-layer causal transformer
+//   xs = downsample(xs)              # extra ×2 → 40 frames @ 12.5 Hz
+//   codes = quantizer.encode(xs)     # split RVQ → [B, 16, T] indices
+//
+// This is a faithful MLX port of mlx-audio's Mimi modules, using the
+// HuggingFace checkpoint's weight layout (q/k/v/o_proj, fc1/fc2,
+// input/post_attention_layernorm, EMA codebooks via embed_sum/cluster_usage).
+//
+// Everything runs in NLC layout ([B, T, C]); the golden PyTorch tensors are
+// NCL ([B, C, T]) and are transposed for comparison in the validation harness.
 
-/// Mirror of DecoderResidualUnit.
-/// Dilated residual: SnakeBeta -> CausalConv1d(dilated) -> SnakeBeta -> CausalConv1d(1x1) -> residual
-public class EncoderResidualUnit: Module {
-    @ModuleInfo var snake1: SnakeBeta
-    @ModuleInfo var conv1: CausalConv1d
-    @ModuleInfo var snake2: SnakeBeta
-    @ModuleInfo var conv2: CausalConv1d
+/// Fixed config for the 1.7B/0.6B Qwen3-TTS 12 Hz tokenizer (config.json
+/// `encoder_config`). These are model constants, not per-checkpoint knobs.
+public struct MimiEncoderConfig {
+    public let channels = 1
+    public let nFilters = 64
+    public let ratios = [8, 6, 5, 4]          // applied reversed in the encoder
+    public let kSize = 7
+    public let lastKSize = 3
+    public let residualKSize = 3
+    public let dilationBase = 2
+    public let nResidualLayers = 1
+    public let compress = 2                    // extra downsample stride
+    public let dimension = 512                 // SEANet output / transformer dim
+    public let numLayers = 8
+    public let numHeads = 8
+    public let headDim = 64
+    public let intermediateSize = 2048
+    public let ropeTheta: Float = 10000
+    public let codebookDim = 256
+    public let codebookSize = 2048
+    public let numSemanticQuantizers = 1
+    public let validNumQuantizers = 16         // 1 semantic + 15 acoustic
+    public init() {}
+}
 
-    public init(dim: Int, dilation: Int) {
-        self._snake1.wrappedValue = SnakeBeta(channels: dim)
-        self._conv1.wrappedValue = CausalConv1d(
-            inputChannels: dim, outputChannels: dim,
-            kernelSize: 7, dilation: dilation)
-        self._snake2.wrappedValue = SnakeBeta(channels: dim)
-        self._conv2.wrappedValue = CausalConv1d(
-            inputChannels: dim, outputChannels: dim,
-            kernelSize: 1)
+// MARK: - Causal streamable conv (Mimi padding)
 
+/// Conv1d with Mimi's causal padding: pad_total = k_eff - stride on the left,
+/// plus the "extra padding" that makes the framing exact, with a configurable
+/// pad mode (zeros for SEANet convs, edge/replicate for the ×2 downsample).
+public class MimiConv1d: Module {
+    @ModuleInfo var conv: Conv1d
+    let kSize: Int
+    let stride: Int
+    let dilation: Int
+    let padEdge: Bool
+
+    public init(inC: Int, outC: Int, kSize: Int, stride: Int = 1,
+                dilation: Int = 1, bias: Bool = true, padEdge: Bool = false) {
+        self.kSize = kSize
+        self.stride = stride
+        self.dilation = dilation
+        self.padEdge = padEdge
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: inC, outputChannels: outC, kernelSize: kSize,
+            stride: stride, padding: 0, dilation: dilation, groups: 1, bias: bias)
+        super.init()
+    }
+
+    /// Input/Output: [B, T, C]
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let len = x.dim(1)
+        let kEff = (kSize - 1) * dilation + 1
+        let paddingTotal = kEff - stride
+        // extra padding so the last (possibly partial) frame is covered
+        let nframes = Double(max(len + paddingTotal - kEff, 0)) / Double(stride) + 1.0
+        let idealLen = (Int(ceil(nframes)) - 1) * stride + kEff - paddingTotal
+        let extra = max(0, idealLen - len)
+        // causal: all padding on the left, plus the extra on the right
+        let padded = MLX.padded(
+            x,
+            widths: [.init((low: 0, high: 0)),
+                     .init((low: paddingTotal, high: extra)),
+                     .init((low: 0, high: 0))],
+            mode: padEdge ? .edge : .constant)
+        return conv(padded)
+    }
+}
+
+// MARK: - SEANet encoder
+
+/// Residual unit: x + conv2(elu(conv1(elu(x)))). true_skip ⇒ no shortcut conv.
+public class MimiResnetBlock: Module {
+    @ModuleInfo var convA: MimiConv1d   // checkpoint block.1 (k=residual, dilation)
+    @ModuleInfo var convB: MimiConv1d   // checkpoint block.3 (k=1)
+
+    public init(dim: Int, cfg: MimiEncoderConfig, dilation: Int) {
+        let hidden = dim / cfg.compress
+        self._convA.wrappedValue = MimiConv1d(
+            inC: dim, outC: hidden, kSize: cfg.residualKSize, dilation: dilation)
+        self._convB.wrappedValue = MimiConv1d(inC: hidden, outC: dim, kSize: 1)
         super.init()
     }
 
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
-        let residual = x
-        var h = snake1(x)
-        h = conv1(h)
-        h = snake2(h)
-        h = conv2(h)
-        return h + residual
+        var h = convA(elu(x, alpha: 1.0))
+        h = convB(elu(h, alpha: 1.0))
+        return h + x
     }
 }
 
-// MARK: - Encoder Block (Downsample)
+/// One downsample stage: residual block(s) then elu + strided conv.
+public class MimiEncoderLayer: Module {
+    @ModuleInfo var residuals: [MimiResnetBlock]
+    @ModuleInfo var downsample: MimiConv1d
 
-/// Mirror of DecoderBlock, reversed.
-/// 3x EncoderResidualUnit -> SnakeBeta -> CausalConv1d(strided, downsample)
-public class EncoderBlock: Module {
-    @ModuleInfo var residualUnits: [EncoderResidualUnit]
-    @ModuleInfo var snake: SnakeBeta
-    @ModuleInfo var downsample: CausalConv1d
-
-    public init(inputDim: Int, outputDim: Int, stride: Int) {
-        // 3 residual units with dilations [1, 3, 9]
-        self._residualUnits.wrappedValue = [1, 3, 9].map { dilation in
-            EncoderResidualUnit(dim: inputDim, dilation: dilation)
+    public init(dim: Int, ratio: Int, cfg: MimiEncoderConfig) {
+        var dilation = 1
+        var blocks: [MimiResnetBlock] = []
+        for _ in 0..<cfg.nResidualLayers {
+            blocks.append(MimiResnetBlock(dim: dim, cfg: cfg, dilation: dilation))
+            dilation *= cfg.dilationBase
         }
-        self._snake.wrappedValue = SnakeBeta(channels: inputDim)
-        self._downsample.wrappedValue = CausalConv1d(
-            inputChannels: inputDim, outputChannels: outputDim,
-            kernelSize: stride * 2, stride: stride)
-
+        self._residuals.wrappedValue = blocks
+        self._downsample.wrappedValue = MimiConv1d(
+            inC: dim, outC: dim * 2, kSize: ratio * 2, stride: ratio)
         super.init()
     }
 
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         var h = x
-        for unit in residualUnits {
-            h = unit(h)
-        }
-        h = snake(h)
-        return downsample(h)
+        for r in residuals { h = r(h) }
+        return downsample(elu(h, alpha: 1.0))
     }
 }
 
-// MARK: - Encoder Transformer
+public class MimiSeanetEncoder: Module {
+    @ModuleInfo var initConv: MimiConv1d
+    @ModuleInfo var layers: [MimiEncoderLayer]
+    @ModuleInfo var finalConv: MimiConv1d
 
-/// Mirror of DecoderTransformer — 8-layer transformer with 1024→512 bottleneck.
-/// Reuses DecoderTransformerLayer (same attention + SwiGLU MLP + LayerScale).
-public class EncoderTransformer: Module {
-    @ModuleInfo var inputProj: Linear
-    @ModuleInfo var layers: [DecoderTransformerLayer]
-    @ModuleInfo var norm: RMSNorm
-    @ModuleInfo var outputProj: Linear
-
-    public init(config: SpeechTokenizerDecoderConfig) {
-        self._inputProj.wrappedValue = Linear(config.latentDim, config.hiddenSize)
-        self._layers.wrappedValue = (0..<config.numLayers).map { _ in
-            DecoderTransformerLayer(config: config)
+    public init(cfg: MimiEncoderConfig) {
+        self._initConv.wrappedValue = MimiConv1d(
+            inC: cfg.channels, outC: cfg.nFilters, kSize: cfg.kSize)
+        var mult = 1
+        var ls: [MimiEncoderLayer] = []
+        for ratio in cfg.ratios.reversed() {
+            ls.append(MimiEncoderLayer(dim: mult * cfg.nFilters, ratio: ratio, cfg: cfg))
+            mult *= 2
         }
-        self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize)
-        self._outputProj.wrappedValue = Linear(config.hiddenSize, config.latentDim)
-
+        self._layers.wrappedValue = ls
+        self._finalConv.wrappedValue = MimiConv1d(
+            inC: mult * cfg.nFilters, outC: cfg.dimension, kSize: cfg.lastKSize)
         super.init()
     }
 
+    /// [B, T_samples, 1] → [B, T/960, 512]
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
-        var h = inputProj(x)  // [B, T, 1024] → [B, T, 512]
-        for layer in layers {
-            (h, _) = layer(h)  // Discard cache (encoder doesn't need it)
-        }
-        h = norm(h)
-        // Skip outputProj — RVQ encodes in hiddenSize=512 space
-        return h  // [B, T, 512]
+        var h = initConv(x)
+        for l in layers { h = l(h) }
+        h = elu(h, alpha: 1.0)
+        return finalConv(h)
     }
 }
 
-// MARK: - Encoder RVQ (quantize direction)
+// MARK: - Encoder transformer (HF Mimi layout)
 
-/// Quantizes a latent [B, T, hiddenSize] tensor into 16 codebook indices.
-/// Shares codebook weights with SplitResidualVectorQuantizer (decoder-side).
-public class EncoderRVQ: Module {
-    @ModuleInfo var rvqFirst: ResidualVectorQuantizer
-    @ModuleInfo var rvqRest: ResidualVectorQuantizer
+public class MimiTransformerLayer: Module {
+    @ModuleInfo(key: "input_layernorm") var inputLayernorm: LayerNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttnLayernorm: LayerNorm
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "fc1") var fc1: Linear
+    @ModuleInfo(key: "fc2") var fc2: Linear
+    @ParameterInfo(key: "self_attn_scale") var selfAttnScale: MLXArray
+    @ParameterInfo(key: "mlp_scale") var mlpScale: MLXArray
+    let rope: RoPE
+    let numHeads: Int
+    let headDim: Int
+    let scale: Float
 
-    public init(config: SpeechTokenizerDecoderConfig) {
-        self._rvqFirst.wrappedValue = ResidualVectorQuantizer(
-            numQuantizers: 1,
-            codebookSize: config.semanticCodebookSize,
-            codebookDim: config.codebookDim,
-            outputDim: config.hiddenSize)
-        self._rvqRest.wrappedValue = ResidualVectorQuantizer(
-            numQuantizers: config.numQuantizers - 1,
-            codebookSize: config.acousticCodebookSize,
-            codebookDim: config.codebookDim,
-            outputDim: config.hiddenSize)
-
+    public init(cfg: MimiEncoderConfig) {
+        self._inputLayernorm.wrappedValue = LayerNorm(dimensions: cfg.dimension, eps: 1e-5)
+        self._postAttnLayernorm.wrappedValue = LayerNorm(dimensions: cfg.dimension, eps: 1e-5)
+        self._qProj.wrappedValue = Linear(cfg.dimension, cfg.numHeads * cfg.headDim, bias: false)
+        self._kProj.wrappedValue = Linear(cfg.dimension, cfg.numHeads * cfg.headDim, bias: false)
+        self._vProj.wrappedValue = Linear(cfg.dimension, cfg.numHeads * cfg.headDim, bias: false)
+        self._oProj.wrappedValue = Linear(cfg.numHeads * cfg.headDim, cfg.dimension, bias: false)
+        self._fc1.wrappedValue = Linear(cfg.dimension, cfg.intermediateSize, bias: false)
+        self._fc2.wrappedValue = Linear(cfg.intermediateSize, cfg.dimension, bias: false)
+        self._selfAttnScale.wrappedValue = MLXArray.ones([cfg.dimension])
+        self._mlpScale.wrappedValue = MLXArray.ones([cfg.dimension])
+        self.rope = RoPE(dimensions: cfg.headDim, traditional: false, base: cfg.ropeTheta)
+        self.numHeads = cfg.numHeads
+        self.headDim = cfg.headDim
+        self.scale = pow(Float(cfg.headDim), -0.5)
         super.init()
     }
 
-    /// - Parameter h: [B, T, hiddenSize=512]
-    /// - Returns: [B, 16, T] — all codebook indices
+    private func attention(_ x: MLXArray, mask: MLXArray) -> MLXArray {
+        let b = x.dim(0), t = x.dim(1)
+        func heads(_ p: MLXArray) -> MLXArray {
+            p.reshaped([b, t, numHeads, headDim]).transposed(0, 2, 1, 3)  // [B,H,T,Hd]
+        }
+        var q = heads(qProj(x))
+        var k = heads(kProj(x))
+        let v = heads(vProj(x))
+        q = rope(q)
+        k = rope(k)
+        let out = MLXFast.scaledDotProductAttention(
+            queries: q, keys: k, values: v, scale: scale, mask: mask)
+        let merged = out.transposed(0, 2, 1, 3).reshaped([b, t, numHeads * headDim])
+        return oProj(merged)
+    }
+
+    public func callAsFunction(_ x: MLXArray, mask: MLXArray) -> MLXArray {
+        var h = x + selfAttnScale * attention(inputLayernorm(x), mask: mask)
+        h = h + mlpScale * fc2(gelu(fc1(postAttnLayernorm(h))))
+        return h
+    }
+}
+
+public class MimiEncoderTransformer: Module {
+    @ModuleInfo var layers: [MimiTransformerLayer]
+
+    public init(cfg: MimiEncoderConfig) {
+        self._layers.wrappedValue = (0..<cfg.numLayers).map { _ in MimiTransformerLayer(cfg: cfg) }
+        super.init()
+    }
+
+    /// [B, T, 512] → [B, T, 512] (causal self-attention)
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let t = x.dim(1)
+        // additive causal mask [T, T]: -inf above the diagonal
+        let rows = MLXArray(Int32(0)..<Int32(t)).reshaped([t, 1])
+        let cols = MLXArray(Int32(0)..<Int32(t)).reshaped([1, t])
+        let mask = MLX.which(cols .> rows, MLXArray(-Float.greatestFiniteMagnitude), MLXArray(Float(0)))
+        var h = x
+        for l in layers { h = l(h, mask: mask) }
+        return h
+    }
+}
+
+// MARK: - Split residual vector quantizer (encode only)
+
+/// EMA codebook: embedding = embed_sum / max(cluster_usage, eps); nearest by
+/// argmin(‖e‖²/2 − x·e).
+public class MimiEuclideanCodebook: Module {
+    @ParameterInfo(key: "embed_sum") var embedSum: MLXArray
+    @ParameterInfo(key: "cluster_usage") var clusterUsage: MLXArray
+    let dim: Int
+
+    public init(size: Int, dim: Int) {
+        self.dim = dim
+        self._embedSum.wrappedValue = MLXArray.zeros([size, dim])
+        self._clusterUsage.wrappedValue = MLXArray.zeros([size])
+        super.init()
+    }
+
+    /// embedding [size, dim] from EMA stats.
+    func embedding() -> MLXArray {
+        let denom = maximum(clusterUsage, MLXArray(Float(1e-5))).reshaped([clusterUsage.dim(0), 1])
+        return embedSum / denom
+    }
+
+    /// x: [B, T, dim] → indices [B, T]
+    func encode(_ x: MLXArray, embedding e: MLXArray, c2: MLXArray) -> MLXArray {
+        let b = x.dim(0), t = x.dim(1)
+        let flat = x.reshaped([b * t, dim])
+        let dot = matmul(flat, e.transposed(1, 0))          // [B*T, size]
+        let idx = argMin(c2 - dot, axis: -1)                // [B*T]
+        return idx.reshaped([b, t])
+    }
+
+    /// indices [B, T] → vectors [B, T, dim]
+    func decode(_ idx: MLXArray, embedding e: MLXArray) -> MLXArray {
+        let b = idx.dim(0), t = idx.dim(1)
+        return e[idx.reshaped([b * t])].reshaped([b, t, dim])
+    }
+}
+
+/// One residual vector quantizer: 512→256 input_proj, then nq residual codebooks.
+public class MimiResidualVQ: Module {
+    @ModuleInfo(key: "input_proj") var inputProj: MimiConv1d
+    @ModuleInfo var codebooks: [MimiEuclideanCodebook]
+
+    public init(nq: Int, cfg: MimiEncoderConfig) {
+        self._inputProj.wrappedValue = MimiConv1d(
+            inC: cfg.dimension, outC: cfg.codebookDim, kSize: 1, bias: false)
+        self._codebooks.wrappedValue = (0..<nq).map { _ in
+            MimiEuclideanCodebook(size: cfg.codebookSize, dim: cfg.codebookDim)
+        }
+        super.init()
+    }
+
+    /// h: [B, T, 512] → codes [B, nq, T]
     public func encode(_ h: MLXArray) -> MLXArray {
-        let firstCodes = rvqFirst.encode(h)    // [B, 1, T]
-        let restCodes  = rvqRest.encode(h)     // [B, 15, T]
-        return concatenated([firstCodes, restCodes], axis: 1)
+        var residual = inputProj(h)                          // [B, T, 256]
+        var codes: [MLXArray] = []
+        for cb in codebooks {
+            let e = cb.embedding()
+            let c2 = (e * e).sum(axis: -1) / 2
+            let idx = cb.encode(residual, embedding: e, c2: c2)   // [B, T]
+            let quant = cb.decode(idx, embedding: e)              // [B, T, 256]
+            residual = residual - quant
+            codes.append(idx.expandedDimensions(axis: 1))         // [B, 1, T]
+        }
+        return concatenated(codes, axis: 1)                       // [B, nq, T]
     }
 }
 
-// MARK: - Full Speech Tokenizer Encoder
+public class MimiSplitRVQ: Module {
+    @ModuleInfo(key: "semantic_rvq") var semanticRVQ: MimiResidualVQ
+    @ModuleInfo(key: "acoustic_rvq") var acousticRVQ: MimiResidualVQ
 
-/// Mimi-based speech tokenizer encoder.
-/// Converts 24 kHz audio waveform → 16-codebook indices at 12.5 Hz.
-///
-/// Architecture (exact mirror of SpeechTokenizerDecoder, reversed):
-///   1. inputConv:        1 → encoderDim (96)
-///   2. encoderBlocks:    [3x, 4x, 5x, 8x] downsample (channels double each time)
-///   3. postConvNeXt1/2:  latentDim ConvNeXt + 2x downsample (each)
-///   4. postConv:         latentDim (1024) → hiddenSize (512)
-///   5. transformer:      8-layer EncoderTransformer
-///   6. rvq:              EncoderRVQ → [B, 16, T_frames]
-public class SpeechTokenizerEncoder: Module {
-    public let config: SpeechTokenizerDecoderConfig
-
-    @ModuleInfo var inputConv: CausalConv1d
-    @ModuleInfo var encoderBlocks: [EncoderBlock]
-    @ModuleInfo var channelProj: CausalConv1d  // decoderDim → latentDim
-    @ModuleInfo var postConvNeXt1: ConvNeXtBlock
-    @ModuleInfo var postDownsample1: CausalConv1d
-    @ModuleInfo var postConvNeXt2: ConvNeXtBlock
-    @ModuleInfo var postDownsample2: CausalConv1d
-    @ModuleInfo var postConv: CausalConv1d
-    @ModuleInfo var transformer: EncoderTransformer
-    @ModuleInfo var rvq: EncoderRVQ
-
-    public init(config: SpeechTokenizerDecoderConfig) {
-        self.config = config
-
-        // Mirror decoder channel schedule (reversed).
-        // Decoder dims: [1536, 768, 384, 192, 96]
-        // Encoder dims: [96, 192, 384, 768, 1536]
-        var decoderDims: [Int] = [config.decoderDim]
-        for _ in config.upsampleRates {
-            decoderDims.append(decoderDims.last! / 2)
-        }
-        let encoderDims = decoderDims.reversed() as [Int]
-
-        // 1. Input conv: 1 -> encoderDims[0] (=96), kernel=7 (mirrors decoder finalConv)
-        self._inputConv.wrappedValue = CausalConv1d(
-            inputChannels: 1, outputChannels: encoderDims[0],
-            kernelSize: 7)
-
-        // 2. Encoder blocks: downsample rates = decoder upsampleRates reversed [8,5,4,3] → [3,4,5,8]
-        let downsampleRates = config.upsampleRates.reversed() as [Int]
-        self._encoderBlocks.wrappedValue = downsampleRates.enumerated().map { i, rate in
-            EncoderBlock(inputDim: encoderDims[i], outputDim: encoderDims[i + 1], stride: rate)
-        }
-
-        // 3. Channel projection: decoderDim (1536) → latentDim (1024)
-        // Mirrors the decoder's transition from latentDim to decoderDim
-        self._channelProj.wrappedValue = CausalConv1d(
-            inputChannels: config.decoderDim, outputChannels: config.latentDim,
-            kernelSize: 7)
-
-        // 4. Post-downsample (mirror of preUpsample in decoder, reversed)
-        let latent = config.latentDim
-        self._postConvNeXt1.wrappedValue = ConvNeXtBlock(dim: latent)
-        self._postDownsample1.wrappedValue = CausalConv1d(
-            inputChannels: latent, outputChannels: latent,
-            kernelSize: config.upsamplingRatios[1] * 2,
-            stride: config.upsamplingRatios[1])
-        self._postConvNeXt2.wrappedValue = ConvNeXtBlock(dim: latent)
-        self._postDownsample2.wrappedValue = CausalConv1d(
-            inputChannels: latent, outputChannels: latent,
-            kernelSize: config.upsamplingRatios[0] * 2,
-            stride: config.upsamplingRatios[0])
-
-        // 4. Post-conv: latentDim (1024) -> latentDim (1024), kernel=3
-        // Transformer's inputProj handles latentDim→hiddenSize projection
-        self._postConv.wrappedValue = CausalConv1d(
-            inputChannels: config.latentDim, outputChannels: config.latentDim,
-            kernelSize: 3)
-
-        // 5. Transformer
-        self._transformer.wrappedValue = EncoderTransformer(config: config)
-
-        // 6. RVQ
-        self._rvq.wrappedValue = EncoderRVQ(config: config)
-
+    public init(cfg: MimiEncoderConfig) {
+        self._semanticRVQ.wrappedValue = MimiResidualVQ(nq: cfg.numSemanticQuantizers, cfg: cfg)
+        self._acousticRVQ.wrappedValue = MimiResidualVQ(
+            nq: cfg.validNumQuantizers - cfg.numSemanticQuantizers, cfg: cfg)
         super.init()
     }
 
-    /// Encode audio waveform to codec token indices.
-    /// - Parameter audio: [B, T_samples, 1] at 24 kHz
-    /// - Returns: [B, 16, T_frames] at 12.5 Hz
-    public func callAsFunction(_ audio: MLXArray) -> MLXArray {
-        var h = inputConv(audio)
+    /// h: [B, T, 512] → codes [B, 16, T]
+    public func encode(_ h: MLXArray) -> MLXArray {
+        let sem = semanticRVQ.encode(h)        // [B, 1, T]
+        let aco = acousticRVQ.encode(h)        // [B, 15, T]
+        return concatenated([sem, aco], axis: 1)
+    }
+}
 
-        for block in encoderBlocks {
-            h = block(h)
-        }
+// MARK: - Top-level encoder
 
-        // Channel projection: 1536 → 1024
-        h = channelProj(h)
+/// Mimi codec encoder. Public surface (`encode(samples:) -> [1, 16, T]`) is
+/// unchanged so the ICL caller is untouched.
+public class SpeechTokenizerEncoder: Module {
+    @ModuleInfo(key: "seanet") var seanet: MimiSeanetEncoder
+    @ModuleInfo(key: "transformer") var transformer: MimiEncoderTransformer
+    @ModuleInfo(key: "downsample") var downsample: MimiConv1d
+    @ModuleInfo(key: "quantizer") var quantizer: MimiSplitRVQ
+    public let cfg: MimiEncoderConfig
 
-        h = postConvNeXt1(h)
-        h = postDownsample1(h)
-        h = postConvNeXt2(h)
-        h = postDownsample2(h)
-        h = postConv(h)
-        h = transformer(h)
-
-        return rvq.encode(h)
+    public init(config: SpeechTokenizerDecoderConfig) {
+        let c = MimiEncoderConfig()
+        self.cfg = c
+        self._seanet.wrappedValue = MimiSeanetEncoder(cfg: c)
+        self._transformer.wrappedValue = MimiEncoderTransformer(cfg: c)
+        // The extra ×2 downsample uses edge padding and no bias.
+        self._downsample.wrappedValue = MimiConv1d(
+            inC: c.dimension, outC: c.dimension, kSize: c.compress * 2,
+            stride: c.compress, bias: false, padEdge: true)
+        self._quantizer.wrappedValue = MimiSplitRVQ(cfg: c)
+        super.init()
     }
 
-    /// Encode a [Float] mono PCM buffer (24 kHz) to codec indices.
-    /// - Parameter samples: Raw 24 kHz mono samples
-    /// - Returns: [1, 16, T_frames]
+    /// Encode a 24 kHz mono PCM buffer to codec indices [1, 16, T_frames].
     public func encode(samples: [Float]) -> MLXArray {
-        let audio = MLXArray(samples).reshaped([1, samples.count, 1])
-        return callAsFunction(audio)
+        let audio = MLXArray(samples).reshaped([1, samples.count, 1])  // [B, T, 1]
+        var h = seanet(audio)                       // [1, T/960, 512]
+        h = transformer(h)                          // [1, T/960, 512]
+        h = downsample(h)                           // [1, T/1920, 512]
+        return quantizer.encode(h)                  // [1, 16, T/1920]
     }
 }

--- a/Sources/Qwen3TTS/TTSWeightLoading+Encoder.swift
+++ b/Sources/Qwen3TTS/TTSWeightLoading+Encoder.swift
@@ -4,208 +4,91 @@ import MLXNN
 import MLXCommon
 import AudioCommon
 
-/// Extension to TTSWeightLoader that adds weight loading for SpeechTokenizerEncoder.
-/// Mirrors loadSpeechTokenizerDecoderWeights() using the same safetensors file,
-/// but reads from "encoder.*" prefixes instead of "decoder.*".
+/// Weight loading for the Mimi codec encoder (`SpeechTokenizerEncoder`).
+///
+/// Reads `encoder.*` keys from the Qwen3-TTS-Tokenizer-12Hz safetensors
+/// (HuggingFace `MimiModel` layout). The SEANet conv stack is a flat `layers`
+/// list where activations occupy (param-less) indices: 0 = init conv;
+/// per stage k∈0..3 the resnet block is at 1+3k and the strided downsample at
+/// 3+3k; 14 = final conv.
 extension TTSWeightLoader {
-
-    // MARK: - Speech Tokenizer Encoder Weight Loading
 
     public static func loadSpeechTokenizerEncoderWeights(
         into encoder: SpeechTokenizerEncoder,
         from directory: URL
     ) throws {
-        let allWeights = try CommonWeightLoader.loadAllSafetensors(from: directory)
+        let w = try CommonWeightLoader.loadAllSafetensors(from: directory)
+        logLoad("Found \(w.count) speech tokenizer weights total (encoder load)")
 
-        logLoad("Found \(allWeights.count) speech tokenizer weights total (encoder load)")
-
-        // RVQ codebook weights — same codebooks as decoder, stored under encoder prefix
-        loadEncoderRVQWeights(into: encoder.rvq, from: allWeights)
-
-        // Input conv: encoder.encoder.0.conv  (mirrors decoder.decoder.6.conv reversed)
+        // MARK: SEANet conv encoder
+        let seanet = encoder.seanet
         CommonWeightLoader.applyConv1dWeights(
-            to: encoder.inputConv.conv,
-            prefix: "encoder.encoder.0.conv",
-            from: allWeights,
-            transpose: true)
+            to: seanet.initConv.conv, prefix: "encoder.encoder.layers.0.conv", from: w, transpose: true)
 
-        // Encoder blocks: encoder.encoder.{1,2,3,4}
-        // Each block: residualUnits (act1/conv1/act2/conv2) + snake + strided conv
-        for (i, block) in encoder.encoderBlocks.enumerated() {
-            loadEncoderBlockWeights(to: block, blockKey: "encoder.encoder.\(i + 1)", from: allWeights)
+        let resnetIdx = [1, 4, 7, 10]
+        let downIdx = [3, 6, 9, 12]
+        for (k, layer) in seanet.layers.enumerated() {
+            let rb = layer.residuals[0]
+            CommonWeightLoader.applyConv1dWeights(
+                to: rb.convA.conv, prefix: "encoder.encoder.layers.\(resnetIdx[k]).block.1.conv", from: w, transpose: true)
+            CommonWeightLoader.applyConv1dWeights(
+                to: rb.convB.conv, prefix: "encoder.encoder.layers.\(resnetIdx[k]).block.3.conv", from: w, transpose: true)
+            CommonWeightLoader.applyConv1dWeights(
+                to: layer.downsample.conv, prefix: "encoder.encoder.layers.\(downIdx[k]).conv", from: w, transpose: true)
         }
-
-        // Channel projection: encoder.encoder.5.conv (mirrors decoder preConv)
         CommonWeightLoader.applyConv1dWeights(
-            to: encoder.channelProj.conv,
-            prefix: "encoder.encoder.5.conv",
-            from: allWeights,
-            transpose: true)
+            to: seanet.finalConv.conv, prefix: "encoder.encoder.layers.14.conv", from: w, transpose: true)
 
-        // Post-downsample ConvNeXt + strided conv stages: encoder.downsample.{0,1}
-        // Stage 0: .0 = ConvNeXt, .1.conv = strided conv
-        loadConvNeXtBlockWeights(to: encoder.postConvNeXt1, prefix: "encoder.downsample.0.0", from: allWeights)
-        CommonWeightLoader.applyConv1dWeights(
-            to: encoder.postDownsample1.conv,
-            prefix: "encoder.downsample.0.1.conv",
-            from: allWeights,
-            transpose: true)
-        // Stage 1
-        loadConvNeXtBlockWeights(to: encoder.postConvNeXt2, prefix: "encoder.downsample.1.0", from: allWeights)
-        CommonWeightLoader.applyConv1dWeights(
-            to: encoder.postDownsample2.conv,
-            prefix: "encoder.downsample.1.1.conv",
-            from: allWeights,
-            transpose: true)
-
-        // Post-conv: encoder.post_conv.conv  (mirrors decoder.pre_conv.conv)
-        CommonWeightLoader.applyConv1dWeights(
-            to: encoder.postConv.conv,
-            prefix: "encoder.post_conv.conv",
-            from: allWeights,
-            transpose: true)
-
-        // Encoder transformer
-        CommonWeightLoader.applyLinearWeights(
-            to: encoder.transformer.inputProj,
-            prefix: "encoder.pre_transformer.input_proj",
-            from: allWeights)
-        CommonWeightLoader.applyLinearWeights(
-            to: encoder.transformer.outputProj,
-            prefix: "encoder.pre_transformer.output_proj",
-            from: allWeights)
+        // MARK: Encoder transformer (HF Mimi layout)
         for (i, layer) in encoder.transformer.layers.enumerated() {
-            loadEncoderTransformerLayerWeights(to: layer, index: i, from: allWeights)
+            let lp = "encoder.encoder_transformer.layers.\(i)."
+            CommonWeightLoader.applyLayerNormWeights(to: layer.inputLayernorm, prefix: lp + "input_layernorm", from: w)
+            CommonWeightLoader.applyLayerNormWeights(to: layer.postAttnLayernorm, prefix: lp + "post_attention_layernorm", from: w)
+            CommonWeightLoader.applyLinearWeights(to: layer.qProj, prefix: lp + "self_attn.q_proj", from: w)
+            CommonWeightLoader.applyLinearWeights(to: layer.kProj, prefix: lp + "self_attn.k_proj", from: w)
+            CommonWeightLoader.applyLinearWeights(to: layer.vProj, prefix: lp + "self_attn.v_proj", from: w)
+            CommonWeightLoader.applyLinearWeights(to: layer.oProj, prefix: lp + "self_attn.o_proj", from: w)
+            CommonWeightLoader.applyLinearWeights(to: layer.fc1, prefix: lp + "mlp.fc1", from: w)
+            CommonWeightLoader.applyLinearWeights(to: layer.fc2, prefix: lp + "mlp.fc2", from: w)
+            setParam(layer, key: "self_attn_scale", from: w, weightKey: lp + "self_attn_layer_scale.scale")
+            setParam(layer, key: "mlp_scale", from: w, weightKey: lp + "mlp_layer_scale.scale")
         }
-        CommonWeightLoader.applyRMSNormWeights(
-            to: encoder.transformer.norm,
-            prefix: "encoder.pre_transformer.norm",
-            from: allWeights)
 
-        logLoad("Applied weights to Speech Tokenizer Encoder")
-    }
-
-    // MARK: - Encoder RVQ
-
-    private static func loadEncoderRVQWeights(
-        into rvq: EncoderRVQ,
-        from weights: [String: MLXArray]
-    ) {
-        // rvq_first semantic codebook
-        loadEncoderQuantizerCodebook(
-            into: rvq.rvqFirst.quantizers[0].embedding,
-            prefix: "encoder.quantizer.rvq_first.vq.layers.0._codebook",
-            from: weights)
-        // rvq_first input_proj (Conv1d 512->256, kernel=1)
+        // MARK: Extra ×2 downsample
         CommonWeightLoader.applyConv1dWeights(
-            to: rvq.rvqFirst.outputProj,
-            prefix: "encoder.quantizer.rvq_first.input_proj",
-            from: weights,
-            transpose: true)
+            to: encoder.downsample.conv, prefix: "encoder.downsample.conv", from: w, transpose: true)
 
-        // rvq_rest: 15 acoustic codebooks
-        for i in 0..<rvq.rvqRest.numQuantizers {
-            loadEncoderQuantizerCodebook(
-                into: rvq.rvqRest.quantizers[i].embedding,
-                prefix: "encoder.quantizer.rvq_rest.vq.layers.\(i)._codebook",
-                from: weights)
-        }
-        // rvq_rest input_proj
+        // MARK: Split RVQ (semantic + first 15 acoustic)
+        let q = encoder.quantizer
         CommonWeightLoader.applyConv1dWeights(
-            to: rvq.rvqRest.outputProj,
-            prefix: "encoder.quantizer.rvq_rest.input_proj",
-            from: weights,
-            transpose: true)
-    }
+            to: q.semanticRVQ.inputProj.conv,
+            prefix: "encoder.quantizer.semantic_residual_vector_quantizer.input_proj", from: w, transpose: true)
+        setCodebook(q.semanticRVQ.codebooks[0],
+            prefix: "encoder.quantizer.semantic_residual_vector_quantizer.layers.0.codebook", from: w)
 
-    private static func loadEncoderQuantizerCodebook(
-        into embedding: Embedding,
-        prefix: String,
-        from weights: [String: MLXArray]
-    ) {
-        if let embed = weights["\(prefix).embed"] {
-            let params: [String: NestedItem<String, MLXArray>] = ["weight": .value(embed)]
-            embedding.update(parameters: ModuleParameters(values: params))
-            return
-        }
-        if let usage = weights["\(prefix).cluster_usage"],
-           let embSum = weights["\(prefix).embedding_sum"] {
-            let eps = MLXArray(Float(1e-7))
-            let clampedUsage = maximum(usage, eps).expandedDimensions(axis: -1)
-            let computed = embSum / clampedUsage
-            let params: [String: NestedItem<String, MLXArray>] = ["weight": .value(computed)]
-            embedding.update(parameters: ModuleParameters(values: params))
-        }
-    }
-
-    // MARK: - Encoder Block Weights
-
-    /// Load weights for one EncoderBlock.
-    /// Safetensors key structure (encoder side, mirror of decoder):
-    ///   blockKey.block.{0,1,2} = 3 ResidualUnits (act1/conv1/act2/conv2)
-    ///   blockKey.block.3       = SnakeBeta activation
-    ///   blockKey.block.4.conv  = strided CausalConv1d (downsample)
-    private static func loadEncoderBlockWeights(
-        to block: EncoderBlock,
-        blockKey: String,
-        from weights: [String: MLXArray]
-    ) {
-        // Residual units: block.{0,1,2}
-        for (j, unit) in block.residualUnits.enumerated() {
-            let resPrefix = "\(blockKey).block.\(j)"
-            loadSnakeBetaWeights(to: unit.snake1, prefix: "\(resPrefix).act1", from: weights)
-            CommonWeightLoader.applyConv1dWeights(
-                to: unit.conv1.conv, prefix: "\(resPrefix).conv1.conv", from: weights, transpose: true)
-            loadSnakeBetaWeights(to: unit.snake2, prefix: "\(resPrefix).act2", from: weights)
-            CommonWeightLoader.applyConv1dWeights(
-                to: unit.conv2.conv, prefix: "\(resPrefix).conv2.conv", from: weights, transpose: true)
-        }
-
-        // Snake activation before downsample: block.3
-        loadSnakeBetaWeights(to: block.snake, prefix: "\(blockKey).block.3", from: weights)
-
-        // Strided conv (downsample): block.4.conv
         CommonWeightLoader.applyConv1dWeights(
-            to: block.downsample.conv, prefix: "\(blockKey).block.4.conv", from: weights, transpose: true)
+            to: q.acousticRVQ.inputProj.conv,
+            prefix: "encoder.quantizer.acoustic_residual_vector_quantizer.input_proj", from: w, transpose: true)
+        for (j, cb) in q.acousticRVQ.codebooks.enumerated() {
+            setCodebook(cb,
+                prefix: "encoder.quantizer.acoustic_residual_vector_quantizer.layers.\(j).codebook", from: w)
+        }
+
+        logLoad("Applied weights to Mimi codec encoder")
     }
 
-    // MARK: - Encoder Transformer Layer Weights
-
-    private static func loadEncoderTransformerLayerWeights(
-        to layer: DecoderTransformerLayer,
-        index: Int,
-        from weights: [String: MLXArray]
-    ) {
-        let prefix = "encoder.pre_transformer.layers.\(index)"
-
-        CommonWeightLoader.applyLinearWeights(
-            to: layer.selfAttn.qProj, prefix: "\(prefix).self_attn.q_proj", from: weights)
-        CommonWeightLoader.applyLinearWeights(
-            to: layer.selfAttn.kProj, prefix: "\(prefix).self_attn.k_proj", from: weights)
-        CommonWeightLoader.applyLinearWeights(
-            to: layer.selfAttn.vProj, prefix: "\(prefix).self_attn.v_proj", from: weights)
-        CommonWeightLoader.applyLinearWeights(
-            to: layer.selfAttn.oProj, prefix: "\(prefix).self_attn.o_proj", from: weights)
-
-        CommonWeightLoader.applyRMSNormWeights(
-            to: layer.norm1, prefix: "\(prefix).input_layernorm", from: weights)
-        CommonWeightLoader.applyRMSNormWeights(
-            to: layer.norm2, prefix: "\(prefix).post_attention_layernorm", from: weights)
-
-        CommonWeightLoader.applyLinearWeights(
-            to: layer.gateProj, prefix: "\(prefix).mlp.gate_proj", from: weights)
-        CommonWeightLoader.applyLinearWeights(
-            to: layer.upProj, prefix: "\(prefix).mlp.up_proj", from: weights)
-        CommonWeightLoader.applyLinearWeights(
-            to: layer.downProj, prefix: "\(prefix).mlp.down_proj", from: weights)
-
-        if let scale = weights["\(prefix).self_attn_layer_scale.scale"] {
-            let params: [String: NestedItem<String, MLXArray>] = ["scale": .value(scale.reshaped([1, 1, -1]))]
-            layer.attnLayerScale.update(parameters: ModuleParameters(values: params))
+    private static func setParam(_ module: Module, key: String, from w: [String: MLXArray], weightKey: String) {
+        if let v = w[weightKey] {
+            module.update(parameters: ModuleParameters(values: [key: .value(v)]))
         }
-        if let scale = weights["\(prefix).mlp_layer_scale.scale"] {
-            let params: [String: NestedItem<String, MLXArray>] = ["scale": .value(scale.reshaped([1, 1, -1]))]
-            layer.mlpLayerScale.update(parameters: ModuleParameters(values: params))
+    }
+
+    private static func setCodebook(_ cb: MimiEuclideanCodebook, prefix: String, from w: [String: MLXArray]) {
+        var params: [String: NestedItem<String, MLXArray>] = [:]
+        if let e = w["\(prefix).embed_sum"] { params["embed_sum"] = .value(e) }
+        if let c = w["\(prefix).cluster_usage"] { params["cluster_usage"] = .value(c) }
+        if !params.isEmpty {
+            cb.update(parameters: ModuleParameters(values: params))
         }
     }
 }

--- a/Tests/Qwen3TTSTests/ICLVoiceCloningTests.swift
+++ b/Tests/Qwen3TTSTests/ICLVoiceCloningTests.swift
@@ -86,45 +86,60 @@ final class ICLVoiceCloningTests: XCTestCase {
 
     // MARK: - Reference echo trim (unit tests, no model load)
 
-    func testTrimICLReferenceFromWaveform_sameSampleRate() {
-        // Reference is 1s at 24 kHz, waveform is 3s at 24 kHz.
-        // Expect: 2s of audio left after trim.
-        let ref = [Float](repeating: 0.5, count: 24000)
-        let wave = [Float](repeating: 1.0, count: 72000)
-        let trimmed = Qwen3TTSModel.trimICLReferenceFromWaveform(
-            wave, referenceAudio: ref, referenceSampleRate: 24000)
-        XCTAssertEqual(trimmed.count, 48000, "Should drop the first 24000 samples")
-        XCTAssertEqual(trimmed.first, 1.0, "Remaining samples should be from the original waveform tail")
+    func testTrimICLReferenceByFrames_normalTrim() {
+        // Reproduction ≈ referenceFrames, target well above the floor: the exact
+        // frame estimate governs, dropping (referenceFrames + 1) frames.
+        let referenceFrames = 10
+        let wave = [Float](repeating: 1.0, count: 80 * 1920)
+        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
+            wave, referenceFrames: referenceFrames, targetTokenCount: 10)
+        XCTAssertEqual(trimmed.count, wave.count - (referenceFrames + 1) * 1920,
+            "Should drop ~(referenceFrames + 1) frames when the floor is not binding")
+        XCTAssertEqual(trimmed.first, 1.0, "Remaining samples should be the waveform tail")
     }
 
-    func testTrimICLReferenceFromWaveform_resamplesReferenceDuration() {
-        // Reference is 22050 samples at 22050 Hz (= 1s). Waveform is 3s at 24 kHz.
-        // Expect: 24000 samples trimmed (1s at 24 kHz), 48000 left.
-        let ref = [Float](repeating: 0.5, count: 22050)
-        let wave = [Float](repeating: 1.0, count: 72000)
-        let trimmed = Qwen3TTSModel.trimICLReferenceFromWaveform(
-            wave, referenceAudio: ref, referenceSampleRate: 22050)
-        XCTAssertEqual(trimmed.count, 48000,
-            "Reference duration should be converted to 24 kHz before trimming")
-    }
-
-    func testTrimICLReferenceFromWaveform_skipsWhenReferenceLongerThanOutput() {
-        // Reference would consume the entire waveform — leave it alone rather than
-        // returning an empty buffer.
-        let ref = [Float](repeating: 0.5, count: 48000)
-        let wave = [Float](repeating: 1.0, count: 24000)
-        let trimmed = Qwen3TTSModel.trimICLReferenceFromWaveform(
-            wave, referenceAudio: ref, referenceSampleRate: 24000)
+    func testTrimICLReferenceByFrames_zeroFramesPassesThrough() {
+        let wave = [Float](repeating: 1.0, count: 60 * 1920)
+        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
+            wave, referenceFrames: 0, targetTokenCount: 5)
         XCTAssertEqual(trimmed.count, wave.count,
-            "Should return the full waveform when refDuration >= waveform.count")
+            "referenceFrames == 0 should return the waveform unchanged")
     }
 
-    func testTrimICLReferenceFromWaveform_skipsOnEmptyReference() {
-        let wave = [Float](repeating: 1.0, count: 24000)
-        let trimmed = Qwen3TTSModel.trimICLReferenceFromWaveform(
-            wave, referenceAudio: [], referenceSampleRate: 24000)
+    func testTrimICLReferenceByFrames_subFloorPassesThrough() {
+        // Whole take shorter than the target floor (degenerate generation): trim
+        // collapses to 0 and the untrimmed waveform is returned for the grader.
+        let minTarget = 10 * 2 * 1920  // targetTokenCount 10 → 20-frame floor
+        let wave = [Float](repeating: 1.0, count: minTarget - 1920)
+        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
+            wave, referenceFrames: 10, targetTokenCount: 10)
         XCTAssertEqual(trimmed.count, wave.count,
-            "Empty reference should pass the waveform through unchanged")
+            "Output below the target floor should be returned untrimmed for the grader to reject")
+    }
+
+    func testTrimICLReferenceByFrames_floorClampsOverTrim() {
+        // Reproduction came out much shorter than referenceFrames, so the frame
+        // estimate would over-trim into the target — the floor caps the trim and
+        // preserves exactly minTarget samples of audio.
+        let referenceFrames = 100
+        let targetTokenCount = 5
+        let minTarget = max(4 * 1920, targetTokenCount * 2 * 1920)  // 19200
+        let wave = [Float](repeating: 1.0, count: 95 * 1920)
+        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
+            wave, referenceFrames: referenceFrames, targetTokenCount: targetTokenCount)
+        XCTAssertEqual(trimmed.count, minTarget,
+            "Floor should cap the trim so at least minTarget target samples survive")
+    }
+
+    func testTrimICLReferenceByFrames_absoluteFloorForTinyTarget() {
+        // Tiny target (1 token): the 2-frames/token floor (3840) is below the
+        // absolute 4-frame floor (7680), so the absolute floor governs.
+        let referenceFrames = 100
+        let wave = [Float](repeating: 1.0, count: 90 * 1920)
+        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
+            wave, referenceFrames: referenceFrames, targetTokenCount: 1)
+        XCTAssertEqual(trimmed.count, 4 * 1920,
+            "Absolute 4-frame floor should govern when the per-token floor is smaller")
     }
 }
 

--- a/Tests/Qwen3TTSTests/ICLVoiceCloningTests.swift
+++ b/Tests/Qwen3TTSTests/ICLVoiceCloningTests.swift
@@ -35,23 +35,25 @@ final class ICLVoiceCloningTests: XCTestCase {
         XCTAssertEqual(reEncoded[0, 2].item(Int32.self), 100)
     }
 
-    // MARK: - SpeechTokenizerEncoder construction
+    // MARK: - SpeechTokenizerEncoder construction (Mimi)
 
     func testEncoderConstruction() {
         let config = SpeechTokenizerDecoderConfig()
         let encoder = SpeechTokenizerEncoder(config: config)
-        // Verify expected structure
-        XCTAssertEqual(encoder.encoderBlocks.count, 4, "Should have 4 downsample blocks")
-        XCTAssertEqual(encoder.config.numQuantizers, 16, "Should have 16 codebooks")
+        // Mimi SEANet: 4 downsample stages (ratios 8/6/5/4) + transformer + split RVQ.
+        XCTAssertEqual(encoder.seanet.layers.count, 4, "SEANet should have 4 downsample stages")
+        XCTAssertEqual(encoder.transformer.layers.count, 8, "Encoder transformer should have 8 layers")
+        // Split RVQ: 1 semantic + 15 acoustic = 16 valid quantizers.
+        XCTAssertEqual(encoder.quantizer.semanticRVQ.codebooks.count, 1)
+        XCTAssertEqual(encoder.quantizer.acousticRVQ.codebooks.count, 15)
     }
 
     func testEncoderBlockDimensions() {
         let config = SpeechTokenizerDecoderConfig()
         let encoder = SpeechTokenizerEncoder(config: config)
-        // Input conv: 1 → 96 channels
-        XCTAssertNotNil(encoder.inputConv)
-        // Post conv: latentDim → hiddenSize
-        XCTAssertNotNil(encoder.postConv)
+        // Each SEANet stage has a single residual block (nResidualLayers = 1).
+        XCTAssertEqual(encoder.seanet.layers[0].residuals.count, 1)
+        XCTAssertEqual(encoder.cfg.validNumQuantizers, 16)
     }
 
     // MARK: - ResidualVectorQuantizer encode
@@ -84,63 +86,6 @@ final class ICLVoiceCloningTests: XCTestCase {
         XCTAssertNotNil(method)
     }
 
-    // MARK: - Reference echo trim (unit tests, no model load)
-
-    func testTrimICLReferenceByFrames_normalTrim() {
-        // Reproduction ≈ referenceFrames, target well above the floor: the exact
-        // frame estimate governs, dropping (referenceFrames + 1) frames.
-        let referenceFrames = 10
-        let wave = [Float](repeating: 1.0, count: 80 * 1920)
-        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
-            wave, referenceFrames: referenceFrames, targetTokenCount: 10)
-        XCTAssertEqual(trimmed.count, wave.count - (referenceFrames + 1) * 1920,
-            "Should drop ~(referenceFrames + 1) frames when the floor is not binding")
-        XCTAssertEqual(trimmed.first, 1.0, "Remaining samples should be the waveform tail")
-    }
-
-    func testTrimICLReferenceByFrames_zeroFramesPassesThrough() {
-        let wave = [Float](repeating: 1.0, count: 60 * 1920)
-        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
-            wave, referenceFrames: 0, targetTokenCount: 5)
-        XCTAssertEqual(trimmed.count, wave.count,
-            "referenceFrames == 0 should return the waveform unchanged")
-    }
-
-    func testTrimICLReferenceByFrames_subFloorPassesThrough() {
-        // Whole take shorter than the target floor (degenerate generation): trim
-        // collapses to 0 and the untrimmed waveform is returned for the grader.
-        let minTarget = 10 * 2 * 1920  // targetTokenCount 10 → 20-frame floor
-        let wave = [Float](repeating: 1.0, count: minTarget - 1920)
-        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
-            wave, referenceFrames: 10, targetTokenCount: 10)
-        XCTAssertEqual(trimmed.count, wave.count,
-            "Output below the target floor should be returned untrimmed for the grader to reject")
-    }
-
-    func testTrimICLReferenceByFrames_floorClampsOverTrim() {
-        // Reproduction came out much shorter than referenceFrames, so the frame
-        // estimate would over-trim into the target — the floor caps the trim and
-        // preserves exactly minTarget samples of audio.
-        let referenceFrames = 100
-        let targetTokenCount = 5
-        let minTarget = max(4 * 1920, targetTokenCount * 2 * 1920)  // 19200
-        let wave = [Float](repeating: 1.0, count: 95 * 1920)
-        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
-            wave, referenceFrames: referenceFrames, targetTokenCount: targetTokenCount)
-        XCTAssertEqual(trimmed.count, minTarget,
-            "Floor should cap the trim so at least minTarget target samples survive")
-    }
-
-    func testTrimICLReferenceByFrames_absoluteFloorForTinyTarget() {
-        // Tiny target (1 token): the 2-frames/token floor (3840) is below the
-        // absolute 4-frame floor (7680), so the absolute floor governs.
-        let referenceFrames = 100
-        let wave = [Float](repeating: 1.0, count: 90 * 1920)
-        let trimmed = Qwen3TTSModel.trimICLReferenceByFrames(
-            wave, referenceFrames: referenceFrames, targetTokenCount: 1)
-        XCTAssertEqual(trimmed.count, 4 * 1920,
-            "Absolute 4-frame floor should govern when the per-token floor is smaller")
-    }
 }
 
 // MARK: - E2E Tests
@@ -152,16 +97,25 @@ final class E2EICLVoiceCloningTests: XCTestCase {
         let (tts, encoder) = try await Qwen3TTSModel.fromPretrainedWithEncoder()
 
         // Verify encoder loaded
-        XCTAssertEqual(encoder.encoderBlocks.count, 4)
+        XCTAssertEqual(encoder.seanet.layers.count, 4)
 
-        // Quick forward pass with silence
-        let silence = [Float](repeating: 0, count: 24000)  // 1s at 24kHz
-        let codes = encoder.encode(samples: silence)
+        // Encode real speech: a correctly-loaded Mimi encoder must produce codec
+        // that VARIES frame-to-frame. The previous (wrong-architecture, unloaded)
+        // encoder emitted the same index on every frame — the bug that made ICL
+        // re-speak the reference. Guard against its return.
+        let refAudio = try AudioFileLoader.load(
+            url: URL(fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav"),
+            targetSampleRate: 24000)
+        let speech = Array(refAudio[Int(5.17 * 24000)..<min(Int(8.37 * 24000), refAudio.count)])
+        let codes = encoder.encode(samples: speech)
         eval(codes)
         XCTAssertEqual(codes.dim(0), 1, "Batch size should be 1")
         XCTAssertEqual(codes.dim(1), 16, "Should have 16 codebooks")
         XCTAssertGreaterThan(codes.dim(2), 0, "Should produce at least 1 frame")
-        print("Encoder: 1s silence → \(codes.dim(2)) codec frames")
+        let cb0 = codes[0, 0, 0...].asArray(Int32.self)
+        XCTAssertGreaterThan(Set(cb0).count, 1,
+            "Codebook 0 must vary across frames — constant codes indicate an unloaded/wrong encoder")
+        print("Encoder: \(speech.count) samples → \(codes.dim(2)) frames, codebook0 distinct=\(Set(cb0).count)")
     }
 
     func testE2EICLRoundTrip() async throws {


### PR DESCRIPTION
## Summary

Qwen3-TTS ICL voice clone re-spoke the reference before the target — the leak that forced ASR-graded seed-ladder retries. The real root cause (found by a golden-tensor diff against the running qwen-tts reference) is that **the codec encoder was non-functional**, not the prefill or the trim.

## Root cause

Encoding the reference audio, our codec was constant — the same index on every frame (codebook 0 = `1270` for all 40 frames) — while the reference's varies normally (0% match). So the talker never saw a valid "reference already spoken" codec and regenerated it from the transcript. Injecting the reference's correct `ref_code` into our talker immediately produced clean target-only output, isolating the encoder as the sole fault.

Two faults:

1. **Wrong load directory.** The encoder loaded from the talker bundle (`...1.7B-Base-MLX-bf16/model.safetensors`), which contains only `talker.*` + `speaker_encoder.*` — no codec-tokenizer weights — so it ran on uninitialised weights. The working decoder loads from the separate `Qwen/Qwen3-TTS-Tokenizer-12Hz` bundle.
2. **Wrong architecture.** `SpeechTokenizerEncoder` was a "mirror of the decoder" (Snake + SwiGLU), which the real model doesn't have. The reference encoder is HuggingFace `MimiModel`: a SEANet conv stack, an 8-layer transformer, and a split RVQ (1 semantic + 15 acoustic) with EMA codebooks.

## What changed

- **Reimplemented the Mimi codec encoder** in MLX-Swift (`SpeechTokenizerEncoder`), faithful to mlx-audio's Mimi modules and the HF checkpoint's weight layout: SEANet `encoder.encoder.layers.*` (ELU), `encoder_transformer` (LayerNorm/gelu, q/k/v/o, layer_scale, RoPE), split RVQ with `embed_sum`/`cluster_usage` EMA codebooks. Rewrote the weight loader for the real keys and pointed it at the tokenizer bundle.
- **Streaming prefill overlay** (commit 1) — matches the qwen-tts reference's `generate_icl_prompt` default; the correct prefill, kept.
- **Decode via prepend + ratio-trim** — the talker now generates the target codec only, so we prepend the reference codec (the causal Mimi decoder needs left context) and cut it back off by the exact `refFrames / totalFrames` audio ratio. The interim reference-echo trims (token-ratio and frame-based) are removed.

## Validation (frame-exact, vs the running reference)

- Encoder codec matches the reference **99.4%** exactly; every encoder stage (SEANet conv, transformer, downsample) correlates 1.0.
- Talker generates **target-only (~16 frames vs ~64–119)**; round-trip transcribes cleanly every run — no leak, no clipping, no retries; e2e round-trip ~9.3s (was 13–31s).

## Test plan

- `swift test --filter Qwen3TTSTests.ICLVoiceCloningTests` — 7 unit tests pass (incl. an encoder regression test that fails on constant codec).
- `swift test --filter Qwen3TTSTests.E2EICLVoiceCloningTests` — 4 e2e tests pass (encoder weight loading + non-constant codec, round-trip, German EOS, synthesis).
