### PR TITLE
Add TTS model capability metadata

### DIFF
--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -92,7 +92,7 @@ public struct AudioServer {
         // apart in shape.
         @Sendable
         func modelRow(_ v: ModelVariant) -> [String: Any] {
-            return [
+            var row: [String: Any] = [
                 "id": v.name,
                 "object": "model",
                 "engine": v.engine,
@@ -100,6 +100,21 @@ public struct AudioServer {
                 "model_id": v.modelId,
                 "aliases": v.aliases
             ]
+            if let caps = ttsCapabilities(for: v) {
+                row["display_name"] = caps.displayName
+                row["model_size"] = caps.modelSize
+                row["languages"] = caps.languages
+                row["voice_profile_modes"] = caps.voiceProfileModes.map(\.rawValue)
+                row["requires_reference_audio"] = caps.requiresReferenceAudio
+                row["requires_reference_transcript"] = caps.requiresReferenceTranscript
+                row["supports_instruct"] = caps.supportsInstruct
+                row["style_mode"] = caps.styleMode.rawValue
+                row["supported_markers"] = caps.supportedMarkers
+                row["needs_trim"] = caps.needsTrim
+                row["use_policy"] = caps.usePolicy
+                row["readiness"] = caps.readiness
+            }
+            return row
         }
 
         router.get("/v1/models") { _, _ in

--- a/Sources/AudioServer/ModelRegistry.swift
+++ b/Sources/AudioServer/ModelRegistry.swift
@@ -66,6 +66,79 @@ public struct ModelVariant: Sendable, Equatable {
     }
 }
 
+/// Voice profile shape a TTS model can consume.
+public enum TTSVoiceProfileMode: String, Sendable, Equatable, CaseIterable {
+    case referenceClone = "reference-clone"
+    case presetVoice = "preset-voice"
+    case designedVoice = "designed-voice"
+}
+
+/// Text-side style control exposed by a TTS model.
+public enum TTSStyleMode: String, Sendable, Equatable, CaseIterable {
+    /// Natural-language instruction/caption.
+    case instruction
+    /// Scalar expressiveness control, not a specific emotion.
+    case intensity
+    /// The model accepts tags appended to the utterance, e.g. `text <happy>`.
+    case suffixTag = "suffix-tag"
+    /// The model accepts bracket tags in text, e.g. `[excited] text`.
+    case bracketTag = "bracket-tag"
+    /// No explicit style/emotion control is exposed.
+    case none
+}
+
+/// Runtime-relevant capabilities for a selectable TTS model.
+///
+/// This mirrors the product-facing model registry shape: clients should be
+/// able to decide whether a voice profile is compatible, which languages to
+/// offer, and whether style markers/instructions are meaningful without
+/// hardcoding per-engine behavior.
+public struct TTSModelCapabilities: Sendable, Equatable {
+    public let modelName: String
+    public let displayName: String
+    public let modelSize: String
+    public let languages: [String]
+    public let voiceProfileModes: [TTSVoiceProfileMode]
+    public let requiresReferenceAudio: Bool
+    public let requiresReferenceTranscript: Bool
+    public let supportsInstruct: Bool
+    public let styleMode: TTSStyleMode
+    public let supportedMarkers: [String]
+    public let needsTrim: Bool
+    public let usePolicy: String
+    public let readiness: String
+
+    public init(
+        modelName: String,
+        displayName: String,
+        modelSize: String,
+        languages: [String],
+        voiceProfileModes: [TTSVoiceProfileMode],
+        requiresReferenceAudio: Bool,
+        requiresReferenceTranscript: Bool,
+        supportsInstruct: Bool,
+        styleMode: TTSStyleMode,
+        supportedMarkers: [String],
+        needsTrim: Bool,
+        usePolicy: String = "commercial-safe",
+        readiness: String = "production"
+    ) {
+        self.modelName = modelName
+        self.displayName = displayName
+        self.modelSize = modelSize
+        self.languages = languages
+        self.voiceProfileModes = voiceProfileModes
+        self.requiresReferenceAudio = requiresReferenceAudio
+        self.requiresReferenceTranscript = requiresReferenceTranscript
+        self.supportsInstruct = supportsInstruct
+        self.styleMode = styleMode
+        self.supportedMarkers = supportedMarkers
+        self.needsTrim = needsTrim
+        self.usePolicy = usePolicy
+        self.readiness = readiness
+    }
+}
+
 /// Every model name the Realtime API accepts.
 ///
 /// `modelId` values reference each engine module's `defaultModelId` /
@@ -163,7 +236,15 @@ public let MODEL_REGISTRY: [ModelVariant] = [
           modelId: Qwen3TTSModel.defaultModelId,
           // "qwen3" is shared with the ASR variant — bare "qwen3" lands in
           // both slots so naming the family pairs ASR + TTS in one update.
-          aliases: ["qwen3", "qwen3-tts", "qwen3-speech", "qwen3-tts-1.7b"],
+          aliases: [
+              "qwen3", "qwen3-tts", "qwen3-speech", "qwen3-tts-1.7b",
+              "qwen3-tts-base-1.7b", "qwen3-tts-1.7b-bf16",
+          ],
+          kind: .tts),
+    .init(name: "qwen3-tts-0.6b-base-mlx-8bit",
+          engine: "qwen3-tts",
+          modelId: TTSModelVariant.base.rawValue,
+          aliases: ["qwen3-tts-0.6b", "qwen3-tts-base-0.6b", "qwen3-speech-0.6b"],
           kind: .tts),
     // Magpie ships as a fixed bundle today (the `MagpieTTSVariant.int8`
     // default; int4 was decommissioned). Listing it here keeps it selectable
@@ -346,6 +427,206 @@ public let MODEL_REGISTRY: [ModelVariant] = [
           aliases: ["flashsr-int8"],
           kind: .sr),
 ]
+
+private let qwenTTSLanguages = ["zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"]
+
+/// Capability metadata for TTS variants in `MODEL_REGISTRY`.
+///
+/// This is intentionally keyed by canonical `ModelVariant.name` so protocol
+/// responses can attach capabilities after name resolution. Aliases remain
+/// routing-only.
+public let TTS_MODEL_CAPABILITIES: [String: TTSModelCapabilities] = [
+    "kokoro-82m-coreml": .init(
+        modelName: "kokoro-82m-coreml",
+        displayName: "Kokoro 82M CoreML",
+        modelSize: "82M",
+        languages: ["en", "es", "fr", "hi", "it", "pt", "ja", "zh"],
+        voiceProfileModes: [.presetVoice],
+        requiresReferenceAudio: false,
+        requiresReferenceTranscript: false,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false
+    ),
+    "cosyvoice-3-0.5b-mlx-bf16": .init(
+        modelName: "cosyvoice-3-0.5b-mlx-bf16",
+        displayName: "CosyVoice 3 0.5B MLX bf16",
+        modelSize: "0.5B",
+        languages: ["en", "zh"],
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: true,
+        supportsInstruct: true,
+        styleMode: .instruction,
+        supportedMarkers: ["angry", "calm", "excited", "happy", "sad", "serious", "soft", "whispering"],
+        needsTrim: false
+    ),
+    "cosyvoice-3-0.5b-mlx-8bit": .init(
+        modelName: "cosyvoice-3-0.5b-mlx-8bit",
+        displayName: "CosyVoice 3 0.5B MLX 8bit",
+        modelSize: "0.5B",
+        languages: ["en", "zh"],
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: true,
+        supportsInstruct: true,
+        styleMode: .instruction,
+        supportedMarkers: ["angry", "calm", "excited", "happy", "sad", "serious", "soft", "whispering"],
+        needsTrim: false
+    ),
+    "cosyvoice-3-0.5b-mlx-8bit-full": .init(
+        modelName: "cosyvoice-3-0.5b-mlx-8bit-full",
+        displayName: "CosyVoice 3 0.5B MLX 8bit full",
+        modelSize: "0.5B",
+        languages: ["en", "zh"],
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: true,
+        supportsInstruct: true,
+        styleMode: .instruction,
+        supportedMarkers: ["angry", "calm", "excited", "happy", "sad", "serious", "soft", "whispering"],
+        needsTrim: false
+    ),
+    "voxcpm2-mlx-bf16": .init(
+        modelName: "voxcpm2-mlx-bf16",
+        displayName: "VoxCPM2 MLX bf16",
+        modelSize: "1.7B",
+        languages: ["en", "zh"],
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: false,
+        supportsInstruct: true,
+        styleMode: .instruction,
+        supportedMarkers: ["angry", "calm", "excited", "happy", "sad", "serious", "soft", "whispering"],
+        needsTrim: false
+    ),
+    "voxcpm2-mlx-int8": .init(
+        modelName: "voxcpm2-mlx-int8",
+        displayName: "VoxCPM2 MLX int8",
+        modelSize: "1.7B",
+        languages: ["en", "zh"],
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: false,
+        supportsInstruct: true,
+        styleMode: .instruction,
+        supportedMarkers: ["angry", "calm", "excited", "happy", "sad", "serious", "soft", "whispering"],
+        needsTrim: false
+    ),
+    "indic-mio-mlx-fp16": .init(
+        modelName: "indic-mio-mlx-fp16",
+        displayName: "Indic-Mio MLX fp16",
+        modelSize: "0.6B",
+        languages: ["hi", "en"],
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: false,
+        supportsInstruct: false,
+        styleMode: .suffixTag,
+        supportedMarkers: ["<happy>", "<sad>", "<angry>", "<disgust>", "<fear>", "<surprise>"],
+        needsTrim: false
+    ),
+    "qwen3-tts-1.7b-mlx-bf16": .init(
+        modelName: "qwen3-tts-1.7b-mlx-bf16",
+        displayName: "Qwen3-TTS 1.7B Base MLX bf16",
+        modelSize: "1.7B",
+        languages: qwenTTSLanguages,
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: true,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false
+    ),
+    "qwen3-tts-0.6b-base-mlx-8bit": .init(
+        modelName: "qwen3-tts-0.6b-base-mlx-8bit",
+        displayName: "Qwen3-TTS 0.6B Base MLX 8bit",
+        modelSize: "0.6B",
+        languages: qwenTTSLanguages,
+        voiceProfileModes: [.referenceClone],
+        requiresReferenceAudio: true,
+        requiresReferenceTranscript: true,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false,
+        readiness: "experimental"
+    ),
+    "magpie-tts-multilingual-mlx-int8": .init(
+        modelName: "magpie-tts-multilingual-mlx-int8",
+        displayName: "Magpie TTS Multilingual MLX int8",
+        modelSize: "multilingual",
+        languages: ["en"],
+        voiceProfileModes: [.presetVoice],
+        requiresReferenceAudio: false,
+        requiresReferenceTranscript: false,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false
+    ),
+    "magpie-tts-multilingual-357m-coreml-int8": .init(
+        modelName: "magpie-tts-multilingual-357m-coreml-int8",
+        displayName: "Magpie TTS 357M CoreML int8",
+        modelSize: "357M",
+        languages: ["en"],
+        voiceProfileModes: [.presetVoice],
+        requiresReferenceAudio: false,
+        requiresReferenceTranscript: false,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false
+    ),
+    "qwen3-tts-coreml": .init(
+        modelName: "qwen3-tts-coreml",
+        displayName: "Qwen3-TTS CoreML",
+        modelSize: "0.6B",
+        languages: qwenTTSLanguages,
+        voiceProfileModes: [.presetVoice],
+        requiresReferenceAudio: false,
+        requiresReferenceTranscript: false,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false
+    ),
+    "vibevoice-realtime-0.5b-mlx-int4": .init(
+        modelName: "vibevoice-realtime-0.5b-mlx-int4",
+        displayName: "VibeVoice Realtime 0.5B MLX int4",
+        modelSize: "0.5B",
+        languages: ["en"],
+        voiceProfileModes: [.presetVoice],
+        requiresReferenceAudio: false,
+        requiresReferenceTranscript: false,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false,
+        readiness: "experimental"
+    ),
+    "vibevoice-1.5b-mlx-int4": .init(
+        modelName: "vibevoice-1.5b-mlx-int4",
+        displayName: "VibeVoice 1.5B MLX int4",
+        modelSize: "1.5B",
+        languages: ["en"],
+        voiceProfileModes: [.presetVoice],
+        requiresReferenceAudio: false,
+        requiresReferenceTranscript: false,
+        supportsInstruct: false,
+        styleMode: .none,
+        supportedMarkers: [],
+        needsTrim: false,
+        readiness: "experimental"
+    ),
+]
+
+public func ttsCapabilities(for variant: ModelVariant) -> TTSModelCapabilities? {
+    guard variant.kind == .tts else { return nil }
+    return TTS_MODEL_CAPABILITIES[variant.name]
+}
 
 /// Look up a model name (canonical or alias) in the registry.
 ///

--- a/Tests/AudioServerTests/RealtimeAPITests.swift
+++ b/Tests/AudioServerTests/RealtimeAPITests.swift
@@ -694,6 +694,22 @@ final class RealtimeAPITests: XCTestCase {
                        "aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s")
         XCTAssertEqual(parakeet["aliases"] as? [String],
                        ["parakeet", "parakeet-tdt", "parakeet-tdt-v3"])
+
+        guard let qwenTTS = rows.first(where: {
+            ($0["id"] as? String) == "qwen3-tts-0.6b-base-mlx-8bit"
+        }) else {
+            return XCTFail("Qwen3-TTS 0.6B Base variant missing from /v1/realtime/models")
+        }
+        XCTAssertEqual(qwenTTS["engine"] as? String, "qwen3-tts")
+        XCTAssertEqual(qwenTTS["model_size"] as? String, "0.6B")
+        XCTAssertEqual(qwenTTS["voice_profile_modes"] as? [String], ["reference-clone"])
+        XCTAssertEqual(qwenTTS["requires_reference_audio"] as? Bool, true)
+        XCTAssertEqual(qwenTTS["requires_reference_transcript"] as? Bool, true)
+        XCTAssertEqual(qwenTTS["supports_instruct"] as? Bool, false)
+        XCTAssertEqual(qwenTTS["style_mode"] as? String, "none")
+        XCTAssertEqual(qwenTTS["readiness"] as? String, "experimental")
+        XCTAssertTrue((qwenTTS["languages"] as? [String] ?? []).contains("en"))
+        XCTAssertTrue((qwenTTS["languages"] as? [String] ?? []).contains("ru"))
     }
 }
 
