### PR TITLE
Honor PersonaPlex demo offline cache

### DIFF
--- a/Examples/PersonaPlexDemo/PersonaPlexDemo/AudioRecorder.swift
+++ b/Examples/PersonaPlexDemo/PersonaPlexDemo/AudioRecorder.swift
@@ -17,10 +17,10 @@ final class AudioRecorder {
     private let targetSampleRate: Double
 
     // VAD
-    private let vadProcessor: StreamingVADProcessor
+    private let vadProcessor: StreamingVADProcessor?
     private var speechActive = false
 
-    init(targetSampleRate: Double = 24000, vadProcessor: StreamingVADProcessor) {
+    init(targetSampleRate: Double = 24000, vadProcessor: StreamingVADProcessor? = nil) {
         self.targetSampleRate = targetSampleRate
         self.vadProcessor = vadProcessor
     }
@@ -31,7 +31,7 @@ final class AudioRecorder {
         lock.unlock()
 
         speechActive = false
-        vadProcessor.reset()
+        vadProcessor?.reset()
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
@@ -111,7 +111,7 @@ final class AudioRecorder {
                 let vadCount = Int(vadBuffer.frameLength)
                 let vadChunk = Array(UnsafeBufferPointer(start: vadData, count: vadCount))
 
-                let events = self.vadProcessor.process(samples: vadChunk)
+                let events = self.vadProcessor?.process(samples: vadChunk) ?? []
                 for event in events {
                     switch event {
                     case .speechStarted(let time):

--- a/Examples/PersonaPlexDemo/PersonaPlexDemo/AudioRecorder.swift
+++ b/Examples/PersonaPlexDemo/PersonaPlexDemo/AudioRecorder.swift
@@ -20,10 +20,17 @@ final class AudioRecorder {
     private let vadProcessor: StreamingVADProcessor?
     private var speechActive = false
 
-    init(targetSampleRate: Double = 24000, vadProcessor: StreamingVADProcessor? = nil) {
+    init(targetSampleRate: Double = 24000, vadProcessor: StreamingVADProcessor) {
         self.targetSampleRate = targetSampleRate
         self.vadProcessor = vadProcessor
     }
+
+    #if DEBUG
+    init(targetSampleRate: Double = 24000) {
+        self.targetSampleRate = targetSampleRate
+        self.vadProcessor = nil
+    }
+    #endif
 
     func startRecording() {
         lock.lock()

--- a/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexDemoCachePolicy.swift
+++ b/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexDemoCachePolicy.swift
@@ -4,6 +4,11 @@ import PersonaPlex
 import Qwen3ASR
 import SpeechVAD
 
+struct CacheFileRequirement {
+    var relativePath: String
+    var byteCount: UInt64
+}
+
 enum PersonaPlexDemoCachePolicy {
     static func personaPlexOfflineModeAvailable(
         modelId: String = PersonaPlexModel.modelId8bit
@@ -12,16 +17,13 @@ enum PersonaPlexDemoCachePolicy {
             return false
         }
 
+        guard personaPlexVoiceByteCounts.count == PersonaPlexVoice.allCases.count else {
+            return false
+        }
+
         return cacheComplete(
             in: directory,
-            requiredFiles: [
-                "temporal.safetensors",
-                "depformer.safetensors",
-                "embeddings.safetensors",
-                "mimi.safetensors",
-                "tokenizer_spm_32k_3.model",
-                "config.json",
-            ] + PersonaPlexVoice.allCases.map { "voices/\($0.rawValue).safetensors" },
+            requiredFiles: personaPlexFileRequirements + personaPlexVoiceRequirements,
             requiresWeights: false)
     }
 
@@ -34,13 +36,7 @@ enum PersonaPlexDemoCachePolicy {
 
         return cacheComplete(
             in: directory,
-            requiredFiles: [
-                "config.json",
-                "model.safetensors",
-                "vocab.json",
-                "merges.txt",
-                "tokenizer_config.json",
-            ],
+            requiredFiles: asrFileRequirements,
             requiresWeights: true)
     }
 
@@ -53,13 +49,13 @@ enum PersonaPlexDemoCachePolicy {
 
         return cacheComplete(
             in: directory,
-            requiredFiles: ["config.json", "model.safetensors"],
+            requiredFiles: vadFileRequirements,
             requiresWeights: true)
     }
 
     static func cacheComplete(
         in directory: URL,
-        requiredFiles: [String],
+        requiredFiles: [CacheFileRequirement],
         requiresWeights: Bool
     ) -> Bool {
         let fm = FileManager.default
@@ -73,12 +69,87 @@ enum PersonaPlexDemoCachePolicy {
         }
 
         for file in requiredFiles {
-            let url = directory.appendingPathComponent(file)
+            let url = directory.appendingPathComponent(file.relativePath)
             guard fm.fileExists(atPath: url.path) else {
+                return false
+            }
+
+            guard byteCount(of: url) == file.byteCount else {
                 return false
             }
         }
 
         return true
+    }
+
+    private static let personaPlexFileRequirements: [CacheFileRequirement] = [
+        CacheFileRequirement(relativePath: "config.json", byteCount: 1_462),
+        CacheFileRequirement(relativePath: "depformer.safetensors", byteCount: 1_381_596_968),
+        CacheFileRequirement(relativePath: "embeddings.safetensors", byteCount: 988_459_536),
+        CacheFileRequirement(relativePath: "mimi.safetensors", byteCount: 384_644_900),
+        CacheFileRequirement(relativePath: "temporal.safetensors", byteCount: 6_988_291_888),
+        CacheFileRequirement(relativePath: "tokenizer_spm_32k_3.model", byteCount: 552_778),
+    ]
+
+    private static let personaPlexVoiceByteCounts: [PersonaPlexVoice: UInt64] = [
+        .NATF0: 418_216,
+        .NATF1: 393_640,
+        .NATF2: 418_216,
+        .NATF3: 418_216,
+        .NATM0: 410_024,
+        .NATM1: 418_216,
+        .NATM2: 410_024,
+        .NATM3: 377_256,
+        .VARF0: 557_480,
+        .VARF1: 410_024,
+        .VARF2: 418_216,
+        .VARF3: 508_328,
+        .VARF4: 467_368,
+        .VARM0: 352_680,
+        .VARM1: 377_256,
+        .VARM2: 565_672,
+        .VARM3: 377_256,
+        .VARM4: 450_984,
+    ]
+
+    private static var personaPlexVoiceRequirements: [CacheFileRequirement] {
+        PersonaPlexVoice.allCases.compactMap { voice in
+            guard let byteCount = personaPlexVoiceByteCounts[voice] else {
+                return nil
+            }
+            return CacheFileRequirement(
+                relativePath: "voices/\(voice.rawValue).safetensors",
+                byteCount: byteCount)
+        }
+    }
+
+    private static let asrFileRequirements: [CacheFileRequirement] = [
+        CacheFileRequirement(relativePath: "config.json", byteCount: 7_187),
+        CacheFileRequirement(relativePath: "merges.txt", byteCount: 1_671_853),
+        CacheFileRequirement(relativePath: "model.safetensors", byteCount: 708_236_945),
+        CacheFileRequirement(relativePath: "tokenizer_config.json", byteCount: 12_487),
+        CacheFileRequirement(relativePath: "vocab.json", byteCount: 2_776_833),
+    ]
+
+    private static let vadFileRequirements: [CacheFileRequirement] = [
+        CacheFileRequirement(relativePath: "config.json", byteCount: 456),
+        CacheFileRequirement(relativePath: "model.safetensors", byteCount: 1_237_580),
+    ]
+
+    private static func byteCount(of url: URL) -> UInt64? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+            return nil
+        }
+
+        switch attributes[.size] {
+        case let value as NSNumber:
+            return value.uint64Value
+        case let value as UInt64:
+            return value
+        case let value as Int where value >= 0:
+            return UInt64(value)
+        default:
+            return nil
+        }
     }
 }

--- a/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexDemoCachePolicy.swift
+++ b/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexDemoCachePolicy.swift
@@ -1,0 +1,109 @@
+import Foundation
+import AudioCommon
+import PersonaPlex
+import Qwen3ASR
+import SpeechVAD
+
+struct CacheDirectoryRequirement {
+    var relativePath: String
+    var fileExtension: String
+    var minimumCount: Int
+}
+
+enum PersonaPlexDemoCachePolicy {
+    static func personaPlexOfflineModeAvailable(
+        modelId: String = PersonaPlexModel.modelId8bit
+    ) -> Bool {
+        guard let directory = try? HuggingFaceDownloader.getCacheDirectory(for: modelId) else {
+            return false
+        }
+
+        return cacheComplete(
+            in: directory,
+            requiredFiles: [
+                "temporal.safetensors",
+                "depformer.safetensors",
+                "embeddings.safetensors",
+                "mimi.safetensors",
+                "tokenizer_spm_32k_3.model",
+                "config.json",
+            ],
+            requiresWeights: false,
+            directoryRequirements: [
+                CacheDirectoryRequirement(
+                    relativePath: "voices",
+                    fileExtension: "safetensors",
+                    minimumCount: PersonaPlexVoice.allCases.count)
+            ])
+    }
+
+    static func asrOfflineModeAvailable(
+        modelId: String = Qwen3ASRModel.defaultModelId
+    ) -> Bool {
+        guard let directory = try? HuggingFaceDownloader.getCacheDirectory(for: modelId) else {
+            return false
+        }
+
+        return cacheComplete(
+            in: directory,
+            requiredFiles: ["vocab.json", "merges.txt", "tokenizer_config.json"],
+            requiresWeights: true)
+    }
+
+    static func vadOfflineModeAvailable(
+        modelId: String = SileroVADModel.defaultModelId
+    ) -> Bool {
+        guard let directory = try? HuggingFaceDownloader.getCacheDirectory(for: modelId) else {
+            return false
+        }
+
+        return cacheComplete(
+            in: directory,
+            requiredFiles: ["config.json"],
+            requiresWeights: true)
+    }
+
+    static func cacheComplete(
+        in directory: URL,
+        requiredFiles: [String],
+        requiresWeights: Bool,
+        directoryRequirements: [CacheDirectoryRequirement] = []
+    ) -> Bool {
+        let fm = FileManager.default
+
+        guard fm.fileExists(atPath: directory.path) else {
+            return false
+        }
+
+        if requiresWeights && !HuggingFaceDownloader.weightsExist(in: directory) {
+            return false
+        }
+
+        for file in requiredFiles {
+            let url = directory.appendingPathComponent(file)
+            guard fm.fileExists(atPath: url.path) else {
+                return false
+            }
+        }
+
+        for requirement in directoryRequirements {
+            let dir = directory.appendingPathComponent(requirement.relativePath, isDirectory: true)
+            let entries: [URL]
+            do {
+                entries = try fm.contentsOfDirectory(
+                    at: dir,
+                    includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles])
+            } catch {
+                return false
+            }
+
+            let count = entries.filter { $0.pathExtension == requirement.fileExtension }.count
+            guard count >= requirement.minimumCount else {
+                return false
+            }
+        }
+
+        return true
+    }
+}

--- a/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexDemoCachePolicy.swift
+++ b/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexDemoCachePolicy.swift
@@ -4,12 +4,6 @@ import PersonaPlex
 import Qwen3ASR
 import SpeechVAD
 
-struct CacheDirectoryRequirement {
-    var relativePath: String
-    var fileExtension: String
-    var minimumCount: Int
-}
-
 enum PersonaPlexDemoCachePolicy {
     static func personaPlexOfflineModeAvailable(
         modelId: String = PersonaPlexModel.modelId8bit
@@ -27,14 +21,8 @@ enum PersonaPlexDemoCachePolicy {
                 "mimi.safetensors",
                 "tokenizer_spm_32k_3.model",
                 "config.json",
-            ],
-            requiresWeights: false,
-            directoryRequirements: [
-                CacheDirectoryRequirement(
-                    relativePath: "voices",
-                    fileExtension: "safetensors",
-                    minimumCount: PersonaPlexVoice.allCases.count)
-            ])
+            ] + PersonaPlexVoice.allCases.map { "voices/\($0.rawValue).safetensors" },
+            requiresWeights: false)
     }
 
     static func asrOfflineModeAvailable(
@@ -46,7 +34,13 @@ enum PersonaPlexDemoCachePolicy {
 
         return cacheComplete(
             in: directory,
-            requiredFiles: ["vocab.json", "merges.txt", "tokenizer_config.json"],
+            requiredFiles: [
+                "config.json",
+                "model.safetensors",
+                "vocab.json",
+                "merges.txt",
+                "tokenizer_config.json",
+            ],
             requiresWeights: true)
     }
 
@@ -59,15 +53,14 @@ enum PersonaPlexDemoCachePolicy {
 
         return cacheComplete(
             in: directory,
-            requiredFiles: ["config.json"],
+            requiredFiles: ["config.json", "model.safetensors"],
             requiresWeights: true)
     }
 
     static func cacheComplete(
         in directory: URL,
         requiredFiles: [String],
-        requiresWeights: Bool,
-        directoryRequirements: [CacheDirectoryRequirement] = []
+        requiresWeights: Bool
     ) -> Bool {
         let fm = FileManager.default
 
@@ -82,24 +75,6 @@ enum PersonaPlexDemoCachePolicy {
         for file in requiredFiles {
             let url = directory.appendingPathComponent(file)
             guard fm.fileExists(atPath: url.path) else {
-                return false
-            }
-        }
-
-        for requirement in directoryRequirements {
-            let dir = directory.appendingPathComponent(requirement.relativePath, isDirectory: true)
-            let entries: [URL]
-            do {
-                entries = try fm.contentsOfDirectory(
-                    at: dir,
-                    includingPropertiesForKeys: nil,
-                    options: [.skipsHiddenFiles])
-            } catch {
-                return false
-            }
-
-            let count = entries.filter { $0.pathExtension == requirement.fileExtension }.count
-            guard count >= requirement.minimumCount else {
                 return false
             }
         }

--- a/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexViewModel.swift
+++ b/Examples/PersonaPlexDemo/PersonaPlexDemo/PersonaPlexViewModel.swift
@@ -75,14 +75,21 @@ final class PersonaPlexViewModel {
 
     func loadModel() async {
         isLoading = true
-        loadingStatus = "Downloading PersonaPlex (~5.5 GB)..."
+        let personaPlexOffline = PersonaPlexDemoCachePolicy.personaPlexOfflineModeAvailable()
+        let asrOffline = PersonaPlexDemoCachePolicy.asrOfflineModeAvailable()
+        let vadOffline = PersonaPlexDemoCachePolicy.vadOfflineModeAvailable()
+
+        loadingStatus = personaPlexOffline
+            ? "Loading PersonaPlex from local cache..."
+            : "Downloading PersonaPlex (~5.5 GB)..."
         errorMessage = nil
 
         do {
             let loadStart = CFAbsoluteTimeGetCurrent()
 
             let m = try await PersonaPlexModel.fromPretrained(
-                modelId: PersonaPlexModel.modelId8bit
+                modelId: PersonaPlexModel.modelId8bit,
+                offlineMode: personaPlexOffline
             ) { [weak self] progress, status in
                 DispatchQueue.main.async {
                     self?.loadingStatus = "\(status) (\(Int(progress * 100))%)"
@@ -103,16 +110,22 @@ final class PersonaPlexViewModel {
 
             model = m
 
-            loadingStatus = "Loading ASR model (~400 MB)..."
-            let asr = try await Qwen3ASRModel.fromPretrained { [weak self] progress, status in
+            loadingStatus = asrOffline
+                ? "Loading ASR from local cache..."
+                : "Loading ASR model (~400 MB)..."
+            let asr = try await Qwen3ASRModel.fromPretrained(
+                offlineMode: asrOffline
+            ) { [weak self] progress, status in
                 DispatchQueue.main.async {
                     self?.loadingStatus = "ASR: \(status) (\(Int(progress * 100))%)"
                 }
             }
             asrModel = asr
 
-            loadingStatus = "Loading VAD model..."
-            let vad = try await SileroVADModel.fromPretrained()
+            loadingStatus = vadOffline
+                ? "Loading VAD from local cache..."
+                : "Loading VAD model..."
+            let vad = try await SileroVADModel.fromPretrained(offlineMode: vadOffline)
             vadModel = vad
             let vadConfig = VADConfig(
                 onset: 0.5, offset: 0.35,

--- a/Examples/PersonaPlexDemo/Tests/PersonaPlexDemoCachePolicyTests.swift
+++ b/Examples/PersonaPlexDemo/Tests/PersonaPlexDemoCachePolicyTests.swift
@@ -1,0 +1,93 @@
+#if os(macOS)
+import XCTest
+@testable import PersonaPlexDemo
+
+final class PersonaPlexDemoCachePolicyTests: XCTestCase {
+    func testCacheCompleteRequiresRequiredFiles() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try touch("model.safetensors", in: dir)
+        try touch("vocab.json", in: dir)
+
+        XCTAssertFalse(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: ["vocab.json", "merges.txt"],
+                requiresWeights: true))
+
+        try touch("merges.txt", in: dir)
+
+        XCTAssertTrue(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: ["vocab.json", "merges.txt"],
+                requiresWeights: true))
+    }
+
+    func testCacheCompleteRequiresWeightWhenRequested() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try touch("config.json", in: dir)
+
+        XCTAssertFalse(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: ["config.json"],
+                requiresWeights: true))
+
+        try touch("weights.safetensors", in: dir)
+
+        XCTAssertTrue(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: ["config.json"],
+                requiresWeights: true))
+    }
+
+    func testCacheCompleteRequiresDirectoryEntries() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try touch("temporal.safetensors", in: dir)
+        try touch("config.json", in: dir)
+        let voices = dir.appendingPathComponent("voices", isDirectory: true)
+        try FileManager.default.createDirectory(at: voices, withIntermediateDirectories: true)
+        try touch("NATM0.safetensors", in: voices)
+
+        let requirement = CacheDirectoryRequirement(
+            relativePath: "voices",
+            fileExtension: "safetensors",
+            minimumCount: 2)
+
+        XCTAssertFalse(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: ["temporal.safetensors", "config.json"],
+                requiresWeights: false,
+                directoryRequirements: [requirement]))
+
+        try touch("NATF0.safetensors", in: voices)
+
+        XCTAssertTrue(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: ["temporal.safetensors", "config.json"],
+                requiresWeights: false,
+                directoryRequirements: [requirement]))
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("personaplex-demo-cache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func touch(_ name: String, in directory: URL) throws {
+        let url = directory.appendingPathComponent(name)
+        try Data().write(to: url)
+    }
+}
+#endif

--- a/Examples/PersonaPlexDemo/Tests/PersonaPlexDemoCachePolicyTests.swift
+++ b/Examples/PersonaPlexDemo/Tests/PersonaPlexDemoCachePolicyTests.swift
@@ -46,7 +46,7 @@ final class PersonaPlexDemoCachePolicyTests: XCTestCase {
                 requiresWeights: true))
     }
 
-    func testCacheCompleteRequiresDirectoryEntries() throws {
+    func testCacheCompleteRequiresNestedRequiredFiles() throws {
         let dir = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
 
@@ -54,28 +54,31 @@ final class PersonaPlexDemoCachePolicyTests: XCTestCase {
         try touch("config.json", in: dir)
         let voices = dir.appendingPathComponent("voices", isDirectory: true)
         try FileManager.default.createDirectory(at: voices, withIntermediateDirectories: true)
-        try touch("NATM0.safetensors", in: voices)
-
-        let requirement = CacheDirectoryRequirement(
-            relativePath: "voices",
-            fileExtension: "safetensors",
-            minimumCount: 2)
+        try touch("NATF0.safetensors", in: voices)
 
         XCTAssertFalse(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
-                requiredFiles: ["temporal.safetensors", "config.json"],
-                requiresWeights: false,
-                directoryRequirements: [requirement]))
+                requiredFiles: [
+                    "temporal.safetensors",
+                    "config.json",
+                    "voices/NATF0.safetensors",
+                    "voices/NATM0.safetensors",
+                ],
+                requiresWeights: false))
 
-        try touch("NATF0.safetensors", in: voices)
+        try touch("NATM0.safetensors", in: voices)
 
         XCTAssertTrue(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
-                requiredFiles: ["temporal.safetensors", "config.json"],
-                requiresWeights: false,
-                directoryRequirements: [requirement]))
+                requiredFiles: [
+                    "temporal.safetensors",
+                    "config.json",
+                    "voices/NATF0.safetensors",
+                    "voices/NATM0.safetensors",
+                ],
+                requiresWeights: false))
     }
 
     private func makeTempDirectory() throws -> URL {

--- a/Examples/PersonaPlexDemo/Tests/PersonaPlexDemoCachePolicyTests.swift
+++ b/Examples/PersonaPlexDemo/Tests/PersonaPlexDemoCachePolicyTests.swift
@@ -7,21 +7,27 @@ final class PersonaPlexDemoCachePolicyTests: XCTestCase {
         let dir = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        try touch("model.safetensors", in: dir)
-        try touch("vocab.json", in: dir)
+        try write("model.safetensors", byteCount: 4, in: dir)
+        try write("vocab.json", byteCount: 2, in: dir)
 
         XCTAssertFalse(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
-                requiredFiles: ["vocab.json", "merges.txt"],
+                requiredFiles: [
+                    CacheFileRequirement(relativePath: "vocab.json", byteCount: 2),
+                    CacheFileRequirement(relativePath: "merges.txt", byteCount: 3),
+                ],
                 requiresWeights: true))
 
-        try touch("merges.txt", in: dir)
+        try write("merges.txt", byteCount: 3, in: dir)
 
         XCTAssertTrue(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
-                requiredFiles: ["vocab.json", "merges.txt"],
+                requiredFiles: [
+                    CacheFileRequirement(relativePath: "vocab.json", byteCount: 2),
+                    CacheFileRequirement(relativePath: "merges.txt", byteCount: 3),
+                ],
                 requiresWeights: true))
     }
 
