### PR TITLE
Speed up diarization: batch segmentation windows, memoize clustering distances

### DIFF
--- a/Sources/SpeechVAD/DiarizationHelpers.swift
+++ b/Sources/SpeechVAD/DiarizationHelpers.swift
@@ -100,6 +100,21 @@ enum DiarizationHelpers {
         var clusterWindows = items.map { Set([$0.windowIndex]) }
         var active = Set(0..<n)
 
+        // Memoized pairwise distances (flat n*n, symmetric). Constrained pairs
+        // are stored as +inf. A pair's distance (and its constraint state) only
+        // changes when one side merges, and the merged cluster's row/column is
+        // recomputed below — so the cache is always exact and the merge order
+        // is identical to the original recompute-every-iteration loop, at
+        // O(n^2) total distance work instead of O(n^3).
+        var dist = [Float](repeating: .infinity, count: n * n)
+        for i in 0..<n {
+            for j in (i + 1)..<n where items[i].windowIndex != items[j].windowIndex {
+                let d = cosineDistance(centroids[i], centroids[j])
+                dist[i * n + j] = d
+                dist[j * n + i] = d
+            }
+        }
+
         while active.count > 1 {
             // Find closest unconstrained pair
             var bestDist: Float = Float.greatestFiniteMagnitude
@@ -109,15 +124,9 @@ enum DiarizationHelpers {
             for ai in 0..<activeList.count {
                 for aj in (ai + 1)..<activeList.count {
                     let ci = activeList[ai], cj = activeList[aj]
-
-                    // Same-window constraint: if clusters share any window, skip
-                    if !clusterWindows[ci].isDisjoint(with: clusterWindows[cj]) {
-                        continue
-                    }
-
-                    let dist = cosineDistance(centroids[ci], centroids[cj])
-                    if dist < bestDist {
-                        bestDist = dist
+                    let d = dist[ci * n + cj]
+                    if d < bestDist {
+                        bestDist = d
                         bestI = ci
                         bestJ = cj
                     }
@@ -148,6 +157,16 @@ enum DiarizationHelpers {
             clusterWindows[bestI].formUnion(clusterWindows[bestJ])
 
             active.remove(bestJ)
+
+            // Refresh the merged cluster's cached distances (its centroid and
+            // window set both changed); everything else is untouched.
+            for other in active where other != bestI {
+                let d: Float = clusterWindows[bestI].isDisjoint(with: clusterWindows[other])
+                    ? cosineDistance(centroids[bestI], centroids[other])
+                    : .infinity
+                dist[bestI * n + other] = d
+                dist[other * n + bestI] = d
+            }
         }
 
         // Build final compact assignment

--- a/Sources/SpeechVAD/DiarizationPipeline.swift
+++ b/Sources/SpeechVAD/DiarizationPipeline.swift
@@ -339,27 +339,43 @@ public final class PyannoteDiarizationPipeline {
 
         let emptyResult = DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
 
-        for (posIdx, (start, end)) in positions.enumerated() {
-            completedUnits += 1
-            if progressHandler?(Float(completedUnits) / Float(totalUnits), "Segmenting \(posIdx + 1)/\(positions.count)") == false {
+        // Windows are batched through the segmentation model: the BiLSTM runs
+        // ~600 sequential timesteps of tiny ops per window, so per-op dispatch
+        // overhead dominates a batch-of-1 forward pass. Stacking windows on the
+        // batch axis amortizes it (measured ~5x on the segmentation stage).
+        let segmentationBatch = 8
+        var batchStart = 0
+        while batchStart < positions.count {
+            let batchEnd = min(batchStart + segmentationBatch, positions.count)
+            if progressHandler?(Float(completedUnits) / Float(totalUnits), "Segmenting \(batchStart + 1)/\(positions.count)") == false {
                 return emptyResult
             }
 
-            var window = Array(samples[start..<end])
-            if window.count < windowSamples {
-                window.append(contentsOf: [Float](repeating: 0, count: windowSamples - window.count))
+            var flat = [Float]()
+            flat.reserveCapacity((batchEnd - batchStart) * windowSamples)
+            for p in batchStart..<batchEnd {
+                let (start, end) = positions[p]
+                flat.append(contentsOf: samples[start..<end])
+                if end - start < windowSamples {
+                    flat.append(contentsOf: [Float](repeating: 0, count: windowSamples - (end - start)))
+                }
             }
 
-            let input = MLXArray(window).reshaped(1, 1, windowSamples)
+            let input = MLXArray(flat).reshaped(batchEnd - batchStart, 1, windowSamples)
             let posteriors = segmentationModel(input)
             let speakerProbs = PowersetDecoder.speakerProbabilities(from: posteriors)
             eval(speakerProbs)
 
-            var tracks = [[Float]]()
-            for spk in 0..<3 {
-                tracks.append(speakerProbs[0, 0..., spk].asArray(Float.self))
+            for (bi, p) in (batchStart..<batchEnd).enumerated() {
+                var tracks = [[Float]]()
+                for spk in 0..<3 {
+                    tracks.append(speakerProbs[bi, 0..., spk].asArray(Float.self))
+                }
+                windowProbs.append(WindowProbs(startSample: positions[p].start,
+                                               endSample: positions[p].end, tracks: tracks))
             }
-            windowProbs.append(WindowProbs(startSample: start, endSample: end, tracks: tracks))
+            completedUnits += batchEnd - batchStart
+            batchStart = batchEnd
         }
 
         guard !windowProbs.isEmpty else {

--- a/Tests/SpeechVADTests/DiarizationHelpersTests.swift
+++ b/Tests/SpeechVADTests/DiarizationHelpersTests.swift
@@ -298,6 +298,29 @@ final class DiarizationHelpersTests: XCTestCase {
         XCTAssertEqual(centroids.count, 2)
     }
 
+    func testClusteringUsesUpdatedCentroidDistances() {
+        // Unit vectors at 0°, 20°, 50°. d(A,B)=0.060 merges first; the merged
+        // centroid points at 10°, so d({A,B},C)=1-cos40°≈0.234 exceeds the
+        // 0.2 threshold and C must stay out — even though d(B,C)=1-cos30°≈0.134
+        // was below it. Centroid linkage requires the post-merge distance;
+        // reusing B's pre-merge distance would degrade to single linkage.
+        let items = [
+            DiarizationHelpers.ClusterItem(windowIndex: 0, localSpeakerId: 0,
+                                           embedding: [1, 0]),                  // A: 0°
+            DiarizationHelpers.ClusterItem(windowIndex: 1, localSpeakerId: 0,
+                                           embedding: [0.9397, 0.3420]),        // B: 20°
+            DiarizationHelpers.ClusterItem(windowIndex: 2, localSpeakerId: 0,
+                                           embedding: [0.6428, 0.7660]),        // C: 50°
+        ]
+        let (assignment, centroids) = DiarizationHelpers.constrainedAgglomerativeClustering(
+            items: items, threshold: 0.2)
+
+        XCTAssertEqual(assignment[0], assignment[1], "A and B should merge")
+        XCTAssertNotEqual(assignment[2], assignment[0],
+                          "C must be measured against the merged centroid, not its nearest member")
+        XCTAssertEqual(centroids.count, 2)
+    }
+
     func testClusteringMultipleSpeakers() {
         // 2 speakers across 3 windows — speaker embeddings are clearly separated
         let spk0: [Float] = [1, 0, 0, 0]


### PR DESCRIPTION
## Summary

Two independent hotspots made `PyannoteDiarizationPipeline.diarize` scale badly with input length. On a 22-minute recording (M-series, debug build) the full pipeline dropped from **363s to 55s** with byte-identical output (same segments, same cluster assignment, same centroids).

### 1. Batch segmentation windows through the model (`DiarizationPipeline.swift`)

The 10s windows ran the PyanNet forward pass one at a time. The BiLSTM inside executes ~600 sequential timesteps of small ops per window, so per-op dispatch overhead dominates a batch-of-1 pass. Windows now stack up to 8 on the batch axis (the model is batch-first end to end): the segmentation stage drops from 14.3s to ~2s on a 2-minute clip, ~165s to ~22s on the 22-minute recording. Progress reporting moves from per-window to per-batch.

### 2. Memoize pairwise distances in constrained clustering (`DiarizationHelpers.swift`)

`constrainedAgglomerativeClustering` recomputed every active pair's cosine distance *and* same-window `isDisjoint` check on every merge iteration — O(n³) distance work plus O(n²) set operations per merge. At ~550 items (22 minutes of audio) this stage alone took ~170s.

Distances now fill a flat `n×n` matrix once, with constrained pairs stored as `+inf`; after each merge only the merged cluster's row/column is refreshed, re-deriving the propagated window constraint at that point. Total distance work becomes O(n²) (~1s on the same input). The merge order is unchanged: cached entries are bit-identical to recomputation because a pair's distance and constraint state can only change when one side merges, and that is exactly when its row is refreshed.

## Verification

- `swift test --filter DiarizationHelpersTests` — 34 tests pass, including a new regression test (`testClusteringUsesUpdatedCentroidDistances`) pinning centroid-linkage semantics: a stale cache that reuses a pre-merge member distance would degrade to single linkage and fail it. The existing `testClusteringTransitiveConstraints` guards the constraint-refresh path.
- End-to-end on three real recordings (2 min / 10 min / 22 min, 3-speaker bilingual interview): identical segment boundaries, cluster counts, and pairwise centroid distances before/after on all three.

| Input | Before | After |
|---|---|---|
| 2 min | 17.2s | 5.0s |
| 10 min | 39.9s | 24.2s |
| 22 min | 363s | 54.8s |

(Remaining time at longer lengths is dominated by per-window speaker-embedding extraction, untouched here.)