### PR TITLE
Add Gemma 4 and dense Qwen3 chat backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — On-device flow-matching TTS (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 languages, 10 voices, G2P-free, 44.1 kHz)
 - **[Chatterbox TTS](https://huggingface.co/aufklarer/Chatterbox-Multilingual-MLX-fp16)** — Multilingual TTS with zero-shot voice cloning (Resemble AI Chatterbox Multilingual, MLX fp16 ~1.3 GB, 23 languages, MIT)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — Non-autoregressive diffusion TTS with zero-shot voice cloning (k2-fsa OmniVoice, Qwen3 backbone, MLX int8 ~1 GB / fp16, 600+ languages, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — On-device LLM chat (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybrid, streaming tokens)
+- **[Qwen3Chat](https://soniqo.audio/guides/chat)** — On-device LLM chat (Qwen3.5-0.8B MLX/CoreML plus dense Qwen3 4B and Gemma 4 E2B/E4B MLX backends, streaming tokens)
 - **[FunctionGemma](https://soniqo.audio/guides/function-calls)** — On-device LLM for structured function / tool calls (Gemma 3 270M, CoreML 8-bit palettized, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/guides/translate)** — Many-to-many translation across 400+ languages (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Streaming speech-to-speech translation (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi stack, CC-BY-4.0)
@@ -144,7 +144,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 | [Magpie-TTS Multilingual](https://soniqo.audio/guides/magpie) | Text → Speech (5 baked speakers, streaming) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML excludes JA) |
 | [Chatterbox Multilingual](https://huggingface.co/aufklarer/Chatterbox-Multilingual-MLX-fp16) | Text → Speech (zero-shot cloning) | MLX | 0.8B (fp16) | 23 |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | Text → Speech (NAR diffusion, zero-shot cloning) | MLX | 0.8B (int8/fp16) | **600+** |
-| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Text → Text (LLM) | MLX, CoreML | 0.8B | Multi |
+| [Qwen3Chat](https://soniqo.audio/guides/chat) | Text → Text (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Multi |
 | [FunctionGemma](https://soniqo.audio/guides/function-calls) | Text → Tool calls (LLM) | CoreML | 270M | EN-tuned |
 | [MADLAD-400](https://soniqo.audio/guides/translate) | Text → Text (Translation) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Speech → Speech (Translation) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -310,6 +310,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Translation — [full guide →](https://soniqo.audio/guides/translate)

--- a/README_ar.md
+++ b/README_ar.md
@@ -47,7 +47,7 @@
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — تحويل النص إلى كلام على الجهاز بمطابقة التدفق (Supertone Supertonic-3 99M، CoreML/Neural Engine، 31 لغة، 10 أصوات، بدون G2P، 44.1 كيلوهرتز)
 - **[Chatterbox TTS](https://huggingface.co/aufklarer/Chatterbox-Multilingual-MLX-fp16)** — تحويل النص إلى كلام متعدد اللغات مع استنساخ الصوت بدون تدريب مسبق (Resemble AI Chatterbox Multilingual، MLX fp16 ~1.3 غيغابايت، 23 لغة، MIT)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — تحويل النص إلى كلام بالانتشار غير الانحداري التلقائي مع استنساخ الصوت بدون تدريب مسبق (k2-fsa OmniVoice، عمود Qwen3 الفقري، MLX int8 ~1 GB / fp16، أكثر من 600 لغة، Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/ar/guides/chat)** — محادثة LLM على الجهاز (0.8B، MLX INT4 + CoreML INT8، DeltaNet هجين، رموز تدفقية)
+- **[Qwen3Chat](https://soniqo.audio/ar/guides/chat)** — محادثة LLM على الجهاز (Qwen3.5-0.8B عبر MLX/CoreML، إضافة إلى خلفيات MLX لـ Qwen3 dense بحجم 4B و Gemma 4 E2B/E4B، رموز تدفقية)
 - **[FunctionGemma](https://soniqo.audio/ar/guides/function-calls)** — نموذج لغوي على الجهاز للاستدعاءات المنظمة للدوال / الأدوات (Gemma 3 270M، CoreML بترميز 8-بت، Neural Engine، حوالي 252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/ar/guides/translate)** — ترجمة متعددة الاتجاهات عبر أكثر من 400 لغة (3B، MLX INT4 + INT8، T5 v1.1، Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — ترجمة تدفقية من كلام إلى كلام (FR/ES/PT/DE → EN، MLX INT4 + INT8، حزمة Kyutai Moshi/Mimi، CC-BY-4.0)
@@ -188,7 +188,7 @@ struct DictateView: View {
 | [VibeVoice Realtime-0.5B](https://soniqo.audio/ar/guides/vibevoice) | نص → كلام (نص طويل، متعدد المتحدثين) | MLX | 0.5B | EN/ZH |
 | [VibeVoice 1.5B](https://soniqo.audio/ar/guides/vibevoice) | نص → كلام (بودكاست حتى 90 دقيقة) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/ar/guides/magpie) | نص → كلام (5 متحدثين جاهزين، تدفق) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML يستثني JA) |
-| [Qwen3.5-Chat](https://soniqo.audio/ar/guides/chat) | نص → نص (LLM) | MLX, CoreML | 0.8B | متعدد |
+| [Qwen3Chat](https://soniqo.audio/ar/guides/chat) | نص → نص (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | متعدد |
 | [FunctionGemma](https://soniqo.audio/ar/guides/function-calls) | نص → استدعاءات الأدوات (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/ar/guides/translate) | نص → نص (ترجمة) | MLX | 3B | **أكثر من 400** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | كلام → كلام (ترجمة) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -394,6 +394,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### الترجمة — [الدليل الكامل →](https://soniqo.audio/ar/guides/translate)

--- a/README_de.md
+++ b/README_de.md
@@ -37,7 +37,7 @@ Spracherkennung, -synthese und -verständnis auf dem Gerät für Mac und iOS. L�
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — Flow-Matching-TTS auf dem Gerät (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 Sprachen, 10 Stimmen, G2P-frei, 44,1 kHz)
 - **[Chatterbox TTS](https://huggingface.co/aufklarer/Chatterbox-Multilingual-MLX-fp16)** — Mehrsprachiges TTS mit Zero-Shot-Stimmklonen (Resemble AI Chatterbox Multilingual, MLX fp16 ~1,3 GB, 23 Sprachen, MIT)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — Nicht-autoregressives Diffusions-TTS mit Zero-Shot-Stimmklonen (k2-fsa OmniVoice, Qwen3-Backbone, MLX int8 ~1 GB / fp16, 600+ Sprachen, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/de/guides/chat)** — LLM-Chat auf dem Gerät (0.8B, MLX INT4 + CoreML INT8, DeltaNet-Hybrid, Token-Streaming)
+- **[Qwen3Chat](https://soniqo.audio/de/guides/chat)** — LLM-Chat auf dem Gerät (Qwen3.5-0.8B mit MLX/CoreML plus dense Qwen3-4B- und Gemma-4-E2B/E4B-MLX-Backends, Token-Streaming)
 - **[FunctionGemma](https://soniqo.audio/de/guides/function-calls)** — On-Device-LLM für strukturierte Funktions- / Tool-Aufrufe (Gemma 3 270M, CoreML 8-Bit-Palettierung, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/de/guides/translate)** — Mehrsprachige Übersetzung über 400+ Sprachen (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Streaming-Sprache-zu-Sprache-Übersetzung (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi-Stack, CC-BY-4.0)
@@ -144,7 +144,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 | [VibeVoice Realtime-0.5B](https://soniqo.audio/de/guides/vibevoice) | Text → Sprache (Langform, Multi-Speaker) | MLX | 0.5B | EN/ZH |
 | [VibeVoice 1.5B](https://soniqo.audio/de/guides/vibevoice) | Text → Sprache (bis zu 90 Min. Podcast) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/de/guides/magpie) | Text → Sprache (5 vordefinierte Sprecher, Streaming) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML ohne JA) |
-| [Qwen3.5-Chat](https://soniqo.audio/de/guides/chat) | Text → Text (LLM) | MLX, CoreML | 0.8B | Multi |
+| [Qwen3Chat](https://soniqo.audio/de/guides/chat) | Text → Text (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Multi |
 | [FunctionGemma](https://soniqo.audio/de/guides/function-calls) | Text → Tool-Aufrufe (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/de/guides/translate) | Text → Text (Übersetzung) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Sprache → Sprache (Übersetzung) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -312,6 +312,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Übersetzung — [vollständige Anleitung →](https://soniqo.audio/de/guides/translate)

--- a/README_es.md
+++ b/README_es.md
@@ -37,7 +37,7 @@ Reconocimiento, síntesis y comprensión de voz en el dispositivo para Mac e iOS
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — TTS de flow-matching en el dispositivo (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 idiomas, 10 voces, sin G2P, 44.1 kHz)
 - **[Chatterbox TTS](https://huggingface.co/aufklarer/Chatterbox-Multilingual-MLX-fp16)** — TTS multilingüe con clonación de voz zero-shot (Resemble AI Chatterbox Multilingual, MLX fp16 ~1,3 GB, 23 idiomas, MIT)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — TTS de difusión no autorregresivo con clonación de voz zero-shot (k2-fsa OmniVoice, backbone Qwen3, MLX int8 ~1 GB / fp16, 600+ idiomas, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/es/guides/chat)** — Chat LLM en el dispositivo (0.8B, MLX INT4 + CoreML INT8, DeltaNet híbrido, tokens en streaming)
+- **[Qwen3Chat](https://soniqo.audio/es/guides/chat)** — Chat LLM en el dispositivo (Qwen3.5-0.8B con MLX/CoreML, más backends MLX dense Qwen3 4B y Gemma 4 E2B/E4B, tokens en streaming)
 - **[FunctionGemma](https://soniqo.audio/es/guides/function-calls)** — LLM en el dispositivo para llamadas estructuradas a funciones / herramientas (Gemma 3 270M, CoreML paletizado de 8 bits, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/es/guides/translate)** — Traducción multidireccional entre 400+ idiomas (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Traducción voz a voz en streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, pila Kyutai Moshi/Mimi, CC-BY-4.0)
@@ -144,7 +144,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 | [VibeVoice Realtime-0.5B](https://soniqo.audio/es/guides/vibevoice) | Texto → Voz (formato largo, múltiples hablantes) | MLX | 0.5B | EN/ZH |
 | [VibeVoice 1.5B](https://soniqo.audio/es/guides/vibevoice) | Texto → Voz (podcast de hasta 90 min) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/es/guides/magpie) | Texto → Voz (5 hablantes preconfigurados, streaming) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML excluye JA) |
-| [Qwen3.5-Chat](https://soniqo.audio/es/guides/chat) | Texto → Texto (LLM) | MLX, CoreML | 0.8B | Multi |
+| [Qwen3Chat](https://soniqo.audio/es/guides/chat) | Texto → Texto (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Multi |
 | [FunctionGemma](https://soniqo.audio/es/guides/function-calls) | Texto → Llamadas a herramientas (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/es/guides/translate) | Texto → Texto (Traducción) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Voz → Voz (Traducción) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -312,6 +312,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Traducción — [guía completa →](https://soniqo.audio/es/guides/translate)

--- a/README_fr.md
+++ b/README_fr.md
@@ -37,7 +37,7 @@ Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'e
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — TTS embarque par appariement de flux (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 langues, 10 voix, sans G2P, 44.1 kHz)
 - **[Chatterbox TTS](https://huggingface.co/aufklarer/Chatterbox-Multilingual-MLX-fp16)** — TTS multilingue avec clonage vocal zero-shot (Resemble AI Chatterbox Multilingual, MLX fp16 ~1,3 Go, 23 langues, MIT)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — TTS à diffusion non autorégressive avec clonage vocal zero-shot (k2-fsa OmniVoice, backbone Qwen3, MLX int8 ~1 Go / fp16, 600+ langues, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/fr/guides/chat)** -- Chat LLM embarque (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybride, tokens en streaming)
+- **[Qwen3Chat](https://soniqo.audio/fr/guides/chat)** -- Chat LLM embarque (Qwen3.5-0.8B MLX/CoreML plus backends MLX Qwen3 dense 4B et Gemma 4 E2B/E4B, tokens en streaming)
 - **[FunctionGemma](https://soniqo.audio/fr/guides/function-calls)** — LLM embarque pour les appels structures de fonctions / outils (Gemma 3 270M, CoreML palettisation 8 bits, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/fr/guides/translate)** — Traduction multidirectionnelle entre 400+ langues (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Traduction parole-a-parole en streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, pile Kyutai Moshi/Mimi, CC-BY-4.0)
@@ -144,7 +144,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 | [VibeVoice Realtime-0.5B](https://soniqo.audio/fr/guides/vibevoice) | Texte → Parole (long format, multi-locuteurs) | MLX | 0.5B | EN/ZH |
 | [VibeVoice 1.5B](https://soniqo.audio/fr/guides/vibevoice) | Texte → Parole (podcast jusqu'a 90 min) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/fr/guides/magpie) | Texte → Voix (5 voix prédéfinies, streaming) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML sans JA) |
-| [Qwen3.5-Chat](https://soniqo.audio/fr/guides/chat) | Texte → Texte (LLM) | MLX, CoreML | 0.8B | Multi |
+| [Qwen3Chat](https://soniqo.audio/fr/guides/chat) | Texte → Texte (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Multi |
 | [FunctionGemma](https://soniqo.audio/fr/guides/function-calls) | Texte → Appels d'outils (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/fr/guides/translate) | Texte → Texte (Traduction) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Parole → Parole (Traduction) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -312,6 +312,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Traduction — [guide complet →](https://soniqo.audio/fr/guides/translate)

--- a/README_hi.md
+++ b/README_hi.md
@@ -37,7 +37,7 @@ Mac और iOS के लिए ऑन-डिवाइस स्पीच रि
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — ऑन-डिवाइस फ़्लो-मैचिंग TTS (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 भाषाएँ, 10 वॉयस, G2P-free, 44.1 kHz)
 - **[Chatterbox TTS](https://huggingface.co/aufklarer/Chatterbox-Multilingual-MLX-fp16)** — ज़ीरो-शॉट वॉयस क्लोनिंग के साथ बहुभाषी TTS (Resemble AI Chatterbox Multilingual, MLX fp16 ~1.3 GB, 23 भाषाएँ, MIT)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — ज़ीरो-शॉट वॉयस क्लोनिंग के साथ नॉन-ऑटोरिग्रेसिव डिफ्यूज़न TTS (k2-fsa OmniVoice, Qwen3 बैकबोन, MLX int8 ~1 GB / fp16, 600+ भाषाएँ, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/hi/guides/chat)** — ऑन-डिवाइस LLM चैट (0.8B, MLX INT4 + CoreML INT8, DeltaNet हाइब्रिड, स्ट्रीमिंग टोकन)
+- **[Qwen3Chat](https://soniqo.audio/hi/guides/chat)** — ऑन-डिवाइस LLM चैट (Qwen3.5-0.8B MLX/CoreML के साथ dense Qwen3 4B और Gemma 4 E2B/E4B MLX बैकएंड, स्ट्रीमिंग टोकन)
 - **[FunctionGemma](https://soniqo.audio/hi/guides/function-calls)** — संरचित फ़ंक्शन / टूल कॉल के लिए ऑन-डिवाइस LLM (Gemma 3 270M, CoreML 8-बिट पैलेटाइज़, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/hi/guides/translate)** — 400+ भाषाओं में बहु-दिशात्मक अनुवाद (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — स्ट्रीमिंग स्पीच-टू-स्पीच अनुवाद (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi स्टैक, CC-BY-4.0)
@@ -144,7 +144,7 @@ struct DictateView: View {
 | [VibeVoice Realtime-0.5B](https://soniqo.audio/hi/guides/vibevoice) | टेक्स्ट → स्पीच (लंबे-रूप, बहु-वक्ता) | MLX | 0.5B | EN/ZH |
 | [VibeVoice 1.5B](https://soniqo.audio/hi/guides/vibevoice) | टेक्स्ट → स्पीच (90 मिनट तक पॉडकास्ट) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/hi/guides/magpie) | टेक्स्ट → वाक् (5 पूर्व-निर्धारित वक्ता, स्ट्रीमिंग) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML में JA नहीं) |
-| [Qwen3.5-Chat](https://soniqo.audio/hi/guides/chat) | टेक्स्ट → टेक्स्ट (LLM) | MLX, CoreML | 0.8B | बहुभाषी |
+| [Qwen3Chat](https://soniqo.audio/hi/guides/chat) | टेक्स्ट → टेक्स्ट (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | बहुभाषी |
 | [FunctionGemma](https://soniqo.audio/hi/guides/function-calls) | टेक्स्ट → टूल कॉल (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/hi/guides/translate) | टेक्स्ट → टेक्स्ट (अनुवाद) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | स्पीच → स्पीच (अनुवाद) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -312,6 +312,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### अनुवाद — [पूरी गाइड →](https://soniqo.audio/hi/guides/translate)

--- a/README_ja.md
+++ b/README_ja.md
@@ -36,7 +36,7 @@ Mac・iOS向けのオンデバイス音声認識・合成・理解。Apple Silic
 - **[Magpie TTS](https://soniqo.audio/ja/guides/magpie)** — 多言語 TTS（NVIDIA Magpie-TTS Multilingual 357M、MLX INT8 411 MB または CoreML INT8 342 MB、9 言語、5 つの組み込みスピーカー、MLX でストリーミング）
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — オンデバイスのフローマッチングTTS（Supertone Supertonic-3 99M、CoreML/Neural Engine、31言語、10ボイス、G2P-free、44.1 kHz）
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — ゼロショット音声クローンに対応した非自己回帰拡散TTS（k2-fsa OmniVoice、Qwen3バックボーン、MLX int8 ~1 GB / fp16、600+言語、Apache-2.0）
-- **[Qwen3.5-Chat](https://soniqo.audio/ja/guides/chat)** — オンデバイスLLMチャット（0.8B、MLX INT4 + CoreML INT8、DeltaNetハイブリッド、ストリーミングトークン）
+- **[Qwen3Chat](https://soniqo.audio/ja/guides/chat)** — オンデバイスLLMチャット（Qwen3.5-0.8BのMLX/CoreMLに加え、dense Qwen3 4BとGemma 4 E2B/E4BのMLXバックエンド、ストリーミングトークン）
 - **[FunctionGemma](https://soniqo.audio/ja/guides/function-calls)** — オンデバイスの構造化された関数 / ツール呼び出し用 LLM（Gemma 3 270M、CoreML 8-bit パレタイズ、Neural Engine、約 252 tok/s）
 - **[MADLAD-400](https://soniqo.audio/ja/guides/translate)** — 400+言語間の多対多翻訳（3B、MLX INT4 + INT8、T5 v1.1、Apache 2.0）
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — ストリーミング音声間翻訳（FR/ES/PT/DE → EN、MLX INT4 + INT8、Kyutai Moshi/Mimi スタック、CC-BY-4.0）
@@ -142,7 +142,7 @@ struct DictateView: View {
 | [VibeVoice 1.5B](https://soniqo.audio/ja/guides/vibevoice) | テキスト → 音声（最長90分のポッドキャスト） | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/ja/guides/magpie) | テキスト → 音声（5 つの組み込みスピーカー、ストリーミング） | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9（CoreML は日本語を除く） |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | テキスト → 音声（NAR 拡散、ゼロショットクローン） | MLX | 0.8B (int8/fp16) | **600+** |
-| [Qwen3.5-Chat](https://soniqo.audio/ja/guides/chat) | テキスト → テキスト（LLM） | MLX、CoreML | 0.8B | 多言語 |
+| [Qwen3Chat](https://soniqo.audio/ja/guides/chat) | テキスト → テキスト（LLM） | MLX、CoreML | 0.8B, 4B, E2B/E4B | 多言語 |
 | [FunctionGemma](https://soniqo.audio/ja/guides/function-calls) | テキスト → ツール呼び出し（LLM） | CoreML | 270M | 英語主体 |
 | [MADLAD-400](https://soniqo.audio/ja/guides/translate) | テキスト → テキスト（翻訳） | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | 音声 → 音声（翻訳） | MLX | 3B | FR/ES/PT/DE → EN |
@@ -310,6 +310,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### 翻訳 — [完全ガイド →](https://soniqo.audio/ja/guides/translate)

--- a/README_ko.md
+++ b/README_ko.md
@@ -36,7 +36,7 @@ Mac과 iOS를 위한 온디바이스 음성 인식, 합성 및 이해. Apple Sil
 - **[Magpie TTS](https://soniqo.audio/ko/guides/magpie)** — 다국어 TTS (NVIDIA Magpie-TTS Multilingual 357M, MLX INT8 411 MB 또는 CoreML INT8 342 MB, 9개 언어, 5개 내장 스피커, MLX 스트리밍)
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — 온디바이스 flow-matching TTS (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31개 언어, 10개 음색, G2P-free, 44.1 kHz)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — 제로샷 음성 복제를 지원하는 비자기회귀 확산 TTS (k2-fsa OmniVoice, Qwen3 백본, MLX int8 ~1 GB / fp16, 600+개 언어, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/ko/guides/chat)** — 온디바이스 LLM 채팅 (0.8B, MLX INT4 + CoreML INT8, DeltaNet 하이브리드, 스트리밍 토큰)
+- **[Qwen3Chat](https://soniqo.audio/ko/guides/chat)** — 온디바이스 LLM 채팅 (Qwen3.5-0.8B MLX/CoreML에 dense Qwen3 4B 및 Gemma 4 E2B/E4B MLX 백엔드 추가, 스트리밍 토큰)
 - **[FunctionGemma](https://soniqo.audio/ko/guides/function-calls)** — 온디바이스 구조화된 함수 / 도구 호출 LLM (Gemma 3 270M, CoreML 8비트 팔레타이즈, Neural Engine, 약 252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/ko/guides/translate)** — 400+ 언어 간 다대다 번역 (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — 스트리밍 음성-음성 번역 (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi 스택, CC-BY-4.0)
@@ -142,7 +142,7 @@ struct DictateView: View {
 | [VibeVoice 1.5B](https://soniqo.audio/ko/guides/vibevoice) | 텍스트 → 음성 (최대 90분 팟캐스트) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/ko/guides/magpie) | 텍스트 → 음성 (5개 내장 스피커, 스트리밍) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML은 일본어 제외) |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | 텍스트 → 음성 (NAR 확산, 제로샷 복제) | MLX | 0.8B (int8/fp16) | **600+** |
-| [Qwen3.5-Chat](https://soniqo.audio/ko/guides/chat) | 텍스트 → 텍스트 (LLM) | MLX, CoreML | 0.8B | 다언어 |
+| [Qwen3Chat](https://soniqo.audio/ko/guides/chat) | 텍스트 → 텍스트 (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | 다언어 |
 | [FunctionGemma](https://soniqo.audio/ko/guides/function-calls) | 텍스트 → 도구 호출 (LLM) | CoreML | 270M | 영어 위주 |
 | [MADLAD-400](https://soniqo.audio/ko/guides/translate) | 텍스트 → 텍스트 (번역) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | 음성 → 음성 (번역) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -310,6 +310,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### 번역 — [전체 가이드 →](https://soniqo.audio/ko/guides/translate)

--- a/README_pt.md
+++ b/README_pt.md
@@ -36,7 +36,7 @@ Reconhecimento, sintese e compreensao de fala no dispositivo para Mac e iOS. Exe
 - **[Magpie TTS](https://soniqo.audio/pt/guides/magpie)** — TTS multilíngue (NVIDIA Magpie-TTS Multilingual 357M, MLX INT8 411 MB ou CoreML INT8 342 MB, 9 idiomas, 5 oradores predefinidos, streaming em MLX)
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — TTS de flow-matching no dispositivo (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 idiomas, 10 vozes, sem G2P, 44.1 kHz)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — TTS de difusao nao-autorregressiva com clonagem de voz zero-shot (k2-fsa OmniVoice, backbone Qwen3, MLX int8 ~1 GB / fp16, 600+ idiomas, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/pt/guides/chat)** — Chat LLM no dispositivo (0.8B, MLX INT4 + CoreML INT8, DeltaNet hibrido, tokens em streaming)
+- **[Qwen3Chat](https://soniqo.audio/pt/guides/chat)** — Chat LLM no dispositivo (Qwen3.5-0.8B MLX/CoreML mais backends MLX dense Qwen3 4B e Gemma 4 E2B/E4B, tokens em streaming)
 - **[FunctionGemma](https://soniqo.audio/pt/guides/function-calls)** — LLM no dispositivo para chamadas estruturadas de funcoes / ferramentas (Gemma 3 270M, CoreML paletizado de 8 bits, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/pt/guides/translate)** — Tradução multidirecional entre 400+ idiomas (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Tradução de fala para fala em streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, stack Kyutai Moshi/Mimi, CC-BY-4.0)
@@ -142,7 +142,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 | [VibeVoice 1.5B](https://soniqo.audio/pt/guides/vibevoice) | Texto → Fala (podcast de ate 90 min) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/pt/guides/magpie) | Texto → Fala (5 oradores predefinidos, streaming) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML exclui JA) |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | Texto → Fala (difusao NAR, clonagem zero-shot) | MLX | 0.8B (int8/fp16) | 600+ |
-| [Qwen3.5-Chat](https://soniqo.audio/pt/guides/chat) | Texto → Texto (LLM) | MLX, CoreML | 0.8B | Multi |
+| [Qwen3Chat](https://soniqo.audio/pt/guides/chat) | Texto → Texto (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Multi |
 | [FunctionGemma](https://soniqo.audio/pt/guides/function-calls) | Texto → Chamadas de ferramentas (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/pt/guides/translate) | Texto → Texto (Tradução) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Fala → Fala (Tradução) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -310,6 +310,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Tradução — [guia completo →](https://soniqo.audio/pt/guides/translate)

--- a/README_ru.md
+++ b/README_ru.md
@@ -36,7 +36,7 @@
 - **[Magpie TTS](https://soniqo.audio/ru/guides/magpie)** — Многоязычный TTS (NVIDIA Magpie-TTS Multilingual 357M, MLX INT8 411 МБ или CoreML INT8 342 МБ, 9 языков, 5 встроенных голосов, стриминг на MLX)
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — Синтез речи на устройстве на основе flow-matching (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 язык, 10 голосов, G2P-free, 44.1 кГц)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — Неавторегрессионный диффузионный TTS с zero-shot клонированием голоса (k2-fsa OmniVoice, бэкбон Qwen3, MLX int8 ~1 ГБ / fp16, 600+ языков, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/ru/guides/chat)** — Локальный чат на базе LLM (0.8B, MLX INT4 + CoreML INT8, гибрид DeltaNet, потоковая генерация токенов)
+- **[Qwen3Chat](https://soniqo.audio/ru/guides/chat)** — Локальный чат на базе LLM (Qwen3.5-0.8B MLX/CoreML плюс MLX-бэкенды dense Qwen3 4B и Gemma 4 E2B/E4B, потоковая генерация токенов)
 - **[FunctionGemma](https://soniqo.audio/ru/guides/function-calls)** — Локальный LLM для структурированных вызовов функций / инструментов (Gemma 3 270M, CoreML 8-битная палитризация, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/ru/guides/translate)** — Многоязычный перевод между 400+ языками (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Потоковый перевод речи в речь (FR/ES/PT/DE → EN, MLX INT4 + INT8, стек Kyutai Moshi/Mimi, CC-BY-4.0)
@@ -142,7 +142,7 @@ struct DictateView: View {
 | [VibeVoice 1.5B](https://soniqo.audio/ru/guides/vibevoice) | Текст → Речь (подкаст до 90 минут) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/ru/guides/magpie) | Текст → Речь (5 встроенных голосов, стриминг) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML без JA) |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | Текст → Речь (NAR-диффузия, zero-shot клонирование) | MLX | 0.8B (int8/fp16) | **600+** |
-| [Qwen3.5-Chat](https://soniqo.audio/ru/guides/chat) | Текст → Текст (LLM) | MLX, CoreML | 0.8B | Многоязычный |
+| [Qwen3Chat](https://soniqo.audio/ru/guides/chat) | Текст → Текст (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Многоязычный |
 | [FunctionGemma](https://soniqo.audio/ru/guides/function-calls) | Текст → Вызовы инструментов (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/ru/guides/translate) | Текст → Текст (Перевод) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Речь → Речь (Перевод) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -310,6 +310,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Перевод — [полное руководство →](https://soniqo.audio/ru/guides/translate)

--- a/README_th.md
+++ b/README_th.md
@@ -36,7 +36,7 @@
 - **[Magpie TTS](https://soniqo.audio/guides/magpie)** — TTS หลายภาษา (NVIDIA Magpie-TTS Multilingual 357M, MLX INT8 411 MB หรือ CoreML INT8 342 MB, 9 ภาษา, 5 ผู้พูดสำเร็จรูป สตรีมมิ่งบน MLX)
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — TTS แบบ flow-matching บนอุปกรณ์ (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 ภาษา, 10 เสียง, G2P-free, 44.1 kHz)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — TTS แบบ diffusion non-autoregressive พร้อมการโคลนเสียงแบบ zero-shot (k2-fsa OmniVoice, backbone Qwen3, MLX int8 ~1 GB / fp16, 600+ ภาษา, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — แชท LLM บนอุปกรณ์ (0.8B, MLX INT4 + CoreML INT8, DeltaNet ไฮบริด สตรีมมิ่งโทเค็น)
+- **[Qwen3Chat](https://soniqo.audio/guides/chat)** — แชท LLM บนอุปกรณ์ (Qwen3.5-0.8B MLX/CoreML พร้อมแบ็กเอนด์ MLX ของ dense Qwen3 4B และ Gemma 4 E2B/E4B, สตรีมมิ่งโทเค็น)
 - **[FunctionGemma](https://soniqo.audio/guides/function-calls)** — LLM บนอุปกรณ์สำหรับการเรียกฟังก์ชัน / เครื่องมือแบบมีโครงสร้าง (Gemma 3 270M, CoreML 8-bit palettize, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/guides/translate)** — การแปลแบบหลายต่อหลายระหว่างกว่า 400 ภาษา (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — การแปลเสียงพูดสู่เสียงพูดแบบสตรีมมิ่ง (FR/ES/PT/DE → EN, MLX INT4 + INT8, สแต็ก Kyutai Moshi/Mimi, CC-BY-4.0)
@@ -142,7 +142,7 @@ struct DictateView: View {
 | [VibeVoice 1.5B](https://soniqo.audio/guides/vibevoice) | ข้อความ → เสียงพูด (พอดแคสต์ยาวสุด 90 นาที) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/guides/magpie) | ข้อความ → เสียงพูด (5 ผู้พูดสำเร็จรูป สตรีมมิ่ง) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML ไม่รวม JA) |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | ข้อความ → เสียงพูด (diffusion NAR, การโคลนแบบ zero-shot) | MLX | 0.8B (int8/fp16) | 600+ |
-| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | ข้อความ → ข้อความ (LLM) | MLX, CoreML | 0.8B | หลายภาษา |
+| [Qwen3Chat](https://soniqo.audio/guides/chat) | ข้อความ → ข้อความ (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | หลายภาษา |
 | [FunctionGemma](https://soniqo.audio/guides/function-calls) | ข้อความ → การเรียกเครื่องมือ (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/guides/translate) | ข้อความ → ข้อความ (การแปล) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | เสียงพูด → เสียงพูด (การแปล) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -308,6 +308,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### การแปล — [คู่มือฉบับเต็ม →](https://soniqo.audio/guides/translate)

--- a/README_tr.md
+++ b/README_tr.md
@@ -36,7 +36,7 @@ Mac ve iOS için cihaz üzerinde konuşma tanıma, sentezleme ve anlama. Apple S
 - **[Magpie TTS](https://soniqo.audio/guides/magpie)** — Çok dilli TTS (NVIDIA Magpie-TTS Multilingual 357M, MLX INT8 411 MB veya CoreML INT8 342 MB, 9 dil, 5 hazır konuşmacı, MLX'te akış)
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — Cihaz üzerinde flow-matching TTS (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 dil, 10 ses, G2P-free, 44.1 kHz)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — Zero-shot ses klonlama ile otoregresif olmayan difüzyon TTS (k2-fsa OmniVoice, Qwen3 omurgası, MLX int8 ~1 GB / fp16, 600+ dil, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — Cihaz üzerinde LLM sohbet (0.8B, MLX INT4 + CoreML INT8, DeltaNet hibrit, akış token'ları)
+- **[Qwen3Chat](https://soniqo.audio/guides/chat)** — Cihaz üzerinde LLM sohbet (Qwen3.5-0.8B MLX/CoreML artı dense Qwen3 4B ve Gemma 4 E2B/E4B MLX arka uçları, akış token'ları)
 - **[FunctionGemma](https://soniqo.audio/guides/function-calls)** — Cihaz üzerinde yapılandırılmış fonksiyon / araç çağrıları için LLM (Gemma 3 270M, CoreML 8-bit paletleme, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/guides/translate)** — 400+ dil arasında çoktan-çoğa çeviri (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Akışlı konuşmadan konuşmaya çeviri (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi yığını, CC-BY-4.0)
@@ -142,7 +142,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 | [VibeVoice 1.5B](https://soniqo.audio/guides/vibevoice) | Metin → Konuşma (90 dakikaya kadar podcast) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/guides/magpie) | Metin → Konuşma (5 hazır konuşmacı, akış) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML, JA hariç) |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | Metin → Konuşma (NAR difüzyon, zero-shot klonlama) | MLX | 0.8B (int8/fp16) | **600+** |
-| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Metin → Metin (LLM) | MLX, CoreML | 0.8B | Çoklu |
+| [Qwen3Chat](https://soniqo.audio/guides/chat) | Metin → Metin (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Çoklu |
 | [FunctionGemma](https://soniqo.audio/guides/function-calls) | Metin → Araç çağrıları (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/guides/translate) | Metin → Metin (Çeviri) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Konuşma → Konuşma (Çeviri) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -308,6 +308,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Çeviri — [tam rehber →](https://soniqo.audio/guides/translate)

--- a/README_vi.md
+++ b/README_vi.md
@@ -36,7 +36,7 @@ Nhận dạng, tổng hợp và hiểu giọng nói trên thiết bị cho Mac v
 - **[Magpie TTS](https://soniqo.audio/guides/magpie)** — TTS đa ngôn ngữ (NVIDIA Magpie-TTS Multilingual 357M, MLX INT8 411 MB hoặc CoreML INT8 342 MB, 9 ngôn ngữ, 5 giọng nói có sẵn, streaming trên MLX)
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — TTS flow-matching trên thiết bị (Supertone Supertonic-3 99M, CoreML/Neural Engine, 31 ngôn ngữ, 10 giọng, không cần G2P, 44,1 kHz)
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — TTS khuếch tán phi tự hồi quy với nhân bản giọng nói zero-shot (k2-fsa OmniVoice, backbone Qwen3, MLX int8 ~1 GB / fp16, 600+ ngôn ngữ, Apache-2.0)
-- **[Qwen3.5-Chat](https://soniqo.audio/guides/chat)** — Chat LLM trên thiết bị (0.8B, MLX INT4 + CoreML INT8, DeltaNet hybrid, token streaming)
+- **[Qwen3Chat](https://soniqo.audio/guides/chat)** — Chat LLM trên thiết bị (Qwen3.5-0.8B MLX/CoreML cùng các backend MLX dense Qwen3 4B và Gemma 4 E2B/E4B, token streaming)
 - **[FunctionGemma](https://soniqo.audio/guides/function-calls)** — LLM trên thiết bị cho các lệnh gọi hàm / công cụ có cấu trúc (Gemma 3 270M, CoreML palette hóa 8-bit, Neural Engine, ~252 tok/s)
 - **[MADLAD-400](https://soniqo.audio/guides/translate)** — Dịch nhiều-sang-nhiều giữa hơn 400 ngôn ngữ (3B, MLX INT4 + INT8, T5 v1.1, Apache 2.0)
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Dịch giọng nói sang giọng nói streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, stack Kyutai Moshi/Mimi, CC-BY-4.0)
@@ -142,7 +142,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 | [VibeVoice 1.5B](https://soniqo.audio/guides/vibevoice) | Văn bản → Giọng nói (podcast đến 90 phút) | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/guides/magpie) | Văn bản → Giọng nói (5 giọng có sẵn, streaming) | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9 (CoreML loại trừ JA) |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | Văn bản → Giọng nói (khuếch tán NAR, nhân bản zero-shot) | MLX | 0.8B (int8/fp16) | **600+** |
-| [Qwen3.5-Chat](https://soniqo.audio/guides/chat) | Văn bản → Văn bản (LLM) | MLX, CoreML | 0.8B | Đa ngôn ngữ |
+| [Qwen3Chat](https://soniqo.audio/guides/chat) | Văn bản → Văn bản (LLM) | MLX, CoreML | 0.8B, 4B, E2B/E4B | Đa ngôn ngữ |
 | [FunctionGemma](https://soniqo.audio/guides/function-calls) | Văn bản → Lệnh gọi công cụ (LLM) | CoreML | 270M | EN |
 | [MADLAD-400](https://soniqo.audio/guides/translate) | Văn bản → Văn bản (Dịch) | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | Giọng nói → Giọng nói (Dịch) | MLX | 3B | FR/ES/PT/DE → EN |
@@ -308,6 +308,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### Dịch — [hướng dẫn đầy đủ →](https://soniqo.audio/guides/translate)

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,7 +36,7 @@
 - **[Magpie TTS](https://soniqo.audio/zh/guides/magpie)** — 多语言 TTS（NVIDIA Magpie-TTS Multilingual 357M，MLX INT8 411 MB 或 CoreML INT8 342 MB，9 种语言，5 位预设说话人，MLX 端流式）
 - **[Supertonic TTS](https://soniqo.audio/guides/supertonic)** — 端侧流匹配 TTS（Supertone Supertonic-3 99M，CoreML/神经引擎，31 种语言，10 种音色，G2P-free，44.1 kHz）
 - **[OmniVoice TTS](https://huggingface.co/aufklarer/OmniVoice-MLX-int8)** — 支持零样本语音克隆的非自回归扩散 TTS（k2-fsa OmniVoice，Qwen3 骨干，MLX int8 ~1 GB / fp16，600+ 种语言，Apache-2.0）
-- **[Qwen3.5-Chat](https://soniqo.audio/zh/guides/chat)** — 端侧 LLM 对话（0.8B，MLX INT4 + CoreML INT8，DeltaNet 混合架构，流式 token）
+- **[Qwen3Chat](https://soniqo.audio/zh/guides/chat)** — 端侧 LLM 对话（Qwen3.5-0.8B MLX/CoreML，加 dense Qwen3 4B 与 Gemma 4 E2B/E4B 的 MLX 后端，流式 token）
 - **[FunctionGemma](https://soniqo.audio/zh/guides/function-calls)** — 端侧结构化函数 / 工具调用 LLM（Gemma 3 270M，CoreML 8 位调色板量化，Neural Engine，约 252 tok/s）
 - **[MADLAD-400](https://soniqo.audio/zh/guides/translate)** — 400+ 语言间的多对多翻译（3B，MLX INT4 + INT8，T5 v1.1，Apache 2.0）
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — 流式语音到语音翻译（FR/ES/PT/DE → EN，MLX INT4 + INT8，Kyutai Moshi/Mimi 技术栈，CC-BY-4.0）
@@ -142,7 +142,7 @@ struct DictateView: View {
 | [VibeVoice 1.5B](https://soniqo.audio/zh/guides/vibevoice) | 文本 → 语音（最长 90 分钟播客） | MLX | 1.5B | EN/ZH |
 | [Magpie-TTS Multilingual](https://soniqo.audio/zh/guides/magpie) | 文本 → 语音（5 位预设说话人，流式） | MLX / CoreML | 357M (MLX INT8, CoreML INT8) | 9（CoreML 不含日语） |
 | [OmniVoice](https://huggingface.co/aufklarer/OmniVoice-MLX-int8) | 文本 → 语音（NAR 扩散，零样本克隆） | MLX | 0.8B (int8/fp16) | **600+** |
-| [Qwen3.5-Chat](https://soniqo.audio/zh/guides/chat) | 文本 → 文本（LLM） | MLX、CoreML | 0.8B | 多语言 |
+| [Qwen3Chat](https://soniqo.audio/zh/guides/chat) | 文本 → 文本（LLM） | MLX、CoreML | 0.8B, 4B, E2B/E4B | 多语言 |
 | [FunctionGemma](https://soniqo.audio/zh/guides/function-calls) | 文本 → 工具调用（LLM） | CoreML | 270M | 主英语 |
 | [MADLAD-400](https://soniqo.audio/zh/guides/translate) | 文本 → 文本（翻译） | MLX | 3B | **400+** |
 | [Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate) | 语音 → 语音（翻译） | MLX | 3B | FR/ES/PT/DE → EN |
@@ -310,6 +310,11 @@ let chat = try await Qwen35MLXChat.fromPretrained()
 chat.chat(messages: [(.user, "Explain MLX in one sentence")]) { token, isFinal in
     print(token, terminator: "")
 }
+
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ### 翻译 — [完整指南 →](https://soniqo.audio/zh/guides/translate)

--- a/Sources/MLXCommon/PreQuantizedEmbedding.swift
+++ b/Sources/MLXCommon/PreQuantizedEmbedding.swift
@@ -19,8 +19,9 @@ public class PreQuantizedEmbedding: Module {
         self.groupSize = groupSize
         self.bits = bits
 
-        // Packed dimensions: 8 values per uint32 for 4-bit
-        let packedDim = dimensions / (32 / bits)
+        // Packed last dim = dimensions * bits / 32 (MLX convention). For 4/8-bit this equals
+        // dimensions/(32/bits); written this way it also supports 3/5/6-bit quantized embeddings.
+        let packedDim = dimensions * bits / 32
         let numGroups = dimensions / groupSize
 
         // Initialize with zeros - will be loaded from weights

--- a/Sources/Qwen3Chat/ChatSampler.swift
+++ b/Sources/Qwen3Chat/ChatSampler.swift
@@ -18,90 +18,112 @@ enum ChatSampler {
         config: ChatSamplingConfig,
         previousTokens: [Int] = []
     ) -> Int {
-        var logits = logits
+        let vocab = logits.count
+        if vocab == 0 { return 0 }
 
-        // Repetition penalty
+        // Repetition penalty — one O(V) copy + O(seen) in-place updates.
+        var scaled = logits
         if config.repetitionPenalty > 1.0 {
-            let seen = Set(previousTokens.suffix(64))
-            for tokenId in seen {
-                if tokenId < logits.count {
-                    if logits[tokenId] > 0 {
-                        logits[tokenId] /= config.repetitionPenalty
-                    } else {
-                        logits[tokenId] *= config.repetitionPenalty
+            let p = config.repetitionPenalty
+            for tokenId in Set(previousTokens.suffix(64)) where tokenId >= 0 && tokenId < vocab {
+                scaled[tokenId] = scaled[tokenId] > 0 ? scaled[tokenId] / p : scaled[tokenId] * p
+            }
+        }
+
+        // Greedy (argmax) when temperature is 0.
+        if config.temperature <= 0 {
+            var best = 0
+            for i in 1..<vocab where scaled[i] > scaled[best] { best = i }
+            return best
+        }
+
+        // Candidate set = top-K indices. A size-K min-heap finds them in O(V*log K), instead of
+        // the previous O(V*log V) full sort of the entire vocab (~248K tokens) — which dominated
+        // generation latency. Top-K by logit equals top-K by softmax probability because softmax is
+        // monotonic, so everything after this operates on just K elements.
+        let k = (config.topK > 0 && config.topK < vocab) ? config.topK : vocab
+        var candidates: [Int]
+        if k >= vocab {
+            candidates = Array(0..<vocab)
+        } else {
+            var heap: [Int] = []
+            heap.reserveCapacity(k)
+            for i in 0..<vocab {
+                if heap.count < k {
+                    heap.append(i)
+                    var child = heap.count - 1
+                    while child > 0 {
+                        let parent = (child - 1) / 2
+                        if scaled[heap[child]] < scaled[heap[parent]] {
+                            heap.swapAt(child, parent)
+                            child = parent
+                        } else {
+                            break
+                        }
+                    }
+                } else if scaled[i] > scaled[heap[0]] {
+                    heap[0] = i
+                    var parent = 0
+                    while true {
+                        let left = 2 * parent + 1
+                        let right = 2 * parent + 2
+                        var smallest = parent
+                        if left < k && scaled[heap[left]] < scaled[heap[smallest]] { smallest = left }
+                        if right < k && scaled[heap[right]] < scaled[heap[smallest]] { smallest = right }
+                        if smallest == parent { break }
+                        heap.swapAt(smallest, parent)
+                        parent = smallest
                     }
                 }
             }
+            candidates = heap
         }
 
-        // Greedy (argmax) when temperature is 0
-        if config.temperature <= 0 {
-            var maxIdx = 0
-            var maxVal = logits[0]
-            for i in 1..<logits.count {
-                if logits[i] > maxVal {
-                    maxVal = logits[i]
-                    maxIdx = i
+        // Softmax over candidates only, with temperature.
+        let temperature = config.temperature
+        var maxLogit = -Float.greatestFiniteMagnitude
+        for i in candidates {
+            let value = scaled[i] / temperature
+            if value > maxLogit { maxLogit = value }
+        }
+
+        var probs = [Float](repeating: 0, count: candidates.count)
+        var sum: Float = 0
+        for (index, tokenId) in candidates.enumerated() {
+            let p = exp(scaled[tokenId] / temperature - maxLogit)
+            probs[index] = p
+            sum += p
+        }
+        if sum > 0 {
+            for i in probs.indices { probs[i] /= sum }
+        }
+
+        // Sort candidates by probability descending for top-P and sampling. K is normally small.
+        var order = Array(0..<candidates.count)
+        order.sort { probs[$0] > probs[$1] }
+
+        // Top-P (nucleus): keep the shortest prefix whose cumulative probability reaches topP.
+        var cutoff = order.count
+        if config.topP < 1.0 {
+            var cumulative: Float = 0
+            for (rank, index) in order.enumerated() {
+                cumulative += probs[index]
+                if cumulative >= config.topP {
+                    cutoff = rank + 1
+                    break
                 }
             }
-            return maxIdx
         }
 
-        // Temperature scaling
-        if config.temperature != 1.0 {
-            for i in 0..<logits.count {
-                logits[i] /= config.temperature
-            }
-        }
-
-        // Softmax
-        let maxLogit = logits.max() ?? 0
-        var probs = logits.map { exp($0 - maxLogit) }
-        let sum = probs.reduce(0, +)
-        probs = probs.map { $0 / sum }
-
-        // Top-K filtering
-        if config.topK > 0 && config.topK < probs.count {
-            let indexed = probs.enumerated().sorted { $0.element > $1.element }
-            let topK = Array(indexed.prefix(config.topK))
-            var filtered = [Float](repeating: 0, count: probs.count)
-            for (idx, prob) in topK {
-                filtered[idx] = prob
-            }
-            let filteredSum = filtered.reduce(0, +)
-            if filteredSum > 0 {
-                probs = filtered.map { $0 / filteredSum }
-            }
-        }
-
-        // Top-P (nucleus) filtering
-        if config.topP < 1.0 {
-            let indexed = probs.enumerated().sorted { $0.element > $1.element }
-            var cumProb: Float = 0
-            var mask = [Bool](repeating: false, count: probs.count)
-            for (idx, prob) in indexed {
-                cumProb += prob
-                mask[idx] = true
-                if cumProb >= config.topP { break }
-            }
-            for i in 0..<probs.count {
-                if !mask[i] { probs[i] = 0 }
-            }
-            let filteredSum = probs.reduce(0, +)
-            if filteredSum > 0 {
-                probs = probs.map { $0 / filteredSum }
-            }
-        }
-
-        // Sample from distribution
-        let r = Float.random(in: 0..<1)
+        // Sample within the kept nucleus, renormalized.
+        var keptSum: Float = 0
+        for rank in 0..<cutoff { keptSum += probs[order[rank]] }
+        let target = Float.random(in: 0..<1) * (keptSum > 0 ? keptSum : 1)
         var cumulative: Float = 0
-        for (i, p) in probs.enumerated() {
-            cumulative += p
-            if cumulative >= r {
-                return i
-            }
+        for rank in 0..<cutoff {
+            cumulative += probs[order[rank]]
+            if cumulative >= target { return candidates[order[rank]] }
         }
-        return probs.count - 1
+        return candidates[order[cutoff - 1]]
     }
 }

--- a/Sources/Qwen3Chat/ChatTokenizer.swift
+++ b/Sources/Qwen3Chat/ChatTokenizer.swift
@@ -126,6 +126,10 @@ public final class ChatTokenizer: @unchecked Sendable {
 
     // MARK: - Encode
 
+    /// Token id for an exact token string (special/added tokens or a vocab entry), or nil.
+    /// Used to build chat templates without hardcoding model-specific special-token IDs.
+    public func tokenId(_ token: String) -> Int? { addedTokens[token] ?? tokenToId[token] }
+
     /// Encode text to token IDs using BPE.
     public func encode(_ text: String) -> [Int] {
         if text.isEmpty { return [] }

--- a/Sources/Qwen3Chat/Gemma4Chat.swift
+++ b/Sources/Qwen3Chat/Gemma4Chat.swift
@@ -1,0 +1,283 @@
+import Foundation
+import MLX
+import AudioCommon
+
+/// Streaming chat backend for the hand-written `Gemma4Model` (Gemma 4 text, E2B/E4B MLX int4).
+///
+/// Mirrors `Qwen35MLXChat`: load tokenizer + config + weights, encode the chat template, prefill,
+/// then decode one token per step against the incremental KV cache. Two Gemma-4 specifics:
+///   • the chat template is the `<|turn>{role}\n…<turn|>\n` form (NOT the older `<start_of_turn>`),
+///     terminated by `<|turn>model\n` for the generation prompt — see `Gemma4ChatTemplate`.
+///   • a reasoning *channel* `<|channel>thought\n…\n<channel|>` is emitted before the answer; for a
+///     voice assistant we suppress it and stream only the post-channel answer text.
+public final class Gemma4Chat: @unchecked Sendable {
+    /// Gemma-4 architecture config (used by the model + parity harness).
+    public let denseConfig: Gemma4DenseConfig
+    let model: Gemma4Model
+    public let gemmaTokenizer: Gemma4Tokenizer
+    /// GPT-2-scheme tokenizer kept only to satisfy `Qwen35ChatBackend.tokenizer`; the generation
+    /// path uses `gemmaTokenizer` (SentencePiece byte-fallback) for correct encode/decode.
+    public let tokenizer: ChatTokenizer
+    var state: Gemma4Model.InferenceState
+    var _isLoaded = true
+
+    private init(config: Gemma4DenseConfig, gemmaTokenizer: Gemma4Tokenizer,
+                 tokenizer: ChatTokenizer, model: Gemma4Model) {
+        self.denseConfig = config
+        self.gemmaTokenizer = gemmaTokenizer
+        self.tokenizer = tokenizer
+        self.model = model
+        self.state = .initial(config: config)
+    }
+
+    // MARK: - Loading
+
+    /// Load from a local MLX model directory (config.json + tokenizer.json + safetensors).
+    public static func fromDirectory(
+        _ directory: URL, progressHandler: ((Double, String) -> Void)? = nil
+    ) throws -> Gemma4Chat {
+        let config = try Gemma4DenseConfig.load(from: directory.appendingPathComponent("config.json"))
+        let gemmaTok = Gemma4Tokenizer()
+        try gemmaTok.load(from: directory)
+        let tok = ChatTokenizer()
+        try? tok.load(from: directory)   // best-effort; only the protocol surface needs it
+        let model = Gemma4Model(config: config)
+        try Gemma4WeightLoader.loadWeights(into: model, from: directory, progressHandler: progressHandler)
+        return Gemma4Chat(config: config, gemmaTokenizer: gemmaTok, tokenizer: tok, model: model)
+    }
+
+    /// Download + load from HuggingFace (e.g. `aufklarer/gemma-4-E4B-it-MLX-4bit`).
+    public static func fromPretrained(
+        modelId: String = "aufklarer/gemma-4-E4B-it-MLX-4bit",
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> Gemma4Chat {
+        let cacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: cacheDir,
+            additionalFiles: [
+                "config.json", "tokenizer.json", "tokenizer_config.json",
+                "generation_config.json", "model.safetensors", "model.safetensors.index.json",
+            ],
+            offlineMode: offlineMode,
+            progressHandler: { progressHandler?($0 * 0.6, "Downloading...") })
+        return try fromDirectory(cacheDir) { p, m in progressHandler?(0.6 + p * 0.4, m) }
+    }
+
+    // MARK: - State
+
+    public func resetState() { state = .initial(config: denseConfig) }
+
+    // MARK: - Generation
+
+    /// Buffered (non-streaming) generation — returns the full thinking-free reply.
+    public func generate(
+        messages: [ChatMessage], sampling: ChatSamplingConfig = .default
+    ) throws -> String {
+        var reply = ""
+        let sem = DispatchSemaphore(value: 0)
+        var err: Error?
+        Task {
+            do { for try await chunk in generateStream(messages: messages, sampling: sampling) { reply += chunk } }
+            catch { err = error }
+            sem.signal()
+        }
+        sem.wait()
+        if let err { throw err }
+        return reply
+    }
+
+    /// Streaming generation. Suppresses the reasoning channel and only yields answer text.
+    public func generateStream(
+        messages: [ChatMessage], sampling: ChatSamplingConfig = .default
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                self.resetState()
+
+                let promptTokens = Gemma4ChatTemplate.encode(
+                    messages: messages, tokenizer: self.gemmaTokenizer)
+
+                // Prefill.
+                let promptArray = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
+                let prefillLogits = self.model.forward(inputIds: promptArray, state: &self.state)
+                eval(prefillLogits)
+                var logits = self.lastLogits(prefillLogits)
+
+                var history = promptTokens
+                var produced = false
+                var filter = Gemma4AnswerFilter(tokenizer: self.gemmaTokenizer)
+
+                for _ in 0..<sampling.maxTokens {
+                    // Don't let the model end the turn before emitting any visible answer.
+                    if !produced { self.suppressEndTokens(&logits) }
+
+                    let next = ChatSampler.sample(
+                        logits: logits, config: sampling, previousTokens: history)
+
+                    if self.gemmaTokenizer.eosTokenIds.contains(next) { break }
+                    history.append(next)
+
+                    let text = filter.consume(next)
+                    if !text.isEmpty { produced = true; continuation.yield(text) }
+
+                    // Decode one step.
+                    let arr = MLXArray([Int32(next)]).expandedDimensions(axis: 0)
+                    let step = self.model.forward(inputIds: arr, state: &self.state)
+                    eval(step)
+                    logits = self.lastLogits(step)
+                }
+
+                if let tail = filter.flush(), !tail.isEmpty { continuation.yield(tail) }
+                continuation.finish()
+            }
+        }
+    }
+
+    // MARK: - Parity harness (unchanged surface used by Gemma4ParityTests)
+
+    /// Numeric-parity helper: argmax + next-token logits for a fixed prompt (no sampling, no cache).
+    public func nextTokenArgmax(promptTokens: [Int]) -> (argmax: Int, logit: Float, top5: [(Int, Float)]) {
+        let arr = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
+        let logits = model.forward(inputIds: arr)
+        eval(logits)
+        let t = logits.dim(1)
+        let last = logits[0, t - 1].asType(.float32)
+        eval(last)
+        let l = Array(last.asArray(Float.self).prefix(denseConfig.vocabSize))
+        var best = 0
+        for i in 1..<l.count where l[i] > l[best] { best = i }
+        let top5 = l.enumerated().sorted { $0.element > $1.element }.prefix(5).map { ($0.offset, $0.element) }
+        return (best, l[best], Array(top5))
+    }
+
+    /// Sanity helper: argmax of the next token computed through the incremental KV-cache prefill
+    /// (used by tests to confirm the cache path matches `nextTokenArgmax`'s single forward).
+    public func firstTokenViaCache(promptTokens: [Int]) -> Int {
+        var st = Gemma4Model.InferenceState.initial(config: denseConfig)
+        let arr = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
+        let logits = model.forward(inputIds: arr, state: &st)
+        eval(logits)
+        let t = logits.dim(1)
+        let last = logits[0, t - 1].asType(.float32)
+        eval(last)
+        let l = Array(last.asArray(Float.self).prefix(denseConfig.vocabSize))
+        var best = 0
+        for i in 1..<l.count where l[i] > l[best] { best = i }
+        return best
+    }
+
+    // MARK: - Helpers
+
+    private func suppressEndTokens(_ logits: inout [Float]) {
+        let ninf = -Float.greatestFiniteMagnitude
+        for id in gemmaTokenizer.eosTokenIds where id >= 0 && id < logits.count { logits[id] = ninf }
+    }
+
+    private func lastLogits(_ logits: MLXArray) -> [Float] {
+        let t = logits.dim(1)
+        let last = logits[0, t - 1].asType(.float32)
+        eval(last)
+        let all: [Float] = last.asArray(Float.self)
+        return Array(all.prefix(denseConfig.vocabSize))
+    }
+}
+
+// MARK: - Qwen35ChatBackend conformance
+
+extension Gemma4Chat: Qwen35ChatBackend {
+    /// Bridge the Gemma-4 config to the `Qwen3ChatConfig` shape the backend protocol exposes.
+    /// Only the fields consumers read (vocab size, eos, etc.) are meaningful here.
+    public var config: Qwen3ChatConfig {
+        Qwen3ChatConfig(
+            hiddenSize: denseConfig.hiddenSize,
+            numHiddenLayers: denseConfig.numHiddenLayers,
+            numAttentionHeads: denseConfig.numAttentionHeads,
+            numKeyValueHeads: denseConfig.numKeyValueHeads,
+            headDim: denseConfig.headDim,
+            intermediateSize: denseConfig.intermediateSize,
+            vocabSize: denseConfig.vocabSize,
+            maxSeqLen: denseConfig.maxPositionEmbeddings,
+            ropeTheta: Double(denseConfig.fullRopeTheta),
+            rmsNormEps: Double(denseConfig.rmsNormEps),
+            eosTokenId: denseConfig.eosTokenId,
+            padTokenId: 0,
+            quantization: "int\(denseConfig.quantBits)",
+            modelType: nil,
+            layerTypes: denseConfig.layerTypes,
+            fullAttentionInterval: nil,
+            linearNumKeyHeads: nil,
+            linearKeyHeadDim: nil,
+            linearNumValueHeads: nil,
+            linearValueHeadDim: nil,
+            linearConvKernelDim: nil,
+            partialRotaryFactor: Double(denseConfig.fullPartialRotaryFactor),
+            tieWordEmbeddings: denseConfig.tieWordEmbeddings)
+    }
+}
+
+// MARK: - Reasoning-channel filter
+
+/// Streaming filter that suppresses Gemma 4's reasoning channel and emits only the spoken answer.
+///
+/// Gemma 4 may emit `<|channel>thought\n …thinking… \n<channel|>` (ids 100 … 101) before the answer.
+/// We drop every token from the opening `<|channel>` (100) through the matching `<channel|>` (101),
+/// and never emit special/markup tokens. Everything else is byte-accumulated and decoded as UTF-8
+/// (BPE can split one character across tokens). Because the channel markers are single vocab tokens,
+/// id-matching is exact; the inner thought text — which *can* span many tokens — is still fully
+/// skipped, so the filter is robust to multi-token reasoning blocks.
+struct Gemma4AnswerFilter {
+    private let tokenizer: Gemma4Tokenizer
+    private let channelOpen = 100
+    private let channelClose = 101
+    private var inThoughtChannel = false
+    private var pending: [UInt8] = []
+
+    init(tokenizer: Gemma4Tokenizer) { self.tokenizer = tokenizer }
+
+    /// Feed one generated token id; returns any answer text now decodable (often empty).
+    mutating func consume(_ id: Int) -> String {
+        if id == channelOpen { inThoughtChannel = true; return "" }
+        if id == channelClose { inThoughtChannel = false; return "" }
+        guard !inThoughtChannel, !tokenizer.isSpecialToken(id) else { return "" }
+        pending.append(contentsOf: tokenizer.tokenBytes(id))
+        let (text, rest) = ChatTokenizer.decodeUTF8Prefix(pending)
+        pending = rest
+        return text
+    }
+
+    /// Flush any trailing bytes (lossy) when the stream ends.
+    mutating func flush() -> String? {
+        guard !pending.isEmpty else { return nil }
+        let s = String(decoding: pending, as: UTF8.self)
+        pending = []
+        return s
+    }
+}
+
+// MARK: - Gemma 4 chat template
+
+/// Renders the Gemma 4 `<|turn>` chat template (matches the model's `chat_template.jinja`):
+///
+/// ```
+/// <bos><|turn>system\n{system}<turn|>\n<|turn>user\n{user}<turn|>\n<|turn>model\n
+/// ```
+///
+/// Special token ids (confirmed against the model tokenizer): `<bos>`=2, `<|turn>`=105,
+/// `<turn|>`=106, `\n`=107, role words `system`/`user`/`model`. We render via the tokenizer's
+/// encode so a vocab change can't desync the ids.
+enum Gemma4ChatTemplate {
+    static func encode(messages: [ChatMessage], tokenizer: Gemma4Tokenizer) -> [Int] {
+        var tokens: [Int] = [tokenizer.bosTokenId]
+        for m in messages {
+            let role = (m.role == .assistant) ? "model" : m.role.rawValue
+            tokens.append(contentsOf: tokenizer.encode("<|turn>" + role + "\n"))
+            tokens.append(contentsOf: tokenizer.encode(m.content))
+            tokens.append(contentsOf: tokenizer.encode("<turn|>\n"))
+        }
+        tokens.append(contentsOf: tokenizer.encode("<|turn>model\n"))
+        return tokens
+    }
+}

--- a/Sources/Qwen3Chat/Gemma4Model.swift
+++ b/Sources/Qwen3Chat/Gemma4Model.swift
@@ -1,0 +1,621 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXFast
+import MLXCommon
+
+// Hand-written MLX implementation of the **Gemma 4 text** transformer (model_type "gemma4_text"),
+// a 1:1 Swift port of `mlx_lm/models/gemma4_text.py` (the E2B / E4B dense, non-MoE configuration).
+// Mirrors the structure of `Qwen3DenseModel` but implements every Gemma-4-specific detail:
+//
+//   • embed_scale = sqrt(hidden_size); Per-Layer Embeddings (PLE) projected per layer.
+//   • Sandwich norms (input / post_attention / pre_feedforward / post_feedforward).
+//   • Attention scale = 1.0 (NOT 1/sqrt(d)); q_norm/k_norm (RMSNorm) + v_norm (RMSNorm no-scale).
+//   • head_dim differs by layer type: full_attention → 512, sliding_attention → 256.
+//   • Dual RoPE: sliding = standard nn.RoPE(256, base 1e4); full = ProportionalRoPE(512, rotated 128, base 1e6).
+//   • KV-sharing: the last `num_kv_shared_layers` layers reuse post-RoPE K/V from the last earlier
+//     producing layer of the same layer_type (no k/v projections of their own).
+//   • Double-wide MLP on KV-shared layers (use_double_wide_mlp).
+//   • Per-layer input gating after the FFN block; per-layer layer_scalar.
+//   • Final: norm → tied lm_head → logit_softcap(30).
+//
+// This is a parity port — a single forward pass over the prompt (no incremental KV cache object);
+// shared layers reuse the (keys, values) computed by their producing layer in the same pass.
+
+// MARK: - Config
+
+/// Parsed from a Gemma 4 multimodal `config.json` (`text_config` block).
+public struct Gemma4DenseConfig: Sendable {
+    public let hiddenSize: Int
+    public let numHiddenLayers: Int
+    public let intermediateSize: Int
+    public let numAttentionHeads: Int
+    public let headDim: Int            // sliding head_dim
+    public let globalHeadDim: Int      // full_attention head_dim
+    public let numKeyValueHeads: Int
+    public let numKVSharedLayers: Int
+    public let hiddenSizePerLayerInput: Int
+    public let vocabSize: Int
+    public let vocabSizePerLayerInput: Int
+    public let rmsNormEps: Float
+    public let slidingWindow: Int
+    public let maxPositionEmbeddings: Int
+    public let fullRopeTheta: Float
+    public let fullPartialRotaryFactor: Float
+    public let slidingRopeTheta: Float
+    public let finalLogitSoftcapping: Float
+    public let useDoubleWideMLP: Bool
+    public let tieWordEmbeddings: Bool
+    public let layerTypes: [String]    // "full_attention" | "sliding_attention"
+    public let eosTokenId: Int
+    public let quantGroupSize: Int
+    public let quantBits: Int
+
+    public static func load(from url: URL) throws -> Gemma4DenseConfig {
+        let root = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any] ?? [:]
+        // Text fields live under "text_config" for the multimodal checkpoint; fall back to root.
+        let tc = (root["text_config"] as? [String: Any]) ?? root
+        func int(_ d: [String: Any], _ k: String, _ def: Int) -> Int { (d[k] as? NSNumber)?.intValue ?? def }
+        func dbl(_ d: [String: Any], _ k: String, _ def: Double) -> Double { (d[k] as? NSNumber)?.doubleValue ?? def }
+
+        let numLayers = int(tc, "num_hidden_layers", 35)
+        let slidingWindowPattern = int(tc, "sliding_window_pattern", 5)
+
+        // layer_types: explicit list, else derived from sliding_window_pattern (last of each block is full).
+        let layerTypes: [String]
+        if let lt = tc["layer_types"] as? [String] {
+            layerTypes = lt
+        } else {
+            var pattern = Array(repeating: "sliding_attention", count: slidingWindowPattern - 1)
+            pattern.append("full_attention")
+            var derived: [String] = []
+            while derived.count < numLayers { derived.append(contentsOf: pattern) }
+            layerTypes = Array(derived.prefix(numLayers))
+        }
+
+        // rope_parameters: { full_attention: {partial_rotary_factor, rope_theta, rope_type},
+        //                    sliding_attention: {rope_theta, rope_type} }
+        let ropeParams = tc["rope_parameters"] as? [String: Any]
+        let fullRope = ropeParams?["full_attention"] as? [String: Any]
+        let slidingRope = ropeParams?["sliding_attention"] as? [String: Any]
+        let fullTheta = (fullRope?["rope_theta"] as? NSNumber)?.doubleValue ?? 1_000_000.0
+        let fullPRF = (fullRope?["partial_rotary_factor"] as? NSNumber)?.doubleValue ?? 0.25
+        let slidingTheta = (slidingRope?["rope_theta"] as? NSNumber)?.doubleValue ?? 10_000.0
+
+        // eos can be int or list (use first).
+        let eos: Int
+        if let n = tc["eos_token_id"] as? NSNumber { eos = n.intValue }
+        else if let a = tc["eos_token_id"] as? [NSNumber], let f = a.first { eos = f.intValue }
+        else if let n = root["eos_token_id"] as? NSNumber { eos = n.intValue }
+        else if let a = root["eos_token_id"] as? [NSNumber], let f = a.first { eos = f.intValue }
+        else { eos = 1 }
+
+        // quantization lives at the root of the MLX config.
+        let quant = (root["quantization"] as? [String: Any]) ?? (tc["quantization"] as? [String: Any])
+
+        return Gemma4DenseConfig(
+            hiddenSize: int(tc, "hidden_size", 1536),
+            numHiddenLayers: numLayers,
+            intermediateSize: int(tc, "intermediate_size", 6144),
+            numAttentionHeads: int(tc, "num_attention_heads", 8),
+            headDim: int(tc, "head_dim", 256),
+            globalHeadDim: int(tc, "global_head_dim", 512),
+            numKeyValueHeads: int(tc, "num_key_value_heads", 1),
+            numKVSharedLayers: int(tc, "num_kv_shared_layers", 20),
+            hiddenSizePerLayerInput: int(tc, "hidden_size_per_layer_input", 256),
+            vocabSize: int(tc, "vocab_size", 262144),
+            vocabSizePerLayerInput: int(tc, "vocab_size_per_layer_input", 262144),
+            rmsNormEps: Float(dbl(tc, "rms_norm_eps", 1e-6)),
+            slidingWindow: int(tc, "sliding_window", 512),
+            maxPositionEmbeddings: int(tc, "max_position_embeddings", 131072),
+            fullRopeTheta: Float(fullTheta),
+            fullPartialRotaryFactor: Float(fullPRF),
+            slidingRopeTheta: Float(slidingTheta),
+            finalLogitSoftcapping: Float(dbl(tc, "final_logit_softcapping", 30.0)),
+            useDoubleWideMLP: (tc["use_double_wide_mlp"] as? Bool) ?? true,
+            tieWordEmbeddings: (tc["tie_word_embeddings"] as? Bool) ?? true,
+            layerTypes: layerTypes,
+            eosTokenId: eos,
+            quantGroupSize: (quant?["group_size"] as? NSNumber)?.intValue ?? 64,
+            quantBits: (quant?["bits"] as? NSNumber)?.intValue ?? 4
+        )
+    }
+
+    /// Index of the first KV-shared layer.
+    public var firstKVSharedLayer: Int { numHiddenLayers - numKVSharedLayers }
+
+    public func isKVSharedLayer(_ i: Int) -> Bool {
+        let first = firstKVSharedLayer
+        return i >= first && first > 0
+    }
+
+    public func headDim(forLayer i: Int) -> Int {
+        layerTypes[i] == "full_attention" ? globalHeadDim : headDim
+    }
+
+    /// Maps each layer index → the producing layer whose post-RoPE K/V it reuses.
+    /// Producing layers map to themselves. Mirrors `Gemma4TextModel.previous_kvs`.
+    public var previousKVs: [Int] {
+        var prev = Array(0..<numHiddenLayers)
+        guard numKVSharedLayers > 0 else { return prev }
+        let m = firstKVSharedLayer
+        var lastOfType: [String: Int] = [:]
+        for i in 0..<m { lastOfType[layerTypes[i]] = i }
+        for j in m..<numHiddenLayers { prev[j] = lastOfType[layerTypes[j]]! }
+        return prev
+    }
+}
+
+// MARK: - RMSNorm without scale (matches RMSNormNoScale → rms_norm(x, None, eps))
+
+/// `mx.fast.rms_norm(x, None, eps)` — normalises by RMS with no learnable weight.
+/// Implemented via the fast kernel with a frozen ones-weight (numerically identical).
+public final class Gemma4RMSNormNoScale: Module {
+    let eps: Float
+    let ones: MLXArray
+    public init(dimensions: Int, eps: Float) {
+        self.eps = eps
+        self.ones = MLXArray.ones([dimensions], dtype: .float32)
+        super.init()
+        self.freeze()
+    }
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(x, weight: ones.asType(x.dtype), eps: eps)
+    }
+}
+
+// MARK: - Proportional RoPE (full_attention layers)
+
+/// Port of `rope_utils.ProportionalRoPE`. Rotates only the first `rotatedDims` of `dims`,
+/// with frequencies computed over the FULL `dims` (the "proportional" detail), leaving the
+/// rest unrotated (freqs set to +inf → zero rotation).
+public final class Gemma4ProportionalRoPE {
+    let dims: Int
+    let freqs: MLXArray
+
+    public init(dims: Int, rotatedDims: Int, base: Float, factor: Float = 1.0) {
+        self.dims = dims
+        precondition(rotatedDims <= dims, "rotatedDims must be <= dims")
+        // exponents = arange(0, rotatedDims, 2) / dims   (NOTE: divide by `dims`, not rotatedDims)
+        let nReal = (rotatedDims + 1) / 2   // count of arange(0, rotatedDims, 2)
+        var freqVals = [Float](repeating: 0, count: nReal)
+        for (idx, e) in stride(from: 0, to: rotatedDims, by: 2).enumerated() {
+            freqVals[idx] = factor * pow(base, Float(e) / Float(dims))
+        }
+        let nInf = (dims - rotatedDims) / 2
+        let infVals = [Float](repeating: Float.infinity, count: nInf)
+        self.freqs = MLXArray(freqVals + infVals).asType(.float32)
+    }
+
+    public func callAsFunction(_ x: MLXArray, offset: Int) -> MLXArray {
+        MLXFast.RoPE(
+            x, dimensions: dims, traditional: false, base: nil, scale: 1.0,
+            offset: offset, freqs: freqs)
+    }
+}
+
+// MARK: - Attention
+
+public final class Gemma4Attention: Module {
+    let layerIdx: Int
+    let isSliding: Bool
+    let hasKV: Bool
+    let headDim: Int
+    let nHeads: Int
+    let nKVHeads: Int
+    let scale: Float = 1.0
+
+    @ModuleInfo(key: "q_proj") var qProj: QuantizedLinear
+    @ModuleInfo(key: "k_proj") var kProj: QuantizedLinear?
+    @ModuleInfo(key: "v_proj") var vProj: QuantizedLinear?
+    @ModuleInfo(key: "o_proj") var oProj: QuantizedLinear
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm?
+    var vNorm: Gemma4RMSNormNoScale?
+
+    // RoPE: one of the two paths is used per layer type.
+    let slidingRope: RoPE?
+    let fullRope: Gemma4ProportionalRoPE?
+
+    public init(_ c: Gemma4DenseConfig, layerIdx: Int) {
+        self.layerIdx = layerIdx
+        let layerType = c.layerTypes[layerIdx]
+        self.isSliding = layerType == "sliding_attention"
+        self.hasKV = layerIdx < c.numHiddenLayers - c.numKVSharedLayers
+        self.headDim = c.headDim(forLayer: layerIdx)
+        self.nHeads = c.numAttentionHeads
+        self.nKVHeads = c.numKeyValueHeads
+
+        let gs = c.quantGroupSize, bits = c.quantBits
+        let dim = c.hiddenSize
+        let qDim = nHeads * headDim
+        let kvDim = nKVHeads * headDim
+
+        _qProj = ModuleInfo(wrappedValue: QuantizedLinear(dim, qDim, bias: false, groupSize: gs, bits: bits))
+        _oProj = ModuleInfo(wrappedValue: QuantizedLinear(qDim, dim, bias: false, groupSize: gs, bits: bits))
+        _qNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: headDim, eps: c.rmsNormEps))
+
+        if hasKV {
+            _kProj = ModuleInfo(wrappedValue: QuantizedLinear(dim, kvDim, bias: false, groupSize: gs, bits: bits))
+            _vProj = ModuleInfo(wrappedValue: QuantizedLinear(dim, kvDim, bias: false, groupSize: gs, bits: bits))
+            _kNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: headDim, eps: c.rmsNormEps))
+            self.vNorm = Gemma4RMSNormNoScale(dimensions: headDim, eps: c.rmsNormEps)
+        } else {
+            _kProj = ModuleInfo(wrappedValue: nil)
+            _vProj = ModuleInfo(wrappedValue: nil)
+            _kNorm = ModuleInfo(wrappedValue: nil)
+            self.vNorm = nil
+        }
+
+        if isSliding {
+            self.slidingRope = RoPE(dimensions: headDim, traditional: false, base: c.slidingRopeTheta)
+            self.fullRope = nil
+        } else {
+            let rotated = Int(Float(headDim) * c.fullPartialRotaryFactor)
+            self.fullRope = Gemma4ProportionalRoPE(dims: headDim, rotatedDims: rotated, base: c.fullRopeTheta)
+            self.slidingRope = nil
+        }
+
+        super.init()
+    }
+
+    private func applyRope(_ x: MLXArray, offset: Int) -> MLXArray {
+        if let r = slidingRope { return r(x, offset: offset) }
+        return fullRope!(x, offset: offset)
+    }
+
+    /// - Parameters:
+    ///   - sharedKV: post-RoPE (keys, values) from the producing layer (KV-shared layers only).
+    ///     When non-nil this is the FULL cache to attend over (no past is concatenated).
+    ///   - pastKV: previously cached post-RoPE (keys, values) for a *producing* layer in incremental
+    ///     decode; this step's new K/V are concatenated onto it. Ignored when `sharedKV` is set.
+    ///   - mask: additive float mask [1,1,Tq,Tk] (already causal / windowed).
+    ///   - offset: RoPE position offset for the *new* tokens (== number of cached positions).
+    /// - Returns: (output [B,T,hidden], full (keys,values) attended over [B,Hkv,Tk,D]).
+    public func callAsFunction(
+        _ x: MLXArray, mask: MLXArray, sharedKV: (MLXArray, MLXArray)?,
+        pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let b = x.dim(0), t = x.dim(1)
+
+        var q = qNorm(qProj(x).reshaped(b, t, nHeads, headDim))   // q_norm before transpose
+
+        let keys: MLXArray
+        let values: MLXArray
+        if let (sk, sv) = sharedKV {
+            // KV-shared layer: attend over the producing layer's full cache, read-only.
+            keys = sk
+            values = sv
+        } else {
+            var k = kNorm!(kProj!(x).reshaped(b, t, nKVHeads, headDim))
+            k = k.transposed(0, 2, 1, 3)
+            k = applyRope(k, offset: offset)
+
+            var v = vNorm!(vProj!(x).reshaped(b, t, nKVHeads, headDim))
+            v = v.transposed(0, 2, 1, 3)
+
+            // Producing layer: append this step's post-RoPE K/V to the running cache.
+            if let (pk, pv) = pastKV {
+                k = concatenated([pk, k], axis: 2)
+                v = concatenated([pv, v], axis: 2)
+            }
+            keys = k
+            values = v
+        }
+
+        q = q.transposed(0, 2, 1, 3)
+        q = applyRope(q, offset: offset)
+
+        let attnOut = SDPA.attendAndMerge(
+            qHeads: q, kHeads: keys, vHeads: values, scale: scale, mask: mask)
+        return (oProj(attnOut), (keys, values))
+    }
+}
+
+// MARK: - MLP (GeGLU; double-wide on KV-shared layers)
+
+public final class Gemma4MLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: QuantizedLinear
+    @ModuleInfo(key: "up_proj") var upProj: QuantizedLinear
+    @ModuleInfo(key: "down_proj") var downProj: QuantizedLinear
+
+    public init(_ c: Gemma4DenseConfig, layerIdx: Int) {
+        let h = c.hiddenSize, gs = c.quantGroupSize, bits = c.quantBits
+        let useDoubleWide = c.useDoubleWideMLP && c.isKVSharedLayer(layerIdx)
+        let inter = c.intermediateSize * (useDoubleWide ? 2 : 1)
+        _gateProj = ModuleInfo(wrappedValue: QuantizedLinear(h, inter, bias: false, groupSize: gs, bits: bits))
+        _upProj = ModuleInfo(wrappedValue: QuantizedLinear(h, inter, bias: false, groupSize: gs, bits: bits))
+        _downProj = ModuleInfo(wrappedValue: QuantizedLinear(inter, h, bias: false, groupSize: gs, bits: bits))
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // geglu(gate, x) = gelu_approx(gate) * x   (gate = gate_proj(x), x = up_proj(x))
+        downProj(geluApproximate(gateProj(x)) * upProj(x))
+    }
+}
+
+// MARK: - Decoder layer
+
+public final class Gemma4Layer: Module {
+    @ModuleInfo(key: "self_attn") var attn: Gemma4Attention
+    @ModuleInfo var mlp: Gemma4MLP
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayerNorm: RMSNorm
+
+    // Per-layer input gating.
+    @ModuleInfo(key: "per_layer_input_gate") var perLayerInputGate: QuantizedLinear
+    @ModuleInfo(key: "per_layer_projection") var perLayerProjection: QuantizedLinear
+    @ModuleInfo(key: "post_per_layer_input_norm") var postPerLayerInputNorm: RMSNorm
+
+    // NB: reassigning a `@ParameterInfo` in init() drops any explicit `key:`, so the parameter is
+    // registered under the Swift property name `layerScalar`; the loader updates it by that name.
+    @ParameterInfo var layerScalar: MLXArray
+
+    public init(_ c: Gemma4DenseConfig, layerIdx: Int) {
+        _attn = ModuleInfo(wrappedValue: Gemma4Attention(c, layerIdx: layerIdx))
+        _mlp = ModuleInfo(wrappedValue: Gemma4MLP(c, layerIdx: layerIdx))
+        _inputLayerNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+        _postAttentionLayerNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+        _preFeedforwardLayerNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+        _postFeedforwardLayerNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+
+        let ple = c.hiddenSizePerLayerInput
+        _perLayerInputGate = ModuleInfo(wrappedValue: QuantizedLinear(
+            c.hiddenSize, ple, bias: false, groupSize: c.quantGroupSize, bits: c.quantBits))
+        _perLayerProjection = ModuleInfo(wrappedValue: QuantizedLinear(
+            ple, c.hiddenSize, bias: false, groupSize: c.quantGroupSize, bits: c.quantBits))
+        _postPerLayerInputNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+
+        _layerScalar = ParameterInfo(wrappedValue: MLXArray.ones([1]))
+        super.init()
+    }
+
+    /// - Returns: (hidden_out, (keys,values) this layer used) so producing layers' K/V can be shared.
+    public func callAsFunction(
+        _ x: MLXArray, mask: MLXArray, perLayerInput: MLXArray,
+        sharedKV: (MLXArray, MLXArray)?, pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        var residual = x
+
+        var h = inputLayerNorm(x)
+        let (attnOut, kv) = attn(h, mask: mask, sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+        h = postAttentionLayerNorm(attnOut)   // post-attn norm applied BEFORE the residual add
+        h = residual + h
+
+        residual = h
+        h = preFeedforwardLayerNorm(h)
+        h = mlp(h)
+        h = postFeedforwardLayerNorm(h)
+        h = residual + h
+
+        // Per-layer input gating.
+        residual = h
+        var gate = perLayerInputGate(h)
+        gate = geluApproximate(gate)
+        gate = gate * perLayerInput
+        gate = perLayerProjection(gate)
+        gate = postPerLayerInputNorm(gate)
+        h = residual + gate
+
+        h = h * layerScalar
+        return (h, kv)
+    }
+}
+
+// MARK: - Model
+
+public final class Gemma4Model: Module {
+    public let config: Gemma4DenseConfig
+    let embedScale: Float
+    let perLayerInputScale: Float        // 2^-0.5
+    let perLayerProjectionScale: Float   // hidden^-0.5
+    let embedTokensPerLayerScale: Float  // sqrt(hidden_size_per_layer_input)
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: PreQuantizedEmbedding
+    @ModuleInfo(key: "embed_tokens_per_layer") var embedTokensPerLayer: PreQuantizedEmbedding
+    @ModuleInfo(key: "per_layer_model_projection") var perLayerModelProjection: QuantizedLinear
+    @ModuleInfo(key: "per_layer_projection_norm") var perLayerProjectionNorm: RMSNorm
+    @ModuleInfo var layers: [Gemma4Layer]
+    @ModuleInfo var norm: RMSNorm
+
+    public init(config c: Gemma4DenseConfig) {
+        self.config = c
+        self.embedScale = sqrt(Float(c.hiddenSize))
+        self.perLayerInputScale = pow(2.0, -0.5)
+        self.perLayerProjectionScale = pow(Float(c.hiddenSize), -0.5)
+        self.embedTokensPerLayerScale = sqrt(Float(c.hiddenSizePerLayerInput))
+
+        _embedTokens = ModuleInfo(wrappedValue: PreQuantizedEmbedding(
+            embeddingCount: c.vocabSize, dimensions: c.hiddenSize,
+            groupSize: c.quantGroupSize, bits: c.quantBits))
+        _embedTokensPerLayer = ModuleInfo(wrappedValue: PreQuantizedEmbedding(
+            embeddingCount: c.vocabSizePerLayerInput,
+            dimensions: c.numHiddenLayers * c.hiddenSizePerLayerInput,
+            groupSize: c.quantGroupSize, bits: c.quantBits))
+        _perLayerModelProjection = ModuleInfo(wrappedValue: QuantizedLinear(
+            c.hiddenSize, c.numHiddenLayers * c.hiddenSizePerLayerInput,
+            bias: false, groupSize: c.quantGroupSize, bits: c.quantBits))
+        _perLayerProjectionNorm = ModuleInfo(wrappedValue: RMSNorm(
+            dimensions: c.hiddenSizePerLayerInput, eps: c.rmsNormEps))
+        _layers = ModuleInfo(wrappedValue: (0..<c.numHiddenLayers).map { Gemma4Layer(c, layerIdx: $0) })
+        _norm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+        super.init()
+    }
+
+    // _get_per_layer_inputs: lookup PLE table → *sqrt(256) → reshape (B,T,L,256).
+    private func getPerLayerInputs(_ inputIds: MLXArray) -> MLXArray {
+        let b = inputIds.dim(0), t = inputIds.dim(1)
+        var result = embedTokensPerLayer(inputIds)              // [B,T, L*256]
+        result = result * embedTokensPerLayerScale
+        return result.reshaped(b, t, config.numHiddenLayers, config.hiddenSizePerLayerInput)
+    }
+
+    // _project_per_layer_inputs: project hidden → *hidden^-0.5 → reshape → RMSNorm(256) →
+    //   (proj + per_layer_inputs) * 2^-0.5.
+    private func projectPerLayerInputs(_ hidden: MLXArray, _ perLayerInputs: MLXArray) -> MLXArray {
+        let b = hidden.dim(0), t = hidden.dim(1)
+        var proj = perLayerModelProjection(hidden)             // [B,T, L*256]
+        proj = proj * perLayerProjectionScale
+        proj = proj.reshaped(b, t, config.numHiddenLayers, config.hiddenSizePerLayerInput)
+        proj = perLayerProjectionNorm(proj)
+        return (proj + perLayerInputs) * perLayerInputScale
+    }
+
+    /// Build an additive float mask [1,1,T,T]: causal, with an optional sliding window.
+    private func makeMask(seqLen t: Int, windowSize: Int?, dtype: DType) -> MLXArray {
+        makeMask(queryLen: t, keyLen: t, offset: 0, windowSize: windowSize, dtype: dtype)
+    }
+
+    /// Build an additive float mask [1,1,Tq,Tk] for incremental decode: the `Tq` new queries
+    /// live at absolute positions `offset ..< offset+Tq`; the `Tk` keys at `0 ..< Tk`
+    /// (`Tk == offset + Tq` for a contiguous cache). Causal, with an optional sliding window.
+    private func makeMask(queryLen tq: Int, keyLen tk: Int, offset: Int,
+                          windowSize: Int?, dtype: DType) -> MLXArray {
+        // query absolute pos qi = offset + i ; key absolute pos kj = j.
+        let qInds = (MLXArray(Int32(0)..<Int32(tq)) + Int32(offset)).reshaped(tq, 1)
+        let kInds = MLXArray(Int32(0)..<Int32(tk)).reshaped(1, tk)
+        var keep = qInds .>= kInds                       // causal
+        if let w = windowSize {
+            keep = logicalAnd(keep, qInds .< (kInds + w))  // sliding window
+        }
+        let zeros = MLXArray.zeros([tq, tk], dtype: dtype)
+        let neg = MLXArray(-Float.greatestFiniteMagnitude).asType(dtype)
+        let mask = MLX.where(keep, zeros, neg)
+        return mask.reshaped(1, 1, tq, tk)
+    }
+
+    /// Debug flag — prints per-stage tensor statistics matching the Python reference dump.
+    public static var debugStats = false
+    private func stat(_ name: String, _ x: MLXArray) {
+        guard Gemma4Model.debugStats else { return }
+        let xf = x.asType(.float32)
+        eval(xf)
+        let mean = xf.mean().item(Float.self)
+        let variance = MLX.mean(MLX.square(xf - mean)).item(Float.self)
+        let std = variance.squareRoot()
+        let absmax = MLX.abs(xf).max().item(Float.self)
+        let first3 = Array(xf.flattened().asArray(Float.self).prefix(3))
+        print(String(format: "[swift] %@: mean=%.5f std=%.5f absmax=%.5f first3=%@",
+                     name, mean, std, absmax, "\(first3.map { String(format: "%.5f", $0) })"))
+    }
+
+    /// Hidden states after the final norm — `[B,T,hidden]`.
+    public func hidden(inputIds: MLXArray) -> MLXArray {
+        let t = inputIds.dim(1)
+
+        // Initial hidden state.
+        var h = embedTokens(inputIds)
+        h = h * embedScale
+        let dtype = h.dtype
+        stat("h_init", h)
+
+        // Per-layer inputs.
+        let pleRaw = getPerLayerInputs(inputIds)
+        stat("ple_raw", pleRaw)
+        let perLayer = projectPerLayerInputs(h, pleRaw)        // [B,T,L,256]
+        stat("ple_proj", perLayer)
+
+        // Masks per layer type.
+        let fullMask = makeMask(seqLen: t, windowSize: nil, dtype: dtype)
+        let slidingMask = makeMask(seqLen: t, windowSize: config.slidingWindow, dtype: dtype)
+
+        let prevKVs = config.previousKVs
+        var produced: [(MLXArray, MLXArray)?] = Array(repeating: nil, count: layers.count)
+
+        for (i, layer) in layers.enumerated() {
+            let isFull = config.layerTypes[i] == "full_attention"
+            let mask = isFull ? fullMask : slidingMask
+            let perLayerInput = perLayer[0..., 0..., i, 0...]    // [B,T,256]
+            let shared = (prevKVs[i] == i) ? nil : produced[prevKVs[i]]
+            let (nh, kv) = layer(h, mask: mask, perLayerInput: perLayerInput,
+                                 sharedKV: shared, offset: 0)
+            h = nh
+            produced[i] = kv
+            if Gemma4Model.debugStats, i < 3 || i == 14 || i == 15 || i == 34 {
+                stat("after_layer_\(i)", h)
+            }
+        }
+
+        let hn = norm(h)
+        stat("after_norm", hn)
+        return hn
+    }
+
+    /// - Returns: logits `[B,T,vocab]` with the final logit softcap applied.
+    public func forward(inputIds: MLXArray) -> MLXArray {
+        let h = hidden(inputIds: inputIds)
+        var logits = embedTokens.asLinear(h)   // tied lm_head
+        let cap = config.finalLogitSoftcapping
+        logits = MLX.tanh(logits / cap) * cap
+        return logits
+    }
+
+    // MARK: - Incremental generation (KV-cache + cross-layer KV sharing)
+
+    /// Per-conversation decode state. We keep a KV cache only for the M = (num_layers −
+    /// num_kv_shared_layers) *producing* layers (slots for shared layers stay nil); each
+    /// shared layer attends over the cache of its mapped producing layer (`previousKVs`).
+    /// `position` is the number of cached token positions (== the RoPE offset for the next step).
+    public struct InferenceState {
+        public var kvCaches: [(MLXArray, MLXArray)?]   // indexed by layer; nil on shared layers
+        public var position: Int
+
+        public static func initial(config c: Gemma4DenseConfig) -> InferenceState {
+            InferenceState(kvCaches: Array(repeating: nil, count: c.numHiddenLayers), position: 0)
+        }
+    }
+
+    /// Incremental forward over `T` new tokens, updating `state`'s caches in place.
+    ///
+    /// Prompt prefill passes the whole prompt (T = prompt length, position 0); each decode step
+    /// passes a single token (T = 1). Producing layers append their post-RoPE K/V to their cache;
+    /// shared layers read the producing layer's (now-updated) cache read-only.
+    ///
+    /// NOTE: sliding-window layers use a simple growing cache (no eviction). For the short voice
+    /// turns this backend targets, sequence length stays well under `slidingWindow`, so the
+    /// windowed mask alone already reproduces the reference attention; eviction would only matter
+    /// for very long contexts.
+    public func forward(inputIds: MLXArray, state: inout InferenceState) -> MLXArray {
+        let t = inputIds.dim(1)
+        let offset = state.position
+
+        var h = embedTokens(inputIds)
+        h = h * embedScale
+        let dtype = h.dtype
+
+        let pleRaw = getPerLayerInputs(inputIds)
+        let perLayer = projectPerLayerInputs(h, pleRaw)        // [B,T,L,256]
+
+        // Masks: keys span [0, offset+t) — a contiguous growing cache. Tq = t, Tk = offset+t.
+        let tk = offset + t
+        let fullMask = makeMask(queryLen: t, keyLen: tk, offset: offset, windowSize: nil, dtype: dtype)
+        let slidingMask = makeMask(queryLen: t, keyLen: tk, offset: offset,
+                                   windowSize: config.slidingWindow, dtype: dtype)
+
+        let prevKVs = config.previousKVs
+        for (i, layer) in layers.enumerated() {
+            let isFull = config.layerTypes[i] == "full_attention"
+            let mask = isFull ? fullMask : slidingMask
+            let perLayerInput = perLayer[0..., 0..., i, 0...]    // [B,T,256]
+
+            let isProducing = (prevKVs[i] == i)
+            let shared = isProducing ? nil : state.kvCaches[prevKVs[i]]
+            let past = isProducing ? state.kvCaches[i] : nil
+            let (nh, kv) = layer(h, mask: mask, perLayerInput: perLayerInput,
+                                 sharedKV: shared, pastKV: past, offset: offset)
+            h = nh
+            if isProducing { state.kvCaches[i] = kv }
+        }
+
+        state.position = tk
+
+        let hn = norm(h)
+        var logits = embedTokens.asLinear(hn)   // tied lm_head
+        let cap = config.finalLogitSoftcapping
+        logits = MLX.tanh(logits / cap) * cap
+        return logits
+    }
+}

--- a/Sources/Qwen3Chat/Gemma4Tokenizer.swift
+++ b/Sources/Qwen3Chat/Gemma4Tokenizer.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// SentencePiece-style BPE tokenizer for the Gemma 4 vocabulary.
+///
+/// The Gemma tokenizer differs from the GPT-2 byte-level scheme used by `ChatTokenizer`:
+///   • space → `▁` (U+2581) normalizer; `▁` is a regular vocab character.
+///   • `byte_fallback: true` — bytes with no single-char token are emitted as `<0xXX>` tokens.
+///   • decode = Replace(`▁`→space) → ByteFallback(`<0xXX>`→byte) → Fuse.
+///
+/// This loads `tokenizer.json` (BPE vocab + merge ranks + added/special tokens) and implements
+/// encode (merge-rank BPE), decode, and the streaming `tokenBytes` surface the generation loop needs.
+public final class Gemma4Tokenizer: @unchecked Sendable {
+    private var tokenToId: [String: Int] = [:]
+    private var idToToken: [Int: String] = [:]
+    private var mergeRanks: [String: Int] = [:]
+    /// content → id for the explicit added/control tokens (e.g. `<|turn>`, `<bos>`).
+    private var specials: [(content: String, id: Int)] = []
+    private var specialIds: Set<Int> = []
+    /// `<0xXX>` byte-fallback token id for each byte value, when present.
+    private var byteFallbackId: [Int] = Array(repeating: -1, count: 256)
+
+    public private(set) var bosTokenId: Int = 2
+    /// Tokens that terminate a model turn: `<eos>`(1), `<turn|>`(106), `<|tool_response>`(50).
+    public private(set) var eosTokenIds: Set<Int> = [1, 106, 50]
+
+    public init() {}
+
+    public func load(from directory: URL) throws {
+        let url = directory.appendingPathComponent("tokenizer.json")
+        let data = try Data(contentsOf: url)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let model = root["model"] as? [String: Any],
+              let vocab = model["vocab"] as? [String: Int] else {
+            throw ChatModelError.tokenizerLoadFailed("Invalid Gemma tokenizer.json")
+        }
+        tokenToId = vocab
+        idToToken = Dictionary(uniqueKeysWithValues: vocab.map { ($1, $0) })
+
+        if let merges = model["merges"] as? [[String]] {
+            for (i, pair) in merges.enumerated() where pair.count == 2 {
+                mergeRanks["\(pair[0]) \(pair[1])"] = i
+            }
+        } else if let merges = model["merges"] as? [String] {
+            for (i, m) in merges.enumerated() {
+                let p = m.split(separator: " ", maxSplits: 1)
+                if p.count == 2 { mergeRanks["\(p[0]) \(p[1])"] = i }
+            }
+        }
+
+        if let added = root["added_tokens"] as? [[String: Any]] {
+            for a in added {
+                guard let content = a["content"] as? String, let id = a["id"] as? Int else { continue }
+                tokenToId[content] = id
+                idToToken[id] = content
+                if (a["special"] as? Bool) ?? false {
+                    specials.append((content, id))
+                    specialIds.insert(id)
+                }
+            }
+        }
+        // Longest content first so e.g. `<|turn>` matches before any shorter prefix.
+        specials.sort { $0.content.count > $1.content.count }
+
+        for b in 0..<256 {
+            if let id = tokenToId[String(format: "<0x%02X>", b)] { byteFallbackId[b] = id }
+        }
+
+        let eosFromConfig = directory.appendingPathComponent("generation_config.json")
+        if let d = try? Data(contentsOf: eosFromConfig),
+           let j = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
+            if let arr = j["eos_token_id"] as? [NSNumber] { eosTokenIds = Set(arr.map { $0.intValue }) }
+            else if let n = j["eos_token_id"] as? NSNumber { eosTokenIds = [n.intValue] }
+            if let n = j["bos_token_id"] as? NSNumber { bosTokenId = n.intValue }
+        }
+    }
+
+    public func isSpecialToken(_ id: Int) -> Bool { specialIds.contains(id) }
+
+    // MARK: - Encode
+
+    /// Encode text. Splits out explicit special tokens, then BPE-encodes plain runs.
+    public func encode(_ text: String) -> [Int] {
+        if text.isEmpty { return [] }
+        var out: [Int] = []
+        encodeSegment(Substring(text), into: &out)
+        return out
+    }
+
+    private func encodeSegment(_ text: Substring, into out: inout [Int]) {
+        if text.isEmpty { return }
+        // Find the earliest special-token occurrence.
+        var bestRange: Range<Substring.Index>? = nil
+        var bestId = -1
+        for (content, id) in specials {
+            if let r = text.range(of: content) {
+                if bestRange == nil || r.lowerBound < bestRange!.lowerBound {
+                    bestRange = r; bestId = id
+                }
+            }
+        }
+        guard let r = bestRange else {
+            bpeEncode(String(text), into: &out)
+            return
+        }
+        if r.lowerBound > text.startIndex { bpeEncode(String(text[text.startIndex..<r.lowerBound]), into: &out) }
+        out.append(bestId)
+        encodeSegment(text[r.upperBound...], into: &out)
+    }
+
+    /// SentencePiece BPE: normalize spaces→`▁`, split into characters (byte-fallback for any char
+    /// with no single-char token), then merge by rank.
+    private func bpeEncode(_ raw: String, into out: inout [Int]) {
+        if raw.isEmpty { return }
+        let normalized = raw.replacingOccurrences(of: " ", with: "\u{2581}")
+
+        // Initial symbols: one per character, falling back to per-byte `<0xXX>` symbols.
+        var symbols: [String] = []
+        for ch in normalized {
+            let s = String(ch)
+            if tokenToId[s] != nil {
+                symbols.append(s)
+            } else {
+                for b in Array(s.utf8) { symbols.append("<0x" + String(format: "%02X", b) + ">") }
+            }
+        }
+        if symbols.isEmpty { return }
+
+        while symbols.count > 1 {
+            var bestRank = Int.max
+            var bestIdx = -1
+            for i in 0..<(symbols.count - 1) {
+                if let rank = mergeRanks["\(symbols[i]) \(symbols[i + 1])"], rank < bestRank {
+                    bestRank = rank; bestIdx = i
+                }
+            }
+            if bestIdx < 0 { break }
+            symbols.replaceSubrange(bestIdx...bestIdx + 1, with: [symbols[bestIdx] + symbols[bestIdx + 1]])
+        }
+
+        for s in symbols {
+            if let id = tokenToId[s] {
+                out.append(id)
+            } else {
+                // Should not happen (byte-fallback guarantees coverage), but stay lossless.
+                for b in Array(s.utf8) where byteFallbackId[Int(b)] >= 0 {
+                    out.append(byteFallbackId[Int(b)])
+                }
+            }
+        }
+    }
+
+    // MARK: - Decode
+
+    /// Raw byte sequence a token maps to: `<0xXX>` → the byte; otherwise the token text with
+    /// `▁`→space, as UTF-8. Streaming decoders accumulate these and decode UTF-8 on the buffer.
+    public func tokenBytes(_ id: Int) -> [UInt8] {
+        guard let piece = idToToken[id] else { return [] }
+        if piece.count == 6, piece.hasPrefix("<0x"), piece.hasSuffix(">"),
+           let b = UInt8(piece.dropFirst(3).dropLast(), radix: 16) {
+            return [b]
+        }
+        return Array(piece.replacingOccurrences(of: "\u{2581}", with: " ").utf8)
+    }
+
+    /// Decode a full token list to text (byte-fallback aware, `▁`→space, UTF-8 fuse).
+    public func decode(_ ids: [Int]) -> String {
+        var bytes: [UInt8] = []
+        for id in ids { bytes.append(contentsOf: tokenBytes(id)) }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}

--- a/Sources/Qwen3Chat/Gemma4WeightLoading.swift
+++ b/Sources/Qwen3Chat/Gemma4WeightLoading.swift
@@ -1,0 +1,100 @@
+import Foundation
+import MLXCommon
+import MLX
+import MLXNN
+
+/// Loads quantized safetensors weights into `Gemma4Model`.
+///
+/// Gemma 4 multimodal MLX checkpoint key layout — keys are prefixed `language_model.model.`
+/// (the text tower of a multimodal model). We strip that prefix to bare keys:
+///   - `embed_tokens.{weight,scales,biases}`                 → tied embedding / lm_head
+///   - `embed_tokens_per_layer.{weight,scales,biases}`       → per-layer embedding table (PLE)
+///   - `per_layer_model_projection.{weight,scales,biases}`   → PLE projection
+///   - `per_layer_projection_norm.weight`                    → PLE projection RMSNorm
+///   - `norm.weight`                                         → final RMSNorm
+///   - `layers.{i}.self_attn.{q,k,v,o}_proj.{weight,scales,biases}` (k/v absent on KV-shared layers)
+///   - `layers.{i}.self_attn.{q,k}_norm.weight`              (k_norm absent on KV-shared layers; no v_norm weight)
+///   - `layers.{i}.mlp.{gate,up,down}_proj.{weight,scales,biases}`
+///   - `layers.{i}.{input,post_attention,pre_feedforward,post_feedforward}_layernorm.weight`
+///   - `layers.{i}.per_layer_input_gate.{weight,scales,biases}`
+///   - `layers.{i}.per_layer_projection.{weight,scales,biases}`
+///   - `layers.{i}.post_per_layer_input_norm.weight`
+///   - `layers.{i}.layer_scalar`
+///
+/// `vision_tower.*` / `audio_tower.*` keys (and the redundant k/v keys some exports emit for KV-shared
+/// layers) are simply ignored — the loader only wires the weights the model actually owns.
+public enum Gemma4WeightLoader {
+    public static func loadWeights(
+        into model: Gemma4Model,
+        from directory: URL,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) throws {
+        progressHandler?(0.05, "Loading weight files...")
+        let all = try CommonWeightLoader.loadAllSafetensors(from: directory)
+        progressHandler?(0.3, "Loaded \(all.count) tensors")
+
+        // Strip the `language_model.model.` prefix (multimodal text tower). Also tolerate the plain
+        // `model.` layout in case a text-only checkpoint is used.
+        var w: [String: MLXArray] = [:]
+        for (key, value) in all {
+            if key.hasPrefix("language_model.model.") {
+                w[String(key.dropFirst("language_model.model.".count))] = value
+            } else if key.hasPrefix("model.") {
+                w[String(key.dropFirst("model.".count))] = value
+            } else {
+                w[key] = value
+            }
+        }
+
+        progressHandler?(0.4, "Embeddings + PLE + final norm...")
+        CommonWeightLoader.applyQuantizedEmbeddingWeights(to: model.embedTokens, prefix: "embed_tokens", from: w)
+        CommonWeightLoader.applyQuantizedEmbeddingWeights(to: model.embedTokensPerLayer, prefix: "embed_tokens_per_layer", from: w)
+        CommonWeightLoader.applyQuantizedLinearWeights(to: model.perLayerModelProjection, prefix: "per_layer_model_projection", from: w)
+        CommonWeightLoader.applyRMSNormWeights(to: model.perLayerProjectionNorm, prefix: "per_layer_projection_norm", from: w)
+        CommonWeightLoader.applyRMSNormWeights(to: model.norm, prefix: "norm", from: w)
+
+        progressHandler?(0.5, "Transformer layers...")
+        let n = model.config.numHiddenLayers
+        for i in 0..<n {
+            let p = "layers.\(i)"
+            let layer = model.layers[i]
+
+            // Sandwich norms.
+            CommonWeightLoader.applyRMSNormWeights(to: layer.inputLayerNorm, prefix: "\(p).input_layernorm", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: layer.postAttentionLayerNorm, prefix: "\(p).post_attention_layernorm", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: layer.preFeedforwardLayerNorm, prefix: "\(p).pre_feedforward_layernorm", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: layer.postFeedforwardLayerNorm, prefix: "\(p).post_feedforward_layernorm", from: w)
+
+            // Attention.
+            let attn = layer.attn
+            CommonWeightLoader.applyQuantizedLinearWeights(to: attn.qProj, prefix: "\(p).self_attn.q_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: attn.oProj, prefix: "\(p).self_attn.o_proj", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: attn.qNorm, prefix: "\(p).self_attn.q_norm", from: w)
+            if let kProj = attn.kProj { CommonWeightLoader.applyQuantizedLinearWeights(to: kProj, prefix: "\(p).self_attn.k_proj", from: w) }
+            if let vProj = attn.vProj { CommonWeightLoader.applyQuantizedLinearWeights(to: vProj, prefix: "\(p).self_attn.v_proj", from: w) }
+            if let kNorm = attn.kNorm { CommonWeightLoader.applyRMSNormWeights(to: kNorm, prefix: "\(p).self_attn.k_norm", from: w) }
+
+            // MLP.
+            let mlp = layer.mlp
+            CommonWeightLoader.applyQuantizedLinearWeights(to: mlp.gateProj, prefix: "\(p).mlp.gate_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: mlp.upProj, prefix: "\(p).mlp.up_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: mlp.downProj, prefix: "\(p).mlp.down_proj", from: w)
+
+            // Per-layer input gating.
+            CommonWeightLoader.applyQuantizedLinearWeights(to: layer.perLayerInputGate, prefix: "\(p).per_layer_input_gate", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: layer.perLayerProjection, prefix: "\(p).per_layer_projection", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: layer.postPerLayerInputNorm, prefix: "\(p).post_per_layer_input_norm", from: w)
+
+            // Layer scalar. NB: the `@ParameterInfo(key:)` is lost once reassigned in init(), so the
+            // update key must be the Swift property name (`layerScalar`), not the safetensors key.
+            if let ls = w["\(p).layer_scalar"] {
+                layer.update(parameters: ModuleParameters(values: ["layerScalar": .value(ls)]))
+            }
+
+            progressHandler?(0.5 + 0.45 * Double(i + 1) / Double(n), "Layer \(i + 1)/\(n)")
+        }
+
+        eval(model)
+        progressHandler?(1.0, "Weights loaded")
+    }
+}

--- a/Sources/Qwen3Chat/MLXGenerator.swift
+++ b/Sources/Qwen3Chat/MLXGenerator.swift
@@ -184,6 +184,19 @@ public final class Qwen35MLXChat: @unchecked Sendable {
         metrics = Metrics()
     }
 
+    // MARK: - GPU memory controls
+
+    /// Cap MLX's GPU buffer cache in bytes. MLX keeps freed buffers for reuse; a modest cap trades
+    /// a little speed for lower resident memory on constrained devices.
+    public static func setGPUCacheLimit(_ bytes: Int) {
+        MLX.Memory.cacheLimit = bytes
+    }
+
+    /// Release MLX's cached recyclable GPU buffers, for example between conversation turns.
+    public static func clearGPUCache() {
+        MLX.Memory.clearCache()
+    }
+
     // MARK: - Generation
 
     /// Generate a response from chat messages.

--- a/Sources/Qwen3Chat/Qwen3DenseChat.swift
+++ b/Sources/Qwen3Chat/Qwen3DenseChat.swift
@@ -1,0 +1,172 @@
+import Foundation
+import MLX
+import AudioCommon
+
+/// Chat backend for the hand-written `Qwen3DenseModel` (standard Qwen3: 1.7B / 4B / 8B …).
+///
+/// Conforms to `Qwen35ChatBackend`, so `Qwen35PipelineLLM(model:)` and the rest of the stack accept
+/// it with no changes — the larger chat model is a drop-in for the 0.8B. Reuses the shared
+/// `ChatTokenizer` (byte-level decode) + the optimised `ChatSampler`. Non-thinking instruct models
+/// (e.g. Qwen3-*-Instruct-2507), so no `<think>` handling.
+public final class Qwen3DenseChat: @unchecked Sendable {
+    public let dc: Qwen3DenseConfig
+    public let tokenizer: ChatTokenizer
+    let model: Qwen3DenseModel
+    var state: Qwen3DenseModel.InferenceState
+
+    private let imStartId: Int
+    private let imEndId: Int
+    private let newlineId: Int
+
+    private init(dc: Qwen3DenseConfig, tokenizer: ChatTokenizer, model: Qwen3DenseModel) {
+        self.dc = dc
+        self.tokenizer = tokenizer
+        self.model = model
+        self.state = .initial(config: dc)
+        self.imStartId = tokenizer.tokenId("<|im_start|>") ?? 151644
+        self.imEndId = tokenizer.tokenId("<|im_end|>") ?? 151645
+        self.newlineId = tokenizer.tokenId("\u{010A}") ?? 198   // byte-level "\n"
+    }
+
+    // MARK: - Loading
+
+    /// Load from a local MLX model directory (config.json + tokenizer + safetensors).
+    public static func fromDirectory(
+        _ directory: URL, progressHandler: ((Double, String) -> Void)? = nil
+    ) throws -> Qwen3DenseChat {
+        let config = try Qwen3DenseConfig.load(from: directory.appendingPathComponent("config.json"))
+        let tokenizer = ChatTokenizer()
+        try tokenizer.load(from: directory)
+        tokenizer.eosTokenId = config.eosTokenId
+        let model = Qwen3DenseModel(config: config)
+        try Qwen3DenseWeightLoader.loadWeights(into: model, from: directory, progressHandler: progressHandler)
+        return Qwen3DenseChat(dc: config, tokenizer: tokenizer, model: model)
+    }
+
+    /// Download an MLX model from HuggingFace, then load it. Defaults to the int5 export (best
+    /// quality/size for on-device chat); pass `…-MLX-4bit` for a smaller, lower-RAM variant.
+    public static func fromPretrained(
+        modelId: String = "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit",
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> Qwen3DenseChat {
+        let dir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId, to: dir,
+            additionalFiles: [
+                "config.json", "tokenizer.json", "tokenizer_config.json", "vocab.json",
+                "merges.txt", "added_tokens.json", "special_tokens_map.json",
+                "model.safetensors", "model.safetensors.index.json",
+            ],
+            offlineMode: offlineMode,
+            progressHandler: { progressHandler?($0 * 0.5, "Downloading…") }
+        )
+        return try fromDirectory(dir, progressHandler: { progressHandler?(0.5 + $0 * 0.5, $1) })
+    }
+
+    // MARK: - Chat template (Qwen3 ChatML)
+
+    private func encodeChat(_ messages: [ChatMessage]) -> [Int] {
+        var ids: [Int] = []
+        func turn(_ role: String, _ content: String) {
+            ids.append(imStartId)
+            ids.append(contentsOf: tokenizer.encode(role))
+            ids.append(newlineId)
+            ids.append(contentsOf: tokenizer.encode(content))
+            ids.append(imEndId)
+            ids.append(newlineId)
+        }
+        for m in messages { turn(m.role.rawValue, m.content) }
+        ids.append(imStartId)
+        ids.append(contentsOf: tokenizer.encode("assistant"))
+        ids.append(newlineId)
+        return ids
+    }
+
+    // MARK: - Generation
+
+    private func lastLogits(_ logits: MLXArray) -> [Float] {
+        let t = logits.dim(1)
+        let last = logits[0, t - 1].asType(.float32)
+        eval(last)
+        return Array(last.asArray(Float.self).prefix(dc.vocabSize))
+    }
+
+    private func suppressEnd(_ logits: inout [Float]) {
+        let ninf = -Float.greatestFiniteMagnitude
+        for id in [dc.eosTokenId, imEndId] where id >= 0 && id < logits.count { logits[id] = ninf }
+    }
+
+    public func resetState() { state = .initial(config: dc) }
+
+    /// Numeric-parity helper: argmax + the next-token logits for a fixed prompt (no sampling).
+    public func nextTokenArgmax(promptTokens: [Int]) -> (argmax: Int, logit: Float, top5: [(Int, Float)]) {
+        resetState()
+        let arr = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
+        let (logits, _) = model.forward(inputIds: arr, state: state)
+        eval(logits)
+        let l = lastLogits(logits)
+        var best = 0
+        for i in 1..<l.count where l[i] > l[best] { best = i }
+        let top5 = l.enumerated().sorted { $0.element > $1.element }.prefix(5).map { ($0.offset, $0.element) }
+        return (best, l[best], Array(top5))
+    }
+
+    public func generateStream(
+        messages: [ChatMessage], sampling: ChatSamplingConfig = .default
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                self.resetState()
+                let prompt = self.encodeChat(messages)
+                let promptArray = MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0)
+                let (prefill, prefillState) = self.model.forward(inputIds: promptArray, state: self.state)
+                eval(prefill)
+                self.state = prefillState
+                var logits = self.lastLogits(prefill)
+
+                var generated: [Int] = []
+                var producedContent = false
+                var pending: [UInt8] = []
+
+                for _ in 0..<sampling.maxTokens {
+                    if !producedContent { self.suppressEnd(&logits) }
+                    let next = ChatSampler.sample(
+                        logits: logits, config: sampling, previousTokens: prompt + generated)
+                    if next == self.dc.eosTokenId || next == self.imEndId { break }
+                    generated.append(next)
+                    if !self.tokenizer.isSpecialToken(next) {
+                        producedContent = true
+                        pending.append(contentsOf: self.tokenizer.tokenBytes(next))
+                        let (text, rem) = ChatTokenizer.decodeUTF8Prefix(pending)
+                        pending = rem
+                        if !text.isEmpty { continuation.yield(text) }
+                    }
+                    let arr = MLXArray([Int32(next)]).expandedDimensions(axis: 0)
+                    let (step, ns) = self.model.forward(inputIds: arr, state: self.state)
+                    eval(step)
+                    self.state = ns
+                    logits = self.lastLogits(step)
+                }
+                if !pending.isEmpty { continuation.yield(String(decoding: pending, as: UTF8.self)) }
+                continuation.finish()
+            }
+        }
+    }
+
+    /// A `Qwen3ChatConfig` view for `Qwen35ChatBackend` conformance (the pipeline doesn't read the
+    /// Qwen3.5-specific fields). Internal memberwise init is visible within this module.
+    public lazy var config: Qwen3ChatConfig = Qwen3ChatConfig(
+        hiddenSize: dc.hiddenSize, numHiddenLayers: dc.numHiddenLayers,
+        numAttentionHeads: dc.numAttentionHeads, numKeyValueHeads: dc.numKeyValueHeads,
+        headDim: dc.headDim, intermediateSize: dc.intermediateSize, vocabSize: dc.vocabSize,
+        maxSeqLen: 32768, ropeTheta: Double(dc.ropeTheta), rmsNormEps: Double(dc.rmsNormEps),
+        eosTokenId: dc.eosTokenId, padTokenId: dc.eosTokenId, quantization: "int4",
+        modelType: nil, layerTypes: nil, fullAttentionInterval: nil,
+        linearNumKeyHeads: nil, linearKeyHeadDim: nil, linearNumValueHeads: nil,
+        linearValueHeadDim: nil, linearConvKernelDim: nil, partialRotaryFactor: nil,
+        tieWordEmbeddings: dc.tieWordEmbeddings)
+}
+
+extension Qwen3DenseChat: Qwen35ChatBackend {}

--- a/Sources/Qwen3Chat/Qwen3DenseModel.swift
+++ b/Sources/Qwen3Chat/Qwen3DenseModel.swift
@@ -1,0 +1,224 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXFast
+import MLXCommon
+
+// Hand-written MLX implementation of the standard **Qwen3 dense** transformer (model_type "qwen3"),
+// in the same style as Qwen35MLXModel but for the plain dense architecture used by the larger chat
+// models (Qwen3-1.7B / 4B / 8B …). Reuses the shared building blocks (PreQuantizedEmbedding,
+// QuantizedLinear, RMSNorm, RoPE, SDPA). No DeltaNet, no attention gate — every layer is a standard
+// GQA block: q/k/v/o projections, per-head q_norm/k_norm, full RoPE, SwiGLU MLP, pre-norm residuals.
+
+// MARK: - Config
+
+/// Parsed from a standard Qwen3 `config.json`.
+public struct Qwen3DenseConfig: Sendable {
+    public let hiddenSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let intermediateSize: Int
+    public let vocabSize: Int
+    public let ropeTheta: Float
+    public let rmsNormEps: Float
+    public let tieWordEmbeddings: Bool
+    public let eosTokenId: Int
+    public let quantGroupSize: Int
+    public let quantBits: Int
+
+    public static func load(from url: URL) throws -> Qwen3DenseConfig {
+        let obj = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any] ?? [:]
+        func int(_ k: String, _ d: Int) -> Int { (obj[k] as? NSNumber)?.intValue ?? d }
+        func dbl(_ k: String, _ d: Double) -> Double { (obj[k] as? NSNumber)?.doubleValue ?? d }
+        let hidden = int("hidden_size", 2560)
+        let heads = int("num_attention_heads", 32)
+        // head_dim may be omitted → hidden/heads
+        let headDim = obj["head_dim"] != nil ? int("head_dim", 128) : hidden / heads
+        // eos_token_id can be an int or a list
+        let eos: Int
+        if let n = obj["eos_token_id"] as? NSNumber { eos = n.intValue }
+        else if let a = obj["eos_token_id"] as? [NSNumber], let f = a.first { eos = f.intValue }
+        else { eos = 151645 }  // <|im_end|>
+        let quant = obj["quantization"] as? [String: Any]
+        return Qwen3DenseConfig(
+            hiddenSize: hidden,
+            numHiddenLayers: int("num_hidden_layers", 36),
+            numAttentionHeads: heads,
+            numKeyValueHeads: int("num_key_value_heads", 8),
+            headDim: headDim,
+            intermediateSize: int("intermediate_size", 9728),
+            vocabSize: int("vocab_size", 151936),
+            ropeTheta: Float(dbl("rope_theta", 5_000_000)),
+            rmsNormEps: Float(dbl("rms_norm_eps", 1e-6)),
+            tieWordEmbeddings: (obj["tie_word_embeddings"] as? Bool) ?? true,
+            eosTokenId: eos,
+            quantGroupSize: (quant?["group_size"] as? NSNumber)?.intValue ?? 64,
+            quantBits: (quant?["bits"] as? NSNumber)?.intValue ?? 4
+        )
+    }
+}
+
+// MARK: - Attention (standard GQA)
+
+public final class Qwen3DenseAttention: Module {
+    let numQHeads: Int, numKVHeads: Int, headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: QuantizedLinear
+    @ModuleInfo(key: "k_proj") var kProj: QuantizedLinear
+    @ModuleInfo(key: "v_proj") var vProj: QuantizedLinear
+    @ModuleInfo(key: "o_proj") var oProj: QuantizedLinear
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+    let rope: RoPE
+
+    public init(_ c: Qwen3DenseConfig) {
+        numQHeads = c.numAttentionHeads
+        numKVHeads = c.numKeyValueHeads
+        headDim = c.headDim
+        scale = 1.0 / sqrt(Float(c.headDim))
+        let gs = c.quantGroupSize, bits = c.quantBits
+        let qDim = numQHeads * headDim, kvDim = numKVHeads * headDim
+        _qProj = ModuleInfo(wrappedValue: QuantizedLinear(c.hiddenSize, qDim, bias: false, groupSize: gs, bits: bits))
+        _kProj = ModuleInfo(wrappedValue: QuantizedLinear(c.hiddenSize, kvDim, bias: false, groupSize: gs, bits: bits))
+        _vProj = ModuleInfo(wrappedValue: QuantizedLinear(c.hiddenSize, kvDim, bias: false, groupSize: gs, bits: bits))
+        _oProj = ModuleInfo(wrappedValue: QuantizedLinear(qDim, c.hiddenSize, bias: false, groupSize: gs, bits: bits))
+        _qNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: headDim, eps: c.rmsNormEps))
+        _kNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: headDim, eps: c.rmsNormEps))
+        rope = RoPE(dimensions: headDim, traditional: false, base: c.ropeTheta)
+        super.init()
+    }
+
+    /// - Returns: (output [B,T,hidden], updated KV cache (keys, values) each [B, Hkv, S, D]).
+    public func callAsFunction(
+        _ x: MLXArray, cache: (MLXArray, MLXArray)?, offset: Int
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let b = x.dim(0), t = x.dim(1)
+        // Project, reshape to heads, per-head q/k RMSNorm (Qwen3 normalises before RoPE).
+        var q = qNorm(qProj(x).reshaped(b, t, numQHeads, headDim))
+        var k = kNorm(kProj(x).reshaped(b, t, numKVHeads, headDim))
+        var v = vProj(x).reshaped(b, t, numKVHeads, headDim)
+        q = q.transposed(0, 2, 1, 3)
+        k = k.transposed(0, 2, 1, 3)
+        v = v.transposed(0, 2, 1, 3)
+
+        let ropeOffset = cache?.0.dim(2) ?? offset
+        q = rope(q, offset: ropeOffset)
+        k = rope(k, offset: ropeOffset)
+
+        var ck = k, cv = v
+        if let (pk, pv) = cache {
+            ck = concatenated([pk, k], axis: 2)
+            cv = concatenated([pv, v], axis: 2)
+        }
+
+        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
+        if t <= 1 && (cache != nil || offset > 0) {
+            maskMode = .none
+        } else {
+            let kvLen = ck.dim(2)
+            let pastLen = kvLen - t
+            let causal = MLXArray.tri(t, m: kvLen, k: pastLen, type: Float.self) - 1
+            let additive = causal * Float.greatestFiniteMagnitude  // 0 attended, -inf masked
+            maskMode = .array(additive.reshaped(1, 1, t, kvLen).asType(q.dtype))
+        }
+
+        let attnOut = SDPA.attendAndMerge(qHeads: q, kHeads: ck, vHeads: cv, scale: scale, mask: maskMode)
+        return (oProj(attnOut), (ck, cv))
+    }
+}
+
+// MARK: - SwiGLU MLP
+
+public final class Qwen3DenseMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: QuantizedLinear
+    @ModuleInfo(key: "up_proj") var upProj: QuantizedLinear
+    @ModuleInfo(key: "down_proj") var downProj: QuantizedLinear
+
+    public init(_ c: Qwen3DenseConfig) {
+        let h = c.hiddenSize, i = c.intermediateSize, gs = c.quantGroupSize, bits = c.quantBits
+        _gateProj = ModuleInfo(wrappedValue: QuantizedLinear(h, i, bias: false, groupSize: gs, bits: bits))
+        _upProj = ModuleInfo(wrappedValue: QuantizedLinear(h, i, bias: false, groupSize: gs, bits: bits))
+        _downProj = ModuleInfo(wrappedValue: QuantizedLinear(i, h, bias: false, groupSize: gs, bits: bits))
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+// MARK: - Transformer layer
+
+public final class Qwen3DenseLayer: Module {
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+    @ModuleInfo(key: "self_attn") var attn: Qwen3DenseAttention
+    @ModuleInfo var mlp: Qwen3DenseMLP
+
+    public init(_ c: Qwen3DenseConfig) {
+        _inputLayerNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+        _postAttentionLayerNorm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+        _attn = ModuleInfo(wrappedValue: Qwen3DenseAttention(c))
+        _mlp = ModuleInfo(wrappedValue: Qwen3DenseMLP(c))
+        super.init()
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, cache: (MLXArray, MLXArray)?, offset: Int
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let (a, newCache) = attn(inputLayerNorm(x), cache: cache, offset: offset)
+        let h = x + a
+        return (h + mlp(postAttentionLayerNorm(h)), newCache)
+    }
+}
+
+// MARK: - Model
+
+public final class Qwen3DenseModel: Module {
+    public let config: Qwen3DenseConfig
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: PreQuantizedEmbedding
+    @ModuleInfo var layers: [Qwen3DenseLayer]
+    @ModuleInfo var norm: RMSNorm
+    // Present only when embeddings are untied.
+    @ModuleInfo(key: "lm_head") var lmHead: QuantizedLinear?
+
+    public init(config c: Qwen3DenseConfig) {
+        self.config = c
+        _embedTokens = ModuleInfo(wrappedValue: PreQuantizedEmbedding(
+            embeddingCount: c.vocabSize, dimensions: c.hiddenSize,
+            groupSize: c.quantGroupSize, bits: c.quantBits))
+        _layers = ModuleInfo(wrappedValue: (0..<c.numHiddenLayers).map { _ in Qwen3DenseLayer(c) })
+        _norm = ModuleInfo(wrappedValue: RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps))
+        _lmHead = ModuleInfo(wrappedValue: c.tieWordEmbeddings ? nil
+            : QuantizedLinear(c.hiddenSize, c.vocabSize, bias: false, groupSize: c.quantGroupSize, bits: c.quantBits))
+        super.init()
+    }
+
+    /// KV cache for every layer + the current sequence position (RoPE offset).
+    public struct InferenceState {
+        public var kvCaches: [(MLXArray, MLXArray)?]
+        public var position: Int
+        public static func initial(config c: Qwen3DenseConfig) -> InferenceState {
+            InferenceState(kvCaches: Array(repeating: nil, count: c.numHiddenLayers), position: 0)
+        }
+    }
+
+    /// - Returns: (logits [B,T,vocab], updated state).
+    public func forward(inputIds: MLXArray, state: InferenceState) -> (MLXArray, InferenceState) {
+        let t = inputIds.dim(1)
+        var h = embedTokens(inputIds)
+        var caches = state.kvCaches
+        for (i, layer) in layers.enumerated() {
+            let (nh, nc) = layer(h, cache: state.kvCaches[i], offset: state.position)
+            h = nh
+            caches[i] = nc
+        }
+        h = norm(h)
+        let logits = lmHead?(h) ?? embedTokens.asLinear(h)  // tied → reuse embedding
+        return (logits, InferenceState(kvCaches: caches, position: state.position + t))
+    }
+}

--- a/Sources/Qwen3Chat/Qwen3DenseWeightLoading.swift
+++ b/Sources/Qwen3Chat/Qwen3DenseWeightLoading.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MLXCommon
+import MLX
+import MLXNN
+
+/// Loads quantized safetensors weights into `Qwen3DenseModel`.
+///
+/// Standard Qwen3 key layout (mlx-community / mlx_lm format), `model.` prefix stripped:
+///   - `embed_tokens.{weight,scales,biases}`           → embed_tokens (PreQuantizedEmbedding)
+///   - `norm.weight`                                    → final RMSNorm
+///   - `layers.{i}.input_layernorm.weight`
+///   - `layers.{i}.post_attention_layernorm.weight`
+///   - `layers.{i}.self_attn.{q,k,v,o}_proj.{weight,scales,biases}`
+///   - `layers.{i}.self_attn.{q,k}_norm.weight`
+///   - `layers.{i}.mlp.{gate,up,down}_proj.{weight,scales,biases}`
+///   - `lm_head.{weight,scales,biases}` (only when embeddings are untied)
+public enum Qwen3DenseWeightLoader {
+    public static func loadWeights(
+        into model: Qwen3DenseModel,
+        from directory: URL,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) throws {
+        progressHandler?(0.05, "Loading weight files...")
+        let all = try CommonWeightLoader.loadAllSafetensors(from: directory)
+        progressHandler?(0.3, "Loaded \(all.count) tensors")
+
+        var w: [String: MLXArray] = [:]
+        for (key, value) in all {
+            if key.hasPrefix("model.") {
+                w[String(key.dropFirst("model.".count))] = value
+            } else {
+                w[key] = value   // keeps top-level "lm_head.*"
+            }
+        }
+
+        progressHandler?(0.4, "Embeddings + final norm...")
+        CommonWeightLoader.applyQuantizedEmbeddingWeights(to: model.embedTokens, prefix: "embed_tokens", from: w)
+        CommonWeightLoader.applyRMSNormWeights(to: model.norm, prefix: "norm", from: w)
+        if let lmHead = model.lmHead {
+            CommonWeightLoader.applyQuantizedLinearWeights(to: lmHead, prefix: "lm_head", from: w)
+        }
+
+        progressHandler?(0.5, "Transformer layers...")
+        let n = model.config.numHiddenLayers
+        for i in 0..<n {
+            let p = "layers.\(i)"
+            let layer = model.layers[i]
+            CommonWeightLoader.applyRMSNormWeights(to: layer.inputLayerNorm, prefix: "\(p).input_layernorm", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: layer.postAttentionLayerNorm, prefix: "\(p).post_attention_layernorm", from: w)
+
+            let attn = layer.attn
+            CommonWeightLoader.applyQuantizedLinearWeights(to: attn.qProj, prefix: "\(p).self_attn.q_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: attn.kProj, prefix: "\(p).self_attn.k_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: attn.vProj, prefix: "\(p).self_attn.v_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: attn.oProj, prefix: "\(p).self_attn.o_proj", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: attn.qNorm, prefix: "\(p).self_attn.q_norm", from: w)
+            CommonWeightLoader.applyRMSNormWeights(to: attn.kNorm, prefix: "\(p).self_attn.k_norm", from: w)
+
+            let mlp = layer.mlp
+            CommonWeightLoader.applyQuantizedLinearWeights(to: mlp.gateProj, prefix: "\(p).mlp.gate_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: mlp.upProj, prefix: "\(p).mlp.up_proj", from: w)
+            CommonWeightLoader.applyQuantizedLinearWeights(to: mlp.downProj, prefix: "\(p).mlp.down_proj", from: w)
+
+            progressHandler?(0.5 + 0.45 * Double(i + 1) / Double(n), "Layer \(i + 1)/\(n)")
+        }
+
+        eval(model)
+        progressHandler?(1.0, "Weights loaded")
+    }
+}

--- a/Tests/Qwen3ChatTests/ChatModelConfigTests.swift
+++ b/Tests/Qwen3ChatTests/ChatModelConfigTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import Qwen3Chat
+
+final class ChatModelConfigTests: XCTestCase {
+    private func writeConfig(_ json: String, named name: String = "config.json") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("qwen3-chat-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try Data(json.utf8).write(to: url)
+        return url
+    }
+
+    func testQwen3DenseConfigParsesStandardMLXConfig() throws {
+        let url = try writeConfig("""
+        {
+          "hidden_size": 2560,
+          "num_hidden_layers": 36,
+          "num_attention_heads": 32,
+          "num_key_value_heads": 8,
+          "intermediate_size": 9728,
+          "vocab_size": 151936,
+          "rope_theta": 5000000,
+          "rms_norm_eps": 0.000001,
+          "tie_word_embeddings": true,
+          "eos_token_id": [151645, 151643],
+          "quantization": {"group_size": 64, "bits": 5}
+        }
+        """)
+
+        let config = try Qwen3DenseConfig.load(from: url)
+
+        XCTAssertEqual(config.hiddenSize, 2560)
+        XCTAssertEqual(config.numHiddenLayers, 36)
+        XCTAssertEqual(config.headDim, 80)
+        XCTAssertEqual(config.eosTokenId, 151645)
+        XCTAssertEqual(config.quantBits, 5)
+        XCTAssertTrue(config.tieWordEmbeddings)
+    }
+
+    func testGemma4ConfigParsesNestedTextConfigAndDerivedLayerTypes() throws {
+        let url = try writeConfig("""
+        {
+          "eos_token_id": [1, 106],
+          "quantization": {"group_size": 64, "bits": 4},
+          "text_config": {
+            "hidden_size": 1536,
+            "num_hidden_layers": 6,
+            "intermediate_size": 6144,
+            "num_attention_heads": 8,
+            "head_dim": 256,
+            "global_head_dim": 512,
+            "num_key_value_heads": 1,
+            "num_kv_shared_layers": 2,
+            "hidden_size_per_layer_input": 256,
+            "vocab_size": 262144,
+            "vocab_size_per_layer_input": 262144,
+            "sliding_window_pattern": 3,
+            "rope_parameters": {
+              "full_attention": {"rope_theta": 1000000, "partial_rotary_factor": 0.25},
+              "sliding_attention": {"rope_theta": 10000}
+            }
+          }
+        }
+        """)
+
+        let config = try Gemma4DenseConfig.load(from: url)
+
+        XCTAssertEqual(config.hiddenSize, 1536)
+        XCTAssertEqual(config.numHiddenLayers, 6)
+        XCTAssertEqual(config.numKVSharedLayers, 2)
+        XCTAssertEqual(config.eosTokenId, 1)
+        XCTAssertEqual(config.quantBits, 4)
+        XCTAssertEqual(config.headDim(forLayer: 0), 256)
+        XCTAssertEqual(config.headDim(forLayer: 2), 512)
+        XCTAssertEqual(config.layerTypes, [
+            "sliding_attention", "sliding_attention", "full_attention",
+            "sliding_attention", "sliding_attention", "full_attention",
+        ])
+    }
+}

--- a/Tests/Qwen3ChatTests/E2EGemma4GenTests.swift
+++ b/Tests/Qwen3ChatTests/E2EGemma4GenTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import Foundation
+@testable import Qwen3Chat
+
+/// End-to-end streaming generation: the incremental KV-cache + chat-template path must produce a
+/// coherent, thinking-free reply. Asserts the streamed answer to a factual prompt contains "Paris"
+/// and carries no chat-template / reasoning-channel markup.
+final class E2EGemma4GenTests: XCTestCase {
+    private static let modelDir: URL = {
+        if let p = ProcessInfo.processInfo.environment["GEMMA4_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return URL(fileURLWithPath:
+            "/Users/ivan/repos/runner-speech-models/speech-models/out/mlx/gemma-4-E2B-it-MLX-4bit")
+    }()
+
+    func testStreamingReplyAboutParis() throws {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDir.appendingPathComponent("config.json").path) else {
+            throw XCTSkip("Gemma 4 model dir unavailable: \(Self.modelDir.path)")
+        }
+
+        let chat: Gemma4Chat
+        do {
+            chat = try Gemma4Chat.fromDirectory(Self.modelDir)
+        } catch {
+            throw XCTSkip("model load failed (weights/metallib): \(error)")
+        }
+
+        let messages = [
+            ChatMessage(role: .system, content: "You are a helpful assistant. Give short direct answers."),
+            ChatMessage(role: .user, content: "What is the capital of France? Answer in one short sentence."),
+        ]
+        // Greedy for determinism; cap tokens so a runaway thought channel can't hang the test.
+        let sampling = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 64,
+                                          repetitionPenalty: 1.0)
+
+        let reply = try chat.generate(messages: messages, sampling: sampling)
+        print("[gemma4-gen] reply=\(reply.debugDescription)")
+
+        XCTAssertFalse(reply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                       "streamed reply must be non-empty")
+        XCTAssertTrue(reply.contains("Paris"), "reply must name Paris — got: \(reply)")
+        for marker in ["<|channel>", "<channel|>", "<|turn>", "<turn|>", "<start_of_turn>",
+                       "<end_of_turn>", "thought", "<bos>", "<eos>"] {
+            XCTAssertFalse(reply.contains(marker), "reply must not contain '\(marker)' — got: \(reply)")
+        }
+    }
+
+    /// Deterministic (no model): the reasoning-channel filter drops a `<|channel>thought … <channel|>`
+    /// block and emits only the answer text after it, decoding the SentencePiece byte-fallback tokens.
+    func testAnswerFilterSuppressesThoughtChannel() throws {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDir.appendingPathComponent("tokenizer.json").path) else {
+            throw XCTSkip("Gemma 4 tokenizer unavailable: \(Self.modelDir.path)")
+        }
+        let tok = Gemma4Tokenizer()
+        try tok.load(from: Self.modelDir)
+
+        // Build a synthetic stream: <|channel>(100) "thought\n let me think \n" <channel|>(101)
+        // then the real answer "Paris." — only the answer must survive.
+        var stream: [Int] = [100]
+        stream += tok.encode("thought\nThe user wants the capital. Let me think.\n")
+        stream += [101]
+        stream += tok.encode("Paris.")
+
+        var filter = Gemma4AnswerFilter(tokenizer: tok)
+        var out = ""
+        for id in stream { out += filter.consume(id) }
+        if let tail = filter.flush() { out += tail }
+
+        print("[gemma4-gen] filtered=\(out.debugDescription)")
+        XCTAssertEqual(out, "Paris.", "thought channel must be fully suppressed")
+        XCTAssertFalse(out.contains("think"))
+        XCTAssertFalse(out.contains("<|channel>"))
+
+        // And with no channel block, text passes through unchanged.
+        var f2 = Gemma4AnswerFilter(tokenizer: tok)
+        var out2 = ""
+        for id in tok.encode("The capital of France is Paris.") { out2 += f2.consume(id) }
+        if let t = f2.flush() { out2 += t }
+        XCTAssertEqual(out2, "The capital of France is Paris.")
+    }
+
+    /// Sanity: the first token off the incremental KV-cache path must equal a single-forward argmax,
+    /// proving the cache + cross-layer KV sharing reproduce the no-cache forward.
+    func testCacheFirstTokenMatchesSingleForward() throws {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDir.appendingPathComponent("config.json").path) else {
+            throw XCTSkip("Gemma 4 model dir unavailable: \(Self.modelDir.path)")
+        }
+        let chat: Gemma4Chat
+        do { chat = try Gemma4Chat.fromDirectory(Self.modelDir) }
+        catch { throw XCTSkip("model load failed: \(error)") }
+
+        let prompt = [818, 5279, 529, 7001, 563]   // same prompt as the parity test
+        let singleForwardArgmax = chat.nextTokenArgmax(promptTokens: prompt).argmax
+        let cacheArgmax = chat.firstTokenViaCache(promptTokens: prompt)
+        print("[gemma4-gen] single=\(singleForwardArgmax) cache=\(cacheArgmax)")
+        XCTAssertEqual(cacheArgmax, singleForwardArgmax,
+                       "KV-cache prefill must match the single-forward argmax")
+    }
+}

--- a/Tests/Qwen3ChatTests/E2EGemma4ParityTests.swift
+++ b/Tests/Qwen3ChatTests/E2EGemma4ParityTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import Foundation
+@testable import Qwen3Chat
+
+/// Numeric parity: the hand-written `Gemma4Model` must produce the same next-token logits as the
+/// Python `mlx_lm` reference for a fixed prompt — proving the full Gemma-4 forward pass (PLE,
+/// sandwich norms, dual RoPE, KV-sharing, double-wide MLP, per-layer gating, logit softcap, and
+/// quantized weight loading) is correct.
+///
+/// Reference (mlx_lm, gemma-4-E2B-it MLX int4, tokens [818, 5279, 529, 7001, 563]):
+///   argmax 7001 (logit -2.078),
+///   top5 [(7001,-2.078), (531,-12.5), (711,-13.94), (529,-15.13), (496,-15.56)].
+final class E2EGemma4ParityTests: XCTestCase {
+    /// Local MLX export directory (int4). Override with GEMMA4_MODEL_DIR if needed.
+    private static let modelDir: URL = {
+        if let p = ProcessInfo.processInfo.environment["GEMMA4_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return URL(fileURLWithPath:
+            "/Users/ivan/repos/runner-speech-models/speech-models/out/mlx/gemma-4-E2B-it-MLX-4bit")
+    }()
+
+    func testNextTokenArgmaxMatchesReference() throws {
+        guard FileManager.default.fileExists(atPath: Self.modelDir.appendingPathComponent("config.json").path) else {
+            throw XCTSkip("Gemma 4 model dir unavailable: \(Self.modelDir.path)")
+        }
+        Gemma4Model.debugStats = ProcessInfo.processInfo.environment["GEMMA4_DEBUG"] != nil
+        let chat: Gemma4Chat
+        do {
+            chat = try Gemma4Chat.fromDirectory(Self.modelDir)
+        } catch {
+            throw XCTSkip("model load failed (weights/metallib): \(error)")
+        }
+        let r = chat.nextTokenArgmax(promptTokens: [818, 5279, 529, 7001, 563])
+        print("[gemma4-parity] argmax=\(r.argmax) logit=\(String(format: "%.4f", r.logit)) "
+            + "top5=\(r.top5.map { "(\($0.0), \(String(format: "%.3f", $0.1)))" }.joined(separator: " "))")
+        XCTAssertEqual(r.argmax, 7001, "hand-written Gemma 4 forward must match mlx_lm reference argmax")
+        // Logit parity (quantized int4 → allow a small tolerance).
+        XCTAssertEqual(r.logit, -2.078, accuracy: 0.5, "top logit must match reference")
+    }
+}

--- a/Tests/Qwen3ChatTests/E2EQwen3DenseGenTests.swift
+++ b/Tests/Qwen3ChatTests/E2EQwen3DenseGenTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import Foundation
+@testable import Qwen3Chat
+
+/// End-to-end generation through the hand-written Qwen3 dense backend: chat template + tokenizer +
+/// the optimised sampler must produce coherent text (the forward pass is already parity-verified).
+final class E2EQwen3DenseGenTests: XCTestCase {
+    private static let modelDir: URL = {
+        if let p = ProcessInfo.processInfo.environment["QWEN3_DENSE_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return URL(fileURLWithPath:
+            "/Users/ivan/repos/runner-speech-models/speech-models/out/mlx/Qwen3-4B-Instruct-2507-MLX-4bit")
+    }()
+
+    func testGeneratesCoherentReply() async throws {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDir.appendingPathComponent("config.json").path) else {
+            throw XCTSkip("Qwen3 dense model dir unavailable: \(Self.modelDir.path)")
+        }
+
+        let chat: Qwen3DenseChat
+        do {
+            chat = try Qwen3DenseChat.fromDirectory(Self.modelDir)
+        } catch {
+            throw XCTSkip("model load failed (weights/metallib): \(error)")
+        }
+        let sampling = ChatSamplingConfig(temperature: 0.5, topK: 50, topP: 0.9, maxTokens: 40, repetitionPenalty: 1.1)
+
+        for prompt in ["What is the capital of France?", "Say hello in one short sentence."] {
+            var reply = ""
+            for try await chunk in chat.generateStream(
+                messages: [ChatMessage(role: .user, content: prompt)], sampling: sampling) {
+                reply += chunk
+            }
+            reply = reply.trimmingCharacters(in: .whitespacesAndNewlines)
+            print("[dense-gen] «\(prompt)» → «\(reply)»")
+            XCTAssertFalse(reply.isEmpty, "should generate text")
+            XCTAssertFalse(reply.contains("\u{FFFD}"), "no mojibake")
+            XCTAssertFalse(reply.contains("<|"), "no leaked special tokens")
+        }
+    }
+}

--- a/Tests/Qwen3ChatTests/E2EQwen3DenseParityTests.swift
+++ b/Tests/Qwen3ChatTests/E2EQwen3DenseParityTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import Foundation
+@testable import Qwen3Chat
+
+/// Numeric parity: the hand-written `Qwen3DenseModel` must produce the same next-token logits as the
+/// Python `mlx_lm` reference for a fixed prompt — proving the forward pass (attention/MLP/RoPE/QK-norm/
+/// quantized weight loading) is correct before trusting any generation.
+///
+/// Reference (mlx_lm, Qwen3-4B-Instruct-2507 MLX int4, tokens [9707, 11, 1879, 0]):
+///   argmax 358 (logit 11.31), top5 [358, 220, 320, 1096, 11162].
+final class E2EQwen3DenseParityTests: XCTestCase {
+    private static let modelDir: URL = {
+        if let p = ProcessInfo.processInfo.environment["QWEN3_DENSE_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return URL(fileURLWithPath:
+            "/Users/ivan/repos/runner-speech-models/speech-models/out/mlx/Qwen3-4B-Instruct-2507-MLX-4bit")
+    }()
+
+    func testNextTokenArgmaxMatchesReference() async throws {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDir.appendingPathComponent("config.json").path) else {
+            throw XCTSkip("Qwen3 dense model dir unavailable: \(Self.modelDir.path)")
+        }
+
+        let chat: Qwen3DenseChat
+        do {
+            chat = try Qwen3DenseChat.fromDirectory(Self.modelDir)
+        } catch {
+            throw XCTSkip("model load failed (weights/metallib): \(error)")
+        }
+        let r = chat.nextTokenArgmax(promptTokens: [9707, 11, 1879, 0])
+        print("[dense-parity] argmax=\(r.argmax) logit=\(String(format: "%.4f", r.logit)) top5=\(r.top5.map { "(\($0.0), \(String(format: "%.3f", $0.1)))" }.joined(separator: " "))")
+        XCTAssertEqual(r.argmax, 358, "hand-written forward must match mlx_lm reference argmax")
+    }
+}

--- a/docs/models/gemma4-chat.md
+++ b/docs/models/gemma4-chat.md
@@ -1,0 +1,128 @@
+# Gemma 4 Chat Model
+
+Swift MLX backend for Gemma 4 text checkpoints in the `Qwen3Chat` module. The public entry point is `Gemma4Chat`, which conforms to the same `Qwen35ChatBackend` protocol used by `Qwen35PipelineLLM`.
+
+## Overview
+
+`Gemma4Chat` loads Gemma 4 text weights from MLX safetensors exports such as:
+
+- `aufklarer/gemma-4-E4B-it-MLX-4bit`
+- `aufklarer/gemma-4-E2B-it-MLX-4bit`
+
+The implementation targets the text tower from Gemma 4 multimodal-style configs. It is a hand-written Swift port of the Gemma 4 text architecture, not a wrapper around `mlx-swift-lm`.
+
+## Architecture
+
+Gemma 4 text differs from Qwen-style dense chat models in several important ways:
+
+| Component | Gemma 4 behavior |
+|---|---|
+| Chat template | `<|turn>role\n...<turn|>\n`, with assistant role rendered as `model` |
+| Tokenizer | SentencePiece-style tokenizer with byte fallback |
+| Layer input | Per-layer embeddings projected from token ids |
+| Norms | Sandwich RMSNorm blocks around attention and feed-forward stages |
+| Attention | Sliding-attention and full-attention layers with different head dimensions |
+| RoPE | Standard sliding RoPE plus proportional RoPE for full attention |
+| KV sharing | Later layers reuse K/V from earlier producer layers of the same attention type |
+| MLP | Double-wide MLP on KV-shared layers when configured |
+| Logits | Tied LM head followed by final logit softcap |
+
+The config parser reads the nested `text_config` block used by Gemma 4 exports and falls back to root-level fields for standalone text configs.
+
+## Chat Template
+
+Gemma 4 does not use ChatML and does not use the older Gemma `<start_of_turn>` format. The runtime renders:
+
+```text
+<bos><|turn>system
+...
+<turn|>
+<|turn>user
+...
+<turn|>
+<|turn>model
+```
+
+Assistant messages in history are mapped to the `model` role. Generation starts after the final `<|turn>model\n` prompt.
+
+## Reasoning Channel
+
+Some Gemma 4 checkpoints may emit a thought channel before the user-visible answer:
+
+```text
+<|channel>thought
+...
+<channel|>
+```
+
+`Gemma4AnswerFilter` suppresses that channel by exact token id, drops special tokens, and streams only answer text. Text bytes are buffered until they form valid UTF-8, which prevents partial byte-fallback tokens from leaking mojibake into downstream TTS.
+
+## Loading
+
+```swift
+import Qwen3Chat
+
+let chat = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit"
+)
+```
+
+For local or test exports:
+
+```swift
+let dir = URL(fileURLWithPath: "/path/to/gemma-4-E4B-it-MLX-4bit")
+let chat = try Gemma4Chat.fromDirectory(dir)
+```
+
+Required files:
+
+- `config.json`
+- `tokenizer.json`
+- `tokenizer_config.json`
+- `generation_config.json`
+- `model.safetensors` and/or `model.safetensors.index.json`
+
+## Streaming
+
+```swift
+let messages = [
+    ChatMessage(role: .system, content: "You are concise."),
+    ChatMessage(role: .user, content: "What is the capital of France?")
+]
+
+let sampling = ChatSamplingConfig(
+    temperature: 0.3,
+    topK: 50,
+    topP: 0.9,
+    maxTokens: 80,
+    repetitionPenalty: 1.05
+)
+
+for try await chunk in chat.generateStream(messages: messages, sampling: sampling) {
+    print(chunk, terminator: "")
+}
+```
+
+## Verification
+
+The backend has both deterministic and E2E coverage:
+
+- `ChatModelConfigTests` checks nested Gemma 4 config parsing and derived layer types.
+- `E2EGemma4ParityTests` verifies next-token argmax against the `mlx_lm` reference.
+- `E2EGemma4GenTests` verifies streaming generation, thought-channel suppression, and cache-path first-token parity.
+
+Reference parity prompt:
+
+| Prompt tokens | Expected argmax |
+|---|---:|
+| `[818, 5279, 529, 7001, 563]` | `7001` |
+
+## Source Files
+
+```text
+Sources/Qwen3Chat/
+  Gemma4Chat.swift           Public loader, streaming generation, answer filter, chat template
+  Gemma4Model.swift          Gemma 4 text transformer layers and incremental state
+  Gemma4Tokenizer.swift      SentencePiece byte-fallback tokenizer
+  Gemma4WeightLoading.swift  MLX safetensors loader for Gemma 4 key layout
+```

--- a/docs/models/qwen35-chat.md
+++ b/docs/models/qwen35-chat.md
@@ -1,8 +1,16 @@
-# Qwen3.5-0.8B Chat Model
+# Qwen3Chat Models
 
-On-device LLM for chat using the Qwen3.5-0.8B hybrid architecture (DeltaNet + GatedAttention).
+On-device text generation backends exposed by the `Qwen3Chat` target. The module now covers:
+
+- `Qwen35MLXChat` / `Qwen35CoreMLChat`: Qwen3.5-0.8B hybrid chat for low-memory agents.
+- `Qwen3DenseChat`: standard dense Qwen3 instruct checkpoints such as Qwen3-4B.
+- `Gemma4Chat`: Gemma 4 text checkpoints such as E2B and E4B, including Gemma's native turn template and reasoning-channel filtering.
+
+All three conform to the same streaming backend surface used by `Qwen35PipelineLLM`, so voice-agent code can swap models without changing the pipeline wrapper.
 
 ## Architecture
+
+### Qwen3.5-0.8B Hybrid
 
 Qwen3.5-0.8B is a **hybrid recurrent-attention** model with 24 transformer layers:
 
@@ -76,7 +84,7 @@ Standard multi-head attention with these specifics:
 
 ## Weight Formats
 
-### MLX (Mac GPU)
+### Qwen3.5 MLX (Mac GPU)
 
 Repo: `aufklarer/Qwen3.5-0.8B-Chat-MLX` with `int4/` and `int8/` subdirectories.
 
@@ -92,7 +100,7 @@ Key naming:
 - GatedAttention: `layers.{i}.self_attn.{q_proj, k_proj, v_proj, o_proj, q_norm, k_norm}`
 - MLP: `layers.{i}.mlp.{gate_proj, up_proj, down_proj}`
 
-### CoreML (iOS Neural Engine)
+### Qwen3.5 CoreML (iOS Neural Engine)
 
 Repo: `aufklarer/Qwen3.5-0.8B-Chat-CoreML` with `int4/` and `int8/` subdirectories.
 
@@ -100,6 +108,42 @@ Split into two pre-compiled models (shipped as `.mlmodelc`; the legacy
 `.mlpackage` still lives in the repo for older builds):
 - `embedding.mlmodelc` — token embedding lookup
 - `decoder.mlmodelc` — full transformer with stateful DeltaNet (MLState) and KV cache
+
+### Dense Qwen3 MLX
+
+Repo examples:
+
+- `aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit`
+- `aufklarer/Qwen3-4B-Instruct-2507-MLX-4bit`
+
+`Qwen3DenseChat` loads standard MLX safetensors with `model.`-prefixed keys. It implements the normal dense Qwen3 transformer:
+
+- grouped-query attention with per-head Q/K RMSNorm
+- full RoPE
+- SwiGLU MLP blocks
+- tied or untied LM head
+- ChatML `<|im_start|>...<|im_end|>` prompting
+
+The shared `PreQuantizedEmbedding` path supports non-4/8-bit packing, so 5-bit MLX exports can be used directly.
+
+### Gemma 4 MLX
+
+Repo examples:
+
+- `aufklarer/gemma-4-E4B-it-MLX-4bit`
+- `aufklarer/gemma-4-E2B-it-MLX-4bit`
+
+`Gemma4Chat` loads the text tower from Gemma 4 multimodal-style MLX exports. The Swift model mirrors the Gemma 4 text architecture:
+
+- per-layer embeddings (PLE)
+- sandwich RMSNorm blocks
+- dual/proportional RoPE for sliding and full-attention layers
+- KV sharing across later layers
+- double-wide MLP on shared-KV layers
+- final logit softcap
+- SentencePiece byte-fallback tokenizer
+
+Gemma 4 uses a `<|turn>role\n...<turn|>` chat template, not ChatML. The streaming backend filters the optional `<|channel>thought ... <channel|>` reasoning channel and yields only assistant-visible answer text.
 
 ## Swift API
 
@@ -120,6 +164,14 @@ let response = try model.generate(
 for try await chunk in model.generateStream(messages: messages) {
     print(chunk, terminator: "")
 }
+
+// Dense Qwen3 MLX (for larger on-device chat)
+let qwen4b = try await Qwen3DenseChat.fromPretrained(
+    modelId: "aufklarer/Qwen3-4B-Instruct-2507-MLX-5bit")
+
+// Gemma 4 MLX
+let gemma = try await Gemma4Chat.fromPretrained(
+    modelId: "aufklarer/gemma-4-E4B-it-MLX-4bit")
 ```
 
 ## Token IDs

--- a/docs/models/qwen35-chat.md
+++ b/docs/models/qwen35-chat.md
@@ -4,7 +4,7 @@ On-device text generation backends exposed by the `Qwen3Chat` target. The module
 
 - `Qwen35MLXChat` / `Qwen35CoreMLChat`: Qwen3.5-0.8B hybrid chat for low-memory agents.
 - `Qwen3DenseChat`: standard dense Qwen3 instruct checkpoints such as Qwen3-4B.
-- `Gemma4Chat`: Gemma 4 text checkpoints such as E2B and E4B, including Gemma's native turn template and reasoning-channel filtering.
+- `Gemma4Chat`: Gemma 4 text checkpoints such as E2B and E4B, including Gemma's native turn template and reasoning-channel filtering. See [`gemma4-chat.md`](gemma4-chat.md) for the dedicated Gemma 4 model notes.
 
 All three conform to the same streaming backend surface used by `Qwen35PipelineLLM`, so voice-agent code can swap models without changing the pipeline wrapper.
 


### PR DESCRIPTION
## Summary

Adds two larger chat backends to the existing `Qwen3Chat` module:

- `Gemma4Chat` for Gemma 4 E2B/E4B MLX text checkpoints, including the native `<|turn>` chat template, SentencePiece byte-fallback tokenizer, KV sharing, dual/proportional RoPE, sandwich norms, logit softcap, and reasoning-channel suppression.
- `Qwen3DenseChat` for standard dense Qwen3 instruct MLX checkpoints such as Qwen3-4B, with ChatML prompting and streaming generation.

Also updates shared chat runtime support:

- Adds exact-token lookup to `ChatTokenizer` for model-specific chat templates.
- Optimizes `ChatSampler` by sampling from a bounded top-K candidate set instead of sorting the full vocabulary.
- Supports non-4/8-bit packed quantized embeddings for 5-bit MLX exports.
- Exposes MLX GPU cache controls for chat apps.

## Docs

- Expands `docs/models/qwen35-chat.md` into a `Qwen3Chat` model doc covering Qwen3.5, dense Qwen3, and Gemma 4.
- Updates `README.md` and all translated READMEs with the new chat model coverage and examples.

## Validation

- `swift build`
- `swift test --filter ChatModelConfigTests`
- `swift test --filter E2EGemma4`
- `swift test --filter E2EQwen3Dense`
- `git diff --check`