@@ -29,20 +35,46 @@ final class PersonaPlexDemoCachePolicyTests: XCTestCase {
         let dir = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        try touch("config.json", in: dir)
+        try write("config.json", byteCount: 2, in: dir)
 
         XCTAssertFalse(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
-                requiredFiles: ["config.json"],
+                requiredFiles: [CacheFileRequirement(relativePath: "config.json", byteCount: 2)],
                 requiresWeights: true))
 
-        try touch("weights.safetensors", in: dir)
+        try write("weights.safetensors", byteCount: 5, in: dir)
 
         XCTAssertTrue(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
-                requiredFiles: ["config.json"],
+                requiredFiles: [CacheFileRequirement(relativePath: "config.json", byteCount: 2)],
+                requiresWeights: true))
+    }
+
+    func testCacheCompleteRequiresExpectedByteCount() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try write("config.json", byteCount: 2, in: dir)
+        try write("model.safetensors", byteCount: 5, in: dir)
+
+        XCTAssertFalse(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: [
+                    CacheFileRequirement(relativePath: "config.json", byteCount: 3),
+                    CacheFileRequirement(relativePath: "model.safetensors", byteCount: 5),
+                ],
+                requiresWeights: true))
+
+        XCTAssertTrue(
+            PersonaPlexDemoCachePolicy.cacheComplete(
+                in: dir,
+                requiredFiles: [
+                    CacheFileRequirement(relativePath: "config.json", byteCount: 2),
+                    CacheFileRequirement(relativePath: "model.safetensors", byteCount: 5),
+                ],
                 requiresWeights: true))
     }
 
