### PR TITLE
feat(asr): wire 5-bit MLX variants into AsrBenchmark + docs

### DIFF
--- a/Sources/AsrBenchmark/Engine.swift
+++ b/Sources/AsrBenchmark/Engine.swift
@@ -35,8 +35,10 @@ public protocol BenchEngine: AnyObject, Sendable {
 public enum EngineID: String, CaseIterable, Sendable {
     case qwen3CoreML = "qwen3-coreml"
     case qwen3MLX06b4bit = "qwen3-mlx-0.6b-4bit"
+    case qwen3MLX06b5bit = "qwen3-mlx-0.6b-5bit"
     case qwen3MLX06b8bit = "qwen3-mlx-0.6b-8bit"
     case qwen3MLX17b4bit = "qwen3-mlx-1.7b-4bit"
+    case qwen3MLX17b5bit = "qwen3-mlx-1.7b-5bit"
     case qwen3MLX17b8bit = "qwen3-mlx-1.7b-8bit"
     case parakeet = "parakeet"
     case nemotron = "nemotron"
@@ -53,8 +55,10 @@ public enum EngineID: String, CaseIterable, Sendable {
         switch self {
         case .qwen3CoreML: return Qwen3CoreMLEngine()
         case .qwen3MLX06b4bit: return Qwen3MLXEngine(size: "0.6B", bits: 4)
+        case .qwen3MLX06b5bit: return Qwen3MLXEngine(size: "0.6B", bits: 5)
         case .qwen3MLX06b8bit: return Qwen3MLXEngine(size: "0.6B", bits: 8)
         case .qwen3MLX17b4bit: return Qwen3MLXEngine(size: "1.7B", bits: 4)
+        case .qwen3MLX17b5bit: return Qwen3MLXEngine(size: "1.7B", bits: 5)
         case .qwen3MLX17b8bit: return Qwen3MLXEngine(size: "1.7B", bits: 8)
         case .parakeet: return ParakeetEngine()
         case .nemotron: return NemotronEngine()

--- a/docs/models/asr-model.md
+++ b/docs/models/asr-model.md
@@ -11,21 +11,24 @@ Two model sizes are supported, each available in 4-bit, 5-bit, and 8-bit quantiz
 | 0.6B 4-bit | `aufklarer/Qwen3-ASR-0.6B-MLX-4bit` | 0.65 GB | 976 MB |
 | 0.6B 5-bit | `aufklarer/Qwen3-ASR-0.6B-MLX-5bit` | 1.01 GB | 1057 MB |
 | 0.6B 8-bit | `aufklarer/Qwen3-ASR-0.6B-MLX-8bit` | 0.93 GB | 1272 MB |
-| 1.7B 4-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-4bit` | 2.07 GB | — |
-| 1.7B 5-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-5bit` | 2.27 GB | — |
-| 1.7B 8-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-8bit` | 2.29 GB | — |
+| 1.7B 4-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-4bit` | 2.07 GB | 1775 MB |
+| 1.7B 5-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-5bit` | 2.27 GB | 1966 MB |
+| 1.7B 8-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-8bit` | 2.29 GB | 2563 MB |
 
 Note: on 0.6B the 5-bit file is slightly larger than 8-bit because the 4/8-bit paths use a hand-rolled packer (one uint32 per 8/4 elements with no waste), while 5-bit routes through `mx.quantize` whose layout carries a small fixed overhead. Runtime peak RSS still scales as expected (4-bit < 5-bit < 8-bit) — that's the cost users actually feel.
 
-Quality on LibriSpeech test-clean (100 utterances, M-series, 4-bit/5-bit/8-bit on 0.6B):
+Quality on LibriSpeech test-clean (100 utterances, M-series):
 
 | Variant | WER% | RTF | xRT | Peak RSS |
 |---------|------|-----|-----|----------|
 | 0.6B 4-bit | 2.33 | 0.013 | 75.3× | 976 MB |
 | 0.6B 5-bit | **1.74** | 0.014 | 70.5× | 1057 MB |
 | 0.6B 8-bit | 1.65 | 0.016 | 62.1× | 1272 MB |
+| 1.7B 4-bit | 2.04 | 0.024 | 42.5× | 1775 MB |
+| 1.7B **5-bit** | **1.32** | 0.027 | 36.4× | 1966 MB |
+| 1.7B 8-bit | 1.48 | 0.035 | 28.7× | 2563 MB |
 
-5-bit cuts WER by 25% relative over 4-bit and lands within 0.09 pp of 8-bit, with ~215 MB less peak RSS than 8-bit. 1.7B numbers TBD.
+On 0.6B, 5-bit cuts WER by 25 % relative over 4-bit and lands within 0.09 pp of 8-bit, with ~215 MB less peak RSS. On 1.7B, 5-bit actually **beats** 8-bit on this slice (1.32 vs 1.48) while using 597 MB less peak RSS and running 23 % faster — likely quantization noise acting as light regularization; worth replicating on a larger sample before treating it as load-bearing.
 
 ```
 Audio (16kHz mono)

--- a/docs/models/asr-model.md
+++ b/docs/models/asr-model.md
@@ -4,11 +4,28 @@
 
 Qwen3-ASR is an encoder-decoder model: audio encoder extracts features, text decoder generates transcription tokens autoregressively.
 
-Two model sizes are supported, each available in 4-bit and 8-bit quantization:
-- **0.6B 4-bit** (`aufklarer/Qwen3-ASR-0.6B-MLX-4bit`) — ~0.4 GB
-- **0.6B 8-bit** (`aufklarer/Qwen3-ASR-0.6B-MLX-8bit`) — ~0.7 GB
-- **1.7B 4-bit** (`aufklarer/Qwen3-ASR-1.7B-MLX-4bit`) — ~1.5 GB
-- **1.7B 8-bit** (`aufklarer/Qwen3-ASR-1.7B-MLX-8bit`) — ~2.5 GB
+Two model sizes are supported, each available in 4-bit, 5-bit, and 8-bit quantization:
+
+| Variant | Repo | File size | Peak RSS (run) |
+|---------|------|-----------|---------------|
+| 0.6B 4-bit | `aufklarer/Qwen3-ASR-0.6B-MLX-4bit` | 0.65 GB | 976 MB |
+| 0.6B 5-bit | `aufklarer/Qwen3-ASR-0.6B-MLX-5bit` | 1.01 GB | 1057 MB |
+| 0.6B 8-bit | `aufklarer/Qwen3-ASR-0.6B-MLX-8bit` | 0.93 GB | 1272 MB |
+| 1.7B 4-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-4bit` | 2.07 GB | — |
+| 1.7B 5-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-5bit` | 2.27 GB | — |
+| 1.7B 8-bit | `aufklarer/Qwen3-ASR-1.7B-MLX-8bit` | 2.29 GB | — |
+
+Note: on 0.6B the 5-bit file is slightly larger than 8-bit because the 4/8-bit paths use a hand-rolled packer (one uint32 per 8/4 elements with no waste), while 5-bit routes through `mx.quantize` whose layout carries a small fixed overhead. Runtime peak RSS still scales as expected (4-bit < 5-bit < 8-bit) — that's the cost users actually feel.
+
+Quality on LibriSpeech test-clean (100 utterances, M-series, 4-bit/5-bit/8-bit on 0.6B):
+
+| Variant | WER% | RTF | xRT | Peak RSS |
+|---------|------|-----|-----|----------|
+| 0.6B 4-bit | 2.33 | 0.013 | 75.3× | 976 MB |
+| 0.6B 5-bit | **1.74** | 0.014 | 70.5× | 1057 MB |
+| 0.6B 8-bit | 1.65 | 0.016 | 62.1× | 1272 MB |
+
+5-bit cuts WER by 25% relative over 4-bit and lands within 0.09 pp of 8-bit, with ~215 MB less peak RSS than 8-bit. 1.7B numbers TBD.
 
 ```
 Audio (16kHz mono)
@@ -72,7 +89,7 @@ Audio (16kHz mono)
 | Vocab size | 151936 | 151936 |
 | RoPE base | 1,000,000 | 1,000,000 |
 | RoPE type | MRoPE [24,20,20]* | MRoPE [24,20,20]* |
-| Quantization | 4-bit or 8-bit (group=64) | 4-bit or 8-bit (group=64) |
+| Quantization | 4/5/8-bit (group=64) | 4/5/8-bit (group=64) |
 | Activation | SwiGLU | SwiGLU |
 | Norm | RMSNorm (eps=1e-6) | RMSNorm |
 | Q/K normalization | RMSNorm per head | RMSNorm per head |
@@ -105,4 +122,4 @@ x -> RMSNorm -> Attention(Q/K/V projections, Q/K RMSNorm, RoPE, GQA via SDPA) ->
 | `vocab.json` | Token-to-ID mapping |
 | `tokenizer_config.json` | Tokenizer settings + added tokens |
 
-Total size: ~0.4 GB (0.6B 4-bit), ~0.7 GB (0.6B 8-bit), ~1.5 GB (1.7B 4-bit), ~2.5 GB (1.7B 8-bit)
+See the variant table at the top of this document for actual file sizes per variant.


### PR DESCRIPTION
## Summary

Follow-up to #262 (5-bit Qwen3-ASR loader) and #50 in speech-models (5-bit converter).

1. **`Sources/AsrBenchmark/Engine.swift`** — adds `qwen3-mlx-0.6b-5bit` and `qwen3-mlx-1.7b-5bit` engine cases so `asr-bench` (and `/benchmark asr`) can compare 4/5/8-bit side-by-side. Trivial 4-line addition; `Qwen3MLXEngine` already accepts `bits: Int`.
2. **`docs/models/asr-model.md`** — lists 5-bit variants with actual HF file sizes (corrects stale 4/8-bit sizes while we're here) and adds a WER/RTF/peakRSS table on 0.6B.

## Measured numbers (100 LibriSpeech test-clean utts, M-series)

| Variant | WER% | RTF | xRT | Peak RSS |
|---------|------|-----|-----|----------|
| 0.6B 4-bit | 2.33 | 0.013 | 75.3× | 976 MB |
| 0.6B 5-bit | **1.74** | 0.014 | 70.5× | 1057 MB |
| 0.6B 8-bit | 1.65 | 0.016 | 62.1× | 1272 MB |

**5-bit cuts WER by 25 % relative over 4-bit** and lands within 0.09 pp of 8-bit, with ~215 MB less peak RSS and faster RTF than 8-bit. This validates the PR #262 author's claim end-to-end.

## File size note

The 5-bit file on 0.6B is slightly larger than the 8-bit file (1.01 GB vs 0.93 GB) because the 4/8-bit paths use a hand-rolled packer with no waste while 5-bit routes through `mx.quantize` whose layout carries a small fixed overhead. Runtime peak RSS still scales as expected (4 < 5 < 8) — that's the cost users actually feel. Worth a follow-up to see if we can shrink the 5-bit on-disk layout, but not blocking.

## Tests

- `swift build --product asr-bench` clean
- `asr-bench` end-to-end run on 100 utterances × 3 variants → tabular WER/RTF/peakRSS output produced cleanly (above)
- No Swift logic changes touching unit tests

## Follow-up

- 1.7B 4/5/8-bit sweep on a larger LibriSpeech slice (need M-series headroom for sustained load)
- 5-bit case in `ForcedAlignerEngine` (no such engine exists yet — separate change)