### PR TITLE
Fix OmniVoice instruct conditioning

### DIFF
--- a/Sources/OmniVoiceTTS/OmniVoiceTTSModel.swift
+++ b/Sources/OmniVoiceTTS/OmniVoiceTTSModel.swift
@@ -65,14 +65,29 @@ public final class OmniVoiceTTSModel {
     ) async throws -> OmniVoiceTTSModel {
         let dir = try HuggingFaceDownloader.getCacheDirectory(for: modelId)
         let fm = FileManager.default
-        if !fm.fileExists(atPath: dir.appendingPathComponent("model.safetensors").path) {
+        // Repair incomplete or pre-tokenizer-config caches. The HF snapshot fetch
+        // is incremental, so already-present blobs are not refetched.
+        let requiredFiles = [
+            "model.safetensors",
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "audio_tokenizer/model.safetensors",
+        ]
+        let hasMissingFile = requiredFiles.contains {
+            !fm.fileExists(atPath: dir.appendingPathComponent($0).path)
+        }
+        if hasMissingFile {
             progressHandler?(0.0, "Downloading \(modelId)...")
             // No explicit `.safetensors` in additionalFiles keeps the automatic
             // `*.safetensors` glob (fetches the top-level backbone); `audio_tokenizer/*`
-            // pulls the codec + its config.
+            // pulls the codec + its config. `tokenizer_config.json` carries the
+            // tokenizer class the loader needs.
             try await HuggingFaceDownloader.downloadWeights(
                 modelId: modelId, to: dir,
-                additionalFiles: ["config.json", "tokenizer.json", "audio_tokenizer/*"],
+                additionalFiles: [
+                    "config.json", "tokenizer.json", "tokenizer_config.json", "audio_tokenizer/*",
+                ],
                 offlineMode: offlineMode
             ) { progressHandler?($0 * 0.9, "Downloading model...") }
         }
@@ -88,6 +103,8 @@ public final class OmniVoiceTTSModel {
     ///   - referenceAudio: reference clip to clone (any format/rate; resampled to 24 kHz).
     ///   - referenceText: optional transcript of the reference (improves prosody).
     ///   - language: OmniVoice language id (e.g. "en"); the model covers 600+.
+    ///   - instruct: optional restricted OmniVoice style item (accent / age / gender /
+    ///     pitch / whisper); `nil` for neutral.
     ///   - duration: optional fixed output length in seconds; `nil` estimates from text.
     ///   - numSteps: diffusion steps (16 default; 12 is a faster, near-equal setting).
     /// - Returns: mono Float samples at `sampleRate`.
@@ -96,6 +113,7 @@ public final class OmniVoiceTTSModel {
         referenceAudio: URL,
         referenceText: String?,
         language: String = "en",
+        instruct: String? = nil,
         duration: Double? = nil,
         numSteps: Int = 16
     ) throws -> [Float] {
@@ -104,17 +122,81 @@ public final class OmniVoiceTTSModel {
         let refWav = MLXArray(refSamples).reshaped([1, 1, refSamples.count])
         let refTokens = encoder.encode(refWav)
 
-        let targetLen = duration.map { max(1, Int(($0 * frameRate).rounded())) }
-            ?? builder.estimateTargetLen(text: text, lang: language, frameRate: frameRate)
+        // Target length: an explicit duration wins; otherwise estimate the token
+        // count from the reference's pace (its text weight vs its token count),
+        // matching OmniVoice's `_estimate_target_tokens`.
+        let targetLen: Int
+        if let d = duration {
+            targetLen = max(1, Int((d * frameRate).rounded()))
+        } else {
+            let refTokenCount = refTokens.dim(refTokens.ndim - 1)
+            targetLen = RuleDurationEstimator.shared.estimateTargetTokens(
+                targetText: text, refText: referenceText, numRefAudioTokens: refTokenCount)
+        }
 
         let (ids, mask) = builder.buildInputs(
             text: text, refText: referenceText, lang: language,
-            refAudioTokens: refTokens, targetLen: targetLen, denoise: true, instruct: nil)
+            refAudioTokens: refTokens, targetLen: targetLen, denoise: true, instruct: instruct)
         let tokens = model.generateTokens(
             condInputIds: ids, audioMask: mask, targetLen: targetLen, numSteps: numSteps)
         let wav = codec.decode(tokens)
         MLX.eval(wav)
-        return wav.asType(.float32).asArray(Float.self)
+        let samples = wav.asType(.float32).asArray(Float.self)
+        let trimmed = Self.trimLeadingNoise(samples, sampleRate: cfg.sampleRate)
+        return Self.applyEdgeFades(trimmed, sampleRate: cfg.sampleRate)
+    }
+
+    /// Raised-cosine fade in/out over the edges, matching the reference's
+    /// `fade_and_pad_audio` (`fade_duration` 0.1 s). The long fade ramps over the
+    /// kept leading silence so the diffusion+codec onset transient is inaudible,
+    /// and removes any tail click, without shortening the speech (the fade sits on
+    /// the silence the trim left, not on the words).
+    static func applyEdgeFades(_ input: [Float], sampleRate: Int) -> [Float] {
+        var s = input
+        let n = s.count
+        let fade = min(sampleRate / 10, n / 2)  // ~100 ms (or half the clip)
+        guard fade > 0 else { return s }
+        for i in 0 ..< fade {
+            let w = Float(0.5 * (1.0 - cos(Double.pi * Double(i) / Double(fade))))
+            s[i] *= w
+            s[n - 1 - i] *= w
+        }
+        return s
+    }
+
+    /// Drop the brief codec/diffusion startup transient and any leading silence:
+    /// find where the signal first stays above a small energy threshold for a
+    /// sustained span (real speech, not the millisecond startup burst) and cut
+    /// just before it, keeping a short lead-in. Returns the input unchanged when
+    /// no sustained onset is found (e.g. an already-clean or silent clip).
+    static func trimLeadingNoise(_ s: [Float], sampleRate: Int) -> [Float] {
+        guard !s.isEmpty else { return s }
+        let win = max(1, sampleRate / 100)  // 10 ms windows
+        let sustain = 6  // require ~60 ms continuously above threshold = real speech
+        let threshold: Float = 0.02
+        func windowRMS(_ start: Int) -> Float {
+            let end = min(start + win, s.count)
+            var acc: Float = 0
+            for j in start ..< end { acc += s[j] * s[j] }
+            return (acc / Float(max(1, end - start))).squareRoot()
+        }
+        var start = 0
+        var found = false
+        while start + win * sustain <= s.count {
+            var ok = true
+            var k = 0
+            while k < sustain {
+                if windowRMS(start + k * win) < threshold { ok = false; break }
+                k += 1
+            }
+            if ok { found = true; break }
+            start += win
+        }
+        guard found, start > 0 else { return s }
+        // Keep 100 ms of leading silence (matches the reference's `lead_sil`); the
+        // 100 ms fade then ramps over it, reaching the speech onset gently.
+        let cut = max(0, start - sampleRate / 10)
+        return Array(s[cut...])
     }
 
     private static func readQuantization(_ url: URL) -> (groupSize: Int, bits: Int)? {

--- a/Sources/OmniVoiceTTS/RuleDurationEstimator.swift
+++ b/Sources/OmniVoiceTTS/RuleDurationEstimator.swift
@@ -106,6 +106,37 @@ public final class RuleDurationEstimator: @unchecked Sendable {
         return sum
     }
 
+    /// Estimate the target audio **token** count, matching OmniVoice's
+    /// `_estimate_target_tokens` -> `estimate_duration`. The reference's *token
+    /// count* (not its wall-clock seconds) sets the speaker's pace: a target whose
+    /// text weight is k times the reference's gets roughly k times the reference's
+    /// tokens. When the reference text/length is absent, the reference falls back
+    /// to a fixed prior ("Nice to meet you." / 25 tokens). Short estimates get a
+    /// power-curve boost.
+    public func estimateTargetTokens(
+        targetText: String, refText: String?, numRefAudioTokens: Int?,
+        lowThreshold: Double = 50, boostStrength: Double = 3
+    ) -> Int {
+        let effectiveRefText: String
+        let effectiveRefTokens: Int
+        if let refText, !refText.isEmpty, let numRefAudioTokens {
+            effectiveRefText = refText
+            effectiveRefTokens = numRefAudioTokens
+        } else {
+            effectiveRefText = "Nice to meet you."
+            effectiveRefTokens = 25
+        }
+        let refDuration = Double(effectiveRefTokens)
+        let refWeight = totalWeight(effectiveRefText)
+        guard refDuration > 0, refWeight > 0 else { return 1 }
+        let speedFactor = refWeight / refDuration
+        var est = totalWeight(targetText) / speedFactor
+        if est < lowThreshold {
+            est = lowThreshold * pow(est / lowThreshold, 1.0 / boostStrength)
+        }
+        return max(1, Int(est))
+    }
+
     /// First letter of the Unicode general category (`L`/`M`/`N`/`P`/`S`/`Z`/…),
     /// matching Python `unicodedata.category(c)[0]` for the cases the estimator
     /// branches on.

--- a/Tests/OmniVoiceTTSTests/InputConstructionTests.swift
+++ b/Tests/OmniVoiceTTSTests/InputConstructionTests.swift
@@ -115,4 +115,47 @@ final class InputConstructionTests: XCTestCase {
         // CJK char weighs 3.0.
         XCTAssertEqual(est.totalWeight("\u{4F60}"), 3.0, accuracy: 1e-9)
     }
+
+    func testReferencePacedTargetTokenEstimator() {
+        let est = RuleDurationEstimator.shared
+        let target = "The quick brown fox jumps over the lazy dog."
+        let ref = "Hello there, this is a cloned voice."
+
+        let shortRef = est.estimateTargetTokens(
+            targetText: target, refText: ref, numRefAudioTokens: 25)
+        let longRef = est.estimateTargetTokens(
+            targetText: target, refText: ref, numRefAudioTokens: 75)
+
+        XCTAssertGreaterThan(longRef, shortRef, "slower reference should produce more target tokens")
+        XCTAssertGreaterThan(est.estimateTargetTokens(
+            targetText: target, refText: nil, numRefAudioTokens: nil), 0)
+    }
+
+    func testTrimLeadingNoiseKeepsShortLeadInBeforeSustainedSpeech() {
+        let sampleRate = 100
+        let input = Array(repeating: Float(0), count: 30)
+            + Array(repeating: Float(0.03), count: 20)
+            + Array(repeating: Float(0), count: 10)
+
+        let trimmed = OmniVoiceTTSModel.trimLeadingNoise(input, sampleRate: sampleRate)
+
+        XCTAssertEqual(trimmed.count, 40)
+        XCTAssertEqual(Array(trimmed.prefix(10)), Array(repeating: Float(0), count: 10))
+        XCTAssertEqual(Array(trimmed.dropFirst(10).prefix(20)), Array(repeating: Float(0.03), count: 20))
+    }
+
+    func testTrimLeadingNoiseLeavesSilentClipUnchanged() {
+        let input = Array(repeating: Float(0), count: 64)
+        XCTAssertEqual(OmniVoiceTTSModel.trimLeadingNoise(input, sampleRate: 100), input)
+    }
+
+    func testApplyEdgeFadesKeepsLengthAndFadesEdges() {
+        let input = Array(repeating: Float(1), count: 20)
+        let faded = OmniVoiceTTSModel.applyEdgeFades(input, sampleRate: 100)
+
+        XCTAssertEqual(faded.count, input.count)
+        XCTAssertEqual(faded.first ?? -1, Float(0), accuracy: Float(1e-6))
+        XCTAssertEqual(faded.last ?? -1, Float(0), accuracy: Float(1e-6))
+        XCTAssertGreaterThan(faded[10], Float(0.9))
+    }
 }


### PR DESCRIPTION
## Summary

Adds the OmniVoice `generate(..., instruct:)` API that Speech Studio needs, and keeps the generation path on the reference-compatible runtime behavior.

## What changed

- Passes the optional OmniVoice `instruct` value into input construction instead of hardcoding neutral conditioning.
- Repairs incomplete pretrained caches by fetching all required bundle files, including `tokenizer_config.json`.
- Uses reference-paced target token estimation when no explicit duration is provided.
- Applies leading-transient trim and edge fades to generated audio.
- Adds unit coverage for reference-paced duration, leading trim, silent clips, and edge fades.

## Why

Speech Studio maps script markers to OmniVoice's restricted instruct vocabulary. Its sidecar now calls `OmniVoiceTTSModel.generate(..., instruct:)`, so this API needs to land in speech-swift before the Studio PR can pass macOS CI.

## Test plan

- `swift test --filter InputConstructionTests`
- `make test`