### PR TITLE
Add resumable Fish Audio downloads

### DIFF
--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -214,6 +214,71 @@ public enum HuggingFaceDownloader {
                 + (lastError?.localizedDescription ?? "unknown"))
     }
 
+    /// Download an explicit file list with progress weighted by byte size.
+    ///
+    /// `HubApi.snapshot()` reports useful progress for many repos, but for
+    /// large Xet-backed checkpoints it can advance by manifest/file count and
+    /// then remain quiet while multi-GB shards download. This path resolves
+    /// each file with `HEAD`, sums real `Content-Length` values, skips already
+    /// complete files, and reports progress from actual transferred bytes.
+    public static func downloadFilesByteWeighted(
+        modelId: String,
+        to directory: URL,
+        files: [String],
+        expectedSizes: [String: Int64]? = nil,
+        offlineMode: Bool = false,
+        retryDelaysSeconds: [Int]? = nil,
+        progressHandler: ((Double, Int64, Int64, String) -> Void)? = nil
+    ) async throws {
+        if files.isEmpty {
+            progressHandler?(1.0, 0, 0, "")
+            return
+        }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let safeFiles = try files.map(validatedRemoteFileName)
+        if offlineMode {
+            let missing = safeFiles.first {
+                !FileManager.default.fileExists(atPath: directory.appendingPathComponent($0).path)
+            }
+            if let missing {
+                throw DownloadError.failedToDownload(
+                    "\(modelId) offline cache miss: \(missing) is not present in \(directory.path)")
+            }
+            progressHandler?(1.0, 1, 1, "")
+            return
+        }
+
+        let delays = retryDelaysSeconds ?? downloadRetryDelaysSeconds
+        let maxAttempts = delays.count + 1
+        var lastError: Error?
+        for attempt in 1...maxAttempts {
+            do {
+                let remoteFiles = try await resolveRemoteFiles(
+                    modelId: modelId,
+                    files: safeFiles,
+                    expectedSizes: expectedSizes)
+                try await downloadResolvedFilesByteWeighted(
+                    remoteFiles,
+                    modelId: modelId,
+                    to: directory,
+                    progressHandler: progressHandler)
+                return
+            } catch {
+                lastError = error
+                if attempt < maxAttempts {
+                    try await Task.sleep(for: .seconds(delays[attempt - 1]))
+                }
+            }
+        }
+
+        throw DownloadError.failedToDownload(
+            "\(modelId) after \(maxAttempts) attempt\(maxAttempts == 1 ? "" : "s") "
+                + "(target: \(directory.path)): "
+                + (lastError?.localizedDescription ?? "unknown"))
+    }
+
     // MARK: - Retry ladder
 
     /// Delays between download attempts. One more attempt than entries:
@@ -417,5 +482,512 @@ public enum HuggingFaceDownloader {
             downloadBase = resolveBaseCacheDir(cacheDirName: repoDir.deletingLastPathComponent().lastPathComponent)
         }
         return HubApi(downloadBase: downloadBase, endpoint: resolvedEndpoint(), useOfflineMode: offlineMode)
