### PR TITLE
feat(forced-aligner): CoreML runtime + speech align --engine coreml

### DIFF
--- a/Sources/AudioCLILib/AlignCommand.swift
+++ b/Sources/AudioCLILib/AlignCommand.swift
@@ -18,8 +18,11 @@ public struct AlignCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "ASR model for transcription: 0.6B (default), 1.7B, or full ID")
     public var model: String = "0.6B"
 
-    @Option(name: .long, help: "Forced aligner model ID")
-    public var alignerModel: String = "aufklarer/Qwen3-ForcedAligner-0.6B-4bit"
+    @Option(name: .long, help: "Forced aligner backend: mlx (default) or coreml")
+    public var engine: String = "mlx"
+
+    @Option(name: .long, help: "Forced aligner model ID (defaults depend on --engine)")
+    public var alignerModel: String?
 
     @Option(name: .long, help: "Language hint (optional)")
     public var language: String?
@@ -38,7 +41,6 @@ public struct AlignCommand: ParsableCommand {
 
             var textToAlign = text
 
-            // If no text provided, transcribe first
             if textToAlign == nil {
                 let modelId = resolveASRModelId(model)
                 let detectedSize = ASRModelSize.detect(from: modelId)
@@ -62,26 +64,67 @@ public struct AlignCommand: ParsableCommand {
                 throw ExitCode(1)
             }
 
-            print("Loading aligner model: \(alignerModel)")
-            let aligner = try await Qwen3ForcedAligner.fromPretrained(
-                modelId: alignerModel, progressHandler: reportProgress)
-
-            print("Aligning...")
-            let start = Date()
-            let aligned = aligner.alignLong(
-                audio: audio,
-                text: alignText,
-                sampleRate: 24000,
-                language: language ?? "English",
-                progressHandler: { msg in print("  \(msg)") })
-            let elapsed = Date().timeIntervalSince(start)
-
-            for word in aligned {
-                let startStr = String(format: "%.2f", word.startTime)
-                let endStr = String(format: "%.2f", word.endTime)
-                print("[\(startStr)s - \(endStr)s] \(word.text)")
+            switch engine.lowercased() {
+            case "coreml":
+                #if canImport(CoreML)
+                try await runCoreML(audio: audio, text: alignText)
+                #else
+                print("Error: CoreML not available on this platform")
+                throw ExitCode(1)
+                #endif
+            case "mlx", "":
+                try await runMLX(audio: audio, text: alignText)
+            default:
+                print("Error: unknown --engine '\(engine)'. Expected mlx or coreml.")
+                throw ExitCode(1)
             }
-            print("Alignment took \(String(format: "%.2f", elapsed))s")
+        }
+    }
+
+    // MARK: - Engines
+
+    private func runMLX(audio: [Float], text: String) async throws {
+        let modelId = alignerModel ?? "aufklarer/Qwen3-ForcedAligner-0.6B-4bit"
+        print("Loading MLX aligner: \(modelId)")
+        let aligner = try await Qwen3ForcedAligner.fromPretrained(
+            modelId: modelId, progressHandler: reportProgress)
+        print("Aligning (MLX)...")
+        let start = Date()
+        let aligned = aligner.alignLong(
+            audio: audio,
+            text: text,
+            sampleRate: 24000,
+            language: language ?? "English",
+            progressHandler: { msg in print("  \(msg)") })
+        let elapsed = Date().timeIntervalSince(start)
+        printAligned(aligned)
+        print("Alignment took \(String(format: "%.2f", elapsed))s")
+    }
+
+    #if canImport(CoreML)
+    private func runCoreML(audio: [Float], text: String) async throws {
+        let modelId = alignerModel ?? "aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16"
+        print("Loading CoreML aligner: \(modelId)")
+        let aligner = try await CoreMLForcedAligner.fromPretrained(
+            modelId: modelId, progressHandler: reportProgress)
+        print("Aligning (CoreML)...")
+        let start = Date()
+        let aligned = try aligner.align(
+            audio: audio,
+            text: text,
+            sampleRate: 24000,
+            language: language ?? "English")
+        let elapsed = Date().timeIntervalSince(start)
+        printAligned(aligned)
+        print("Alignment took \(String(format: "%.2f", elapsed))s")
+    }
+    #endif
+
+    private func printAligned(_ aligned: [AlignedWord]) {
+        for word in aligned {
+            let startStr = String(format: "%.2f", word.startTime)
+            let endStr = String(format: "%.2f", word.endTime)
+            print("[\(startStr)s - \(endStr)s] \(word.text)")
         }
     }
 }

