### PR TITLE
ChatterboxTTS: fix from-pretrained dropping model.safetensors

### DIFF
--- a/Sources/ChatterboxTTS/ChatterboxTTSModel.swift
+++ b/Sources/ChatterboxTTS/ChatterboxTTSModel.swift
@@ -206,9 +206,13 @@ public final class ChatterboxTTSModel {
         let fm = FileManager.default
         if !fm.fileExists(atPath: bundleDir.appendingPathComponent("model.safetensors").path) {
             progressHandler?(0.0, "Downloading \(modelId)...")
+            // No `.safetensors` in additionalFiles: that keeps downloadWeights'
+            // automatic `*.safetensors` glob enabled, which fetches the bundle's
+            // model + conformer (+ tokenizer) weights together. Listing a
+            // `.safetensors` here would disable that glob and drop model.safetensors.
             try await HuggingFaceDownloader.downloadWeights(
                 modelId: modelId, to: bundleDir,
-                additionalFiles: ["config.json", "tokenizer.json", "conformer.safetensors"],
+                additionalFiles: ["config.json", "tokenizer.json"],
                 offlineMode: offlineMode
             ) { progressHandler?($0 * 0.7, "Downloading model...") }
         }


### PR DESCRIPTION
## Summary

`ChatterboxTTSModel.fromPretrained(modelId:)` failed at load with `missingFile(model.safetensors)` — the weights were never downloaded.

`HuggingFaceDownloader.downloadWeights` treats any `.safetensors` entry in `additionalFiles` as the *complete* explicit weights list and, when present, skips its automatic `*.safetensors` glob. A recent change added `conformer.safetensors` to `additionalFiles`, which tripped that flag and dropped `model.safetensors` (and `s3_tokenizer.safetensors`) from the download — only `config.json`, `tokenizer.json`, and `conformer.safetensors` landed.

## Fix

Remove `conformer.safetensors` from `additionalFiles`. The `*.safetensors` glob already fetches every safetensors file in the bundle (model + conformer + tokenizer), and the local-dir loader picks up the bundled `conformer.safetensors` as before.

## Test plan

- Drove the speech-studio sidecar's `synthesize_chatterbox` against this build: the download now fetches `model.safetensors`, the model loads, and `clone()` returns non-silent 2.34 s audio (peak RAM ~3.5 GB). The download path was previously never exercised (tests use the local-dir loader).