### PR TITLE
Add Indic-Mio raw reference cloning

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -43,10 +43,10 @@ public struct SpeakCommand: ParsableCommand {
     @Option(name: .long, help: "[qwen3] Style instruction (requires CustomVoice model)")
     public var instruct: String?
 
-    @Option(name: .long, help: "Reference audio file for voice cloning (qwen3 Base, cosyvoice, or voxcpm2)")
+    @Option(name: .long, help: "Reference audio file for voice cloning (qwen3 Base, cosyvoice, voxcpm2, or indic-mio)")
     public var voiceSample: String?
 
-    @Flag(name: .long, help: "Restore (denoise + dereverb) the voice-cloning reference with Sidon before cloning. Opt-in; preserves speaker identity. Applies to qwen3/cosyvoice/voxcpm2 references.")
+    @Flag(name: .long, help: "Restore (denoise + dereverb) the voice-cloning reference with Sidon before cloning. Opt-in; preserves speaker identity. Applies to qwen3/cosyvoice/voxcpm2/indic-mio references.")
     public var cleanReference: Bool = false
 
     @Option(name: .long, help: "Sidon variant for --clean-reference: fp16 (default) or int8")
@@ -222,14 +222,11 @@ public struct SpeakCommand: ParsableCommand {
             if stream {
                 throw ValidationError("--engine indic-mio does not support --stream yet")
             }
-            if voiceSample != nil {
-                throw ValidationError(
-                    "--engine indic-mio does not support raw --voice-sample cloning yet. " +
-                    "Use --indic-mio-global-embedding with a 128-float MioCodec global embedding, " +
-                    "or wait for the WavLM reference-embedding path.")
+            if voiceSample != nil && indicMioGlobalEmbedding != nil {
+                throw ValidationError("--engine indic-mio accepts either --voice-sample or --indic-mio-global-embedding, not both")
             }
-            if cleanReference {
-                throw ValidationError("--clean-reference requires --voice-sample and is not supported by --engine indic-mio yet")
+            if cleanReference && voiceSample == nil {
+                throw ValidationError("--clean-reference requires --voice-sample")
             }
             if speaker != nil {
                 throw ValidationError("--engine indic-mio does not support --speaker; pass emotion markers in text, e.g. '<happy>'")
@@ -888,6 +885,13 @@ public struct SpeakCommand: ParsableCommand {
             )
 
             let embedding = try indicMioGlobalEmbedding.map { try loadIndicMioGlobalEmbedding(from: $0) }
+            let referenceAudio: [Float]?
+            if let voiceSample {
+                referenceAudio = try loadReference(path: voiceSample, targetSampleRate: model.sampleRate)
+                print("  Reference audio: \(referenceAudio?.count ?? 0) samples @ \(model.sampleRate) Hz")
+            } else {
+                referenceAudio = nil
+            }
             let sampling = IndicMioSamplingConfig(
                 maxNewTokens: maxTokens,
                 temperature: temperature,
@@ -899,16 +903,34 @@ public struct SpeakCommand: ParsableCommand {
             let markers = IndicMioPrompt.indianLanguageEmotionMarkers.joined(separator: ", ")
             var info = "Synthesizing with Indic-Mio (language: \(effectiveIndicMioLanguage))"
             if embedding != nil { info += " [global speaker embedding]" }
+            if referenceAudio != nil { info += " [voice clone: WavLM global embedding]" }
             print(info)
             print("  Emotion markers: \(markers)")
 
             let start = CFAbsoluteTimeGetCurrent()
-            let samples = try await model.generate(
-                text: inputText,
-                language: effectiveIndicMioLanguage,
-                globalEmbedding: embedding,
-                sampling: sampling
-            )
+            let samples: [Float]
+            if let embedding {
+                samples = try await model.generate(
+                    text: inputText,
+                    language: effectiveIndicMioLanguage,
+                    globalEmbedding: embedding,
+                    sampling: sampling
+                )
+            } else if let referenceAudio {
+                samples = try await model.generate(
+                    text: inputText,
+                    language: effectiveIndicMioLanguage,
+                    referenceAudio: referenceAudio,
+                    referenceSampleRate: model.sampleRate,
+                    sampling: sampling
+                )
+            } else {
+                samples = try await model.generate(
+                    text: inputText,
+                    language: effectiveIndicMioLanguage,
+                    sampling: sampling
+                )
+            }
             let elapsed = CFAbsoluteTimeGetCurrent() - start
 
             guard !samples.isEmpty else {

--- a/Sources/IndicMioTTS/IndicMioTTSModel.swift
+++ b/Sources/IndicMioTTS/IndicMioTTSModel.swift
@@ -14,8 +14,10 @@ public final class IndicMioTTSModel: SpeechGenerationModel, @unchecked Sendable 
     private let tokenizer: IndicMioTokenizer
     private let languageModel: IndicMioQwen3Model
     private let contentDecoder: MioCodecContentDecoder
+    private let globalEncoder: MioCodecGlobalEncoder
     private let waveDecoder: MioCodecWaveDecoder
     private var state: IndicMioQwen3Model.InferenceState
+    private var wavLMReferenceEncoder: IndicMioWavLMFeatureModel?
 
     private init(
         bundleDirectory: URL,
@@ -24,6 +26,7 @@ public final class IndicMioTTSModel: SpeechGenerationModel, @unchecked Sendable 
         tokenizer: IndicMioTokenizer,
         languageModel: IndicMioQwen3Model,
         contentDecoder: MioCodecContentDecoder,
+        globalEncoder: MioCodecGlobalEncoder,
         waveDecoder: MioCodecWaveDecoder
     ) {
         self.bundleDirectory = bundleDirectory
@@ -33,6 +36,7 @@ public final class IndicMioTTSModel: SpeechGenerationModel, @unchecked Sendable 
         self.tokenizer = tokenizer
         self.languageModel = languageModel
         self.contentDecoder = contentDecoder
+        self.globalEncoder = globalEncoder
         self.waveDecoder = waveDecoder
         self.state = .initial(config: modelConfig)
     }
@@ -95,6 +99,10 @@ public final class IndicMioTTSModel: SpeechGenerationModel, @unchecked Sendable 
         let contentDecoder = MioCodecContentDecoder()
         contentDecoder.loadWeights(from: codecWeights)
 
+        progressHandler?(0.91, "Loading MioCodec global encoder")
+        let globalEncoder = MioCodecGlobalEncoder()
+        globalEncoder.loadWeights(from: codecWeights)
+
         progressHandler?(0.94, "Loading MioCodec wave decoder")
         let waveDecoder = MioCodecWaveDecoder()
         waveDecoder.loadWeights(from: codecWeights)
@@ -107,6 +115,7 @@ public final class IndicMioTTSModel: SpeechGenerationModel, @unchecked Sendable 
             tokenizer: tokenizer,
             languageModel: languageModel,
             contentDecoder: contentDecoder,
+            globalEncoder: globalEncoder,
             waveDecoder: waveDecoder)
     }
 
@@ -176,8 +185,14 @@ public final class IndicMioTTSModel: SpeechGenerationModel, @unchecked Sendable 
         referenceSampleRate: Int,
         sampling: IndicMioSamplingConfig = .default
     ) async throws -> [Float] {
-        throw IndicMioError.speakerEmbeddingNotImplemented(
-            "raw reference audio requires MioCodec's WavLM-based SSL feature extractor; pass a 128-dim globalEmbedding until that bundle is exported and ported")
+        let globalEmbedding = try await extractGlobalEmbedding(
+            referenceAudio: referenceAudio,
+            referenceSampleRate: referenceSampleRate)
+        return try await generate(
+            text: text,
+            language: language,
+            globalEmbedding: globalEmbedding,
+            sampling: sampling)
     }
 
     public func generate(text: String, language: String?) async throws -> [Float] {
@@ -190,6 +205,87 @@ public final class IndicMioTTSModel: SpeechGenerationModel, @unchecked Sendable 
         globalEmbedding: [Float]
     ) async throws -> [Float] {
         try await generate(text: text, language: language, globalEmbedding: globalEmbedding, sampling: .default)
+    }
+
+    public func extractGlobalEmbedding(
+        referenceAudio: [Float],
+        referenceSampleRate: Int
+    ) async throws -> [Float] {
+        guard !referenceAudio.isEmpty else {
+            throw IndicMioError.invalidConfig("reference audio must not be empty")
+        }
+
+        let wavlm = try await referenceEncoder()
+        let prepared = prepareReferenceAudioForWavLM(
+            referenceAudio,
+            sourceSampleRate: referenceSampleRate,
+            wavlm: wavlm)
+        let sslFeatures = wavlm.averagedGlobalFeatures(audio16k: prepared)
+        let embedding = globalEncoder(sslFeatures).asType(.float32).squeezed()
+        eval(embedding)
+        return embedding.asArray(Float.self)
+    }
+
+    private func referenceEncoder() async throws -> IndicMioWavLMFeatureModel {
+        if let wavLMReferenceEncoder {
+            return wavLMReferenceEncoder
+        }
+
+        if let bundle = ProcessInfo.processInfo.environment["INDIC_MIO_WAVLM_BUNDLE"], !bundle.isEmpty {
+            let model = try IndicMioWavLMFeatureModel.fromBundle(
+                URL(fileURLWithPath: bundle, isDirectory: true))
+            wavLMReferenceEncoder = model
+            return model
+        }
+
+        let model = try await IndicMioWavLMFeatureModel.fromPretrained()
+        wavLMReferenceEncoder = model
+        return model
+    }
+
+    private func prepareReferenceAudioForWavLM(
+        _ audio: [Float],
+        sourceSampleRate: Int,
+        wavlm: IndicMioWavLMFeatureModel
+    ) -> [Float] {
+        let audio24k = sourceSampleRate == IndicMioReferenceConfig.codecSampleRate
+            ? audio
+            : AudioFileLoader.resample(
+                audio,
+                from: sourceSampleRate,
+                to: IndicMioReferenceConfig.codecSampleRate)
+
+        let padding = referencePaddingSamples24k(
+            audioLength: audio24k.count,
+            wavlm: wavlm)
+        let padded: [Float]
+        if padding > 0 {
+            padded = [Float](repeating: 0, count: padding)
+                + audio24k
+                + [Float](repeating: 0, count: padding)
+        } else {
+            padded = audio24k
+        }
+
+        return AudioFileLoader.resample(
+            padded,
+            from: IndicMioReferenceConfig.codecSampleRate,
+            to: IndicMioReferenceConfig.wavLMSampleRate)
+    }
+
+    private func referencePaddingSamples24k(
+        audioLength: Int,
+        wavlm: IndicMioWavLMFeatureModel
+    ) -> Int {
+        let resampledLength = Double(audioLength)
+            / Double(IndicMioReferenceConfig.codecSampleRate)
+            * Double(IndicMioReferenceConfig.wavLMSampleRate)
+        let expectedFrames = Int(ceil(resampledLength / Double(IndicMioReferenceConfig.wavLMHopSize)))
+        let required16k = wavlm.minimumWavLMInputLength(forFeatureFrames: max(1, expectedFrames))
+        let required24k = Double(required16k)
+            / Double(IndicMioReferenceConfig.wavLMSampleRate)
+            * Double(IndicMioReferenceConfig.codecSampleRate)
+        return max(0, Int(ceil((required24k - Double(audioLength)) / 2.0)))
     }
 
     private func generateSpeechTokens(

--- a/Sources/IndicMioTTS/IndicMioWavLM.swift
+++ b/Sources/IndicMioTTS/IndicMioWavLM.swift
@@ -1,0 +1,434 @@
+import AudioCommon
+import Foundation
+import MLX
+import MLXCommon
+import MLXNN
+
+public enum IndicMioReferenceConfig {
+    public static let defaultWavLMModelId = "aufklarer/WavLM-Base-Plus-MLX-fp16"
+    public static let microsoftWavLMModelId = "microsoft/wavlm-base-plus"
+    public static let codecSampleRate = 24_000
+    public static let wavLMSampleRate = 16_000
+    public static let wavLMHopSize = 320
+}
+
+final class IndicMioWavLMConvLayer: Module {
+    @ModuleInfo var conv: MioConv1dNCL
+    @ModuleInfo(key: "layer_norm") var layerNorm: GroupNorm?
+    let useGroupNorm: Bool
+
+    init(inputChannels: Int, outputChannels: Int, kernelSize: Int, stride: Int, useGroupNorm: Bool) {
+        self._conv.wrappedValue = MioConv1dNCL(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: kernelSize,
+            stride: stride,
+            bias: false)
+        self.useGroupNorm = useGroupNorm
+        self._layerNorm.wrappedValue = useGroupNorm
+            ? GroupNorm(
+                groupCount: outputChannels,
+                dimensions: outputChannels,
+                eps: 1e-5,
+                affine: true,
+                pytorchCompatible: true)
+            : nil
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv(x)
+        if useGroupNorm, let layerNorm {
+            h = layerNorm(h.transposed(0, 2, 1)).transposed(0, 2, 1)
+        }
+        return gelu(h)
+    }
+
+    func loadWeights(prefix: String, from weights: [String: MLXArray]) {
+        CommonWeightLoader.applyConv1dWeights(
+            to: conv.conv,
+            prefix: "\(prefix).conv",
+            from: weights,
+            transpose: true)
+        if let layerNorm {
+            applyMioGroupNormWeights(to: layerNorm, prefix: "\(prefix).layer_norm", from: weights)
+        }
+    }
+}
+
+final class IndicMioWavLMFeatureEncoder: Module {
+    @ModuleInfo(key: "conv_layers") var convLayers: [IndicMioWavLMConvLayer]
+
+    let kernels = [10, 3, 3, 3, 3, 2, 2]
+    let strides = [5, 2, 2, 2, 2, 2, 2]
+
+    override init() {
+        var layers: [IndicMioWavLMConvLayer] = []
+        var inputChannels = 1
+        for i in 0..<kernels.count {
+            layers.append(IndicMioWavLMConvLayer(
+                inputChannels: inputChannels,
+                outputChannels: 512,
+                kernelSize: kernels[i],
+                stride: strides[i],
+                useGroupNorm: i == 0))
+            inputChannels = 512
+        }
+        self._convLayers.wrappedValue = layers
+        super.init()
+    }
+
+    /// Input `[B, samples]`, output `[B, 512, T]`.
+    func callAsFunction(_ inputValues: MLXArray) -> MLXArray {
+        var h = inputValues.expandedDimensions(axis: 1)
+        for layer in convLayers {
+            h = layer(h)
+        }
+        return h
+    }
+
+    func getMinimumInputLength(desiredOutputLength: Int) -> Int {
+        var length = desiredOutputLength
+        for (kernel, stride) in zip(kernels, strides).reversed() {
+            length = (length - 1) * stride + kernel
+        }
+        return length
+    }
+
+    func loadWeights(from weights: [String: MLXArray]) {
+        for i in convLayers.indices {
+            convLayers[i].loadWeights(prefix: "feature_extractor.conv_layers.\(i)", from: weights)
+        }
+    }
+}
+
+final class IndicMioWavLMFeatureProjection: Module {
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo var projection: Linear
+
+    override init() {
+        self._layerNorm.wrappedValue = LayerNorm(dimensions: 512, eps: 1e-5)
+        self._projection.wrappedValue = Linear(512, 768, bias: true)
+        super.init()
+    }
+
+    /// Input `[B, T, 512]`, output `[B, T, 768]`.
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        projection(layerNorm(x))
+    }
+
+    func loadWeights(from weights: [String: MLXArray]) {
+        CommonWeightLoader.applyLayerNormWeights(to: layerNorm, prefix: "feature_projection.layer_norm", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: projection, prefix: "feature_projection.projection", from: weights)
+    }
+}
+
+final class IndicMioWavLMPositionConv: Module {
+    @ModuleInfo var conv: MioConv1dNCL
+
+    override init() {
+        self._conv.wrappedValue = MioConv1dNCL(
+            inputChannels: 768,
+            outputChannels: 768,
+            kernelSize: 128,
+            padding: 64,
+            groups: 16)
+        super.init()
+    }
+
+    /// Input `[B, T, 768]`, output `[B, T, 768]`.
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let length = x.dim(1)
+        var h = conv(x.transposed(0, 2, 1)).transposed(0, 2, 1)
+        h = h[0..., 0..<length, 0...]
+        return gelu(h)
+    }
+
+    func loadWeights(from weights: [String: MLXArray]) {
+        var params: [String: NestedItem<String, MLXArray>] = [:]
+        if let g = weights["encoder.pos_conv_embed.conv.weight_g"],
+           let v = weights["encoder.pos_conv_embed.conv.weight_v"] {
+            let vf = v.asType(.float32)
+            let gf = g.asType(.float32)
+            let norm = MLX.sqrt((vf * vf).sum(axes: [0, 1], keepDims: true))
+            params["weight"] = .value((gf * vf / norm).transposed(0, 2, 1))
+        } else if let weight = weights["encoder.pos_conv_embed.conv.weight"] {
+            params["weight"] = .value(weight.transposed(0, 2, 1))
+        }
+        if let bias = weights["encoder.pos_conv_embed.conv.bias"] {
+            params["bias"] = .value(bias)
+        }
+        if !params.isEmpty {
+            conv.conv.update(parameters: ModuleParameters(values: params))
+        }
+    }
+}
+
+final class IndicMioWavLMAttention: Module {
+    let numHeads = 12
+    let headDim = 64
+    let scale: Float = 1.0 / Foundation.sqrt(Float(64))
+    let numBuckets = 320
+    let maxDistance = 800
+
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+    @ModuleInfo(key: "gru_rel_pos_linear") var gruRelPosLinear: Linear
+    @ModuleInfo(key: "rel_attn_embed") var relAttnEmbed: Embedding?
+    @ParameterInfo(key: "gru_rel_pos_const") var gruRelPosConst: MLXArray
+
+    init(hasRelativePositionBias: Bool) {
+        self._kProj.wrappedValue = Linear(768, 768, bias: true)
+        self._vProj.wrappedValue = Linear(768, 768, bias: true)
+        self._qProj.wrappedValue = Linear(768, 768, bias: true)
+        self._outProj.wrappedValue = Linear(768, 768, bias: true)
+        self._gruRelPosLinear.wrappedValue = Linear(headDim, 8, bias: true)
+        self._relAttnEmbed.wrappedValue = hasRelativePositionBias
+            ? Embedding(embeddingCount: numBuckets, dimensions: numHeads)
+            : nil
+        self._gruRelPosConst = ParameterInfo(wrappedValue: MLXArray.ones([1, numHeads, 1, 1]))
+        super.init()
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray, positionBias: MLXArray?) -> (MLXArray, MLXArray) {
+        let batch = hiddenStates.dim(0)
+        let targetLength = hiddenStates.dim(1)
+
+        let basePositionBias = positionBias ?? computeBias(queryLength: targetLength, keyLength: targetLength)
+
+        let gatedHidden = hiddenStates
+            .reshaped(batch, targetLength, numHeads, headDim)
+            .transposed(0, 2, 1, 3)
+        let relativePositionProj = gruRelPosLinear(gatedHidden)
+            .reshaped(batch, numHeads, targetLength, 2, 4)
+            .sum(axis: -1)
+        let gateA = sigmoid(relativePositionProj[0..., 0..., 0..., 0]).expandedDimensions(axis: -1)
+        let gateB = sigmoid(relativePositionProj[0..., 0..., 0..., 1]).expandedDimensions(axis: -1)
+        let gateOutput = gateA * (gateB * gruRelPosConst - 1.0) + 2.0
+        let gatedPositionBias = gateOutput * basePositionBias
+
+        let q = qProj(hiddenStates)
+            .reshaped(batch, targetLength, numHeads, headDim)
+            .transposed(0, 2, 1, 3)
+        let k = kProj(hiddenStates)
+            .reshaped(batch, targetLength, numHeads, headDim)
+            .transposed(0, 2, 1, 3)
+        let v = vProj(hiddenStates)
+            .reshaped(batch, targetLength, numHeads, headDim)
+            .transposed(0, 2, 1, 3)
+        let attended = SDPA.attendAndMerge(
+            qHeads: q,
+            kHeads: k,
+            vHeads: v,
+            scale: scale,
+            mask: gatedPositionBias.asType(q.dtype))
+        return (outProj(attended), basePositionBias)
+    }
+
+    func loadWeights(prefix: String, from weights: [String: MLXArray]) {
+        CommonWeightLoader.applyLinearWeights(to: kProj, prefix: "\(prefix).k_proj", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: vProj, prefix: "\(prefix).v_proj", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: qProj, prefix: "\(prefix).q_proj", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: outProj, prefix: "\(prefix).out_proj", from: weights)
+        CommonWeightLoader.applyLinearWeights(
+            to: gruRelPosLinear,
+            prefix: "\(prefix).gru_rel_pos_linear",
+            from: weights)
+        if let relAttnEmbed {
+            CommonWeightLoader.applyEmbeddingWeights(
+                to: relAttnEmbed,
+                prefix: "\(prefix).rel_attn_embed",
+                from: weights)
+        }
+        if let value = weights["\(prefix).gru_rel_pos_const"] {
+            update(parameters: ModuleParameters(values: ["gru_rel_pos_const": .value(value)]))
+        }
+    }
+
+    private func computeBias(queryLength: Int, keyLength: Int) -> MLXArray {
+        guard let relAttnEmbed else {
+            fatalError("First WavLM layer must own rel_attn_embed")
+        }
+        var buckets = [Int32]()
+        buckets.reserveCapacity(queryLength * keyLength)
+        for query in 0..<queryLength {
+            for key in 0..<keyLength {
+                buckets.append(Int32(relativePositionBucket(key - query)))
+            }
+        }
+        let bucketIds = MLXArray(buckets).reshaped(queryLength, keyLength)
+        let values = relAttnEmbed(bucketIds)
+        return values.transposed(2, 0, 1).expandedDimensions(axis: 0)
+    }
+
+    private func relativePositionBucket(_ relativePosition: Int) -> Int {
+        let halfBuckets = numBuckets / 2
+        var bucket = relativePosition > 0 ? halfBuckets : 0
+        let n = abs(relativePosition)
+        let maxExact = halfBuckets / 2
+        if n < maxExact {
+            bucket += n
+        } else {
+            let logRatio = Foundation.log(Double(max(n, 1)) / Double(maxExact))
+                / Foundation.log(Double(maxDistance) / Double(maxExact))
+            let large = min(halfBuckets - 1, maxExact + Int(logRatio * Double(halfBuckets - maxExact)))
+            bucket += large
+        }
+        return bucket
+    }
+}
+
+final class IndicMioWavLMFeedForward: Module {
+    @ModuleInfo(key: "intermediate_dense") var intermediateDense: Linear
+    @ModuleInfo(key: "output_dense") var outputDense: Linear
+
+    override init() {
+        self._intermediateDense.wrappedValue = Linear(768, 3_072, bias: true)
+        self._outputDense.wrappedValue = Linear(3_072, 768, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        outputDense(gelu(intermediateDense(x)))
+    }
+
+    func loadWeights(prefix: String, from weights: [String: MLXArray]) {
+        CommonWeightLoader.applyLinearWeights(
+            to: intermediateDense,
+            prefix: "\(prefix).intermediate_dense",
+            from: weights)
+        CommonWeightLoader.applyLinearWeights(to: outputDense, prefix: "\(prefix).output_dense", from: weights)
+    }
+}
+
+final class IndicMioWavLMEncoderLayer: Module {
+    @ModuleInfo var attention: IndicMioWavLMAttention
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo(key: "feed_forward") var feedForward: IndicMioWavLMFeedForward
+    @ModuleInfo(key: "final_layer_norm") var finalLayerNorm: LayerNorm
+
+    init(hasRelativePositionBias: Bool) {
+        self._attention.wrappedValue = IndicMioWavLMAttention(
+            hasRelativePositionBias: hasRelativePositionBias)
+        self._layerNorm.wrappedValue = LayerNorm(dimensions: 768, eps: 1e-5)
+        self._feedForward.wrappedValue = IndicMioWavLMFeedForward()
+        self._finalLayerNorm.wrappedValue = LayerNorm(dimensions: 768, eps: 1e-5)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, positionBias: MLXArray?) -> (MLXArray, MLXArray) {
+        let (attended, nextBias) = attention(x, positionBias: positionBias)
+        var h = layerNorm(x + attended)
+        h = finalLayerNorm(h + feedForward(h))
+        return (h, nextBias)
+    }
+
+    func loadWeights(prefix: String, from weights: [String: MLXArray]) {
+        attention.loadWeights(prefix: "\(prefix).attention", from: weights)
+        CommonWeightLoader.applyLayerNormWeights(to: layerNorm, prefix: "\(prefix).layer_norm", from: weights)
+        feedForward.loadWeights(prefix: "\(prefix).feed_forward", from: weights)
+        CommonWeightLoader.applyLayerNormWeights(
+            to: finalLayerNorm,
+            prefix: "\(prefix).final_layer_norm",
+            from: weights)
+    }
+}
+
+public final class IndicMioWavLMFeatureModel: Module {
+    public static let defaultModelId = IndicMioReferenceConfig.defaultWavLMModelId
+
+    @ModuleInfo(key: "feature_extractor") var featureExtractor: IndicMioWavLMFeatureEncoder
+    @ModuleInfo(key: "feature_projection") var featureProjection: IndicMioWavLMFeatureProjection
+    @ModuleInfo(key: "pos_conv_embed") var posConvEmbed: IndicMioWavLMPositionConv
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo var layers: [IndicMioWavLMEncoderLayer]
+
+    public override init() {
+        self._featureExtractor.wrappedValue = IndicMioWavLMFeatureEncoder()
+        self._featureProjection.wrappedValue = IndicMioWavLMFeatureProjection()
+        self._posConvEmbed.wrappedValue = IndicMioWavLMPositionConv()
+        self._layerNorm.wrappedValue = LayerNorm(dimensions: 768, eps: 1e-5)
+        self._layers.wrappedValue = [
+            IndicMioWavLMEncoderLayer(hasRelativePositionBias: true),
+            IndicMioWavLMEncoderLayer(hasRelativePositionBias: false),
+        ]
+        super.init()
+    }
+
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> IndicMioWavLMFeatureModel {
+        let directory = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: directory,
+            additionalFiles: ["config.json", "model.safetensors"],
+            offlineMode: offlineMode,
+            progressHandler: { progressHandler?($0, "Downloading WavLM reference encoder") })
+        return try fromBundle(directory)
+    }
+
+    public static func fromBundle(_ directory: URL) throws -> IndicMioWavLMFeatureModel {
+        let weights = try CommonWeightLoader.loadAllSafetensors(from: directory)
+        let model = IndicMioWavLMFeatureModel()
+        model.loadWeights(from: weights)
+        return model
+    }
+
+    public func averagedGlobalFeatures(audio16k: [Float]) -> MLXArray {
+        let waveform = MLXArray(audio16k).expandedDimensions(axis: 0)
+        var features = featureExtractor(waveform)
+        features = features.transposed(0, 2, 1)
+        var hidden = featureProjection(features)
+        let pos = posConvEmbed(hidden)
+        hidden = layerNorm(hidden + pos)
+
+        var positionBias: MLXArray?
+        var selected: [MLXArray] = []
+        selected.reserveCapacity(layers.count)
+        for layer in layers {
+            let (next, bias) = layer(hidden, positionBias: positionBias)
+            hidden = next
+            positionBias = bias
+            selected.append(hidden)
+        }
+        return (selected[0] + selected[1]) / 2.0
+    }
+
+    public func minimumWavLMInputLength(forFeatureFrames frames: Int) -> Int {
+        featureExtractor.getMinimumInputLength(desiredOutputLength: frames)
+    }
+
+    func loadWeights(from weights: [String: MLXArray]) {
+        featureExtractor.loadWeights(from: weights)
+        featureProjection.loadWeights(from: weights)
+        posConvEmbed.loadWeights(from: weights)
+        CommonWeightLoader.applyLayerNormWeights(to: layerNorm, prefix: "encoder.layer_norm", from: weights)
+        for i in layers.indices {
+            layers[i].loadWeights(prefix: "encoder.layers.\(i)", from: weights)
+        }
+        eval(self)
+    }
+}
+
+private func applyMioGroupNormWeights(
+    to groupNorm: GroupNorm,
+    prefix: String,
+    from weights: [String: MLXArray]
+) {
+    var params: [String: NestedItem<String, MLXArray>] = [:]
+    if let weight = weights["\(prefix).weight"] {
+        params["weight"] = .value(weight)
+    }
+    if let bias = weights["\(prefix).bias"] {
+        params["bias"] = .value(bias)
+    }
+    if !params.isEmpty {
+        groupNorm.update(parameters: ModuleParameters(values: params))
+    }
+}

--- a/Sources/IndicMioTTS/MioCodecGlobalEncoder.swift
+++ b/Sources/IndicMioTTS/MioCodecGlobalEncoder.swift
@@ -1,0 +1,172 @@
+import Foundation
+import MLX
+import MLXCommon
+import MLXNN
+
+final class MioGlobalConvNeXtBlock: Module {
+    @ModuleInfo(key: "dwconv") var depthwiseConv: MioConv1dNCL
+    @ModuleInfo var norm: LayerNorm
+    @ModuleInfo var pwconv1: Linear
+    @ModuleInfo var pwconv2: Linear
+    @ParameterInfo var gamma: MLXArray
+
+    init(dim: Int = 384, intermediateDim: Int = 1_152) {
+        self._depthwiseConv.wrappedValue = MioConv1dNCL(
+            inputChannels: dim,
+            outputChannels: dim,
+            kernelSize: 7,
+            padding: 3,
+            groups: dim)
+        self._norm.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6)
+        self._pwconv1.wrappedValue = Linear(dim, intermediateDim, bias: true)
+        self._pwconv2.wrappedValue = Linear(intermediateDim, dim, bias: true)
+        self._gamma = ParameterInfo(wrappedValue: MLXArray.ones([dim]))
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let residual = x
+        var h = depthwiseConv(x)
+        h = h.transposed(0, 2, 1)
+        h = norm(h)
+        h = pwconv1(h)
+        h = gelu(h)
+        h = pwconv2(h)
+        h = gamma * h
+        return residual + h.transposed(0, 2, 1)
+    }
+
+    func loadWeights(prefix: String, from weights: [String: MLXArray]) {
+        CommonWeightLoader.applyConv1dWeights(
+            to: depthwiseConv.conv,
+            prefix: "\(prefix).dwconv",
+            from: weights,
+            transpose: true)
+        CommonWeightLoader.applyLayerNormWeights(to: norm, prefix: "\(prefix).norm", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: pwconv1, prefix: "\(prefix).pwconv1", from: weights)
+        CommonWeightLoader.applyLinearWeights(to: pwconv2, prefix: "\(prefix).pwconv2", from: weights)
+        if let gamma = weights["\(prefix).gamma"] {
+            update(parameters: ModuleParameters(values: ["gamma": .value(gamma)]))
+        }
+    }
+}
+
+final class MioGlobalConvNeXtBackbone: Module {
+    @ModuleInfo var embed: MioConv1dNCL
+    @ModuleInfo var norm: LayerNorm
+    @ModuleInfo var convnext: [MioGlobalConvNeXtBlock]
+    @ModuleInfo(key: "final_layer_norm") var finalLayerNorm: LayerNorm
+
+    init(inputChannels: Int = 768, dim: Int = 384, intermediateDim: Int = 1_152, numLayers: Int = 4) {
+        self._embed.wrappedValue = MioConv1dNCL(
+            inputChannels: inputChannels,
+            outputChannels: dim,
+            kernelSize: 7,
+            padding: 3)
+        self._norm.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6)
+        self._convnext.wrappedValue = (0..<numLayers).map { _ in
+            MioGlobalConvNeXtBlock(dim: dim, intermediateDim: intermediateDim)
+        }
+        self._finalLayerNorm.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6)
+        super.init()
+    }
+
+    /// Input `[B, T, C]`, output `[B, T, 384]`.
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = embed(x.transposed(0, 2, 1))
+        h = norm(h.transposed(0, 2, 1)).transposed(0, 2, 1)
+        for block in convnext {
+            h = block(h)
+        }
+        return finalLayerNorm(h.transposed(0, 2, 1))
+    }
+
+    func loadWeights(prefix: String, from weights: [String: MLXArray]) {
+        CommonWeightLoader.applyConv1dWeights(
+            to: embed.conv,
+            prefix: "\(prefix).embed",
+            from: weights,
+            transpose: true)
+        CommonWeightLoader.applyLayerNormWeights(to: norm, prefix: "\(prefix).norm", from: weights)
+        for i in convnext.indices {
+            convnext[i].loadWeights(prefix: "\(prefix).convnext.\(i)", from: weights)
+        }
+        CommonWeightLoader.applyLayerNormWeights(
+            to: finalLayerNorm,
+            prefix: "\(prefix).final_layer_norm",
+            from: weights)
+    }
+}
+
+final class MioAttentiveStatsPool: Module {
+    @ModuleInfo(key: "attn_0") var attn0: MioConv1dNCL
+    @ModuleInfo(key: "attn_2") var attn2: MioConv1dNCL
+    @ModuleInfo var proj: Linear
+    @ModuleInfo var norm: LayerNorm
+
+    init(inputChannels: Int = 384, outputChannels: Int = 128, attentionChannels: Int = 128) {
+        self._attn0.wrappedValue = MioConv1dNCL(
+            inputChannels: inputChannels,
+            outputChannels: attentionChannels,
+            kernelSize: 1)
+        self._attn2.wrappedValue = MioConv1dNCL(
+            inputChannels: attentionChannels,
+            outputChannels: inputChannels,
+            kernelSize: 1)
+        self._proj.wrappedValue = Linear(inputChannels * 2, outputChannels, bias: true)
+        self._norm.wrappedValue = LayerNorm(dimensions: outputChannels, eps: 1e-5)
+        super.init()
+    }
+
+    /// Input `[B, C, T]`, output `[B, 128]`.
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var alpha = attn0(x)
+        alpha = MLX.tanh(alpha)
+        alpha = attn2(alpha)
+        alpha = MLX.softmax(alpha, axis: 2)
+
+        let mean = MLX.sum(alpha * x, axis: 2)
+        let secondMoment = MLX.sum(alpha * x * x, axis: 2)
+        let residuals = MLX.clip(secondMoment - mean * mean, min: MLXArray(Float(1e-4)), max: MLXArray(Float(1e4)))
+        let std = MLX.sqrt(residuals)
+        return norm(proj(concatenated([mean, std], axis: 1)))
+    }
+
+    func loadWeights(prefix: String, from weights: [String: MLXArray]) {
+        CommonWeightLoader.applyConv1dWeights(
+            to: attn0.conv,
+            prefix: "\(prefix).attn.0",
+            from: weights,
+            transpose: true)
+        CommonWeightLoader.applyConv1dWeights(
+            to: attn2.conv,
+            prefix: "\(prefix).attn.2",
+            from: weights,
+            transpose: true)
+        CommonWeightLoader.applyLinearWeights(to: proj, prefix: "\(prefix).proj", from: weights)
+        CommonWeightLoader.applyLayerNormWeights(to: norm, prefix: "\(prefix).norm", from: weights)
+    }
+}
+
+public final class MioCodecGlobalEncoder: Module {
+    @ModuleInfo var backbone: MioGlobalConvNeXtBackbone
+    @ModuleInfo var pooling: MioAttentiveStatsPool
+
+    public override init() {
+        self._backbone.wrappedValue = MioGlobalConvNeXtBackbone()
+        self._pooling.wrappedValue = MioAttentiveStatsPool()
+        super.init()
+    }
+
+    /// Input `[B, T, 768]` averaged WavLM features, output `[B, 128]`.
+    public func callAsFunction(_ sslFeatures: MLXArray) -> MLXArray {
+        let features = backbone(sslFeatures)
+        return pooling(features.transposed(0, 2, 1))
+    }
+
+    public func loadWeights(from weights: [String: MLXArray]) {
+        backbone.loadWeights(prefix: "global_encoder.backbone", from: weights)
+        pooling.loadWeights(prefix: "global_encoder.pooling", from: weights)
+        eval(self)
+    }
+}

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -597,10 +597,26 @@ final class SpeakCommandTests: XCTestCase {
 
     // MARK: - Indic-Mio engine
 
-    func testIndicMioRejectsVoiceSampleUntilReferenceEmbeddingLands() {
+    func testIndicMioAcceptsVoiceSampleReference() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "speak", "नमस्ते <happy>",
+            "--engine", "indic-mio",
+            "--voice-sample", "ref.wav",
+        ])
+        let speak = try XCTUnwrap(cmd as? SpeakCommand)
+        XCTAssertEqual(speak.voiceSample, "ref.wav")
+    }
+
+    func testIndicMioRejectsVoiceSampleWithExplicitEmbedding() {
+        let embedding = Array(repeating: "0", count: 128).joined(separator: ",")
         expectSpeakReject(
-            ["speak", "नमस्ते <happy>", "--engine", "indic-mio", "--voice-sample", "ref.wav"],
-            contains: "--voice-sample")
+            [
+                "speak", "नमस्ते <happy>",
+                "--engine", "indic-mio",
+                "--voice-sample", "ref.wav",
+                "--indic-mio-global-embedding", embedding,
+            ],
+            contains: "either --voice-sample or --indic-mio-global-embedding")
     }
 
     func testIndicMioRejectsQwen3StyleControls() {

--- a/Tests/IndicMioTTSTests/E2EIndicMioTTSTests.swift
+++ b/Tests/IndicMioTTSTests/E2EIndicMioTTSTests.swift
@@ -47,17 +47,37 @@ final class E2EIndicMioTTSTests: XCTestCase {
             sampling: sampling)
         assertUsableWaveform(generated, sampleRate: model.sampleRate)
 
-        do {
-            _ = try await model.generate(
-                text: "यह एक संदर्भ परीक्षण है। <happy>",
-                language: "hindi",
-                referenceAudio: Array(repeating: 0, count: 24_000),
-                referenceSampleRate: 24_000,
-                sampling: sampling)
-            XCTFail("Raw reference audio should stay gated until WavLM speaker embedding is implemented")
-        } catch IndicMioError.speakerEmbeddingNotImplemented(let reason) {
-            XCTAssertTrue(reason.contains("WavLM"))
+    }
+
+    func testRawReferenceAudioSynthesizesWhenWavLMBundleIsAvailable() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let wavlm = env["INDIC_MIO_WAVLM_BUNDLE"], !wavlm.isEmpty else {
+            throw XCTSkip("Set INDIC_MIO_WAVLM_BUNDLE to run Indic-Mio raw-reference cloning E2E")
         }
+
+        let model = try await loadModel()
+        let reference = sineReference(sampleRate: model.sampleRate, seconds: 1.0)
+        let embedding = try await model.extractGlobalEmbedding(
+            referenceAudio: reference,
+            referenceSampleRate: model.sampleRate)
+
+        XCTAssertEqual(embedding.count, MioCodecConfig.default.globalEmbeddingDim)
+        XCTAssertTrue(embedding.allSatisfy(\.isFinite))
+        XCTAssertGreaterThan(embedding.map { abs($0) }.max() ?? 0, 0.0001)
+
+        let sampling = IndicMioSamplingConfig(
+            maxNewTokens: 64,
+            temperature: 0,
+            topK: 1,
+            topP: 1,
+            repetitionPenalty: 1)
+        let waveform = try await model.generate(
+            text: "नमस्ते, यह संदर्भ आवाज़ है। <happy>",
+            language: "hindi",
+            referenceAudio: reference,
+            referenceSampleRate: model.sampleRate,
+            sampling: sampling)
+        assertUsableWaveform(waveform, sampleRate: model.sampleRate)
     }
 
     func testHindiWaveformRoundTripWithASR() async throws {
@@ -97,6 +117,13 @@ final class E2EIndicMioTTSTests: XCTestCase {
         XCTAssertGreaterThan(Double(waveform.count) / Double(sampleRate), 0.05, file: file, line: line)
         XCTAssertTrue(waveform.allSatisfy(\.isFinite), "Waveform must not contain NaN/Inf", file: file, line: line)
         XCTAssertGreaterThan(waveform.map { abs($0) }.max() ?? 0, 0.0001, file: file, line: line)
+    }
+
+    private func sineReference(sampleRate: Int, seconds: Double) -> [Float] {
+        let count = Int(Double(sampleRate) * seconds)
+        return (0..<count).map { i in
+            Float(0.08 * sin(2.0 * Double.pi * 220.0 * Double(i) / Double(sampleRate)))
+        }
     }
 
     private func loadModel() async throws -> IndicMioTTSModel {

--- a/Tests/IndicMioTTSTests/E2EIndicMioTTSTests.swift
+++ b/Tests/IndicMioTTSTests/E2EIndicMioTTSTests.swift
@@ -49,12 +49,7 @@ final class E2EIndicMioTTSTests: XCTestCase {
 
     }
 
-    func testRawReferenceAudioSynthesizesWhenWavLMBundleIsAvailable() async throws {
-        let env = ProcessInfo.processInfo.environment
-        guard let wavlm = env["INDIC_MIO_WAVLM_BUNDLE"], !wavlm.isEmpty else {
-            throw XCTSkip("Set INDIC_MIO_WAVLM_BUNDLE to run Indic-Mio raw-reference cloning E2E")
-        }
-
+    func testRawReferenceAudioSynthesizesFromPublishedWavLMCompanion() async throws {
         let model = try await loadModel()
         let reference = sineReference(sampleRate: model.sampleRate, seconds: 1.0)
         let embedding = try await model.extractGlobalEmbedding(

--- a/Tests/IndicMioTTSTests/IndicMioRuntimeTests.swift
+++ b/Tests/IndicMioTTSTests/IndicMioRuntimeTests.swift
@@ -59,6 +59,21 @@ final class IndicMioRuntimeTests: XCTestCase {
         XCTAssertEqual(plan.stftFrames, 138)
     }
 
+    func testReferenceEncoderUsesSoniqoSafetensorsCompanionId() {
+        XCTAssertEqual(
+            IndicMioWavLMFeatureModel.defaultModelId,
+            "aufklarer/WavLM-Base-Plus-MLX-fp16")
+        XCTAssertEqual(IndicMioReferenceConfig.codecSampleRate, 24_000)
+        XCTAssertEqual(IndicMioReferenceConfig.wavLMSampleRate, 16_000)
+        XCTAssertEqual(IndicMioReferenceConfig.wavLMHopSize, 320)
+    }
+
+    func testWavLMFeatureExtractorMinimumInputLength() {
+        let model = IndicMioWavLMFeatureModel()
+        XCTAssertEqual(model.minimumWavLMInputLength(forFeatureFrames: 1), 400)
+        XCTAssertGreaterThan(model.minimumWavLMInputLength(forFeatureFrames: 50), 16_000)
+    }
+
     func testModelConfigParsesIndicMioShape() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("indic-mio-config-\(UUID().uuidString)", isDirectory: true)

--- a/docs/models/hindi-emotion-tts-candidates.md
+++ b/docs/models/hindi-emotion-tts-candidates.md
@@ -24,7 +24,9 @@ does not need a separate MioCodec model download.
 - decodes content embeddings through the MioCodec wave decoder to 24 kHz
   waveform audio;
 - accepts an explicit 128-dim MioCodec global embedding, or uses a
-  deterministic default embedding for non-cloned synthesis.
+  deterministic default embedding for non-cloned synthesis;
+- extracts the 128-dim MioCodec global embedding from raw reference audio via
+  WavLM-base-plus when the WavLM safetensors companion bundle is available.
 
 It is exposed as the `indic-mio` TTS engine in the model registry, realtime
 server dispatch, one-shot synthesis dispatch, and `speech speak --engine
@@ -32,11 +34,12 @@ indic-mio`. The CLI accepts `--indic-mio-global-embedding` for callers that
 already have a 128-dim MioCodec global speaker embedding.
 
 Indic-Mio's full zero-shot clone path requires a global speaker embedding. The
-bundled MioCodec weights include the decoder path, but the raw reference
-waveform-to-global-embedding path depends on the upstream SSL feature extractor
-(`wavlm_base_plus`), which is not part of the current export. Until that WavLM
-path is exported and ported, raw `--voice-sample` cloning is rejected for
-Indic-Mio and server clone-reference calls return the same runtime limitation.
+bundled MioCodec weights include the global encoder and decoder path. Raw
+reference waveform cloning now runs the WavLM-base-plus SSL feature extractor,
+averages the first two hidden layers, and feeds the result through MioCodec's
+global ConvNeXt encoder. The runtime resolves the WavLM companion from
+`aufklarer/WavLM-Base-Plus-MLX-fp16`, or from `INDIC_MIO_WAVLM_BUNDLE` when
+testing a local export.
 
 E2E coverage currently loads `aufklarer/Indic-Mio-MLX-fp16`, runs Hindi text
 with an emotion tag through Qwen3 speech-token generation, decodes MioCodec
@@ -58,7 +61,7 @@ but the public model card requires non-commercial use.
 
 | Model | HF repo | License posture | Hindi | Explicit emotion control | Voice path | speech-swift status |
 |---|---|---|---:|---|---|---|
-| Indic-Mio | `SPRINGLab/Indic-Mio` / `aufklarer/Indic-Mio-MLX-fp16` | Apache-2.0 | Yes | End-of-utterance tags: `<happy>`, `<sad>`, `<angry>`, `<disgust>`, `<fear>`, `<surprise>` | Speaker embeddings / zero-shot clone path | Runtime: bundle download, token generation, wave decode, CLI/server exposure, Hindi ASR roundtrip; raw-reference embedding pending |
+| Indic-Mio | `SPRINGLab/Indic-Mio` / `aufklarer/Indic-Mio-MLX-fp16` | Apache-2.0 | Yes | End-of-utterance tags: `<happy>`, `<sad>`, `<angry>`, `<disgust>`, `<fear>`, `<surprise>` | Speaker embeddings / zero-shot clone path | Runtime: bundle download, token generation, WavLM raw-reference embedding, wave decode, CLI/server exposure, Hindi ASR roundtrip |
 | Svara-TTS v1 | `kenpath/svara-tts-v1` | Apache-2.0 | Yes | Tags: `<happy>`, `<sad>`, `<anger>`, `<fear>` | Adaptation / speaker identity path; clone quality needs validation | Secondary port candidate |
 | Fish Audio S2 Pro | `fishaudio/s2-pro` | Research/non-commercial public weights | Yes | Inline bracket tags, including `[angry]`, `[sad]`, `[whisper]`, `[shouting]`, `[surprised]` | Reference / speaker conditioning in Fish stack | Benchmark only |
 | Indic Parler-TTS | `ai4bharat/indic-parler-tts` | Apache-2.0 | Yes | Caption/descriptive prompt emotions; Hindi emotion is not officially tested | Preset/descriptive voices | Secondary comparison |
@@ -89,8 +92,9 @@ format:
      CLI synthesis are wired under `indic-mio`.
    - E2E coverage is present for Hindi text plus `<happy>`, including Qwen3ASR
      keyword recovery over synthesized audio.
-   - Next: export/port `wavlm_base_plus` reference waveform to global speaker
-     embedding before adding Studio clone selection.
+   - Raw reference cloning is wired through the WavLM companion bundle.
+   - Next: publish/verify the WavLM safetensors companion and add Studio clone
+     selection copy that explains the extra first-run download.
 
 2. **Svara-TTS v1**
    - Validate whether its speaker/adaptation path can satisfy Studio's

--- a/docs/models/hindi-emotion-tts-candidates.md
+++ b/docs/models/hindi-emotion-tts-candidates.md
@@ -38,8 +38,8 @@ bundled MioCodec weights include the global encoder and decoder path. Raw
 reference waveform cloning now runs the WavLM-base-plus SSL feature extractor,
 averages the first two hidden layers, and feeds the result through MioCodec's
 global ConvNeXt encoder. The runtime resolves the WavLM companion from
-`aufklarer/WavLM-Base-Plus-MLX-fp16`, or from `INDIC_MIO_WAVLM_BUNDLE` when
-testing a local export.
+`aufklarer/WavLM-Base-Plus-MLX-fp16`; `INDIC_MIO_WAVLM_BUNDLE` can override it
+for local export testing.
 
 E2E coverage currently loads `aufklarer/Indic-Mio-MLX-fp16`, runs Hindi text
 with an emotion tag through Qwen3 speech-token generation, decodes MioCodec
@@ -92,9 +92,9 @@ format:
      CLI synthesis are wired under `indic-mio`.
    - E2E coverage is present for Hindi text plus `<happy>`, including Qwen3ASR
      keyword recovery over synthesized audio.
-   - Raw reference cloning is wired through the WavLM companion bundle.
-   - Next: publish/verify the WavLM safetensors companion and add Studio clone
-     selection copy that explains the extra first-run download.
+   - Raw reference cloning is wired through the published WavLM companion bundle.
+   - Next: add Studio clone selection copy that explains the extra first-run
+     download.
 
 2. **Svara-TTS v1**
    - Validate whether its speaker/adaptation path can satisfy Studio's


### PR DESCRIPTION
## Summary

Adds the missing raw WAV zero-shot reference path for Indic-Mio. The runtime now extracts a MioCodec global speaker embedding from reference audio using the published WavLM-base-plus companion encoder, then uses that embedding for Indic-Mio waveform generation.

## What Changed

- Added a Swift/MLX WavLM feature extractor for the first two hidden layers used by MioCodec global conditioning.
- Added the MioCodec global ConvNeXt encoder and attentive stats pooling path.
- Wired `IndicMioTTSModel.generate(... referenceAudio:)` to extract the 128-d global embedding instead of throwing the previous limitation.
- Enabled `speech speak --engine indic-mio --voice-sample ref.wav` while keeping `--voice-sample` and `--indic-mio-global-embedding` mutually exclusive.
- Updated Indic-Mio tests and Hindi emotion model docs.

## Companion Model

Published and verified: `aufklarer/WavLM-Base-Plus-MLX-fp16`

The default runtime path now downloads this companion automatically when raw reference audio is used. `INDIC_MIO_WAVLM_BUNDLE` remains available for local export testing.

Fish Audio S2 Pro remains benchmark-only because the public weights are research/non-commercial and the Swift runtime port is a separate, larger model implementation.

## Test Plan

- `swift test --filter IndicMioRuntimeTests`
- `swift test --filter AudioCLITests`
- `swift test --filter HindiEmotionTTSCatalogTests`
- `INDIC_MIO_WAVLM_BUNDLE=/Users/ivan/.cache/huggingface/hub/models--microsoft--wavlm-base-plus/snapshots/98fd61b9c652129c839c0a25a05987d8f59256a4 swift test --filter E2EIndicMioTTSTests`
- `env -u INDIC_MIO_WAVLM_BUNDLE swift test --filter 'E2EIndicMioTTSTests/testRawReferenceAudioSynthesizesFromPublishedWavLMCompanion'`
- CLI smoke without env override: `env -u INDIC_MIO_WAVLM_BUNDLE .build/debug/speech speak --engine indic-mio --voice-sample Tests/OmnilingualASRTests/Resources/fleurs_hi.wav --max-tokens 64 --temperature 0 --top-k 1 --indic-mio-top-p 1 --output /tmp/indic_mio_published_wavlm_smoke.wav 'नमस्ते, यह प्रकाशित वेवएलएम संदर्भ परीक्षण है। <happy>'`
- ASR sanity on generated WAV: `.build/debug/speech transcribe /tmp/indic_mio_published_wavlm_smoke.wav --language hindi` recovered `नमस्ते यह प्रकाशित वेलम`
- `python scripts/check_download_tracking.py` in speech-models: `aufklarer: 109 tracked, 0 untracked`; `soniqo: 30 tracked, 0 untracked`