@@ -50,33 +82,33 @@ final class PersonaPlexDemoCachePolicyTests: XCTestCase {
         let dir = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        try touch("temporal.safetensors", in: dir)
-        try touch("config.json", in: dir)
+        try write("temporal.safetensors", byteCount: 5, in: dir)
+        try write("config.json", byteCount: 2, in: dir)
         let voices = dir.appendingPathComponent("voices", isDirectory: true)
         try FileManager.default.createDirectory(at: voices, withIntermediateDirectories: true)
-        try touch("NATF0.safetensors", in: voices)
+        try write("NATF0.safetensors", byteCount: 7, in: voices)
 
         XCTAssertFalse(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
                 requiredFiles: [
-                    "temporal.safetensors",
-                    "config.json",
-                    "voices/NATF0.safetensors",
-                    "voices/NATM0.safetensors",
+                    CacheFileRequirement(relativePath: "temporal.safetensors", byteCount: 5),
+                    CacheFileRequirement(relativePath: "config.json", byteCount: 2),
+                    CacheFileRequirement(relativePath: "voices/NATF0.safetensors", byteCount: 7),
+                    CacheFileRequirement(relativePath: "voices/NATM0.safetensors", byteCount: 6),
                 ],
                 requiresWeights: false))
 
-        try touch("NATM0.safetensors", in: voices)
+        try write("NATM0.safetensors", byteCount: 6, in: voices)
 
         XCTAssertTrue(
             PersonaPlexDemoCachePolicy.cacheComplete(
                 in: dir,
                 requiredFiles: [
-                    "temporal.safetensors",
-                    "config.json",
-                    "voices/NATF0.safetensors",
-                    "voices/NATM0.safetensors",
+                    CacheFileRequirement(relativePath: "temporal.safetensors", byteCount: 5),
+                    CacheFileRequirement(relativePath: "config.json", byteCount: 2),
+                    CacheFileRequirement(relativePath: "voices/NATF0.safetensors", byteCount: 7),
+                    CacheFileRequirement(relativePath: "voices/NATM0.safetensors", byteCount: 6),
                 ],
                 requiresWeights: false))
     }
