### PR TITLE
Speed up ranged Hugging Face downloads

### DIFF
--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -317,6 +317,19 @@ public enum HuggingFaceDownloader {
         return 300
     }
 
+    /// Concurrent range requests used by the byte-weighted downloader for
+    /// large files. Fish Audio and similar multi-GB checkpoints are hosted
+    /// behind HF/CDN endpoints where one stream can under-fill the user's
+    /// connection; bounded parallel ranges improve first-run download time
+    /// while still avoiding unbounded request fan-out.
+    static var downloadRangeConcurrency: Int {
+        if let raw = ProcessInfo.processInfo.environment["HF_DOWNLOAD_RANGE_CONCURRENCY"],
+           let v = Int(raw), v > 0 {
+            return min(v, 16)
+        }
+        return 16
+    }
+
     /// Resolve the HuggingFace Hub endpoint, honoring the `HF_ENDPOINT`
     /// environment variable (the same name Python's `huggingface_hub` uses).
     ///
@@ -496,7 +509,6 @@ private struct ResolvedRemoteFile: Sendable {
 private extension HuggingFaceDownloader {
     static let rangedDownloadThresholdBytes: Int64 = 64 * 1_024 * 1_024
     static let rangedDownloadChunkBytes: Int64 = 16 * 1_024 * 1_024
-    static let rangedDownloadConcurrency = 4
 
     static func resolveRemoteFiles(
         modelId: String,
@@ -662,6 +674,11 @@ private extension HuggingFaceDownloader {
             totalBytes: totalBytes,
             fileName: file.fileName,
             progressHandler: progressHandler)
+        let concurrency = downloadRangeConcurrency
+        let configuration = URLSessionConfiguration.default
+        configuration.httpMaximumConnectionsPerHost = max(concurrency, 1)
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
 
         var missingChunks: [DownloadChunk] = []
         missingChunks.reserveCapacity(chunks.count)
@@ -681,7 +698,7 @@ private extension HuggingFaceDownloader {
         if !missingChunks.isEmpty {
             try await withThrowingTaskGroup(of: Void.self) { group in
                 var nextIndex = 0
-                let initial = min(rangedDownloadConcurrency, missingChunks.count)
+                let initial = min(concurrency, missingChunks.count)
                 for _ in 0..<initial {
                     let chunk = missingChunks[nextIndex]
                     nextIndex += 1
@@ -690,7 +707,8 @@ private extension HuggingFaceDownloader {
                             file,
                             chunk: chunk,
                             to: partFileURL(partsDirectory: partsDirectory, chunk: chunk),
-                            state: state)
+                            state: state,
+                            session: session)
                     }
                 }
 
@@ -703,7 +721,8 @@ private extension HuggingFaceDownloader {
                                 file,
                                 chunk: chunk,
                                 to: partFileURL(partsDirectory: partsDirectory, chunk: chunk),
-                                state: state)
+                                state: state,
+                                session: session)
                         }
                     }
                 }
@@ -737,13 +756,14 @@ private extension HuggingFaceDownloader {
         _ file: ResolvedRemoteFile,
         chunk: DownloadChunk,
         to destination: URL,
-        state: RangedDownloadProgress
+        state: RangedDownloadProgress,
+        session: URLSession
     ) async throws {
         var request = URLRequest(url: file.url)
         request.setValue("bytes=\(chunk.start)-\(chunk.end)", forHTTPHeaderField: "Range")
         applyHubAuth(to: &request)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw DownloadError.failedToDownload("\(file.fileName) part \(chunk.index): missing HTTP response")
         }

--- a/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
+++ b/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
@@ -389,4 +389,46 @@ final class HuggingFaceDownloaderTests: XCTestCase {
         XCTAssertLessThanOrEqual(delays.reduce(0, +), 120,
                                  "total backoff should stay bounded")
     }
+
+    // MARK: - Range download concurrency
+
+    private func withEnv(_ key: String, _ value: String?, _ body: () -> Void) {
+        let previous = ProcessInfo.processInfo.environment[key]
+        if let value {
+            setenv(key, value, 1)
+        } else {
+            unsetenv(key)
+        }
+        defer {
+            if let previous { setenv(key, previous, 1) }
+            else { unsetenv(key) }
+        }
+        body()
+    }
+
+    func testRangeDownloadConcurrencyDefaultIsFast() {
+        withEnv("HF_DOWNLOAD_RANGE_CONCURRENCY", nil) {
+            XCTAssertEqual(HuggingFaceDownloader.downloadRangeConcurrency, 16)
+        }
+    }
+
+    func testRangeDownloadConcurrencyHonorsOverride() {
+        withEnv("HF_DOWNLOAD_RANGE_CONCURRENCY", "12") {
+            XCTAssertEqual(HuggingFaceDownloader.downloadRangeConcurrency, 12)
+        }
+    }
+
+    func testRangeDownloadConcurrencyRejectsInvalidOverride() {
+        for raw in ["", "0", "-1", "not-a-number"] {
+            withEnv("HF_DOWNLOAD_RANGE_CONCURRENCY", raw) {
+                XCTAssertEqual(HuggingFaceDownloader.downloadRangeConcurrency, 16)
+            }
+        }
+    }
+
+    func testRangeDownloadConcurrencyCapsOverride() {
+        withEnv("HF_DOWNLOAD_RANGE_CONCURRENCY", "64") {
+            XCTAssertEqual(HuggingFaceDownloader.downloadRangeConcurrency, 16)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- increase byte-weighted ranged download concurrency for large Hugging Face files from 4 to 16 by default
- use a dedicated URLSession with matching per-host connection capacity for ranged chunk downloads
- add downloader tests for the fast default, override, invalid override, and cap behavior

## Why

Fish Audio S2 Pro and similar multi-GB checkpoints can under-fill the user's network when downloading large shards with too few concurrent ranges. The existing byte-weighted downloader already supports resumable chunk files; this raises the default parallelism so first-run downloads complete faster without requiring user env tuning.

## Test plan

- `swift test --filter HuggingFaceDownloaderTests`
- `swift test --filter FishAudioRuntimeTests`
- `./scripts/build_mlx_metallib.sh debug`
- `swift test --skip E2E`
