### PR TITLE
Fix Qwen3.5 streaming decode corruption + empty replies

### DIFF
--- a/Sources/Qwen3Chat/ChatTokenizer.swift
+++ b/Sources/Qwen3Chat/ChatTokenizer.swift
@@ -213,6 +213,41 @@ public final class ChatTokenizer: @unchecked Sendable {
         return decodeBPEString(piece)
     }
 
+    /// Raw byte sequence a (non-special) token maps to under byte-level BPE.
+    ///
+    /// Streaming decoders must accumulate these across tokens and decode UTF-8 on the
+    /// combined buffer — decoding each token's bytes in isolation corrupts any multi-byte
+    /// character (emoji, Cyrillic, CJK) that BPE split across token boundaries.
+    public func tokenBytes(_ tokenId: Int) -> [UInt8] {
+        guard let piece = idToToken[tokenId] else { return [] }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(piece.unicodeScalars.count)
+        for ch in piece {
+            if let b = Self.unicodeToByte[ch] { bytes.append(b) }
+        }
+        return bytes
+    }
+
+    /// Decode the longest valid-UTF-8 prefix of `bytes`, returning the text plus any
+    /// trailing bytes that form an incomplete multi-byte character (≤3 bytes), to be
+    /// completed by the next token. Use `String(decoding:as:)` to flush the remainder
+    /// (lossily) when the stream ends.
+    public static func decodeUTF8Prefix(_ bytes: [UInt8]) -> (text: String, remainder: [UInt8]) {
+        if bytes.isEmpty { return ("", []) }
+        var end = bytes.count
+        // A UTF-8 character is at most 4 bytes, so only the last ≤3 bytes can be incomplete.
+        let floor = max(0, bytes.count - 3)
+        while end > floor {
+            if let s = String(bytes: bytes[0..<end], encoding: .utf8) {
+                return (s, Array(bytes[end...]))
+            }
+            end -= 1
+        }
+        // Whole buffer (or its head) decodes, or it's a genuinely invalid lead — keep buffering.
+        if let s = String(bytes: bytes, encoding: .utf8) { return (s, []) }
+        return ("", bytes)
+    }
+
     /// Convert a BPE token string to UTF-8 text.
     ///
     /// GPT-2/Qwen byte-level BPE represents each byte as a specific Unicode