+    }
+}
+
+// MARK: - Byte-weighted explicit downloads
+
+private struct ResolvedRemoteFile: Sendable {
+    let fileName: String
+    let url: URL
+    let size: Int64
+}
+
+private extension HuggingFaceDownloader {
+    static let rangedDownloadThresholdBytes: Int64 = 64 * 1_024 * 1_024
+    static let rangedDownloadChunkBytes: Int64 = 16 * 1_024 * 1_024
+    static let rangedDownloadConcurrency = 4
+
+    static func resolveRemoteFiles(
+        modelId: String,
+        files: [String],
+        expectedSizes: [String: Int64]?
+    ) async throws -> [ResolvedRemoteFile] {
+        if let expectedSizes {
+            return try files.map { file in
+                guard let size = expectedSizes[file], size > 0 else {
+                    throw DownloadError.failedToDownload("\(modelId)/\(file): missing expected size")
+                }
+                return ResolvedRemoteFile(
+                    fileName: file,
+                    url: try resolveURL(modelId: modelId, file: file),
+                    size: size)
+            }
+        }
+
+        var result: [ResolvedRemoteFile] = []
+        result.reserveCapacity(files.count)
+        for file in files {
+            result.append(try await resolveRemoteFile(modelId: modelId, file: file))
+        }
+        return result
+    }
+
+    static func resolveRemoteFile(modelId: String, file: String) async throws -> ResolvedRemoteFile {
+        let url = try resolveURL(modelId: modelId, file: file)
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        applyHubAuth(to: &request)
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw DownloadError.failedToDownload("\(modelId)/\(file): missing HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw DownloadError.failedToDownload("\(modelId)/\(file): HTTP \(http.statusCode)")
+        }
+        guard let resolved = http.url else {
+            throw DownloadError.failedToDownload("\(modelId)/\(file): missing resolved URL")
+        }
+        let size = headerInt64(http, "Content-Length")
+            ?? headerInt64(http, "x-linked-size")
+            ?? http.expectedContentLength
+        guard size > 0 else {
+            throw DownloadError.failedToDownload("\(modelId)/\(file): unknown remote size")
+        }
+        return ResolvedRemoteFile(fileName: file, url: resolved, size: size)
+    }
+
+    static func downloadResolvedFilesByteWeighted(
+        _ files: [ResolvedRemoteFile],
+        modelId: String,
+        to directory: URL,
+        progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    ) async throws {
+        let totalBytes = files.reduce(Int64(0)) { $0 + $1.size }
+        var completedBytes: Int64 = 0
+
+        for file in files {
+            let localURL = directory.appendingPathComponent(file.fileName, isDirectory: false)
+            let currentSize = localFileSize(localURL)
+            if currentSize == file.size {
+                completedBytes += file.size
+                reportByteProgress(
+                    completedBytes: completedBytes,
+                    totalBytes: totalBytes,
+                    fileName: file.fileName,
+                    progressHandler: progressHandler)
+                continue
+            }
+            if currentSize > 0 {
+                try? FileManager.default.removeItem(at: localURL)
+            }
+
+            reportByteProgress(
+                completedBytes: completedBytes,
+                totalBytes: totalBytes,
+                fileName: file.fileName,
+                progressHandler: progressHandler)
+            if file.size >= rangedDownloadThresholdBytes {
+                try await downloadRangedResolvedFile(
+                    file,
+                    to: localURL,
+                    completedBeforeFile: completedBytes,
+                    totalBytes: totalBytes,
+                    progressHandler: progressHandler)
+            } else {
+                try await downloadSingleResolvedFile(
+                    file,
+                    to: localURL,
+                    completedBeforeFile: completedBytes,
+                    totalBytes: totalBytes,
+                    progressHandler: progressHandler)
+            }
+            completedBytes += file.size
+            reportByteProgress(
+                completedBytes: completedBytes,
+                totalBytes: totalBytes,
+                fileName: file.fileName,
+                progressHandler: progressHandler)
+
+            let writtenSize = localFileSize(localURL)
+            guard writtenSize == file.size else {
+                throw DownloadError.failedToDownload(
+                    "\(modelId)/\(file.fileName): wrote \(writtenSize) bytes, expected \(file.size)")
+            }
+        }
+    }
+
+    static func downloadSingleResolvedFile(
+        _ file: ResolvedRemoteFile,
+        to destination: URL,
+        completedBeforeFile: Int64,
+        totalBytes: Int64,
+        progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    ) async throws {
+        var request = URLRequest(url: file.url)
+        applyHubAuth(to: &request)
+        let tempURL = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).download")
+        try? FileManager.default.removeItem(at: tempURL)
+
+        let delegate = ByteWeightedDownloadDelegate(
+            destination: tempURL,
+            expectedSize: file.size,
+            completedBeforeFile: completedBeforeFile,
+            totalBytes: totalBytes,
+            fileName: file.fileName,
+            progressHandler: progressHandler)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer {
+            session.invalidateAndCancel()
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+
+        try await withTaskCancellationHandler {
+            try await delegate.download(request: request, session: session)
+        } onCancel: {
+            session.invalidateAndCancel()
+        }
+
+        try? FileManager.default.removeItem(at: destination)
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+    }
+
+    static func downloadRangedResolvedFile(
+        _ file: ResolvedRemoteFile,
+        to destination: URL,
+        completedBeforeFile: Int64,
+        totalBytes: Int64,
+        progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    ) async throws {
+        let partsDirectory = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).parts", isDirectory: true)
+        try FileManager.default.createDirectory(at: partsDirectory, withIntermediateDirectories: true)
+
+        let chunks = makeDownloadChunks(fileSize: file.size, chunkBytes: rangedDownloadChunkBytes)
+        let state = RangedDownloadProgress(
+            completedBeforeFile: completedBeforeFile,
+            totalBytes: totalBytes,
+            fileName: file.fileName,
+            progressHandler: progressHandler)
+
+        var missingChunks: [DownloadChunk] = []
+        missingChunks.reserveCapacity(chunks.count)
+        for chunk in chunks {
+            let partURL = partFileURL(partsDirectory: partsDirectory, chunk: chunk)
+            let partSize = localFileSize(partURL)
+            if partSize == chunk.length {
+                await state.addCompletedBytes(chunk.length)
+                continue
+            }
+            if partSize > 0 {
+                try? FileManager.default.removeItem(at: partURL)
+            }
+            missingChunks.append(chunk)
+        }
+
+        if !missingChunks.isEmpty {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                var nextIndex = 0
+                let initial = min(rangedDownloadConcurrency, missingChunks.count)
+                for _ in 0..<initial {
+                    let chunk = missingChunks[nextIndex]
+                    nextIndex += 1
+                    group.addTask {
+                        try await downloadRangeChunk(
+                            file,
+                            chunk: chunk,
+                            to: partFileURL(partsDirectory: partsDirectory, chunk: chunk),
+                            state: state)
+                    }
+                }
+
+                while try await group.next() != nil {
+                    if nextIndex < missingChunks.count {
+                        let chunk = missingChunks[nextIndex]
+                        nextIndex += 1
+                        group.addTask {
+                            try await downloadRangeChunk(
+                                file,
+                                chunk: chunk,
+                                to: partFileURL(partsDirectory: partsDirectory, chunk: chunk),
+                                state: state)
+                        }
+                    }
+                }
+            }
+        }
+
+        let tempURL = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).download")
+        try? FileManager.default.removeItem(at: tempURL)
+        FileManager.default.createFile(atPath: tempURL.path, contents: nil)
+        let output = try FileHandle(forWritingTo: tempURL)
+        defer { try? output.close() }
+
+        for chunk in chunks {
+            let partURL = partFileURL(partsDirectory: partsDirectory, chunk: chunk)
+            let data = try Data(contentsOf: partURL)
+            guard Int64(data.count) == chunk.length else {
+                throw DownloadError.failedToDownload(
+                    "\(file.fileName): part \(chunk.index) has \(data.count) bytes, expected \(chunk.length)")
+            }
+            try output.write(contentsOf: data)
+        }
+
+        try? FileManager.default.removeItem(at: destination)
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+        try? FileManager.default.removeItem(at: partsDirectory)
+    }
+
+    static func downloadRangeChunk(
+        _ file: ResolvedRemoteFile,
+        chunk: DownloadChunk,
+        to destination: URL,
+        state: RangedDownloadProgress
+    ) async throws {
+        var request = URLRequest(url: file.url)
+        request.setValue("bytes=\(chunk.start)-\(chunk.end)", forHTTPHeaderField: "Range")
+        applyHubAuth(to: &request)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw DownloadError.failedToDownload("\(file.fileName) part \(chunk.index): missing HTTP response")
+        }
+        guard http.statusCode == 206 else {
+            throw DownloadError.failedToDownload(
+                "\(file.fileName) part \(chunk.index): expected HTTP 206, got \(http.statusCode)")
+        }
+        guard Int64(data.count) == chunk.length else {
+            throw DownloadError.failedToDownload(
+                "\(file.fileName) part \(chunk.index): got \(data.count) bytes, expected \(chunk.length)")
+        }
+        try data.write(to: destination, options: .atomic)
+        await state.addCompletedBytes(chunk.length)
+    }
+
+    static func makeDownloadChunks(fileSize: Int64, chunkBytes: Int64) -> [DownloadChunk] {
+        guard fileSize > 0 else { return [] }
+        var chunks: [DownloadChunk] = []
+        var start: Int64 = 0
+        var index = 0
+        while start < fileSize {
+            let end = min(fileSize - 1, start + chunkBytes - 1)
+            chunks.append(DownloadChunk(index: index, start: start, end: end))
+            start = end + 1
+            index += 1
+        }
+        return chunks
+    }
+
+    static func partFileURL(partsDirectory: URL, chunk: DownloadChunk) -> URL {
+        partsDirectory.appendingPathComponent(String(format: "%06d.part", chunk.index))
+    }
+
+    static func reportByteProgress(
+        completedBytes: Int64,
+        totalBytes: Int64,
+        fileName: String,
+        progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    ) {
+        guard totalBytes > 0 else {
+            progressHandler?(1.0, completedBytes, totalBytes, fileName)
+            return
+        }
+        let clamped = min(max(completedBytes, 0), totalBytes)
+        progressHandler?(Double(clamped) / Double(totalBytes), clamped, totalBytes, fileName)
+    }
+
+    static func resolveURL(modelId: String, file: String) throws -> URL {
+        let endpoint = (resolvedEndpoint() ?? "https://huggingface.co")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let escapedFile = file.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file
+        guard let url = URL(string: "\(endpoint)/\(modelId)/resolve/main/\(escapedFile)") else {
+            throw DownloadError.failedToDownload("\(modelId)/\(file): invalid URL")
+        }
+        return url
+    }
+
+    static func applyHubAuth(to request: inout URLRequest) {
+        let env = ProcessInfo.processInfo.environment
+        let token = env["HF_TOKEN"] ?? env["HUGGING_FACE_HUB_TOKEN"]
+        if let token, !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    static func headerInt64(_ response: HTTPURLResponse, _ key: String) -> Int64? {
+        for (rawKey, rawValue) in response.allHeaderFields {
+            guard String(describing: rawKey).caseInsensitiveCompare(key) == .orderedSame else {
+                continue
+            }
+            if let value = rawValue as? NSNumber {
+                return value.int64Value
+            }
+            return Int64(String(describing: rawValue))
+        }
+        return nil
+    }
+
+    static func localFileSize(_ url: URL) -> Int64 {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? NSNumber else {
+            return 0
+        }
+        return size.int64Value
+    }
+}
+
+private struct DownloadChunk: Sendable {
+    let index: Int
+    let start: Int64
+    let end: Int64
+
+    var length: Int64 {
+        end - start + 1
+    }
+}
+
+private actor RangedDownloadProgress {
+    private let completedBeforeFile: Int64
+    private let totalBytes: Int64
+    private let fileName: String
+    private let progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    private var fileCompletedBytes: Int64 = 0
+    private var lastReportedMegabytes: Int64 = -1
+
+    init(
+        completedBeforeFile: Int64,
+        totalBytes: Int64,
+        fileName: String,
+        progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    ) {
+        self.completedBeforeFile = completedBeforeFile
+        self.totalBytes = totalBytes
+        self.fileName = fileName
+        self.progressHandler = progressHandler
+    }
+
+    func addCompletedBytes(_ bytes: Int64) {
+        fileCompletedBytes += bytes
+        let completed = completedBeforeFile + fileCompletedBytes
+        let displayedMegabytes = Int64((Double(completed) / 1_000_000.0).rounded())
+        if completed < totalBytes, displayedMegabytes == lastReportedMegabytes {
+            return
+        }
+        lastReportedMegabytes = displayedMegabytes
+        HuggingFaceDownloader.reportByteProgress(
+            completedBytes: completed,
+            totalBytes: totalBytes,
+            fileName: fileName,
+            progressHandler: progressHandler)
+    }
+}
+
+private final class ByteWeightedDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private let destination: URL
+    private let expectedSize: Int64
+    private let completedBeforeFile: Int64
+    private let totalBytes: Int64
+    private let fileName: String
+    private let progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var completed = false
+    private var lastReportedMegabytes: Int64 = -1
+
+    init(
+        destination: URL,
+        expectedSize: Int64,
+        completedBeforeFile: Int64,
+        totalBytes: Int64,
+        fileName: String,
+        progressHandler: ((Double, Int64, Int64, String) -> Void)?
+    ) {
+        self.destination = destination
+        self.expectedSize = expectedSize
+        self.completedBeforeFile = completedBeforeFile
+        self.totalBytes = totalBytes
+        self.fileName = fileName
+        self.progressHandler = progressHandler
+    }
+
+    func download(request: URLRequest, session: URLSession) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            lock.lock()
+            self.continuation = continuation
+            lock.unlock()
+            session.downloadTask(with: request).resume()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let fileBytes = totalBytesWritten >= 0 ? totalBytesWritten : 0
+        let completed = completedBeforeFile + min(fileBytes, expectedSize)
+        let displayedMegabytes = Int64((Double(completed) / 1_000_000.0).rounded())
+        lock.lock()
+        if completed < totalBytes, displayedMegabytes == lastReportedMegabytes {
+            lock.unlock()
+            return
+        }
+        lastReportedMegabytes = displayedMegabytes
+        lock.unlock()
+        HuggingFaceDownloader.reportByteProgress(
+            completedBytes: completed,
+            totalBytes: totalBytes,
+            fileName: fileName,
+            progressHandler: progressHandler)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        if let http = downloadTask.response as? HTTPURLResponse,
+           !(200..<300).contains(http.statusCode) {
+            complete(.failure(DownloadError.failedToDownload("\(fileName): HTTP \(http.statusCode)")))
+            return
+        }
+        do {
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.moveItem(at: location, to: destination)
+            let writtenSize = HuggingFaceDownloader.localFileSize(destination)
+            guard writtenSize == expectedSize else {
+                throw DownloadError.failedToDownload(
+                    "\(fileName): wrote \(writtenSize) bytes, expected \(expectedSize)")
+            }
+            complete(.success(()))
+        } catch {
+            complete(.failure(error))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        if let error {
+            complete(.failure(error))
+        }
+    }
+
+    private func complete(_ result: Result<Void, Error>) {
+        lock.lock()
+        guard !completed else {
+            lock.unlock()
+            return
+        }
+        completed = true
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+
+        switch result {
+        case .success:
+            continuation?.resume()
+        case .failure(let error):
+            continuation?.resume(throwing: error)
+        }
     }
 }