--- a/Sources/Qwen3ASR/CoreMLForcedAligner.swift
+++ b/Sources/Qwen3ASR/CoreMLForcedAligner.swift
@@ -1,0 +1,664 @@
+#if canImport(CoreML)
+import Accelerate
+import CoreML
+import Foundation
+import AudioCommon
+
+/// Forced aligner running entirely on CoreML (Neural Engine + GPU).
+///
+/// Pipeline (mirrors the MLX ``Qwen3ForcedAligner.align`` path but with no
+/// MLX dependency at runtime):
+///
+///   audio → mel (Accelerate) → audio_encoder.mlpackage → audio embeddings
+///   text  → tokenizer → <ts> word <ts> slots
+///   tokens → embedding.mlpackage → token embeddings
+///   embeddings (token slots + audio slot) → text_decoder.mlpackage (single pass)
+///   logits at <ts> positions → argmax → LIS correction → ``[AlignedWord]``
+///
+/// The text decoder is non-autoregressive (one forward pass per align call)
+/// and has no KV cache — input is the full assembled sequence and the
+/// causal mask is provided as a model input so we can use a finite ``-1e4``
+/// fill value (the upstream fp16 graph cannot survive ``-inf`` softmax).
+///
+/// Two variants are supported:
+///   ``coremlFP16`` — full precision, ~1.0 GB on disk, highest fidelity.
+///   ``coremlInt8`` — 8-bit kmeans-palettized, ~570 MB on disk.
+public final class CoreMLForcedAligner {
+    public let audioEncoder: CoreMLForcedAlignerEncoder
+    public let embedding: CoreMLForcedAlignerEmbedding
+    public let textDecoder: CoreMLForcedAlignerDecoder
+    public let featureExtractor: WhisperFeatureExtractor
+    public var tokenizer: Qwen3Tokenizer?
+
+    private let classifyNum: Int
+    private let segmentTime: Float
+
+    public init(
+        audioEncoder: CoreMLForcedAlignerEncoder,
+        embedding: CoreMLForcedAlignerEmbedding,
+        textDecoder: CoreMLForcedAlignerDecoder,
+        classifyNum: Int = 5000,
+        segmentTime: Float = 0.08
+    ) {
+        self.audioEncoder = audioEncoder
+        self.embedding = embedding
+        self.textDecoder = textDecoder
+        self.featureExtractor = WhisperFeatureExtractor()
+        self.classifyNum = classifyNum
+        self.segmentTime = segmentTime
+    }
+
+    /// Load all three component bundles + tokenizer from a local directory.
+    /// Useful for testing a freshly produced converter output before uploading
+    /// to HuggingFace.
+    public static func fromDirectory(
+        _ directory: URL,
+        encoderComputeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine),
+        decoderComputeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all)
+    ) throws -> CoreMLForcedAligner {
+        let enc = try CoreMLForcedAlignerEncoder.load(
+            from: directory, computeUnits: encoderComputeUnits)
+        let emb = try CoreMLForcedAlignerEmbedding.load(from: directory)
+        let dec = try CoreMLForcedAlignerDecoder.load(
+            from: directory, computeUnits: decoderComputeUnits)
+
+        var classifyNum = 5000
+        var segmentTime: Float = 0.08
+        let cfgURL = directory.appendingPathComponent("config.json")
+        if FileManager.default.fileExists(atPath: cfgURL.path),
+           let data = try? Data(contentsOf: cfgURL),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let n = json["classify_num"] as? Int { classifyNum = n }
+            if let t = json["timestamp_segment_time"] as? Double { segmentTime = Float(t) }
+        }
+
+        let aligner = CoreMLForcedAligner(
+            audioEncoder: enc, embedding: emb, textDecoder: dec,
+            classifyNum: classifyNum, segmentTime: segmentTime)
+
+        let vocabURL = directory.appendingPathComponent("vocab.json")
+        if FileManager.default.fileExists(atPath: vocabURL.path) {
+            let tokenizer = Qwen3Tokenizer()
+            try tokenizer.load(from: vocabURL)
+            aligner.tokenizer = tokenizer
+        }
+        return aligner
+    }
+
+    /// Download all three component bundles + tokenizer files from one HuggingFace repo.
+    public static func fromPretrained(
+        modelId: String = "aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16",
+        encoderComputeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine),
+        decoderComputeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all),
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> CoreMLForcedAligner {
+        let dir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+
+        progressHandler?(0.0, "Downloading CoreML aligner...")
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: dir,
+            additionalFiles: [
+                "audio_encoder.mlpackage/**",
+                "text_decoder.mlpackage/**",
+                "audio_encoder.mlmodelc/**",
+                "text_decoder.mlmodelc/**",
+                "embed_tokens.fp16.bin",
+                "config.json",
+                "vocab.json",
+                "merges.txt",
+                "tokenizer_config.json",
+            ],
+            offlineMode: offlineMode
+        ) { fraction in
+            progressHandler?(fraction * 0.8, "Downloading CoreML aligner...")
+        }
+
+        progressHandler?(0.8, "Loading CoreML models...")
+        let enc = try CoreMLForcedAlignerEncoder.load(from: dir, computeUnits: encoderComputeUnits)
+        let emb = try CoreMLForcedAlignerEmbedding.load(from: dir)
+        let dec = try CoreMLForcedAlignerDecoder.load(from: dir, computeUnits: decoderComputeUnits)
+
+        // Read config.json for classify_num + segment time if available.
+        var classifyNum = 5000
+        var segmentTime: Float = 0.08
+        let cfgURL = dir.appendingPathComponent("config.json")
+        if FileManager.default.fileExists(atPath: cfgURL.path),
+           let data = try? Data(contentsOf: cfgURL),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let n = json["classify_num"] as? Int { classifyNum = n }
+            if let t = json["timestamp_segment_time"] as? Double { segmentTime = Float(t) }
+        }
+
+        let aligner = CoreMLForcedAligner(
+            audioEncoder: enc,
+            embedding: emb,
+            textDecoder: dec,
+            classifyNum: classifyNum,
+            segmentTime: segmentTime
+        )
+
+        let vocabURL = dir.appendingPathComponent("vocab.json")
+        if FileManager.default.fileExists(atPath: vocabURL.path) {
+            let tokenizer = Qwen3Tokenizer()
+            try tokenizer.load(from: vocabURL)
+            aligner.tokenizer = tokenizer
+        }
+
+        progressHandler?(1.0, "Ready")
+        return aligner
+    }
+
+    public func warmUp() throws {
+        try audioEncoder.warmUp()
+        try embedding.warmUp()
+        try textDecoder.warmUp()
+    }
+
+    /// Align text to audio in one CoreML forward pass.
+    public func align(
+        audio: [Float],
+        text: String,
+        sampleRate: Int = 16000,
+        language: String = "English"
+    ) throws -> [AlignedWord] {
+        guard let tokenizer = tokenizer else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner", reason: "Tokenizer not loaded")
+        }
+
+        let profile = ProcessInfo.processInfo.environment["COREML_ALIGN_PROFILE"] == "1"
+        let t0 = profile ? CFAbsoluteTimeGetCurrent() : 0
+
+        // 1. Mel features (pure CPU via Accelerate) → audio encoder.
+        let mel = featureExtractor.processRaw(audio, sampleRate: sampleRate)
+        let t1 = profile ? CFAbsoluteTimeGetCurrent() : 0
+        let encoded = try audioEncoder.encode(
+            melData: mel.data, melBins: mel.melBins, timeFrames: mel.timeFrames)
+        let t2 = profile ? CFAbsoluteTimeGetCurrent() : 0
+        let numAudioTokens = encoded.outputLength
+        let audioEmbeds = encoded.embeddings  // MLMultiArray [1, paddedAudioTokens, hidden]
+
+        // 2. Insert <timestamp> slots between words.
+        let slotted = TextPreprocessor.prepareForAlignment(
+            text: text, tokenizer: tokenizer, language: language)
+        guard !slotted.words.isEmpty else { return [] }
+
+        // 3. Build the full prompt token sequence.
+        let prefix = buildPrefixTokens()
+        let suffix = buildSuffixTokens()
+        // Layout: [prefix] + [audioPad × numAudioTokens] + [suffix] + [slotted]
+        var inputIds: [Int] = prefix
+        let audioStart = inputIds.count
+        for _ in 0..<numAudioTokens {
+            inputIds.append(Qwen3ASRTokens.audioTokenId)
+        }
+        inputIds.append(contentsOf: suffix)
+        let slottedStart = inputIds.count
+        inputIds.append(contentsOf: slotted.tokenIds)
+
+        let seqLen = inputIds.count
+        let fixedT = textDecoder.fixedT
+        guard seqLen <= fixedT else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner",
+                reason: "Prompt length \(seqLen) exceeds the exported fixed T=\(fixedT). "
+                + "Trim text or chunk the audio (the 30 s audio encoder takes care of "
+                + "audio-side chunking, but a single align() pass still has to fit T tokens).")
+        }
+
+        // 4. Embed the token sequence (with audioPad placeholders) via the embedding bundle.
+        let hiddenSize = audioEncoder.hiddenSize
+        let tokenEmbeds = try embedding.embed(
+            tokenIds: inputIds, fixedT: fixedT, hiddenSize: hiddenSize)
+        let t3 = profile ? CFAbsoluteTimeGetCurrent() : 0
+
+        // 5. Splice the audio embeddings into the audio_pad slot.
+        try Self.spliceAudioEmbeddings(
+            into: tokenEmbeds,
+            audioEmbeds: audioEmbeds,
+            tokenStart: audioStart,
+            audioTokenCount: numAudioTokens,
+            hiddenSize: hiddenSize
+        )
+        let t4 = profile ? CFAbsoluteTimeGetCurrent() : 0
+
+        // 6. One forward pass through text_decoder + classify head. The
+        // causal mask is baked into the exported graph as a constant.
+        let logits = try textDecoder.run(inputsEmbeds: tokenEmbeds)
+        let t5 = profile ? CFAbsoluteTimeGetCurrent() : 0
+
+        // 8. Extract argmax at <timestamp> positions.
+        let absolutePositions = slotted.timestampPositions.map { $0 + slottedStart }
+        let rawIndices = Self.argmaxAtPositions(
+            logits: logits, positions: absolutePositions, classifyNum: classifyNum)
+        let t6 = profile ? CFAbsoluteTimeGetCurrent() : 0
+
+        // 9. LIS correction + pair into [AlignedWord].
+        let corrected = TimestampCorrection.enforceMonotonicity(rawIndices)
+        let t7 = profile ? CFAbsoluteTimeGetCurrent() : 0
+
+        if profile {
+            let ms = { (a: CFAbsoluteTime, b: CFAbsoluteTime) in (b - a) * 1000 }
+            print(String(format: "[COREML-ALIGN-PROFILE] mel=%.1fms encoder=%.1fms embedding=%.1fms splice=%.1fms decoder=%.1fms argmax=%.1fms lis=%.1fms total=%.1fms (audio=%.1fs, %d audioTokens, T=%d)",
+                ms(t0, t1), ms(t1, t2), ms(t2, t3), ms(t3, t4), ms(t4, t5),
+                ms(t5, t6), ms(t6, t7), ms(t0, t7),
+                Float(audio.count) / Float(sampleRate),
+                numAudioTokens, fixedT))
+        }
+
+        if ProcessInfo.processInfo.environment["ALIGN_DEBUG"] == "1" {
+            print("[coreml-align-debug] seqLen=\(seqLen) fixedT=\(fixedT) "
+                + "numAudioTokens=\(numAudioTokens) audioStart=\(audioStart) "
+                + "slottedStart=\(slottedStart) "
+                + "timestamps=\(absolutePositions.count) words=\(slotted.words.count)")
+            print("[coreml-align-debug] raw:       \(rawIndices)")
+            print("[coreml-align-debug] corrected: \(corrected)")
+        }
+
+        var aligned: [AlignedWord] = []
+        aligned.reserveCapacity(slotted.words.count)
+        for (i, word) in slotted.words.enumerated() {
+            let s = i * 2, e = i * 2 + 1
+            guard e < corrected.count else { break }
+            let st = Float(corrected[s]) * segmentTime
+            let en = Float(corrected[e]) * segmentTime
+            aligned.append(AlignedWord(text: word, startTime: st, endTime: max(en, st)))
+        }
+        return aligned
+    }
+
+    // MARK: - Token sequence construction (matches MLX path)
+
+    private func buildPrefixTokens() -> [Int] {
+        let imStart = Qwen3ASRTokens.imStartTokenId
+        let imEnd = Qwen3ASRTokens.imEndTokenId
+        let audioStart = Qwen3ASRTokens.audioStartTokenId
+        let newline = 198, systemId = 8948, userId = 872
+        return [imStart, systemId, newline, imEnd, newline,
+                imStart, userId, newline, audioStart]
+    }
+
+    private func buildSuffixTokens() -> [Int] {
+        let imStart = Qwen3ASRTokens.imStartTokenId
+        let imEnd = Qwen3ASRTokens.imEndTokenId
+        let audioEnd = Qwen3ASRTokens.audioEndTokenId
+        let newline = 198, assistantId = 77091
+        return [audioEnd, imEnd, newline, imStart, assistantId, newline]
+    }
+
+    // MARK: - MLMultiArray helpers
+
+    /// Overwrite ``tokenEmbeds[0, tokenStart..tokenStart+audioTokenCount, :]`` with
+    /// the corresponding slice of ``audioEmbeds[0, 0..audioTokenCount, :]``.
+    static func spliceAudioEmbeddings(
+        into tokenEmbeds: MLMultiArray,
+        audioEmbeds: MLMultiArray,
+        tokenStart: Int,
+        audioTokenCount: Int,
+        hiddenSize: Int
+    ) throws {
+        guard audioTokenCount > 0 else { return }
+
+        let tShape = tokenEmbeds.shape.map { $0.intValue }
+        let aShape = audioEmbeds.shape.map { $0.intValue }
+        guard tShape.count == 3, aShape.count == 3,
+              tShape[2] == hiddenSize, aShape[2] == hiddenSize
+        else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner",
+                reason: "Embedding shape mismatch: token=\(tShape) audio=\(aShape) hidden=\(hiddenSize)")
+        }
+        guard tokenStart + audioTokenCount <= tShape[1],
+              audioTokenCount <= aShape[1]
+        else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner",
+                reason: "Audio splice out of bounds: tokenStart=\(tokenStart) "
+                + "audioTokenCount=\(audioTokenCount) tokenT=\(tShape[1]) audioT=\(aShape[1])")
+        }
+
+        // Use the per-axis strides from each array — CoreML pads inner dims
+        // for alignment so a tight ``t * hiddenSize`` offset would walk into
+        // the wrong row. Both arrays declare contiguous strides for axis 2
+        // (= 1) but the per-position stride often differs from ``hiddenSize``.
+        let dstStrides = tokenEmbeds.strides.map { $0.intValue }
+        let srcStrides = audioEmbeds.strides.map { $0.intValue }
+        let dstPosStride = dstStrides[1]
+        let srcPosStride = srcStrides[1]
+        let dstPtr = tokenEmbeds.dataPointer.assumingMemoryBound(to: Float.self)
+
+        switch audioEmbeds.dataType {
+        case .float32:
+            // Per-row memcpy. ``dstPosStride`` may be > ``hiddenSize`` because
+            // the destination MLMultiArray rounds the inner dim up for
+            // alignment; that padding belongs to the dst row and shouldn't be
+            // touched.
+            let srcPtr = audioEmbeds.dataPointer.assumingMemoryBound(to: Float.self)
+            let bytesPerRow = hiddenSize * MemoryLayout<Float>.stride
+            for t in 0..<audioTokenCount {
+                let dst = dstPtr.advanced(by: (tokenStart + t) * dstPosStride)
+                let src = srcPtr.advanced(by: t * srcPosStride)
+                memcpy(dst, src, bytesPerRow)
+            }
+        case .float16:
+            // vImage's vImageConvert_Planar16FtoPlanarF unpacks fp16→fp32 on
+            // CPU SIMD in one shot. Doing it row by row keeps the call within
+            // the destination's row padding without spilling into the next row.
+            let srcPtr = audioEmbeds.dataPointer.assumingMemoryBound(to: Float16.self)
+            for t in 0..<audioTokenCount {
+                let dstRow = dstPtr.advanced(by: (tokenStart + t) * dstPosStride)
+                let srcRow = srcPtr.advanced(by: t * srcPosStride)
+                var srcBuf = vImage_Buffer(
+                    data: UnsafeMutableRawPointer(mutating: srcRow),
+                    height: 1,
+                    width: vImagePixelCount(hiddenSize),
+                    rowBytes: hiddenSize * MemoryLayout<Float16>.stride)
+                var dstBuf = vImage_Buffer(
+                    data: dstRow,
+                    height: 1,
+                    width: vImagePixelCount(hiddenSize),
+                    rowBytes: hiddenSize * MemoryLayout<Float>.stride)
+                _ = vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)
+            }
+        default:
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner",
+                reason: "Unsupported audio embeddings dtype \(audioEmbeds.dataType.rawValue)")
+        }
+    }
+
+    static func argmaxAtPositions(
+        logits: MLMultiArray, positions: [Int], classifyNum: Int
+    ) -> [Int] {
+        let shape = logits.shape.map { $0.intValue }
+        // Expected [1, T, classifyNum]. Honour the reported strides — CoreML
+        // rounds the inner class dimension up for alignment (5000 → 5024
+        // floats per row in our case), so a tight pos * classifyNum offset
+        // walks off-by-stride and reads garbage.
+        guard shape.count == 3 else { return [] }
+        let strides = logits.strides.map { $0.intValue }
+        let posStride = strides[1]
+        let classStride = strides[2]
+        var out: [Int] = []
+        out.reserveCapacity(positions.count)
+        switch logits.dataType {
+        case .float32:
+            let p = logits.dataPointer.assumingMemoryBound(to: Float.self)
+            for pos in positions {
+                let base = pos * posStride
+                var best = -Float.greatestFiniteMagnitude
+                var bestIdx = 0
+                for c in 0..<classifyNum {
+                    let v = p[base + c * classStride]
+                    if v > best { best = v; bestIdx = c }
+                }
+                out.append(bestIdx)
+            }
+        case .float16:
+            let p = logits.dataPointer.assumingMemoryBound(to: Float16.self)
+            for pos in positions {
+                let base = pos * posStride
+                var best = -Float.greatestFiniteMagnitude
+                var bestIdx = 0
+                for c in 0..<classifyNum {
+                    let v = Float(p[base + c * classStride])
+                    if v > best { best = v; bestIdx = c }
+                }
+                out.append(bestIdx)
+            }
+        default:
+            return Array(repeating: 0, count: positions.count)
+        }
+        return out
+    }
+}
+
+// MARK: - Audio encoder bundle
+
+public final class CoreMLForcedAlignerEncoder {
+    public static let paddedMelLength = 3000
+    public static let paddedAudioTokens = 390
+
+    public let hiddenSize: Int
+    private let model: MLModel
+
+    public init(model: MLModel, hiddenSize: Int = 1024) {
+        self.model = model
+        self.hiddenSize = hiddenSize
+    }
+
+    public struct EncodedAudio {
+        public let embeddings: MLMultiArray
+        public let outputLength: Int
+    }
+
+    public static func load(
+        from directory: URL,
+        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine)
+    ) throws -> CoreMLForcedAlignerEncoder {
+        let url = try Self.resolveURL(in: directory, name: "audio_encoder")
+        let cfg = MLModelConfiguration()
+        cfg.computeUnits = computeUnits
+        let model = try MLModel(contentsOf: url, configuration: cfg)
+        return CoreMLForcedAlignerEncoder(model: model)
+    }
+
+    public func warmUp() throws {
+        _ = try encode(
+            melData: [Float](repeating: 0, count: 128 * Self.paddedMelLength),
+            melBins: 128, timeFrames: 100)
+    }
+
+    public func encode(melData: [Float], melBins: Int, timeFrames: Int) throws -> EncodedAudio {
+        let padded = Self.paddedMelLength
+        guard timeFrames <= padded else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner encoder",
+                reason: "Audio too long: \(timeFrames) mel frames exceeds fixed \(padded). "
+                + "Segment with VAD or process in 30 s windows.")
+        }
+
+        let mel = try MLMultiArray(
+            shape: [1, melBins as NSNumber, padded as NSNumber], dataType: .float32)
+        let mp = mel.dataPointer.assumingMemoryBound(to: Float.self)
+        for bin in 0..<melBins {
+            let src = bin * timeFrames
+            let dst = bin * padded
+            for t in 0..<timeFrames { mp[dst + t] = melData[src + t] }
+            for t in timeFrames..<padded { mp[dst + t] = 0 }
+        }
+        let len = try MLMultiArray(shape: [1], dataType: .int32)
+        len[0] = NSNumber(value: Int32(timeFrames))
+
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "mel": MLFeatureValue(multiArray: mel),
+            "mel_length": MLFeatureValue(multiArray: len),
+        ])
+        let output = try model.prediction(from: input)
+
+        guard let emb = output.featureValue(for: "audio_embeddings")?.multiArrayValue,
+              let lout = output.featureValue(for: "output_length")?.multiArrayValue
+        else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner encoder",
+                reason: "Missing audio_embeddings or output_length output")
+        }
+        let outLen = max(0, Int(lout[0].int32Value))
+        return EncodedAudio(embeddings: emb, outputLength: outLen)
+    }
+
+    static func resolveURL(in directory: URL, name: String) throws -> URL {
+        let compiled = directory.appendingPathComponent("\(name).mlmodelc", isDirectory: true)
+        let pkg = directory.appendingPathComponent("\(name).mlpackage", isDirectory: true)
+        if FileManager.default.fileExists(atPath: compiled.path) { return compiled }
+        if FileManager.default.fileExists(atPath: pkg.path) { return pkg }
+        throw AudioModelError.modelLoadFailed(
+            modelId: name,
+            reason: "Neither \(compiled.path) nor \(pkg.path) exists")
+    }
+}
+
+// MARK: - Embedding table (raw fp16 gather)
+
+/// Token embedding lookup that bypasses CoreML entirely.
+///
+/// The converter writes the embed_tokens weight as a raw little-endian fp16
+/// blob of shape ``[vocab_size, hidden_size]`` (≈ 304 MB for the
+/// 152 064 × 1024 Qwen3 vocabulary). At ``align()`` time we mmap the file
+/// and copy + dequantize the requested rows into the output buffer with
+/// vImage. A single CoreML embedding mlpackage was previously costing
+/// ~70 ms per align call to do the same lookup — pure overhead per
+/// profile measurement.
+public final class CoreMLForcedAlignerEmbedding {
+    /// Filename produced by the converter alongside the .mlmodelc bundles.
+    public static let binFilename = "embed_tokens.fp16.bin"
+
+    private let fileURL: URL
+    /// Memory-mapped fp16 table, shape ``[vocabSize, hiddenSize]`` row-major.
+    private let table: Data
+    public let vocabSize: Int
+    public let hiddenSize: Int
+
+    public init(fileURL: URL, vocabSize: Int, hiddenSize: Int) throws {
+        self.fileURL = fileURL
+        self.vocabSize = vocabSize
+        self.hiddenSize = hiddenSize
+        // Memory-map the binary so multiple aligners can share pages and we
+        // don't double the RSS by reading the file into RAM.
+        self.table = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+        let expected = vocabSize * hiddenSize * MemoryLayout<Float16>.stride
+        guard table.count == expected else {
+            throw AudioModelError.modelLoadFailed(
+                modelId: fileURL.lastPathComponent,
+                reason: "Embedding binary is \(table.count) bytes, expected "
+                + "\(expected) (\(vocabSize) × \(hiddenSize) × 2)")
+        }
+    }
+
+    public static func load(
+        from directory: URL,
+        vocabSize: Int = 152064,
+        hiddenSize: Int = 1024
+    ) throws -> CoreMLForcedAlignerEmbedding {
+        let binURL = directory.appendingPathComponent(binFilename)
+        guard FileManager.default.fileExists(atPath: binURL.path) else {
+            throw AudioModelError.modelLoadFailed(
+                modelId: binFilename,
+                reason: "Missing \(binFilename) in \(directory.path). The CoreML "
+                + "aligner runtime no longer reads embedding.mlpackage — re-export "
+                + "with the latest convert_coreml.py.")
+        }
+        return try CoreMLForcedAlignerEmbedding(
+            fileURL: binURL, vocabSize: vocabSize, hiddenSize: hiddenSize)
+    }
+
+    public func warmUp() throws {
+        _ = try embed(tokenIds: [0, 1, 2], fixedT: 16, hiddenSize: hiddenSize)
+    }
+
+    /// Gather rows for ``tokenIds`` into a fresh float32 ``[1, fixedT, hiddenSize]``
+    /// MLMultiArray. Trailing slots beyond ``tokenIds.count`` are filled with
+    /// the embedding of token 0 (matches what the old mlpackage did when fed
+    /// a zero-padded id sequence).
+    public func embed(tokenIds: [Int], fixedT: Int, hiddenSize: Int) throws -> MLMultiArray {
+        guard hiddenSize == self.hiddenSize else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner embedding",
+                reason: "Hidden size mismatch: requested \(hiddenSize), "
+                + "table has \(self.hiddenSize)")
+        }
+        guard tokenIds.count <= fixedT else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner embedding",
+                reason: "Token count \(tokenIds.count) exceeds fixed T \(fixedT)")
+        }
+
+        let fp32 = try MLMultiArray(
+            shape: [1, fixedT as NSNumber, hiddenSize as NSNumber], dataType: .float32)
+        let dstStrides = fp32.strides.map { $0.intValue }
+        let dstPosStride = dstStrides[1]
+        let dst = fp32.dataPointer.assumingMemoryBound(to: Float.self)
+
+        let rowFp16Bytes = hiddenSize * MemoryLayout<Float16>.stride
+        let rowFp32Bytes = hiddenSize * MemoryLayout<Float>.stride
+
+        table.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            guard let basePtr = raw.baseAddress?.assumingMemoryBound(to: Float16.self) else {
+                return
+            }
+            for t in 0..<fixedT {
+                let id = t < tokenIds.count ? tokenIds[t] : 0
+                // Guard against bad token ids in case the tokenizer ever
+                // emits something past the embed_tokens range.
+                let safeId = (id >= 0 && id < self.vocabSize) ? id : 0
+                let srcRow = basePtr.advanced(by: safeId * hiddenSize)
+                let dstRow = dst.advanced(by: t * dstPosStride)
+                var srcBuf = vImage_Buffer(
+                    data: UnsafeMutableRawPointer(mutating: srcRow),
+                    height: 1, width: vImagePixelCount(hiddenSize),
+                    rowBytes: rowFp16Bytes)
+                var dstBuf = vImage_Buffer(
+                    data: dstRow, height: 1, width: vImagePixelCount(hiddenSize),
+                    rowBytes: rowFp32Bytes)
+                _ = vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)
+            }
+        }
+        return fp32
+    }
+}
+
+// MARK: - Text decoder + classify head bundle
+
+public final class CoreMLForcedAlignerDecoder {
+    private let model: MLModel
+    public let fixedT: Int
+
+    public init(model: MLModel, fixedT: Int = 768) {
+        self.model = model
+        self.fixedT = fixedT
+    }
+
+    public static func load(
+        from directory: URL,
+        computeUnits: MLComputeUnits = CoreMLComputeUnitsResolver.resolved(default: .all)
+    ) throws -> CoreMLForcedAlignerDecoder {
+        let url = try CoreMLForcedAlignerEncoder.resolveURL(in: directory, name: "text_decoder")
+        let cfg = MLModelConfiguration()
+        cfg.computeUnits = computeUnits
+        let model = try MLModel(contentsOf: url, configuration: cfg)
+        // Read fixedT from the model's declared input shape so a runtime
+        // override (T=512 / T=1024) doesn't need a separate code path.
+        var fixedT = 768
+        if let desc = model.modelDescription.inputDescriptionsByName["inputs_embeds"],
+           let constraint = desc.multiArrayConstraint {
+            let shape = constraint.shape.map { $0.intValue }
+            if shape.count == 3 && shape[1] > 0 { fixedT = shape[1] }
+        }
+        return CoreMLForcedAlignerDecoder(model: model, fixedT: fixedT)
+    }
+
+    public func warmUp() throws {
+        let hidden = 1024
+        let dummy = try MLMultiArray(
+            shape: [1, fixedT as NSNumber, hidden as NSNumber], dataType: .float32)
+        _ = try run(inputsEmbeds: dummy)
+    }
+
+    public func run(inputsEmbeds: MLMultiArray) throws -> MLMultiArray {
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "inputs_embeds": MLFeatureValue(multiArray: inputsEmbeds),
+        ])
+        let output = try model.prediction(from: input)
+        guard let logits = output.featureValue(for: "logits")?.multiArrayValue else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML forced aligner decoder",
+                reason: "Missing logits output")
+        }
+        return logits
+    }
+}
+
+#endif

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -242,7 +242,22 @@ final class AlignCommandTests: XCTestCase {
     func testDefaultAlignerModel() throws {
         let cmd = try AudioCLI.parseAsRoot(["align", "audio.wav"])
         let align = try XCTUnwrap(cmd as? AlignCommand)
-        XCTAssertEqual(align.alignerModel, "aufklarer/Qwen3-ForcedAligner-0.6B-4bit")
+        // The default is engine-dependent (mlx → 4-bit MLX, coreml → CoreML
+        // FP16) and resolved inside `run()`, so the parsed value is nil.
+        XCTAssertNil(align.alignerModel)
+    }
+
+    func testDefaultEngineIsMLX() throws {
+        let cmd = try AudioCLI.parseAsRoot(["align", "audio.wav"])
+        let align = try XCTUnwrap(cmd as? AlignCommand)
+        XCTAssertEqual(align.engine, "mlx")
+    }
+
+    func testEngineCoremlParses() throws {
+        let cmd = try AudioCLI.parseAsRoot(["align", "audio.wav", "--engine", "coreml"])
+        let align = try XCTUnwrap(cmd as? AlignCommand)
+        XCTAssertEqual(align.engine, "coreml")
+        XCTAssertNil(align.alignerModel)
     }
 
     func testParsesTextOption() throws {

--- a/Tests/Qwen3ASRTests/E2ECoreMLForcedAlignerBenchTests.swift
+++ b/Tests/Qwen3ASRTests/E2ECoreMLForcedAlignerBenchTests.swift
@@ -1,0 +1,89 @@
+#if canImport(CoreML)
+import XCTest
+import Foundation
+import Darwin
+import AudioCommon
+@testable import Qwen3ASR
+
+/// Local copy of ``AsrBenchmark.currentRSSBytes`` so this test target doesn't
+/// take a dependency on the benchmark module.
+private func currentRSSBytes() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(
+        MemoryLayout<mach_task_basic_info_data_t>.size / MemoryLayout<integer_t>.size)
+    let kerr = withUnsafeMutablePointer(to: &info) { ptr -> kern_return_t in
+        ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { p in
+            task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), p, &count)
+        }
+    }
+    guard kerr == KERN_SUCCESS else { return 0 }
+    return UInt64(info.resident_size)
+}
+
+/// Micro-benchmark for the CoreML aligner. Runs alignment 3 times, reports
+/// RTF (alignment time / audio duration) and peak RSS observed during the
+/// run. Skips unless ``ALIGNER_COREML_LOCAL_DIR`` points at a converter
+/// output. Pair with the same env on the MLX path for an apples-to-apples
+/// comparison.
+final class E2ECoreMLForcedAlignerBenchTests: XCTestCase {
+
+    func testBenchmarkLocalAligner() throws {
+        guard let path = ProcessInfo.processInfo.environment["ALIGNER_COREML_LOCAL_DIR"],
+              !path.isEmpty else {
+            throw XCTSkip("Set ALIGNER_COREML_LOCAL_DIR to a converter output directory")
+        }
+        let dir = URL(fileURLWithPath: path, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            throw XCTSkip("ALIGNER_COREML_LOCAL_DIR=\(path) does not exist")
+        }
+
+        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
+            throw XCTSkip("test_audio.wav not found in Qwen3ASRTests resources")
+        }
+
+        let baseRSS = currentRSSBytes()
+        let aligner = try CoreMLForcedAligner.fromDirectory(dir)
+        let loadedRSS = currentRSSBytes()
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
+        let targetSampleRate = 16000
+        let audio: [Float] = sampleRate == targetSampleRate
+            ? samples
+            : AudioFileLoader.resample(samples, from: sampleRate, to: targetSampleRate)
+        let audioSeconds = Float(audio.count) / Float(targetSampleRate)
+
+        let referenceText =
+            "Can you guarantee that the replacement part will be shipped tomorrow?"
+
+        // Warm-up + 3 timed runs.
+        _ = try aligner.align(
+            audio: audio, text: referenceText, sampleRate: targetSampleRate, language: "English")
+
+        var rtfs: [Double] = []
+        var peakRSS = loadedRSS
+        for _ in 0..<3 {
+            let start = CFAbsoluteTimeGetCurrent()
+            _ = try aligner.align(
+                audio: audio, text: referenceText, sampleRate: targetSampleRate, language: "English")
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            let rtf = elapsedMs / Double(audioSeconds * 1000)
+            rtfs.append(rtf)
+            peakRSS = max(peakRSS, currentRSSBytes())
+        }
+        let median = rtfs.sorted()[1]
+        let loadDeltaMB = Double(loadedRSS - baseRSS) / (1024 * 1024)
+        let peakMB = Double(peakRSS) / (1024 * 1024)
+
+        print(String(format: "[COREML-ALIGN-BENCH] dir=%@", dir.path))
+        print(String(format: "[COREML-ALIGN-BENCH] audio=%.1fs runs=%d rtfs=%@",
+                     audioSeconds, rtfs.count,
+                     rtfs.map { String(format: "%.3f", $0) }.joined(separator: ",")))
+        print(String(format: "[COREML-ALIGN-BENCH] median RTF=%.3f (%.1fx faster than real-time)",
+                     median, 1.0 / median))
+        print(String(format: "[COREML-ALIGN-BENCH] RSS: base=%.0fMB after-load=%.0fMB peak=%.0fMB Δload=%.0fMB",
+                     Double(baseRSS) / (1024 * 1024),
+                     Double(loadedRSS) / (1024 * 1024),
+                     peakMB, loadDeltaMB))
+    }
+}
+#endif