@@ -88,9 +120,9 @@ final class PersonaPlexDemoCachePolicyTests: XCTestCase {
         return dir
     }
 
-    private func touch(_ name: String, in directory: URL) throws {
+    private func write(_ name: String, byteCount: Int, in directory: URL) throws {
         let url = directory.appendingPathComponent(name)
-        try Data().write(to: url)
+        try Data(repeating: 0, count: byteCount).write(to: url)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- detect complete PersonaPlex, Qwen3-ASR, and Silero VAD caches before demo startup
- pass offlineMode when cached assets are already complete, so startup does not require an active network connection
- require exact PersonaPlex voice files, default ASR/VAD files, and expected byte sizes before claiming offline readiness
- add regression coverage for missing files, nested voice files, required weights, and wrong-size cache entries while keeping first-run downloads unchanged

## Root cause
The PersonaPlex demo loaded all three model components in online-first mode even after their HuggingFace caches were complete. With Wi-Fi disabled, startup could still try remote metadata checks and appear to hang before using local files.

## Validation
- swift test in Examples/PersonaPlexDemo — 11 tests passed
- swift build -c release --disable-sandbox in Examples/PersonaPlexDemo
- git diff --check
- CI-style root unit suite on 991001f: swift test --skip-build with the same E2E/model-heavy skip list as .github/workflows/tests.yml — 836 tests passed, 28 skipped, 0 failures
- GitHub Actions build-and-test passed on 991001f; rerunning on latest 234c819

Notes:
- No separate GUI E2E harness exists for this startup path; the regression coverage exercises the offline/cache decision logic without downloading models.
- Byte sizes come from the current HuggingFace tree metadata for the pinned demo repos. If the same model IDs are republished with different file sizes, the demo will fall back to online-first until these constants are updated.

Fixes #368