--- a/Sources/Qwen3Chat/MLXGenerator.swift
+++ b/Sources/Qwen3Chat/MLXGenerator.swift
@@ -218,12 +218,16 @@ public final class Qwen35MLXChat: @unchecked Sendable {
         var logits = extractLastPositionLogits(prefillLogits)
         var generatedTokens: [Int] = []
         var inThinking = false
+        var producedContent = false
         let thinkBudget = 100
 
         // Decode loop
         let decodeStart = CFAbsoluteTimeGetCurrent()
 
         for _ in 0..<(sampling.maxTokens + thinkBudget) {
+            // Don't let the model end the turn before saying anything (empty reply).
+            if !producedContent { suppressEndTokens(&logits) }
+
             let nextToken = ChatSampler.sample(
                 logits: logits,
                 config: sampling,
@@ -239,6 +243,8 @@ public final class Qwen35MLXChat: @unchecked Sendable {
                 inThinking = true
             } else if nextToken == ChatTemplate.thinkEndId {
                 inThinking = false
+            } else if !self.tokenizer.isSpecialToken(nextToken) {
+                producedContent = true
             }
 
             if inThinking && generatedTokens.count > thinkBudget {
@@ -315,8 +321,15 @@ public final class Qwen35MLXChat: @unchecked Sendable {
                     var logits = self.extractLastPositionLogits(prefillLogits)
                     var generatedTokens: [Int] = []
                     var inThinking = false
+                    var producedContent = false
+                    // Byte-level BPE can split one UTF-8 character across tokens, so accumulate
+                    // raw bytes and only emit complete characters (see ChatTokenizer.tokenBytes).
+                    var pending: [UInt8] = []
 
                     for _ in 0..<sampling.maxTokens {
+                        // Don't let the model end the turn before saying anything (empty reply).
+                        if !producedContent { self.suppressEndTokens(&logits) }
+
                         let nextToken = ChatSampler.sample(
                             logits: logits,
                             config: sampling,
@@ -331,10 +344,12 @@ public final class Qwen35MLXChat: @unchecked Sendable {
                             inThinking = true
                         } else if nextToken == ChatTemplate.thinkEndId {
                             inThinking = false
-                        } else if !inThinking,
-                                  let text = self.tokenizer.decodeToken(nextToken),
-                                  !self.tokenizer.isSpecialToken(nextToken) {
-                            continuation.yield(text)
+                        } else if !inThinking, !self.tokenizer.isSpecialToken(nextToken) {
+                            producedContent = true
+                            pending.append(contentsOf: self.tokenizer.tokenBytes(nextToken))
+                            let (text, remainder) = ChatTokenizer.decodeUTF8Prefix(pending)
+                            pending = remainder
+                            if !text.isEmpty { continuation.yield(text) }
                         }
 
                         let tokenArr = MLXArray([Int32(nextToken)])
@@ -346,6 +361,11 @@ public final class Qwen35MLXChat: @unchecked Sendable {
                         logits = self.extractLastPositionLogits(stepLogits)
                     }
 
+                    // Flush any trailing incomplete bytes (lossy — replacement char if invalid).
+                    if !pending.isEmpty {
+                        continuation.yield(String(decoding: pending, as: UTF8.self))
+                    }
+
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -355,6 +375,18 @@ public final class Qwen35MLXChat: @unchecked Sendable {
     }
 
     // MARK: - Helpers
+
+    /// Forbid the end-of-turn tokens by driving their logits to -inf. Used to stop a small
+    /// model from ending a turn before it has produced any visible content (empty replies).
+    private func suppressEndTokens(_ logits: inout [Float]) {
+        let ninf = -Float.greatestFiniteMagnitude
+        if config.eosTokenId >= 0, config.eosTokenId < logits.count {
+            logits[config.eosTokenId] = ninf
+        }
+        if ChatTemplate.imEndId >= 0, ChatTemplate.imEndId < logits.count {
+            logits[ChatTemplate.imEndId] = ninf
+        }
+    }
 
     /// Extract logits for the last sequence position as a Float array.
     private func extractLastPositionLogits(_ logits: MLXArray) -> [Float] {

--- a/Tests/Qwen3ChatTests/ChatTokenizerDecodeTests.swift
+++ b/Tests/Qwen3ChatTests/ChatTokenizerDecodeTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Qwen3Chat
+
+/// Regression tests for byte-level BPE streaming decode.
+///
+/// Decoding each token's bytes in isolation corrupts any multi-byte UTF-8 character (emoji,
+/// Cyrillic, CJK) that BPE split across token boundaries — the symptom was output like
+/// `todayĠðŁĺĬ` instead of `today 😊`. `decodeUTF8Prefix` fixes this by emitting only complete
+/// characters and carrying incomplete trailing bytes forward to the next token.
+final class ChatTokenizerDecodeTests: XCTestCase {
+
+    func testEmptyBuffer() {
+        let (text, remainder) = ChatTokenizer.decodeUTF8Prefix([])
+        XCTAssertEqual(text, "")
+        XCTAssertTrue(remainder.isEmpty)
+    }
+
+    func testCompleteASCII() {
+        let (text, remainder) = ChatTokenizer.decodeUTF8Prefix(Array("hello".utf8))
+        XCTAssertEqual(text, "hello")
+        XCTAssertTrue(remainder.isEmpty)
+    }
+
+    /// A 4-byte emoji split mid-character must hold back the incomplete tail, not corrupt it.
+    func testSplitEmojiCarriesRemainder() {
+        let emoji = Array("😊".utf8)        // F0 9F 98 8A
+        XCTAssertEqual(emoji.count, 4)
+
+        // First two bytes alone are an incomplete sequence → no text yet, all carried over.
+        let (t1, r1) = ChatTokenizer.decodeUTF8Prefix(Array(emoji.prefix(2)))
+        XCTAssertEqual(t1, "")
+        XCTAssertEqual(r1, Array(emoji.prefix(2)))
+
+        // Completing the sequence yields the emoji and drains the buffer.
+        let (t2, r2) = ChatTokenizer.decodeUTF8Prefix(r1 + Array(emoji.suffix(2)))
+        XCTAssertEqual(t2, "😊")
+        XCTAssertTrue(r2.isEmpty)
+    }
+
+    /// Mixed text + emoji where the emoji is split across the boundary decodes to its prefix
+    /// plus a carried remainder — never the raw byte-level-BPE characters.
+    func testValidPrefixWithIncompleteTail() {
+        let bytes = Array("today ".utf8) + Array("😊".utf8).prefix(1)
+        let (text, remainder) = ChatTokenizer.decodeUTF8Prefix(Array(bytes))
+        XCTAssertEqual(text, "today ")
+        XCTAssertEqual(remainder, Array("😊".utf8).prefix(1).map { $0 })
+    }
+
+    /// Simulate a token-by-token stream of arbitrary byte chunks and assert the reassembled
+    /// text exactly equals the original — covers emoji, Cyrillic, and CJK split anywhere.
+    func testStreamingReassembly() {
+        let samples = [
+            "Hey! How's your day going? 😊✨",
+            "Как дела? Чем занят сегодня?",
+            "今日は何をしていますか？🤖",
+        ]
+        for original in samples {
+            let all = Array(original.utf8)
+            var out = ""
+            var pending: [UInt8] = []
+            // Chunk the bytes irregularly (1..3 bytes) to mimic BPE token boundaries.
+            var i = 0
+            while i < all.count {
+                let n = min((i % 3) + 1, all.count - i)
+                pending.append(contentsOf: all[i..<i + n])
+                let (text, remainder) = ChatTokenizer.decodeUTF8Prefix(pending)
+                out += text
+                pending = remainder
+                i += n
+            }
+            if !pending.isEmpty { out += String(decoding: pending, as: UTF8.self) }
+            XCTAssertEqual(out, original, "streaming reassembly corrupted: \(original)")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Two issues surfaced driving Qwen3.5-0.8B-Chat (MLX int4) through the streaming `PipelineLLM` path:

1. **Mojibake on multi-byte characters.** Byte-level BPE splits a multi-byte UTF-8 character (emoji, Cyrillic, CJK) across token boundaries. `generateStream` decoded each token's bytes in isolation, so any split character failed its per-token UTF-8 decode and fell back to the raw byte-level-BPE characters — e.g. `today 😊` came out as `today Ġð…`.

2. **Occasional empty replies.** A small model sometimes samples the end-of-turn token (`<|im_end|>` / EOS) as the very first token, so the loop breaks before emitting any content and the reply is empty.

## Fix

- **Byte-accurate streaming decode.** `ChatTokenizer.tokenBytes(_:)` exposes a token's raw bytes, and `ChatTokenizer.decodeUTF8Prefix(_:)` decodes the longest valid-UTF-8 prefix of a byte buffer, returning any incomplete trailing bytes (≤3) to carry forward. `generateStream` now accumulates bytes and emits only complete characters, flushing the remainder at the end.
- **No empty turns.** `suppressEndTokens(_:)` drives EOS / `<|im_end|>` logits to -inf until at least one content token has been produced — applied in both `generate()` and `generateStream()`.

## Tests

Adds `ChatTokenizerDecodeTests` (split emoji / Cyrillic / CJK streaming reassembly, incomplete-tail carry, empty/ASCII edge cases). Full `Qwen3ChatTests` suite passes (70/70).