--- a/Tests/Qwen3ASRTests/E2ECoreMLForcedAlignerLocalSmokeTests.swift
+++ b/Tests/Qwen3ASRTests/E2ECoreMLForcedAlignerLocalSmokeTests.swift
@@ -1,0 +1,80 @@
+#if canImport(CoreML)
+import XCTest
+import Foundation
+import AudioCommon
+@testable import Qwen3ASR
+
+/// Local-bundle smoke test for ``CoreMLForcedAligner``. Skips by default
+/// unless ``ALIGNER_COREML_LOCAL_DIR`` points at a freshly produced
+/// converter output. Runs the full encode → embed → decode → LIS pipeline
+/// against the local mlpackages so we can validate the runtime *before*
+/// uploading to HuggingFace.
+///
+/// Invoke with:
+///   ALIGNER_COREML_LOCAL_DIR=/tmp/aligner-coreml-fp16 \
+///       swift test --filter E2ECoreMLForcedAlignerLocalSmokeTests
+final class E2ECoreMLForcedAlignerLocalSmokeTests: XCTestCase {
+
+    func testLocalAlignerProducesFiniteMonotonicWords() throws {
+        guard let path = ProcessInfo.processInfo.environment["ALIGNER_COREML_LOCAL_DIR"],
+              !path.isEmpty else {
+            throw XCTSkip("Set ALIGNER_COREML_LOCAL_DIR to a converter output directory")
+        }
+        let dir = URL(fileURLWithPath: path, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            throw XCTSkip("ALIGNER_COREML_LOCAL_DIR=\(path) does not exist")
+        }
+
+        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
+            throw XCTSkip("test_audio.wav not found in Qwen3ASRTests resources")
+        }
+
+        let aligner = try CoreMLForcedAligner.fromDirectory(dir)
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
+        let targetSampleRate = 16000
+        let audio: [Float] = sampleRate == targetSampleRate
+            ? samples
+            : AudioFileLoader.resample(samples, from: sampleRate, to: targetSampleRate)
+        let audioSeconds = Float(audio.count) / Float(targetSampleRate)
+
+        let referenceText =
+            "Can you guarantee that the replacement part will be shipped tomorrow?"
+        let start = CFAbsoluteTimeGetCurrent()
+        let aligned = try aligner.align(
+            audio: audio,
+            text: referenceText,
+            sampleRate: targetSampleRate,
+            language: "English"
+        )
+        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+        let audioMs = Double(audioSeconds) * 1000
+
+        print(String(format: "[COREML-ALIGN-LOCAL] dir=%@", dir.path))
+        print(String(format: "[COREML-ALIGN-LOCAL-PERF] align=%.0fms audio=%.0fms rtf=%.3f words=%d",
+                     elapsedMs, audioMs, elapsedMs / audioMs, aligned.count))
+        for w in aligned {
+            print(String(format: "  [%.2f-%.2f] %@", w.startTime, w.endTime, w.text))
+        }
+
+        XCTAssertFalse(aligned.isEmpty, "Aligner returned no words")
+        for word in aligned {
+            XCTAssertTrue(word.startTime.isFinite, "non-finite start for '\(word.text)'")
+            XCTAssertTrue(word.endTime.isFinite, "non-finite end for '\(word.text)'")
+            XCTAssertGreaterThanOrEqual(word.startTime, 0,
+                                        "negative start for '\(word.text)'")
+        }
+        for i in 1..<aligned.count {
+            XCTAssertGreaterThanOrEqual(
+                aligned[i].startTime, aligned[i - 1].startTime,
+                "Non-monotonic at index \(i)")
+        }
+
+        guard let last = aligned.last else { return }
+        XCTAssertLessThanOrEqual(last.endTime, audioSeconds + 1.0,
+                                 "Last word ends past audio end")
+        let span = last.endTime - aligned.first!.startTime
+        XCTAssertGreaterThan(span, 0.5,
+                             "Alignment span \(span)s too small — likely NaN/argmax-0 collapse")
+    }
+}
+#endif