@@ -814,6 +830,39 @@ final class ResolveModelToEngineTests: XCTestCase {
                        "aufklarer/Qwen3-ASR-0.6B-MLX-4bit")
         XCTAssertEqual(resolveModelVariant("qwen3-1.7b")?.modelId,
                        "aufklarer/Qwen3-ASR-1.7B-MLX-8bit")
+    }
+
+    func testQwenBaseTTSVariantsAreRegisteredForVoiceCloning() {
+        XCTAssertEqual(resolveModelToTTSEngine("qwen3-tts-1.7b"), "qwen3-tts")
+        XCTAssertEqual(resolveModelVariant("qwen3-tts-1.7b")?.modelId,
+                       "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16")
+        XCTAssertNil(resolveModelVariant("qwen3-tts-1.7b-8bit"))
+        XCTAssertEqual(resolveModelVariant("qwen3-tts-0.6b")?.modelId,
+                       "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit")
+    }
+
+    func testTTSRegistryHasCapabilityRows() throws {
+        let ttsVariants = MODEL_REGISTRY.filter { $0.kind == .tts }
+        for variant in ttsVariants {
+            let caps = try XCTUnwrap(ttsCapabilities(for: variant),
+                                     "\(variant.name) is missing TTS capability metadata")
+            XCTAssertEqual(caps.modelName, variant.name)
+            XCTAssertFalse(caps.displayName.isEmpty)
+            XCTAssertFalse(caps.modelSize.isEmpty)
+            XCTAssertFalse(caps.readiness.isEmpty)
+        }
+    }
+
+    func testQwenBaseCloneCapabilitiesDoNotClaimInstructControl() throws {
+        let variant = try XCTUnwrap(resolveModelVariant("qwen3-tts-0.6b"))
+        let caps = try XCTUnwrap(ttsCapabilities(for: variant))
+        XCTAssertEqual(caps.voiceProfileModes, [.referenceClone])
+        XCTAssertTrue(caps.requiresReferenceAudio)
+        XCTAssertTrue(caps.requiresReferenceTranscript)
+        XCTAssertFalse(caps.supportsInstruct)
+        XCTAssertEqual(caps.styleMode, .none)
+        XCTAssertTrue(caps.languages.contains("en"))
+        XCTAssertTrue(caps.languages.contains("ru"))
     }
 
     func testStreamingAndCoreMLVariantsRegistered() {


### PR DESCRIPTION
Summary
- Add structured TTS capability metadata to the model registry.
- Expose capability fields on /v1/models and /v1/realtime/models.
- Register Qwen3-TTS 1.7B bf16 and 0.6B 8bit Base clone variants, with 0.6B marked experimental and no 1.7B int8 alias.

Test plan
- swift test --filter ResolveModelToEngineTests
- swift test --filter RealtimeAPITests/testRealtimeModelsEndpointRowShape