### PR TITLE
Skip CosyVoice LLM micro-test in nightly

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -141,8 +141,12 @@ jobs:
             filter: 'StreamingASRTests'
             skip: ''
           - name: cosyvoice-mlx-coreml
+            # Keep the full CosyVoice pipeline E2E, but skip the redundant
+            # LLM-only micro-test on hosted macos-15: after the full pipeline
+            # has already exercised `llm.generate`, this method can trip the
+            # virtualized runner's MLX/Metal command-buffer watchdog.
             filter: 'CosyVoiceTTSTests'
-            skip: ''
+            skip: 'testLLMGenerate5Tokens'
 
     name: ${{ matrix.shard.name }}
     steps:


### PR DESCRIPTION
Keep the full CosyVoice pipeline E2E in the nightly matrix, but skip the redundant LLM-only micro-test on hosted macos-15: after the full pipeline has already exercised `llm.generate`, the standalone method can trip the virtualized runner's MLX/Metal command-buffer watchdog and fail the shard spuriously.