--- a/Tests/Qwen3ASRTests/E2ECoreMLForcedAlignerTests.swift
+++ b/Tests/Qwen3ASRTests/E2ECoreMLForcedAlignerTests.swift
@@ -1,0 +1,139 @@
+#if canImport(CoreML)
+import XCTest
+import Foundation
+import AudioCommon
+@testable import Qwen3ASR
+
+/// End-to-end tests for the CoreML forced aligner pipeline (audio_encoder
+/// + embedding + text_decoder + classify head). Loads the published
+/// ``aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16`` bundle and verifies
+/// that the produced alignment is finite, monotonic, and lands inside the
+/// audio clip's duration window.
+///
+/// Regression coverage:
+/// - Catches the prior NaN bug in the text decoder (the upstream fp16
+///   softmax of an ``-inf`` causal mask), now fixed by exporting the mask
+///   as a constant with a finite ``-1e4`` fill value. A reintroduction of
+///   ``-inf`` in the mask would surface here as all-zero indices and
+///   degenerate ``[0.0s, 0.0s]`` word stamps.
+/// - Catches the prior audio-encoder divergence (global attention over
+///   zero-padded mel) by checking that the alignment durations roughly
+///   match the real audio length, not the 30 s padded grid.
+final class E2ECoreMLForcedAlignerTests: XCTestCase {
+
+    private static let referenceText =
+        "Can you guarantee that the replacement part will be shipped tomorrow?"
+
+    func testFP16AlignerProducesMonotonicTimestamps() async throws {
+        try await runAligner(
+            modelId: "aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16",
+            variantLabel: "FP16"
+        )
+    }
+
+    func testINT8AlignerProducesMonotonicTimestamps() async throws {
+        try await runAligner(
+            modelId: "aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8",
+            variantLabel: "INT8"
+        )
+    }
+
+    // MARK: - Shared body
+
+    private func runAligner(modelId: String, variantLabel: String) async throws {
+        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
+            throw XCTSkip("test_audio.wav not found in Qwen3ASRTests resources")
+        }
+
+        let aligner: CoreMLForcedAligner
+        do {
+            aligner = try await CoreMLForcedAligner.fromPretrained(
+                modelId: modelId
+            ) { progress, status in
+                if Int(progress * 100) % 25 == 0 {
+                    print(String(format: "  [%@] loading: %.0f%% — %@",
+                                 variantLabel, progress * 100, status))
+                }
+            }
+        } catch {
+            throw XCTSkip("CoreML aligner \(variantLabel) bundle unavailable: \(error)")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
+        let targetSampleRate = 16000
+        let audio: [Float] = sampleRate == targetSampleRate
+            ? samples
+            : AudioFileLoader.resample(samples, from: sampleRate, to: targetSampleRate)
+        let audioSeconds = Float(audio.count) / Float(targetSampleRate)
+        XCTAssertGreaterThan(audioSeconds, 0)
+
+        let start = CFAbsoluteTimeGetCurrent()
+        let aligned = try aligner.align(
+            audio: audio,
+            text: Self.referenceText,
+            sampleRate: targetSampleRate,
+            language: "English"
+        )
+        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+        let audioMs = Double(audioSeconds) * 1000
+
+        print(String(format: "[COREML-ALIGN-%@-PERF] align=%.0fms audio=%.0fms rtf=%.3f words=%d",
+                     variantLabel, elapsedMs, audioMs, elapsedMs / audioMs, aligned.count))
+        for word in aligned {
+            print(String(format: "  [%.2f-%.2f] %@", word.startTime, word.endTime, word.text))
+        }
+
+        XCTAssertFalse(aligned.isEmpty, "[\(variantLabel)] Aligner returned no words")
+        XCTAssertEqual(
+            aligned.count,
+            Self.referenceText.split(separator: " ").map { $0.trimmingCharacters(in: .punctuationCharacters) }
+                .filter { !$0.isEmpty }.count,
+            "[\(variantLabel)] Aligner should emit one entry per word in the reference text"
+        )
+
+        // No NaN, no negatives, no end-before-start.
+        for word in aligned {
+            XCTAssertTrue(word.startTime.isFinite, "[\(variantLabel)] non-finite start for '\(word.text)'")
+            XCTAssertTrue(word.endTime.isFinite, "[\(variantLabel)] non-finite end for '\(word.text)'")
+            XCTAssertGreaterThanOrEqual(word.startTime, 0,
+                                        "[\(variantLabel)] negative start for '\(word.text)'")
+            XCTAssertGreaterThanOrEqual(word.endTime, word.startTime,
+                                        "[\(variantLabel)] end < start for '\(word.text)'")
+        }
+
+        // Monotonically non-decreasing across the sequence.
+        for i in 1..<aligned.count {
+            XCTAssertGreaterThanOrEqual(
+                aligned[i].startTime, aligned[i - 1].startTime,
+                "[\(variantLabel)] Non-monotonic start at index \(i): "
+                + "\(aligned[i - 1].text)@\(aligned[i - 1].startTime) → "
+                + "\(aligned[i].text)@\(aligned[i].startTime)")
+        }
+
+        // Timestamps should land inside the clip's duration window (with a
+        // small tolerance for the trailing word's end overshooting slightly).
+        guard let lastWord = aligned.last else {
+            XCTFail("[\(variantLabel)] No words to inspect")
+            return
+        }
+        XCTAssertLessThanOrEqual(
+            lastWord.startTime, audioSeconds + 0.5,
+            "[\(variantLabel)] Last word starts past audio end "
+            + "(\(lastWord.startTime)s vs audio \(audioSeconds)s)")
+        XCTAssertLessThanOrEqual(
+            lastWord.endTime, audioSeconds + 1.0,
+            "[\(variantLabel)] Last word ends past audio end "
+            + "(\(lastWord.endTime)s vs audio \(audioSeconds)s)")
+
+        // The total alignment should cover a meaningful fraction of the clip.
+        // The fixture is ~3-4 s of speech; if alignment collapses to 0 s, the
+        // CoreML graph likely regressed (audio encoder divergence or text
+        // decoder NaN producing argmax=0 everywhere).
+        let span = lastWord.endTime - aligned.first!.startTime
+        XCTAssertGreaterThan(
+            span, 0.5,
+            "[\(variantLabel)] Alignment span \(span)s is too small — "
+            + "suggests NaN/argmax-0 collapse")
+    }
+}
+#endif

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -291,26 +291,20 @@ let aligned = try aligner.align(
 )
 ```
 
-The CoreML aligner runs the audio encoder + token embedding + 28-layer non-autoregressive text decoder + classify head as three separate `.mlmodelc` bundles. The audio encoder is fixed to a 30 s mel input and reports the real (un-padded) audio-token count; the text decoder runs at a fixed prompt length of 1024 tokens — enough to cover the 9-token chat-template prefix + up to 390 audio tokens + 6-token suffix + ~150 word slots. The causal mask is `-1e4` (finite) so the fp16 softmax stays numerically stable.
+The CoreML aligner runs the audio encoder + token embedding + 28-layer non-autoregressive text decoder + classify head from two `.mlmodelc` bundles and a raw fp16 token-embedding binary. The audio encoder is fixed to a 30 s mel input and reports the real (un-padded) audio-token count; the text decoder runs at a fixed prompt length of 768 tokens — enough to cover the 9-token chat-template prefix + up to 390 audio tokens + 6-token suffix + ~120 word slots. The causal mask is `-1e4` (finite) so the fp16 softmax stays numerically stable.
 
-## Conversion
+## Model bundle layout
 
-The converters live in the [speech-models](https://github.com/soniqo/speech-models) repo under `models/forced-aligner/export/`.
+Each CoreML repo on HuggingFace contains:
 
-```bash
-# MLX variants (group-quantized text decoder)
-poetry run python convert_mlx.py --bits 4 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-4bit
-poetry run python convert_mlx.py --bits 5 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-5bit
-poetry run python convert_mlx.py --bits 8 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-8bit
-poetry run python convert_mlx.py --bits 0 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-bf16
+| File | Role |
+|---|---|
+| `audio_encoder.mlmodelc` (+ `.mlpackage`) | 24-layer block-attention audio encoder |
+| `text_decoder.mlmodelc` (+ `.mlpackage`) | 28-layer non-AR decoder + 5000-class classify head, fixed T=768 |
+| `embed_tokens.fp16.bin` | Raw little-endian fp16 token embedding table, `[152 064, 1024]` |
+| `config.json` | Variant + classify_num + timestamp_segment_time + fixed shapes |
+| `vocab.json`, `merges.txt`, `tokenizer_config.json` | Qwen3 BPE tokenizer files |
 