--- a/Sources/FishAudioTTS/FishAudioTTSModel.swift
+++ b/Sources/FishAudioTTS/FishAudioTTSModel.swift
@@ -5,6 +5,35 @@ import MLXCommon
 
 public final class FishAudioTTSModel: SpeechGenerationModel, @unchecked Sendable {
     public static let defaultModelId = FishAudioConfig.defaultModelId
+    private static let downloadProgressShare = 0.85
+    private static let requiredFiles = [
+        "LICENSE.md",
+        "README.md",
+        "chat_template.jinja",
+        "codec.safetensors",
+        "config.json",
+        "model.safetensors.index.json",
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+        "soniqo_manifest.json",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ]
+    private static let requiredFileSizes: [String: Int64] = [
+        "LICENSE.md": 10_360,
+        "README.md": 2_421,
+        "chat_template.jinja": 4_116,
+        "codec.safetensors": 1_088_063_508,
+        "config.json": 1_863,
+        "model.safetensors.index.json": 32_686,
+        "model-00001-of-00002.safetensors": 4_986_872_792,
+        "model-00002-of-00002.safetensors": 4_136_875_936,
+        "soniqo_manifest.json": 2_568,
+        "special_tokens_map.json": 101_864,
+        "tokenizer.json": 12_217_872,
+        "tokenizer_config.json": 860_832,
+    ]
 
     public let sampleRate: Int
     public let bundleDirectory: URL
@@ -36,28 +65,20 @@ public final class FishAudioTTSModel: SpeechGenerationModel, @unchecked Sendable
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> FishAudioTTSModel {
         let directory = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        try await HuggingFaceDownloader.downloadWeights(
+        try await HuggingFaceDownloader.downloadFilesByteWeighted(
             modelId: modelId,
             to: directory,
-            additionalFiles: [
-                "LICENSE.md",
-                "README.md",
-                "chat_template.jinja",
-                "codec.safetensors",
-                "config.json",
-                "model.safetensors.index.json",
-                "model-00001-of-00002.safetensors",
-                "model-00002-of-00002.safetensors",
-                "soniqo_manifest.json",
-                "special_tokens_map.json",
-                "tokenizer.json",
-                "tokenizer_config.json",
-            ],
+            files: requiredFiles,
+            expectedSizes: requiredFileSizes,
             offlineMode: offlineMode,
-            progressHandler: { progressHandler?($0 * 0.35, "Downloading Fish Audio S2 Pro") }
+            progressHandler: { progress, downloadedBytes, totalBytes, _ in
+                progressHandler?(
+                    progress * downloadProgressShare,
+                    "Downloading Fish Audio S2 Pro \(formatMegabytes(downloadedBytes)) / \(formatMegabytes(totalBytes))")
+            }
         )
         return try await fromBundle(directory) { progress, message in
-            progressHandler?(0.35 + progress * 0.65, message)
+            progressHandler?(downloadProgressShare + progress * (1.0 - downloadProgressShare), message)
         }
     }
 
@@ -160,4 +181,9 @@ public final class FishAudioTTSModel: SpeechGenerationModel, @unchecked Sendable
     public func decode(_ codebooks: FishAudioGeneratedCodebooks) throws -> [Float] {
         try codec.decode(codebooks)
     }
+}
+
+private func formatMegabytes(_ bytes: Int64) -> String {
+    let mb = Double(bytes) / 1_000_000.0
+    return String(format: "%.0f MB", max(0.0, mb))
 }


### PR DESCRIPTION
Summary
- Add byte-weighted explicit Hugging Face downloads for Fish Audio model files.
- Use expected file sizes to report realistic progress without manifest/file-count jumps.
- Download large files with resumable ranged chunks and limited parallelism.
- Surface Fish Audio download progress as MB totals for Studio.

Why
Single-stream large-file downloads were too slow and discarded partial progress on cancellation. Fish Audio is about 10 GB, so first-run model setup needs accurate, resumable progress.

Validation
- swift test --filter HuggingFaceDownloaderTests
- swift test --filter FishAudioRuntimeTests
- swift build from the Studio sidecar package
- Manual clean-cache Fish Audio smoke: ranged progress advanced in 16 MB chunks and resumed after interruption