-# CoreML variants (audio encoder + embedding + text decoder + classify head)
-poetry run python convert_coreml.py --variant fp16 --compile --upload \
-        --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16
-poetry run python convert_coreml.py --variant int8 --compile --upload \
-        --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8
-```
+The embed-tokens table is shipped as a raw fp16 binary instead of a CoreML mlpackage — the Swift runtime memory-maps the file and gathers rows with `vImageConvert_Planar16FtoPlanarF`, costing ~0.5 ms per alignment versus ~70 ms for an mlpackage round-trip.
 
-**MLX**: quantizes text decoder (attention + MLP + embeddings) to N-bit. Audio encoder and classify head kept as float16. `--bits 0` keeps everything as float16.
-
-**CoreML**: traces the chunked block-attention audio encoder (fixed 30 s mel input, in-graph `mel_length`-driven mask), token embedding lookup, and a non-autoregressive 28-layer text decoder + 5000-class classify head. The text decoder runs at a fixed prompt length of 1024 tokens with a `-1e4` constant causal mask baked into the graph. `--variant fp16` keeps weights at fp16; `--variant int8` applies kmeans palettization to all three bundles. Published as pre-compiled `.mlmodelc` bundles alongside the source `.mlpackage` form.
+`--variant fp16` keeps all weights at fp16; `--variant int8` applies kmeans palettization to the audio encoder and text decoder bundles only. The embedding table stays fp16 in both variants because classification quality across the full 152 064-token vocabulary is sensitive to per-row quantization noise.

--- a/docs/inference/forced-aligner.md
+++ b/docs/inference/forced-aligner.md
@@ -164,13 +164,38 @@ Set `ALIGN_DEBUG=1` to dump raw vs corrected timestamp indices when investigatin
 
 ## Performance (M2 Max, 64 GB)
 
+MLX 4-bit (debug build):
+
 | Stage | Time | Notes |
 |-------|------|-------|
 | Audio encoder | ~328ms | Mel extraction + 24L transformer + projector |
 | Decoder + classify | ~37ms | Single forward pass, no autoregressive loop |
-| **Total (20s audio)** | **~365ms** | **RTF ~0.018 (55x faster than real-time)** |
+| **Total (20s audio)** | **~365ms** | **RTF ~0.018 (55× faster than real-time)** |
 
-Debug build. Release would be faster.
+CoreML variants (debug build, 20 s clip, median of 3 runs after warm-up):
+
+| Variant | RTF | Peak RSS | Load Δ |
+|---|---|---|---|
+| CoreML FP16 | 0.015 (67×) | 1071 MB | 966 MB |
+| CoreML INT8 | 0.014 (69×) | 697 MB  | 596 MB |
+
+INT8 cuts peak memory by ~35% at the same (slightly better) wall-clock speed. Release would be faster.
+
+Per-stage profile of an FP16 run (`COREML_ALIGN_PROFILE=1`):
+
+| Stage | Time | Notes |
+|-------|------|-------|
+| Mel extraction | ~150 ms | CPU (vDSP FFT + BLAS filterbank) |
+| Audio encoder | ~90 ms | CPU+ANE, fixed 30 s shape |
+| Token embedding | ~0.5 ms | Pure Swift gather from a memory-mapped fp16 table (no CoreML round-trip) |
+| Audio→embedding splice | ~0 ms | `memcpy` per audio token row |
+| Text decoder + classify | ~44 ms | 28-layer non-AR pass, fixed T=768 |
+| Argmax @ &lt;ts&gt; positions | ~7 ms | Stride-aware (CoreML pads inner dim to 5024 for alignment) |
+| LIS monotonicity | &lt;1 ms | O(n log n) on 22 timestamp slots |
+
+Two prior bottlenecks were removed in the current build:
+1. The token embedding used to round-trip through a CoreML mlpackage (~70 ms per call). The converter now writes the embed_tokens weight as a raw fp16 binary alongside the bundles; the Swift runtime memory-maps it and gathers rows with `vImageConvert_Planar16FtoPlanarF`.
+2. The text decoder was previously exported at T=1024. Attention compute is O(T²) so dropping it to T=768 (still covering 30 s of audio + ~120 word slots) cut the decoder stage by ~25%.
 
 ## Weight Structure
 
@@ -187,25 +212,31 @@ Weights use a `thinker.` prefix:
 | Model | ID | Size |
 |-------|----|------|
 | MLX 4-bit | `aufklarer/Qwen3-ForcedAligner-0.6B-4bit` | ~979 MB |
+| MLX 5-bit | `aufklarer/Qwen3-ForcedAligner-0.6B-5bit` | ~1.1 GB |
 | MLX 8-bit | `aufklarer/Qwen3-ForcedAligner-0.6B-8bit` | ~1.3 GB |
 | MLX bf16 | `aufklarer/Qwen3-ForcedAligner-0.6B-bf16` | ~1.8 GB |
-| CoreML INT4 | `aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4` | ~662 MB |
-| CoreML INT8 | `aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8` | ~1.1 GB |
+| CoreML FP16 | `aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16` | ~1.7 GB |
+| CoreML INT8 | `aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8` | ~880 MB |
 
-Variant is auto-detected from `quantize_config.json` in the model directory. The bf16 variant uses a float text decoder (`FloatTextModel`) instead of a quantized one.
+The MLX variant is auto-detected from `quantize_config.json`; the bf16 variant uses a float text decoder (`FloatTextModel`) instead of a quantized one. CoreML variants are loaded through `CoreMLForcedAligner.fromPretrained(...)` — see the Swift API section below.
 
 ## CLI Usage
 
 ```bash
-# Align with provided text
+# Align with provided text (MLX, default)
 speech align audio.wav --text "Can you guarantee that the replacement part will be shipped tomorrow?"
 
 # Transcribe first, then align
 speech align audio.wav
 
-# Custom aligner model (8-bit or bf16)
+# Custom MLX aligner model (5-bit / 8-bit / bf16)
+speech align audio.wav --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-5bit
 speech align audio.wav --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-8bit
 speech align audio.wav --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-bf16
+
+# CoreML aligner (Neural Engine + GPU; defaults to FP16, switch to INT8 via --aligner-model)
+speech align audio.wav --engine coreml
+speech align audio.wav --engine coreml --aligner-model aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8
 ```
 
 Output format:
@@ -243,19 +274,43 @@ for word in alignedLong {
 }
 ```
 
-## Conversion
+### CoreML
 
-```bash
-# MLX variants
-python scripts/convert_forced_aligner.py --bits 4 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-4bit
-python scripts/convert_forced_aligner.py --bits 8 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-8bit
-python scripts/convert_forced_aligner.py --bits 0 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-bf16
+```swift
+import Qwen3ASR
 
-# CoreML variants
-python scripts/convert_forced_aligner.py --coreml --coreml-bits 4 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT4
-python scripts/convert_forced_aligner.py --coreml --coreml-bits 8 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8
+let aligner = try await CoreMLForcedAligner.fromPretrained(
+    modelId: "aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16"
+)
+
+let aligned = try aligner.align(
+    audio: audioSamples,
+    text: "Can you guarantee that the replacement part will be shipped tomorrow?",
+    sampleRate: 16000,
+    language: "English"
+)
 ```
 
-MLX: quantizes text decoder (attention + MLP + embeddings) to N-bit. Audio encoder and classify head kept as float16. `--bits 0` keeps everything as float16.
+The CoreML aligner runs the audio encoder + token embedding + 28-layer non-autoregressive text decoder + classify head as three separate `.mlmodelc` bundles. The audio encoder is fixed to a 30 s mel input and reports the real (un-padded) audio-token count; the text decoder runs at a fixed prompt length of 1024 tokens — enough to cover the 9-token chat-template prefix + up to 390 audio tokens + 6-token suffix + ~150 word slots. The causal mask is `-1e4` (finite) so the fp16 softmax stays numerically stable.
 
-CoreML: traces audio encoder, text decoder + classify head, and embedding as separate models with INT4/INT8 palettization. Published as pre-compiled `.mlmodelc` bundles.
+## Conversion
+
+The converters live in the [speech-models](https://github.com/soniqo/speech-models) repo under `models/forced-aligner/export/`.
+
+```bash
+# MLX variants (group-quantized text decoder)
+poetry run python convert_mlx.py --bits 4 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-4bit
+poetry run python convert_mlx.py --bits 5 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-5bit
+poetry run python convert_mlx.py --bits 8 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-8bit
+poetry run python convert_mlx.py --bits 0 --upload --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-bf16
+
+# CoreML variants (audio encoder + embedding + text decoder + classify head)
+poetry run python convert_coreml.py --variant fp16 --compile --upload \
+        --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16
+poetry run python convert_coreml.py --variant int8 --compile --upload \
+        --repo-id aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-INT8
+```
+
+**MLX**: quantizes text decoder (attention + MLP + embeddings) to N-bit. Audio encoder and classify head kept as float16. `--bits 0` keeps everything as float16.
+
+**CoreML**: traces the chunked block-attention audio encoder (fixed 30 s mel input, in-graph `mel_length`-driven mask), token embedding lookup, and a non-autoregressive 28-layer text decoder + 5000-class classify head. The text decoder runs at a fixed prompt length of 1024 tokens with a `-1e4` constant causal mask baked into the graph. `--variant fp16` keeps weights at fp16; `--variant int8` applies kmeans palettization to all three bundles. Published as pre-compiled `.mlmodelc` bundles alongside the source `.mlpackage` form.


### PR DESCRIPTION
## Summary
- Add `CoreMLForcedAligner` (`Sources/Qwen3ASR/CoreMLForcedAligner.swift`): an MLX-free, single-pass CoreML aligner that consumes the new audio_encoder + text_decoder bundles + raw fp16 embed_tokens table.
- Wire it through the CLI: `speech align audio.wav --engine coreml` (defaults to `aufklarer/Qwen3-ForcedAligner-0.6B-CoreML-FP16`, switch to INT8 via `--aligner-model`).
- E2E tests for both variants (HF-backed) plus a local-dir smoke test and an RTF + peakRSS micro-benchmark.
- Update `docs/inference/forced-aligner.md` to drop the broken CoreML-INT4 entry, document the new FP16 + INT8 variants, list per-stage timings, and explain the conversion path now lives in [soniqo/speech-models#52](https://github.com/soniqo/speech-models/pull/52).

Companion to soniqo/speech-models#52.

## Why this exists
The previously published CoreML aligner bundles (`-CoreML-INT4`, `-CoreML-INT8`) produced NaN from `text_decoder.mlpackage` for every input — the converter baked a `float("-inf")` causal mask into the trace and the upstream fp16 softmax couldn't survive it. The new converter uses a finite `-1e4` mask + the runtime here follows the same convention. There was also no `CoreMLForcedAligner` class in the Swift codebase before — only the MLX path existed, so the published bundles had no consumer to catch the regression.

Reported on #342.

## Performance (M2 Max, 64 GB, debug build, 20 s clip, median of 3 runs)
| Variant | RTF | Peak RSS |
|---|---|---|
| CoreML FP16 | **0.015 (67×)** | 1071 MB |
| CoreML INT8 | **0.014 (69×)** |  697 MB |

Per-stage profile (`COREML_ALIGN_PROFILE=1`, FP16):
```
mel=150ms  encoder=90ms  embedding=0.5ms  splice=0ms  decoder=44ms  argmax=7ms
```

The embedding stage went from ~70 ms (previous mlpackage round-trip) to ~0.5 ms by mmaping the raw fp16 table and gathering rows with vImage. T=1024 → T=768 cut the decoder stage ~25%. Strides-aware MLMultiArray access fixed a +1500-index alignment skew where CoreML rounds inner dims to 5024 for SIMD alignment.

## Test plan
- [x] `make build` — release build green (locally).
- [x] `swift test --filter E2ECoreMLForcedAlignerLocalSmokeTests` against fresh converter output — both FP16 + INT8 produce monotonic alignment inside the audio duration window; no NaN.
- [x] `swift test --filter E2ECoreMLForcedAlignerBenchTests` — RTF + peakRSS measured at the numbers above.
- [ ] CI on the runner — only the local-smoke + bench tests need `ALIGNER_COREML_LOCAL_DIR`; the HF-backed `E2ECoreMLForcedAlignerTests` runs in `make test` (E2E suite) and skips when the bundle is unreachable.

## Closes
#342