### PR TITLE
CosyVoice: seeded long-form synthesis + upstream parity fixes

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -899,6 +899,7 @@ public struct SpeakCommand: ParsableCommand {
                         audio: refSamples16k,
                         sampleRate: 16000,
                         speechTokenizer: tokenizer,
+                        camppSpeaker: campp,
                         referenceTranscript: cosyReferenceTranscript
                     )
                     if let p = defaultVoiceProfile {

--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -1051,6 +1051,7 @@ public struct SpeakCommand: ParsableCommand {
                         voiceProfile: profile,
                         language: effectiveLanguage,
                         instruction: instruction,
+                        seed: self.seed,
                         verbose: verbose
                     )
                 } else {

--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -79,6 +79,7 @@ public final class CosyVoiceTTSModel {
                 additionalFiles: [
                     "llm.safetensors", "flow.safetensors", "hifigan.safetensors",
                     "vocab.json", "merges.txt", "tokenizer_config.json", "config.json",
+                    "flow_noise.bin",
                 ],
                 offlineMode: offlineMode
             ) { progress in
@@ -133,6 +134,15 @@ public final class CosyVoiceTTSModel {
         // Without either, the solver uses a deterministic keyed draw.
         let envNoise = ProcessInfo.processInfo.environment["COSY_FIXED_NOISE"]
         let bundleNoisePath = cacheDir.appendingPathComponent("flow_noise.bin").path
+        if envNoise == nil, !FileManager.default.fileExists(atPath: bundleNoisePath) {
+            // Caches created before the bundles shipped flow_noise.bin lack it
+            // (the main download is skipped once weights exist). Fetch it
+            // best-effort — the glob snapshot matches nothing on bundles
+            // without the file, so this cannot fail a load.
+            try? await HuggingFaceDownloader.downloadFiles(
+                modelId: modelId, to: cacheDir,
+                files: ["flow_noise.bin"], offlineMode: offlineMode)
+        }
         let noisePath = envNoise
             ?? (FileManager.default.fileExists(atPath: bundleNoisePath) ? bundleNoisePath : nil)
         if let noisePath {

--- a/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
+++ b/Sources/CosyVoiceTTS/CosyVoiceTTS.swift
@@ -127,6 +127,23 @@ public final class CosyVoiceTTSModel {
         let flowURL = cacheDir.appendingPathComponent("flow.safetensors")
         try CosyVoiceWeightLoader.loadFlow(model.flow, from: flowURL)
 
+        // Fixed flow noise (upstream parity): prefer an explicit
+        // COSY_FIXED_NOISE override, else a bundle-provided flow_noise.bin
+        // (raw float32, upstream's torch-seed-0 rand_noise [1, 80, N]).
+        // Without either, the solver uses a deterministic keyed draw.
+        let envNoise = ProcessInfo.processInfo.environment["COSY_FIXED_NOISE"]
+        let bundleNoisePath = cacheDir.appendingPathComponent("flow_noise.bin").path
+        let noisePath = envNoise
+            ?? (FileManager.default.fileExists(atPath: bundleNoisePath) ? bundleNoisePath : nil)
+        if let noisePath {
+            if let noise = ConditionalFlowMatching.loadFixedNoise(path: noisePath) {
+                model.flow.decoder.fixedNoise = noise
+                print("  Fixed flow noise: \(URL(fileURLWithPath: noisePath).lastPathComponent) [1, 80, \(noise.dim(2))]")
+            } else {
+                print("  WARNING: could not load fixed flow noise from \(noisePath); using keyed draw")
+            }
+        }
+
         progressHandler?(0.9, "Loading vocoder weights...")
         let hifiganURL = cacheDir.appendingPathComponent("hifigan.safetensors")
         try CosyVoiceWeightLoader.loadHiFiGAN(model.hifigan, from: hifiganURL)
@@ -238,10 +255,13 @@ public final class CosyVoiceTTSModel {
         //    instruction. Upstream: `min_len = (text_len - prompt_text_len) * ratio`.
         let contentTokens = tokenizer.encode(text).map { Int32($0) }
 
-        // For an unstyled zero-shot clone, upstream's text input is literally
-        //   concat(transcript_tokens + [<|endofprompt|>], content_tokens)
-        // with the reference speech tokens included in the LLM prefix. This
-        // is the highest-fidelity identity path.
+        // For an unstyled zero-shot clone, upstream CosyVoice3's text input is
+        //   "You are a helpful assistant.<|endofprompt|>" + transcript + content
+        // (example.py passes exactly that as prompt_text; llm.py concatenates
+        // prompt_text + text). Everything after <|endofprompt|> must BEGIN
+        // with the words the prompt audio speaks — placing the marker between
+        // transcript and content makes the model recite the transcript
+        // instead of the content (prompt regurgitation).
         //
         // A non-default instruction selects CosyVoice's `instruct2` layout:
         // the framed instruction becomes the LLM text prefix and the reference
@@ -256,8 +276,10 @@ public final class CosyVoiceTTSModel {
         if useInstructionConditionedClone {
             textTokens = tokenizeText(text, language: language, instruction: instruction)
         } else if let pt = promptText, !pt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let instructionTokens = tokenizer.encode(Self.assistantPrefix).map { Int32($0) }
             let promptTextTokens = tokenizer.encode(pt).map { Int32($0) }
-            textTokens = promptTextTokens + [Self.endOfPromptToken] + contentTokens
+            textTokens = instructionTokens + [Self.endOfPromptToken]
+                + promptTextTokens + contentTokens
         } else {
             textTokens = tokenizeText(text, language: language, instruction: instruction)
         }
@@ -315,20 +337,24 @@ public final class CosyVoiceTTSModel {
         )
         eval(fullMel)
 
-        // Pass the FULL mel (prompt + generation) to HiFi-GAN. Slicing the mel
-        // here means HiFi-GAN's causal convolutions warm up against zero-padded
-        // boundaries, producing a click/transient ~10 mel frames into the
-        // generated audio (the convolutional receptive field). Instead we let
-        // HiFi-GAN render both regions continuously and trim the prompt-region
-        // audio AFTER, where the boundary is smooth.
-        let mel = fullMel
-        let promptAudioSamples: Int
+        // Slice off the prompt region in the MEL domain, exactly like
+        // upstream (`feat = feat[:, :, mel_len1:]`), and vocode only the
+        // generation. Cutting the rendered AUDIO at the prompt boundary
+        // instead leaves a hard, unfaded mid-waveform cut — an audible
+        // click — and re-renders the whole reference through HiFi-GAN for
+        // nothing. The vocoder is causal and trained to start from zero
+        // left-context, so the sliced mel is its in-distribution input.
+        let mel: MLXArray
         if let pf = promptFeat {
             let promptMelLen = pf.dim(2)
-            // mel-rate is 50 Hz, audio sample rate is 24 kHz → 480 samples/mel
-            promptAudioSamples = promptMelLen * (config.sampleRate / 50)
+            let totalMelLen = fullMel.dim(2)
+            if promptMelLen < totalMelLen {
+                mel = fullMel[0..., 0..., promptMelLen...]
+            } else {
+                mel = fullMel
+            }
         } else {
-            promptAudioSamples = 0
+            mel = fullMel
         }
 
         // Optional debug dump of the mel that reaches HiFi-GAN.
@@ -353,16 +379,9 @@ public final class CosyVoiceTTSModel {
             print(String(format: "  HiFi-GAN: %.0fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000))
         }
 
-        // 5. Extract float samples, trimming the prompt-region audio so the
-        //    caller only sees the synthesised content. The boundary inside
-        //    HiFi-GAN's continuous render is smoother than a pre-sliced mel,
-        //    so trimming here removes the slice-boundary click that appeared
-        //    ~10 mel frames into the audio in the old path.
-        var samples = audio.reshaped(-1).asArray(Float.self)
-        if promptAudioSamples > 0 && promptAudioSamples < samples.count {
-            samples = Array(samples[promptAudioSamples...])
-        }
-        return samples
+        // 5. Extract float samples — the mel was already sliced to the
+        //    generation region, so the render is content-only.
+        return audio.reshaped(-1).asArray(Float.self)
     }
 
     /// Synthesize with streaming output.

--- a/Sources/CosyVoiceTTS/FlowMatching.swift
+++ b/Sources/CosyVoiceTTS/FlowMatching.swift
@@ -43,10 +43,20 @@ public class ConditionalFlowMatching: Module {
 
     @ModuleInfo var decoder: DiT
 
-    /// Compiled DiT forward pass for kernel fusion. Uses shapeless=false since
-    /// all shapes are constant across the 10 ODE steps within a generation.
-    /// Hardcodes nil spks/cond path (the common case for CosyVoice3 0.5B).
+    /// Compiled DiT forward passes for kernel fusion. Uses shapeless=false
+    /// since all shapes are constant across the 10 ODE steps within a
+    /// generation. Two variants: nil spks/cond (plain TTS) and full
+    /// conditioning (zero-shot cloning: spks + cond present).
     private var compiledDiTForward: (([MLXArray]) -> [MLXArray])?
+    private var compiledDiTForwardFull: (([MLXArray]) -> [MLXArray])?
+
+    /// Fixed initial ODE noise `[1, 80, N]`. Upstream CausalConditionalCFM
+    /// never samples fresh noise — it slices a fixed torch-seed-0 buffer
+    /// (`rand_noise = randn([1, 80, 50 * 300])`), an implicitly validated
+    /// draw for the 10-step Euler solver. Set from a bundle-provided buffer
+    /// (see `loadFixedNoise`); when nil, a keyed draw provides the same
+    /// fixed-noise property without depending on the global RNG.
+    public var fixedNoise: MLXArray?
 
     public init(config: CosyVoiceFlowConfig) {
         self.config = config
@@ -54,7 +64,19 @@ public class ConditionalFlowMatching: Module {
         super.init()
     }
 
-    /// Set up compiled DiT forward pass for Metal kernel fusion.
+    /// Load a raw little-endian float32 noise buffer and reshape to
+    /// `[1, 80, N]` (the upstream `rand_noise` layout).
+    public static func loadFixedNoise(path: String) -> MLXArray? {
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
+        let count = data.count / MemoryLayout<Float>.size
+        guard count >= 80, count % 80 == 0 else { return nil }
+        let floats = data.withUnsafeBytes { raw in
+            Array(raw.bindMemory(to: Float.self).prefix(count))
+        }
+        return MLXArray(floats, [1, 80, count / 80])
+    }
+
+    /// Set up compiled DiT forward passes for Metal kernel fusion.
     ///
     /// With shapeless=false, the compiled graph is traced once per input shape
     /// and reused across all 10 ODE steps (shapes are identical each step).
@@ -65,17 +87,24 @@ public class ConditionalFlowMatching: Module {
         compiledDiTForward = compile(
             inputs: [decoderRef], outputs: [decoderRef], shapeless: false
         ) { inputs in
-            let x = inputs[0]
-            let mask = inputs[1]
-            let mu = inputs[2]
-            let t = inputs[3]
-            let velocity = decoderRef(x, mask: mask, mu: mu, t: t, spks: nil, cond: nil)
+            let velocity = decoderRef(
+                inputs[0], mask: inputs[1], mu: inputs[2], t: inputs[3],
+                spks: nil, cond: nil)
+            return [velocity]
+        }
+
+        compiledDiTForwardFull = compile(
+            inputs: [decoderRef], outputs: [decoderRef], shapeless: false
+        ) { inputs in
+            let velocity = decoderRef(
+                inputs[0], mask: inputs[1], mu: inputs[2], t: inputs[3],
+                spks: inputs[4], cond: inputs[5])
             return [velocity]
         }
     }
 
-    /// Execute DiT forward pass (compiled when available, falls back to uncompiled).
-    /// Uses compiled path only when spks and cond are nil.
+    /// Execute DiT forward pass (compiled when available, falls back to
+    /// uncompiled for the mixed spks-without-cond case).
     private func executeDiTForward(
         x: MLXArray, mask: MLXArray, mu: MLXArray, t: MLXArray,
         spks: MLXArray?, cond: MLXArray?
@@ -83,25 +112,54 @@ public class ConditionalFlowMatching: Module {
         if let compiled = compiledDiTForward, spks == nil, cond == nil {
             return compiled([x, mask, mu, t])[0]
         }
+        if let compiled = compiledDiTForwardFull, let spks, let cond {
+            return compiled([x, mask, mu, t, spks, cond])[0]
+        }
         return decoder(x, mask: mask, mu: mu, t: t, spks: spks, cond: cond)
     }
 
-    /// Warm up the compiled DiT with a small dummy forward pass.
-    /// Traces the compiled graph and pre-compiles Metal shaders so the first
-    /// real generation pays zero compilation cost.
+    /// Warm up the compiled DiT with small dummy forward passes.
+    /// Traces both compiled graphs and pre-compiles Metal shaders so the
+    /// first real generation pays zero compilation cost. Dummies use the
+    /// loaded weight dtype so the traces match runtime call signatures.
     public func warmUp() {
         guard compiledDiTForward != nil else { return }
 
-        // Small dummy inputs: [2, 80, 4] (batch=2 for CFG doubling, T=4 minimal)
-        let dummyX = MLXArray.zeros([2, 80, 4])
-        let dummyMask = MLXArray.ones([2, 1, 4])
-        let dummyMu = MLXArray.zeros([2, 80, 4])
-        let dummyT = MLXArray.zeros([2])
+        let dtype = decoder.projOut.weight.dtype
+        let melDim = config.dit.melDim
+        let dummyX = MLXArray.zeros([2, melDim, 4]).asType(dtype)
+        let dummyMask = MLXArray.ones([2, 1, 4]).asType(dtype)
+        let dummyMu = MLXArray.zeros([2, melDim, 4]).asType(dtype)
+        let dummyT = MLXArray.zeros([2]).asType(dtype)
 
-        let result = executeDiTForward(
+        let plain = executeDiTForward(
             x: dummyX, mask: dummyMask, mu: dummyMu, t: dummyT,
             spks: nil, cond: nil)
-        eval(result)
+        eval(plain)
+
+        let dummySpks = MLXArray.zeros([2, config.dit.spkDim]).asType(dtype)
+        let dummyCond = MLXArray.zeros([2, melDim, 4]).asType(dtype)
+        let full = executeDiTForward(
+            x: dummyX, mask: dummyMask, mu: dummyMu, t: dummyT,
+            spks: dummySpks, cond: dummyCond)
+        eval(full)
+    }
+
+    /// Initial noise for the ODE solver, always float32.
+    /// Slices the fixed buffer when present (batch 1 and long enough),
+    /// otherwise draws with a fixed key so repeated calls are identical.
+    func initialNoise(batch: Int, timeSteps: Int, temperature: Float) -> MLXArray {
+        var z: MLXArray
+        if let buf = fixedNoise, batch == 1, buf.dim(2) >= timeSteps {
+            z = buf[0..., 0..., 0 ..< timeSteps].asType(.float32)
+        } else {
+            z = MLXRandom.normal(
+                [batch, config.outputSize, timeSteps], key: MLXRandom.key(0))
+        }
+        if temperature != 1.0 {
+            z = z * temperature
+        }
+        return z
     }
 
     /// Solve the flow matching ODE to generate a mel spectrogram.
@@ -127,8 +185,12 @@ public class ConditionalFlowMatching: Module {
         spks: MLXArray? = nil,
         cond: MLXArray? = nil
     ) -> MLXArray {
-        // 1. Sample initial noise: z ~ N(0, temperature^2 * I)
-        let z = MLXRandom.normal(mu.shape).asType(mu.dtype) * MLXArray(temperature)
+        // 1. Initial noise, float32. The solver state stays float32 for the
+        //    whole integration — upstream solves in float32 and returns
+        //    `.float()`; accumulating in the half-precision weight dtype
+        //    adds an audible spectral noise floor over the 10 Euler steps.
+        var x = initialNoise(
+            batch: mu.dim(0), timeSteps: mu.dim(2), temperature: temperature)
 
         // 2. Create time schedule with cosine mapping
         // Python: t_span = torch.linspace(0, 1, n_timesteps + 1)
@@ -138,50 +200,46 @@ public class ConditionalFlowMatching: Module {
             return 1.0 - cos(t * 0.5 * .pi)
         }
 
-        // 3. Euler solver with classifier-free guidance
-        var x = z
-
-        let cfgRate = MLXArray(config.cfgRate).asType(mu.dtype)
+        // 3. Euler solver with classifier-free guidance. The DiT runs in the
+        //    loaded weight dtype; the CFG combine and Euler update run fp32.
+        let ditDtype = mu.dtype
+        let cfgRate = config.cfgRate
 
         // Pre-build unconditioned inputs (zeros) for CFG — reused across all ODE steps
         let muZeros = MLXArray.zeros(mu.shape, dtype: mu.dtype)
-        let spksZeros: MLXArray? = spks.map { MLXArray.zeros($0.shape, dtype: $0.dtype) }
-        let condZeros: MLXArray? = cond.map { MLXArray.zeros($0.shape, dtype: $0.dtype) }
+        let spksZeros: MLXArray? = spks.map { MLXArray.zeros($0.shape, dtype: ditDtype) }
+        let condZeros: MLXArray? = cond.map { MLXArray.zeros($0.shape, dtype: ditDtype) }
 
         for i in 0 ..< nTimesteps {
             let t = tSchedule[i]
             let dt = tSchedule[i + 1] - tSchedule[i]
 
-            let dtScalar = MLXArray(dt).asType(mu.dtype)
-
             // Batch doubling for CFG: run conditioned + unconditioned in one forward pass
             let batchSize = x.dim(0)
-            let xIn = concatenated([x, x], axis: 0)                      // [2B, 80, T]
+            let xIn = concatenated([x, x], axis: 0).asType(ditDtype)      // [2B, 80, T]
             let maskIn = concatenated([mask, mask], axis: 0)              // [2B, 1, T]
             let muIn = concatenated([mu, muZeros], axis: 0)               // [2B, 80, T]
-            let tArr = MLXArray([Float](repeating: t, count: batchSize * 2)).asType(mu.dtype)
+            let tArr = MLXArray([Float](repeating: t, count: batchSize * 2)).asType(ditDtype)
 
             let spksIn: MLXArray? = spks.flatMap { s in
-                spksZeros.map { z in concatenated([s, z], axis: 0) }
+                spksZeros.map { z in concatenated([s.asType(ditDtype), z], axis: 0) }
             }
             let condIn: MLXArray? = cond.flatMap { c in
-                condZeros.map { z in concatenated([c, z], axis: 0) }
+                condZeros.map { z in concatenated([c.asType(ditDtype), z], axis: 0) }
             }
 
             // Single forward pass through DiT with doubled batch
             let velocity = executeDiTForward(
                 x: xIn, mask: maskIn, mu: muIn, t: tArr, spks: spksIn, cond: condIn)
 
-            // Split conditioned and unconditioned predictions
-            let vCond = velocity[0 ..< batchSize]
-            let vUncond = velocity[batchSize...]
-
-            // Apply classifier-free guidance:
+            // Split conditioned and unconditioned predictions, combine in fp32:
             //   v = (1 + cfg_rate) * v_cond - cfg_rate * v_uncond
+            let vCond = velocity[0 ..< batchSize].asType(.float32)
+            let vUncond = velocity[batchSize...].asType(.float32)
             let v = (1.0 + cfgRate) * vCond - cfgRate * vUncond
 
             // Euler step: x_{t+dt} = x_t + dt * v
-            x = x + dtScalar * v
+            x = x + dt * v
 
             // Evaluate to avoid building too large a computation graph
             eval(x)
@@ -194,8 +252,11 @@ public class ConditionalFlowMatching: Module {
 // MARK: - PreLookaheadLayer
 
 /// Causal convolution encoder before DiT.
-/// Two Conv1d layers: conv1(80→1024, k=4) → ReLU → conv2(1024→80, k=3).
-/// Adds local context to token embeddings before flow matching.
+/// conv1(80→1024, k=4, look-ahead) → leaky_relu(0.01) → conv2(1024→80, k=3,
+/// causal) → residual add with the input. The residual and the leaky slope
+/// match upstream `upsample_encoder.PreLookaheadLayer` — the DiT was trained
+/// with `mu = f(tokens) + tokens`, so dropping either shifts the content
+/// conditioning off-distribution on every frame.
 public class PreLookaheadLayer: Module {
     @ModuleInfo var conv1: CausalDilatedConv1d
     @ModuleInfo var conv2: CausalDilatedConv1d
@@ -215,9 +276,9 @@ public class PreLookaheadLayer: Module {
     /// Input: [B, C, T] (NCL) → Output: [B, C, T] (NCL)
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         var h = conv1(x)
-        h = relu(h)
+        h = leakyRelu(h, negativeSlope: 0.01)
         h = conv2(h)
-        return h
+        return h + x
     }
 }
 

--- a/Sources/CosyVoiceTTS/HiFiGAN.swift
+++ b/Sources/CosyVoiceTTS/HiFiGAN.swift
@@ -223,11 +223,30 @@ public class ResBlock: Module {
 
 // MARK: - Sine Generator
 
-/// Generates harmonic sine waves from F0 for the neural source filter.
-/// Produces sine_amp * sin(2*pi * cumsum(f0 * [1..numHarmonics+1] / sampleRate))
-/// with voiced/unvoiced masking.
+/// Harmonic source generator matching upstream `SineGen2` in causal
+/// inference mode — the variant CosyVoice3 (24 kHz) actually runs.
+///
+/// Upstream semantics (generator.py `SineGen2._f02sine`, causal=True):
+///   1. `rad = (f0 · h / sr) % 1` per harmonic, at sample rate.
+///   2. rad is linearly downsampled by 1/upsample_scale back to FRAME rate,
+///      cumsum'd there (phase magnitudes stay small), scaled by 2π and by
+///      upsample_scale, then upsampled with NEAREST — a per-frame staircase.
+///      The vocoder was trained on this staircase source; a smooth
+///      per-sample sine is off-distribution.
+///   3. Voiced: `sine_amp · sin(phase)` + noise_std·noise. Unvoiced:
+///      `(sine_amp / 3) · noise` — uniform [0, 1) at inference (upstream
+///      draws fixed buffers once at init; we use a fixed key instead).
+///
+/// Upstream's `rand_ini` initial-phase offset is applied to the first
+/// SAMPLE before the downsample; align_corners=False sampling never reads
+/// that sample back, so it is a no-op in causal inference and is omitted.
+///
+/// Takes FRAME-rate F0 (`[B, T]`) — the caller's F0 is nearest-upsampled
+/// and frame-constant upstream, so downsampling it back recovers the frame
+/// values exactly; the up/down round trip is skipped.
 public class SineGenerator {
     let sampleRate: Int
+    let upsampleScale: Int    // prod(upsample_rates) * istft_hop = 480
     let harmonicNum: Int      // Number of additional harmonics (total = harmonicNum + 1)
     let sineAmp: Float
     let noiseStd: Float
@@ -235,72 +254,82 @@ public class SineGenerator {
 
     public init(
         sampleRate: Int = 24000,
+        upsampleScale: Int = 480,
         harmonicNum: Int = 8,
         sineAmp: Float = 0.1,
         noiseStd: Float = 0.003,
         voicedThreshold: Float = 10.0
     ) {
         self.sampleRate = sampleRate
+        self.upsampleScale = upsampleScale
         self.harmonicNum = harmonicNum
         self.sineAmp = sineAmp
         self.noiseStd = noiseStd
         self.voicedThreshold = voicedThreshold
     }
 
-    /// Generate sine waves and voiced/unvoiced mask from F0.
-    /// - Parameter f0: [B, T, 1] fundamental frequency in Hz
-    /// - Returns: (sineWaves: [B, T, numHarmonics+1], uvMask: [B, T, 1])
-    public func callAsFunction(_ f0: MLXArray) -> (MLXArray, MLXArray) {
-        let totalHarmonics = harmonicNum + 1  // fundamental + overtones
+    /// Generate the harmonic source from frame-rate F0.
+    /// - Parameter f0Frame: `[B, T]` fundamental frequency in Hz at frame rate
+    /// - Returns: (sineWaves: `[B, T*upsampleScale, H]`, uvMask: `[B, T*upsampleScale, 1]`)
+    public func callAsFunction(_ f0Frame: MLXArray) -> (MLXArray, MLXArray) {
+        let batch = f0Frame.dim(0)
+        let frames = f0Frame.dim(1)
+        let totalHarmonics = harmonicNum + 1
 
-        // Create harmonic multipliers: [1, 2, 3, ..., totalHarmonics]
+        // Harmonic multipliers [1, 2, ..., H]: [1, 1, H]
         let harmonics = MLXArray(Array(1...totalHarmonics).map { Float($0) })
-            .reshaped([1, 1, totalHarmonics])  // [1, 1, H]
+            .reshaped([1, 1, totalHarmonics])
 
-        // f0: [B, T, 1] -> frequencies: [B, T, H]
-        let frequencies = (f0 * harmonics) / Float(sampleRate)
+        // Per-frame rad values with the % 1 wrap (integer cycles carry no
+        // phase; wrapping keeps the cumsum magnitudes small).
+        let f0 = f0Frame.asType(.float32).expandedDimensions(axis: 2)   // [B, T, 1]
+        let radFrame = ((f0 * harmonics) / Float(sampleRate)) % 1.0     // [B, T, H]
 
-        // Voiced mask: f0 > threshold -> 1.0, else 0.0
-        let uvMask = MLX.where(
+        // Frame-rate phase, scaled by 2π·upsample_scale, each frame's value
+        // held for upsample_scale samples (nearest upsample).
+        let phaseFrame = cumsum(radFrame, axis: 1)
+            * MLXArray(Float(2.0 * Float.pi) * Float(upsampleScale))     // [B, T, H]
+        let phaseUp = repeated(
+            phaseFrame.expandedDimensions(axis: 2), count: upsampleScale, axis: 2
+        ).reshaped([batch, frames * upsampleScale, totalHarmonics])      // [B, T*S, H]
+
+        let sines = sin(phaseUp)
+
+        // Voiced mask at sample rate (frame-constant F0 → repeat).
+        let uvFrame = MLX.where(
             f0 .> MLXArray(voicedThreshold),
             MLXArray(Float(1.0)),
-            MLXArray(Float(0.0)))
+            MLXArray(Float(0.0)))                                        // [B, T, 1]
+        let uvMask = repeated(
+            uvFrame.expandedDimensions(axis: 2), count: upsampleScale, axis: 2
+        ).reshaped([batch, frames * upsampleScale, 1])                   // [B, T*S, 1]
 
-        // Zero out unvoiced regions before cumsum to prevent phase drift
-        let maskedFreqs = frequencies * uvMask  // [B, T, H]
+        // Noise: voiced regions get noise_std, unvoiced get sine_amp/3 —
+        // uniform [0, 1) with a fixed key (upstream uses fixed buffers at eval).
+        let noiseAmp = uvMask * noiseStd + (1.0 - uvMask) * (sineAmp / 3.0)
+        let noise = noiseAmp * MLXRandom.uniform(
+            low: Float(0), high: Float(1),
+            [batch, frames * upsampleScale, totalHarmonics],
+            key: MLXRandom.key(0))
 
-        // Phase: 2*pi * cumsum(freq) along time axis
-        let phase = cumsum(maskedFreqs, axis: 1) * MLXArray(Float(2.0 * Float.pi))
-
-        // Add random initial phase offset to avoid artifacts at boundaries
-        let initPhase = MLXRandom.uniform(
-            low: 0,
-            high: Float(2.0 * Float.pi),
-            [f0.dim(0), 1, totalHarmonics])
-        let fullPhase = phase + initPhase
-
-        // Generate sine waves
-        var sineWaves = MLXArray(sineAmp) * sin(fullPhase)  // [B, T, H]
-
-        // Apply voiced mask: voiced -> sine, unvoiced -> noise
-        let noise = MLXRandom.normal(sineWaves.shape) * MLXArray(noiseStd)
-        sineWaves = sineWaves * uvMask + noise * (1.0 - uvMask)
-
+        let sineWaves = sines * sineAmp * uvMask + noise
         return (sineWaves, uvMask)
     }
 }
 
 // MARK: - Source Module (NSF)
 
-/// Neural Source Filter: generates excitation signal by merging harmonic sines.
-/// sine_generator -> linear_merge -> tanh -> add noise
+/// Neural Source Filter: merges harmonic sines into a single excitation.
+/// sine_generator -> linear_merge -> tanh. No noise is added to the merged
+/// source — upstream returns its noise branch separately and the HiFT
+/// decoder never consumes it.
 public class SourceModuleHnNSF: Module {
     let sineGen: SineGenerator
     @ModuleInfo var linearMerge: Linear
-    let noiseStd: Float
 
     public init(
         sampleRate: Int = 24000,
+        upsampleScale: Int = 480,
         harmonicNum: Int = 8,
         sineAmp: Float = 0.1,
         noiseStd: Float = 0.003,
@@ -308,23 +337,21 @@ public class SourceModuleHnNSF: Module {
     ) {
         self.sineGen = SineGenerator(
             sampleRate: sampleRate,
+            upsampleScale: upsampleScale,
             harmonicNum: harmonicNum,
             sineAmp: sineAmp,
             noiseStd: noiseStd,
             voicedThreshold: voicedThreshold)
-        self.noiseStd = noiseStd
         // Merge all harmonics (fundamental + overtones) into 1 channel
         self._linearMerge.wrappedValue = Linear(harmonicNum + 1, 1)
         super.init()
     }
 
-    /// - Parameter f0: [B, T, 1] fundamental frequency in Hz
-    /// - Returns: excitation signal [B, T, 1]
-    public func callAsFunction(_ f0: MLXArray) -> MLXArray {
-        let (sineWaves, _) = sineGen(f0)  // [B, T, H]
-        let merged = tanh(linearMerge(sineWaves))  // [B, T, 1]
-        let noise = MLXRandom.normal(merged.shape) * MLXArray(noiseStd)
-        return merged + noise
+    /// - Parameter f0Frame: `[B, T]` fundamental frequency in Hz at frame rate
+    /// - Returns: excitation signal `[B, T*upsampleScale, 1]`
+    public func callAsFunction(_ f0Frame: MLXArray) -> MLXArray {
+        let (sineWaves, _) = sineGen(f0Frame)          // [B, T*S, H]
+        return tanh(linearMerge(sineWaves))            // [B, T*S, 1]
     }
 }
 
@@ -371,27 +398,6 @@ public class F0Predictor: Module {
         h = h.squeezed(axis: 2)    // [B, T]
         return abs(h)
     }
-}
-
-// MARK: - F0 Interpolation
-
-/// Upsample F0 by a given factor using nearest-neighbor (repeat) interpolation.
-/// - Parameters:
-///   - f0: [B, T] F0 values
-///   - factor: integer upsample factor
-/// - Returns: [B, T * factor] upsampled F0
-private func interpolateF0(_ f0: MLXArray, factor: Int) -> MLXArray {
-    let batch = f0.dim(0)
-    let timeSteps = f0.dim(1)
-    let outLen = timeSteps * factor
-
-    if factor == 1 { return f0 }
-
-    // Nearest-neighbor upsampling: repeat each sample `factor` times
-    // f0: [B, T] -> [B, T, 1] -> repeat -> [B, T, factor] -> reshape [B, T*factor]
-    let expanded = f0.expandedDimensions(axis: 2)  // [B, T, 1]
-    let rep = repeated(expanded, count: factor, axis: 2)  // [B, T, factor]
-    return rep.reshaped([batch, outLen])
 }
 
 // MARK: - STFT
@@ -615,8 +621,15 @@ private func istft(
         }
     }
     let windowNorm = MLXArray(windowSumData).reshaped([1, outLen])
+    let normalized = accumulated / windowNorm
 
-    return accumulated / windowNorm
+    // torch.istft (center=True) trims n_fft/2 partial-window samples from
+    // both ends; keeping them leaves a nonzero first sample — a step
+    // discontinuity that reads as a click at the start of every render.
+    // After the trim the output is exactly hop·(nFrames−1) samples, matching
+    // torch, i.e. 480 samples per mel frame end to end.
+    let edge = nFFT / 2
+    return normalized[0..., edge ..< (outLen - edge)]
 }
 
 // MARK: - HiFi-GAN Generator
@@ -661,6 +674,7 @@ public class HiFiGANGenerator: Module {
         // Source module
         self._source.wrappedValue = SourceModuleHnNSF(
             sampleRate: config.sampleRate,
+            upsampleScale: config.totalUpsampleFactor * config.istftHopLen,
             harmonicNum: config.nbHarmonics,
             sineAmp: config.nsfAlpha,
             noiseStd: config.nsfSigma,
@@ -765,14 +779,10 @@ public class HiFiGANGenerator: Module {
         // 1. Predict F0 from mel: [B, 80, T] -> [B, T]
         let f0 = f0Predictor(melNCL)
 
-        // 2. Upsample F0 to waveform sample rate
-        //    Total upsample: prod(upsampleRates) * istftHopLen = 120 * 4 = 480
-        let totalUpsample = config.totalUpsampleFactor * config.istftHopLen
-        let f0Up = interpolateF0(f0, factor: totalUpsample)  // [B, T*480]
-
-        // 3. Generate source excitation signal
-        let f0UpExpanded = f0Up.expandedDimensions(axis: 2)  // [B, T*480, 1]
-        let sourceSignal = source(f0UpExpanded)  // [B, T*480, 1]
+        // 2-3. Generate source excitation from frame-rate F0. The source
+        //    module upsamples internally (×480 = prod(upsampleRates) ·
+        //    istftHopLen) with SineGen2's frame-staircase phase scheme.
+        let sourceSignal = source(f0)  // [B, T*480, 1]
 
         // 4. STFT of source -> real and imaginary parts in NCL format
         let sourceFlat = sourceSignal.squeezed(axis: 2)  // [B, T*480]
@@ -845,7 +855,9 @@ public class HiFiGANGenerator: Module {
         let magPart = x[0..., 0..<nBins, 0...]             // [B, 9, T_final]
         let phasePart = x[0..., nBins..<(nBins * 2), 0...]  // [B, 9, T_final]
 
-        let outputMag = exp(magPart)
+        // Upstream `_istft` clips magnitude at 1e2 — without it a single
+        // hot logit becomes a full-scale click after exp().
+        let outputMag = minimum(exp(magPart), MLXArray(Float(1e2)))
         let outputPhase = sin(phasePart)
 
         // 9. ISTFT to reconstruct audio

--- a/Sources/CosyVoiceTTS/VoiceCloning.swift
+++ b/Sources/CosyVoiceTTS/VoiceCloning.swift
@@ -175,11 +175,15 @@ extension CosyVoiceTTSModel {
         language: String = "english",
         instruction: String = "You are a helpful assistant.",
         segmentGapSeconds: Float = 0.2,
+        seed: UInt64? = nil,
         verbose: Bool = false
     ) -> [Float] {
         let segments = Self.splitForLongForm(text)
         if segments.count <= 1 {
-            return synthesize(
+            if let seed {
+                MLX.seed(seed)
+            }
+            let samples = synthesize(
                 text: text,
                 language: language,
                 instruction: instruction,
@@ -189,16 +193,16 @@ extension CosyVoiceTTSModel {
                 promptText: voiceProfile.promptText,
                 verbose: verbose
             )
+            return Self.cleanCloneOutput(samples, sampleRate: config.sampleRate)
         }
 
-        let gap = [Float](
-            repeating: 0,
-            count: Int(segmentGapSeconds * Float(config.sampleRate))
-        )
-        var output: [Float] = []
+        var renderedSegments: [[Float]] = []
         for (i, seg) in segments.enumerated() {
             if verbose {
                 print("  Long-form segment \(i + 1)/\(segments.count): \"\(seg)\"")
+            }
+            if let seed {
+                MLX.seed(seed)
             }
             let samples = synthesize(
                 text: seg,
@@ -210,12 +214,106 @@ extension CosyVoiceTTSModel {
                 promptText: voiceProfile.promptText,
                 verbose: verbose
             )
-            if !output.isEmpty && !samples.isEmpty {
-                output.append(contentsOf: gap)
+            let cleaned = Self.trimClonePromptLeak(samples, sampleRate: config.sampleRate)
+            if !cleaned.isEmpty {
+                renderedSegments.append(cleaned)
             }
-            output.append(contentsOf: samples)
         }
+        return Self.stitchLongFormSegments(
+            renderedSegments,
+            sampleRate: config.sampleRate,
+            gapSeconds: segmentGapSeconds
+        )
+    }
+
+    /// Match speech-studio's CosyVoice clone cleanup: the prompt-token +
+    /// prompt-feat path trims the nominal prompt region internally, but HiFi-GAN
+    /// can smear a short fragment of prompt audio past that boundary. Dropping
+    /// the first 300 ms removes that audible leak without changing text-only TTS.
+    static func trimClonePromptLeak(
+        _ samples: [Float],
+        sampleRate: Int,
+        trimSeconds: Float = 0.30
+    ) -> [Float] {
+        let trimCount = max(0, Int(trimSeconds * Float(sampleRate)))
+        guard trimCount > 0, samples.count > trimCount * 2 else {
+            return samples
+        }
+        return Array(samples.dropFirst(trimCount))
+    }
+
+    /// Final cleanup for a single cloned render. CosyVoice's vocoder can leave
+    /// a high-amplitude terminal sample when generation stops, which becomes an
+    /// audible end click when the WAV closes. Fade only the cloned output edge;
+    /// text-only TTS keeps its raw model output.
+    static func cleanCloneOutput(
+        _ samples: [Float],
+        sampleRate: Int,
+        edgeFadeSeconds: Float = 0.03
+    ) -> [Float] {
+        var cleaned = trimClonePromptLeak(samples, sampleRate: sampleRate)
+        let fadeCount = max(0, Int(edgeFadeSeconds * Float(sampleRate)))
+        if fadeCount > 0 {
+            applyFadeIn(&cleaned, count: fadeCount)
+            applyFadeOut(&cleaned, count: fadeCount)
+        }
+        return cleaned
+    }
+
+    /// Stitch independently generated long-form segments without hard waveform
+    /// discontinuities at the inserted silence gaps. Every rendered output —
+    /// including a lone surviving segment — leaves with a tail fade, so no
+    /// path can end on a high-amplitude sample (an audible end click).
+    static func stitchLongFormSegments(
+        _ segments: [[Float]],
+        sampleRate: Int,
+        gapSeconds: Float,
+        fadeSeconds: Float = 0.03
+    ) -> [Float] {
+        let nonEmptySegments = segments.filter { !$0.isEmpty }
+        guard !nonEmptySegments.isEmpty else { return [] }
+
+        let gapCount = max(0, Int(gapSeconds * Float(sampleRate)))
+        let fadeCount = max(0, Int(fadeSeconds * Float(sampleRate)))
+        var output: [Float] = []
+
+        for (index, originalSegment) in nonEmptySegments.enumerated() {
+            var segment = originalSegment
+            if fadeCount > 0 {
+                if index > 0 {
+                    Self.applyFadeIn(&segment, count: fadeCount)
+                }
+                Self.applyFadeOut(&segment, count: fadeCount)
+            }
+
+            if index > 0 && gapCount > 0 {
+                output.append(contentsOf: repeatElement(Float(0), count: gapCount))
+            }
+            output.append(contentsOf: segment)
+        }
+
         return output
+    }
+
+    private static func applyFadeIn(_ samples: inout [Float], count: Int) {
+        let n = min(count, samples.count)
+        guard n > 0 else { return }
+        for i in 0..<n {
+            let t = Float(i + 1) / Float(n + 1)
+            let scale = Float(sin(Double(t * .pi / 2)))
+            samples[i] *= scale
+        }
+    }
+
+    private static func applyFadeOut(_ samples: inout [Float], count: Int) {
+        let n = min(count, samples.count)
+        guard n > 0 else { return }
+        let start = samples.count - n
+        for i in 0..<n {
+            let t = Float(i + 1) / Float(n + 1)
+            let scale = Float(cos(Double(t * .pi / 2)))
+            samples[start + i] *= scale
+        }
     }
 
     /// Split text into segments small enough that the LLM stays inside its
@@ -225,7 +323,7 @@ extension CosyVoiceTTSModel {
     /// are merged so we don't synthesise a 2-word segment unnecessarily.
     static func splitForLongForm(_ text: String) -> [String] {
         let maxWordsPerSegment = 25
-        let minWordsPerSegment = 4
+        let minWordsPerSegment = 6
 
         let input = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty else { return [] }

--- a/Sources/CosyVoiceTTS/VoiceCloning.swift
+++ b/Sources/CosyVoiceTTS/VoiceCloning.swift
@@ -214,9 +214,8 @@ extension CosyVoiceTTSModel {
                 promptText: voiceProfile.promptText,
                 verbose: verbose
             )
-            let cleaned = Self.trimClonePromptLeak(samples, sampleRate: config.sampleRate)
-            if !cleaned.isEmpty {
-                renderedSegments.append(cleaned)
+            if !samples.isEmpty {
+                renderedSegments.append(samples)
             }
         }
         return Self.stitchLongFormSegments(
@@ -226,32 +225,18 @@ extension CosyVoiceTTSModel {
         )
     }
 
-    /// Match speech-studio's CosyVoice clone cleanup: the prompt-token +
-    /// prompt-feat path trims the nominal prompt region internally, but HiFi-GAN
-    /// can smear a short fragment of prompt audio past that boundary. Dropping
-    /// the first 300 ms removes that audible leak without changing text-only TTS.
-    static func trimClonePromptLeak(
-        _ samples: [Float],
-        sampleRate: Int,
-        trimSeconds: Float = 0.30
-    ) -> [Float] {
-        let trimCount = max(0, Int(trimSeconds * Float(sampleRate)))
-        guard trimCount > 0, samples.count > trimCount * 2 else {
-            return samples
-        }
-        return Array(samples.dropFirst(trimCount))
-    }
-
     /// Final cleanup for a single cloned render. CosyVoice's vocoder can leave
     /// a high-amplitude terminal sample when generation stops, which becomes an
     /// audible end click when the WAV closes. Fade only the cloned output edge;
-    /// text-only TTS keeps its raw model output.
+    /// text-only TTS keeps its raw model output. (The prompt region is sliced
+    /// off in the mel domain before vocoding — upstream parity — so no
+    /// audio-domain prompt trim is needed here.)
     static func cleanCloneOutput(
         _ samples: [Float],
         sampleRate: Int,
         edgeFadeSeconds: Float = 0.03
     ) -> [Float] {
-        var cleaned = trimClonePromptLeak(samples, sampleRate: sampleRate)
+        var cleaned = samples
         let fadeCount = max(0, Int(edgeFadeSeconds * Float(sampleRate)))
         if fadeCount > 0 {
             applyFadeIn(&cleaned, count: fadeCount)
@@ -261,9 +246,11 @@ extension CosyVoiceTTSModel {
     }
 
     /// Stitch independently generated long-form segments without hard waveform
-    /// discontinuities at the inserted silence gaps. Every rendered output —
-    /// including a lone surviving segment — leaves with a tail fade, so no
-    /// path can end on a high-amplitude sample (an audible end click).
+    /// discontinuities. Every segment edge is faded — including the FIRST
+    /// segment's head: the vocoder starts each render from zero left-context,
+    /// so the opening samples sit mid-phonation and an unfaded head is an
+    /// audible click at utterance start (mirrors `cleanCloneOutput`, which
+    /// fades both edges of a single-segment render).
     static func stitchLongFormSegments(
         _ segments: [[Float]],
         sampleRate: Int,
@@ -280,9 +267,7 @@ extension CosyVoiceTTSModel {
         for (index, originalSegment) in nonEmptySegments.enumerated() {
             var segment = originalSegment
             if fadeCount > 0 {
-                if index > 0 {
-                    Self.applyFadeIn(&segment, count: fadeCount)
-                }
+                Self.applyFadeIn(&segment, count: fadeCount)
                 Self.applyFadeOut(&segment, count: fadeCount)
             }
 

--- a/Tests/CosyVoiceTTSTests/FlowVocoderParityTests.swift
+++ b/Tests/CosyVoiceTTSTests/FlowVocoderParityTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+import MLX
+import MLXNN
+@testable import CosyVoiceTTS
+
+/// Regression tests pinning the upstream-parity fixes for the CosyVoice3
+/// quality issue (reverby/smeared output). Each test would fail on the
+/// pre-fix implementation.
+final class FlowVocoderParityTests: XCTestCase {
+
+    // MARK: - PreLookaheadLayer
+
+    /// Upstream `PreLookaheadLayer` ends with `outputs = outputs + inputs`.
+    /// With all conv weights zeroed the layer must reduce to the identity —
+    /// the pre-fix implementation (no residual) returns all zeros instead.
+    func testPreLookaheadLayerHasResidualConnection() {
+        let layer = PreLookaheadLayer(inputDim: 4, hiddenDim: 8)
+        zeroConvParameters(layer.conv1)
+        zeroConvParameters(layer.conv2)
+
+        let x = MLXRandom.normal([1, 4, 6])
+        let y = layer(x)
+        eval(y)
+
+        XCTAssertEqual(y.shape, x.shape)
+        let maxDiff = MLX.abs(y - x).max().item(Float.self)
+        XCTAssertEqual(maxDiff, 0, accuracy: 1e-6,
+                       "Zeroed convs must reduce PreLookaheadLayer to identity (residual)")
+    }
+
+    /// The activation between the convs is leaky_relu(0.01), not ReLU:
+    /// negative conv1 outputs must leak through at slope 0.01. With conv1
+    /// fixed to output a negative constant and conv2 an identity-summing
+    /// kernel, ReLU yields exactly x while leaky_relu yields x - 0.01·c·k.
+    func testPreLookaheadLayerUsesLeakyRelu() {
+        let layer = PreLookaheadLayer(inputDim: 2, hiddenDim: 3)
+
+        // conv1: zero weights, bias -1 → pre-activation is -1 everywhere.
+        zeroConvParameters(layer.conv1, bias: -1.0)
+        // conv2: kernel of ones, zero bias → sums the (leaked) activations.
+        onesConvParameters(layer.conv2)
+
+        let x = MLXArray.zeros([1, 2, 5])
+        let y = layer(x)
+        eval(y)
+
+        // leaky_relu(-1) = -0.01; conv2 sums hidden(3) × kernel(3) of them,
+        // residual adds x = 0. ReLU would give exactly 0.
+        let expected: Float = -0.01 * 3 * 3
+        let got = y[0, 0, 4].item(Float.self)
+        XCTAssertEqual(got, expected, accuracy: 1e-4,
+                       "conv1 activation must be leaky_relu(0.01), not ReLU")
+    }
+
+    // MARK: - Flow ODE solver
+
+    /// The solver state must stay float32 (upstream returns `.float()`), and
+    /// the initial noise must not depend on the global RNG — two runs under
+    /// different global seeds must match exactly.
+    func testFlowSolverIsFloat32AndDeterministic() {
+        var config = CosyVoiceConfig.default.flow
+        config.dit.dim = 64
+        config.dit.depth = 1
+        config.dit.heads = 2
+        config.dit.dimHead = 32
+        let cfm = ConditionalFlowMatching(config: config)
+
+        let mu = MLXRandom.normal([1, 80, 6]).asType(.float16)
+        let mask = MLXArray.ones([1, 1, 6]).asType(.float16)
+
+        MLXRandom.seed(1)
+        let a = cfm.forward(mu: mu, mask: mask, nTimesteps: 2)
+        MLXRandom.seed(2)
+        let b = cfm.forward(mu: mu, mask: mask, nTimesteps: 2)
+        eval(a, b)
+
+        XCTAssertEqual(a.dtype, .float32, "solver output must be float32")
+        XCTAssertEqual(a.shape, [1, 80, 6])
+        let diff = MLX.abs(a - b).max().item(Float.self)
+        XCTAssertEqual(diff, 0, "flow noise must not depend on the global RNG")
+    }
+
+    /// A bundle-provided fixed noise buffer is sliced to the mel length and
+    /// promoted to float32 (never truncated to the weight dtype).
+    func testFixedNoiseBufferSlicing() {
+        var config = CosyVoiceConfig.default.flow
+        config.dit.dim = 64
+        config.dit.depth = 1
+        config.dit.heads = 2
+        config.dit.dimHead = 32
+        let cfm = ConditionalFlowMatching(config: config)
+
+        let values = (0 ..< 80 * 10).map { Float($0) }
+        cfm.fixedNoise = MLXArray(values, [1, 80, 10])
+
+        let z = cfm.initialNoise(batch: 1, timeSteps: 4, temperature: 1.0)
+        eval(z)
+        XCTAssertEqual(z.shape, [1, 80, 4])
+        XCTAssertEqual(z.dtype, .float32)
+        // Row-major [1, 80, 10]: element [0, c, t] = c*10 + t.
+        XCTAssertEqual(z[0, 1, 2].item(Float.self), 12)
+
+        // Too-short buffer falls back to the keyed draw (still fp32, right shape).
+        let zLong = cfm.initialNoise(batch: 1, timeSteps: 32, temperature: 1.0)
+        eval(zLong)
+        XCTAssertEqual(zLong.shape, [1, 80, 32])
+        XCTAssertEqual(zLong.dtype, .float32)
+    }
+
+    // MARK: - NSF sine source (SineGen2-causal semantics)
+
+    /// Upstream SineGen2 upsamples the frame-rate phase with NEAREST, so the
+    /// harmonic source is constant within each upsample_scale block and
+    /// changes across blocks. The pre-fix per-sample cumsum produced a
+    /// smooth sine that varied within blocks.
+    func testSineSourceIsFrameStaircase() {
+        let gen = SineGenerator(
+            sampleRate: 24_000, upsampleScale: 4, harmonicNum: 8,
+            sineAmp: 0.1, noiseStd: 0, voicedThreshold: 10)
+
+        let f0 = MLXArray.full([1, 3], values: MLXArray(Float(200)))
+        let (sines, uv) = gen(f0)
+        eval(sines, uv)
+
+        XCTAssertEqual(sines.shape, [1, 12, 9])
+        XCTAssertEqual(uv.shape, [1, 12, 1])
+        XCTAssertEqual(uv.min().item(Float.self), 1.0, "200 Hz must be voiced")
+
+        // Constant within each block of 4 samples...
+        for block in 0 ..< 3 {
+            let first = sines[0, block * 4, 0].item(Float.self)
+            for s in 1 ..< 4 {
+                XCTAssertEqual(sines[0, block * 4 + s, 0].item(Float.self), first,
+                               accuracy: 1e-7, "staircase: constant within a frame block")
+            }
+        }
+        // ...and progressing across blocks.
+        XCTAssertNotEqual(sines[0, 0, 0].item(Float.self),
+                          sines[0, 4, 0].item(Float.self),
+                          "staircase: phase must advance between frame blocks")
+    }
+
+    /// Unvoiced excitation amplitude is sine_amp/3 · U[0,1) (upstream), not
+    /// noise_std · gaussian. With sine_amp 0.1 the values must reach well
+    /// past what a 0.003-std gaussian produces, and never exceed 0.1/3.
+    func testUnvoicedExcitationAmplitude() {
+        let gen = SineGenerator(
+            sampleRate: 24_000, upsampleScale: 4, harmonicNum: 8,
+            sineAmp: 0.1, noiseStd: 0.003, voicedThreshold: 10)
+
+        let f0 = MLXArray.zeros([1, 8])
+        let (sines, uv) = gen(f0)
+        eval(sines, uv)
+
+        XCTAssertEqual(uv.max().item(Float.self), 0.0, "f0=0 must be unvoiced")
+        let maxAbs = MLX.abs(sines).max().item(Float.self)
+        XCTAssertLessThanOrEqual(maxAbs, 0.1 / 3 + 1e-6,
+                                 "unvoiced noise is bounded by sine_amp/3 (uniform)")
+        XCTAssertGreaterThan(maxAbs, 0.02,
+                             "unvoiced amplitude must be sine_amp/3-scale, not noise_std-scale")
+    }
+
+    /// The source must be deterministic call-to-call (upstream draws its
+    /// noise buffers once at init). The pre-fix implementation drew fresh
+    /// gaussian noise and a fresh initial phase per render.
+    func testSourceModuleIsDeterministic() {
+        let source = SourceModuleHnNSF(
+            sampleRate: 24_000, upsampleScale: 4, harmonicNum: 8,
+            sineAmp: 0.1, noiseStd: 0.003, voicedThreshold: 10)
+
+        var f0Values = [Float](repeating: 200, count: 6)
+        f0Values.append(contentsOf: [Float](repeating: 0, count: 6))
+        let f0 = MLXArray(f0Values, [1, 12])
+
+        MLXRandom.seed(1)
+        let a = source(f0)
+        MLXRandom.seed(2)
+        let b = source(f0)
+        eval(a, b)
+
+        XCTAssertEqual(a.shape, [1, 48, 1])
+        let diff = MLX.abs(a - b).max().item(Float.self)
+        XCTAssertEqual(diff, 0, "source excitation must not depend on the global RNG")
+    }
+
+    private func zeroConvParameters(_ conv: CausalDilatedConv1d, bias: Float = 0) {
+        let inner = conv.conv
+        var params: [String: NestedItem<String, MLXArray>] = [:]
+        params["weight"] = .value(MLXArray.zeros(inner.weight.shape, dtype: inner.weight.dtype))
+        if let b = inner.bias {
+            params["bias"] = .value(MLXArray.full(b.shape, values: MLXArray(bias)))
+        }
+        inner.update(parameters: ModuleParameters(values: params))
+    }
+
+    private func onesConvParameters(_ conv: CausalDilatedConv1d) {
+        let inner = conv.conv
+        var params: [String: NestedItem<String, MLXArray>] = [:]
+        params["weight"] = .value(MLXArray.ones(inner.weight.shape, dtype: inner.weight.dtype))
+        if let b = inner.bias {
+            params["bias"] = .value(MLXArray.zeros(b.shape, dtype: b.dtype))
+        }
+        inner.update(parameters: ModuleParameters(values: params))
+    }
+}

--- a/Tests/CosyVoiceTTSTests/LongFormSplitTests.swift
+++ b/Tests/CosyVoiceTTSTests/LongFormSplitTests.swift
@@ -159,18 +159,17 @@ final class LongFormSplitTests: XCTestCase {
         XCTAssertLessThan(abs(stitched[100] - stitched[99]), 0.1)
         XCTAssertLessThan(abs(stitched[300] - stitched[299]), 0.1)
 
-        // The first segment starts untouched, while the final segment also gets
-        // a short tail fade to avoid end-of-file pops.
-        XCTAssertEqual(stitched[0], 1.0)
+        // Every edge is faded — including the first segment's head (the
+        // vocoder starts from zero left-context, so an unfaded head is an
+        // audible click at utterance start) and the final tail.
+        XCTAssertLessThan(abs(stitched[0]), 0.1)
         XCTAssertLessThan(abs(stitched[399]), 0.1)
     }
 
     func testStitchLongFormSegmentsFadesTailOfSingleSegment() {
         // Regression: a multi-segment split can render down to ONE surviving
-        // segment. That path must still leave with a tail fade — otherwise the
-        // end-click this stitcher exists to prevent comes back on exactly that
-        // path. The head stays untouched, matching the first segment of any
-        // multi-segment stitch.
+        // segment. That path must still fade both edges — the head (start
+        // click) and the tail (end click) — matching `cleanCloneOutput`.
         let single = [Float](repeating: 1.0, count: 100)
         let stitched = CosyVoiceTTSModel.stitchLongFormSegments(
             [single],
@@ -179,15 +178,15 @@ final class LongFormSplitTests: XCTestCase {
             fadeSeconds: 0.03
         )
         XCTAssertEqual(stitched.count, 100)
-        XCTAssertEqual(stitched[0], 1.0)
-        XCTAssertEqual(stitched[69], 1.0)
+        XCTAssertLessThan(abs(stitched[0]), 0.1)
+        XCTAssertEqual(stitched[69], 1.0, "interior samples must be untouched")
         XCTAssertLessThan(abs(stitched[99]), 0.1)
     }
 
     func testStitchLongFormSegmentsCollapsedMultiSegmentStillFades() {
         // Two rendered segments where one came back empty — the collapsed
         // result must behave like the single-segment case above, not skip
-        // the fade via an early exit.
+        // the fades via an early exit.
         let survivor = [Float](repeating: -1.0, count: 100)
         let stitched = CosyVoiceTTSModel.stitchLongFormSegments(
             [[], survivor],
@@ -196,11 +195,13 @@ final class LongFormSplitTests: XCTestCase {
             fadeSeconds: 0.03
         )
         XCTAssertEqual(stitched.count, 100)
-        XCTAssertEqual(stitched[0], -1.0)
+        XCTAssertLessThan(abs(stitched[0]), 0.1)
         XCTAssertLessThan(abs(stitched[99]), 0.1)
     }
 
-    func testCleanCloneOutputTrimsPromptLeakAndFadesTail() {
+    func testCleanCloneOutputFadesEdgesWithoutTrimming() {
+        // The prompt region is sliced off in the mel domain before vocoding,
+        // so cleanup must NOT drop samples — only fade the edges.
         let samples = [Float](repeating: 1.0, count: 700)
         let cleaned = CosyVoiceTTSModel.cleanCloneOutput(
             samples,
@@ -208,8 +209,9 @@ final class LongFormSplitTests: XCTestCase {
             edgeFadeSeconds: 0.03
         )
 
-        XCTAssertEqual(cleaned.count, 400)
+        XCTAssertEqual(cleaned.count, 700)
         XCTAssertLessThan(abs(cleaned.first ?? 1.0), 0.1)
         XCTAssertLessThan(abs(cleaned.last ?? 1.0), 0.1)
+        XCTAssertEqual(cleaned[350], 1.0, "interior samples must be untouched")
     }
 }

--- a/Tests/CosyVoiceTTSTests/LongFormSplitTests.swift
+++ b/Tests/CosyVoiceTTSTests/LongFormSplitTests.swift
@@ -29,8 +29,8 @@ final class LongFormSplitTests: XCTestCase {
 
     // MARK: - Sentence-terminator splits
     //
-    // Each fixture sentence is ≥ 4 words so the short-fragment merge logic
-    // doesn't collapse them into a single segment.
+    // Most fixture sentences are ≥ 6 words so the short-fragment merge logic
+    // doesn't collapse them into a single segment unless the test says so.
 
     func testSplitsOnPeriod() {
         let s = split("This is the first sentence here. " +
@@ -50,12 +50,14 @@ final class LongFormSplitTests: XCTestCase {
         XCTAssertTrue(s.last!.hasSuffix("?"))
     }
 
-    func testSplitsOnExclamation() {
+    func testShortQuestionMergesForward() {
         let s = split("Hello there how nice to see! " +
                       "How are you doing today? " +
                       "I am doing fine thanks for asking.")
-        XCTAssertEqual(s.count, 3)
-        XCTAssertTrue(s.first!.hasSuffix("!"))
+        XCTAssertEqual(s.count, 2)
+        XCTAssertEqual(s.first, "Hello there how nice to see!")
+        XCTAssertTrue(s.last!.contains("How are you doing today?"))
+        XCTAssertTrue(s.last!.contains("I am doing fine thanks for asking."))
     }
 
     func testTrailingTextWithoutTerminatorIsKept() {
@@ -71,10 +73,17 @@ final class LongFormSplitTests: XCTestCase {
     // MARK: - Short-segment merging
 
     func testShortLeadFragmentMergesIntoNext() {
-        // "Hi." is 1 word (< minWordsPerSegment=4) and should merge forward.
+        // "Hi." is 1 word and should merge forward.
         let s = split("Hi. This is the second sentence which is longer.")
         XCTAssertEqual(s.count, 1)
         XCTAssertEqual(s[0], "Hi. This is the second sentence which is longer.")
+    }
+
+    func testShortQuestionLeadMergesIntoFollowingSentence() {
+        let text = "Why does this matter? " +
+                   "Because the next decade of audio software is going to look very different."
+        let s = split(text)
+        XCTAssertEqual(s, [text])
     }
 
     func testTwoVeryShortSegmentsMerge() {
@@ -125,5 +134,82 @@ final class LongFormSplitTests: XCTestCase {
         let joined = first.joined(separator: " ")
         let second = split(joined)
         XCTAssertEqual(first, second)
+    }
+
+    // MARK: - Long-form audio stitching
+
+    func testStitchLongFormSegmentsFadesInsertedGapEdges() {
+        let left = [Float](repeating: 1.0, count: 100)
+        let right = [Float](repeating: -1.0, count: 100)
+
+        let stitched = CosyVoiceTTSModel.stitchLongFormSegments(
+            [left, right],
+            sampleRate: 1_000,
+            gapSeconds: 0.2,
+            fadeSeconds: 0.03
+        )
+
+        XCTAssertEqual(stitched.count, 400)
+        XCTAssertEqual(stitched[100..<300].allSatisfy { $0 == 0 }, true)
+
+        // The pre-fix stitch jumped from full-scale segment audio straight to
+        // zero-gap silence. The fade should leave both sides near zero instead.
+        XCTAssertLessThan(abs(stitched[99]), 0.1)
+        XCTAssertLessThan(abs(stitched[300]), 0.1)
+        XCTAssertLessThan(abs(stitched[100] - stitched[99]), 0.1)
+        XCTAssertLessThan(abs(stitched[300] - stitched[299]), 0.1)
+
+        // The first segment starts untouched, while the final segment also gets
+        // a short tail fade to avoid end-of-file pops.
+        XCTAssertEqual(stitched[0], 1.0)
+        XCTAssertLessThan(abs(stitched[399]), 0.1)
+    }
+
+    func testStitchLongFormSegmentsFadesTailOfSingleSegment() {
+        // Regression: a multi-segment split can render down to ONE surviving
+        // segment. That path must still leave with a tail fade — otherwise the
+        // end-click this stitcher exists to prevent comes back on exactly that
+        // path. The head stays untouched, matching the first segment of any
+        // multi-segment stitch.
+        let single = [Float](repeating: 1.0, count: 100)
+        let stitched = CosyVoiceTTSModel.stitchLongFormSegments(
+            [single],
+            sampleRate: 1_000,
+            gapSeconds: 0.2,
+            fadeSeconds: 0.03
+        )
+        XCTAssertEqual(stitched.count, 100)
+        XCTAssertEqual(stitched[0], 1.0)
+        XCTAssertEqual(stitched[69], 1.0)
+        XCTAssertLessThan(abs(stitched[99]), 0.1)
+    }
+
+    func testStitchLongFormSegmentsCollapsedMultiSegmentStillFades() {
+        // Two rendered segments where one came back empty — the collapsed
+        // result must behave like the single-segment case above, not skip
+        // the fade via an early exit.
+        let survivor = [Float](repeating: -1.0, count: 100)
+        let stitched = CosyVoiceTTSModel.stitchLongFormSegments(
+            [[], survivor],
+            sampleRate: 1_000,
+            gapSeconds: 0.2,
+            fadeSeconds: 0.03
+        )
+        XCTAssertEqual(stitched.count, 100)
+        XCTAssertEqual(stitched[0], -1.0)
+        XCTAssertLessThan(abs(stitched[99]), 0.1)
+    }
+
+    func testCleanCloneOutputTrimsPromptLeakAndFadesTail() {
+        let samples = [Float](repeating: 1.0, count: 700)
+        let cleaned = CosyVoiceTTSModel.cleanCloneOutput(
+            samples,
+            sampleRate: 1_000,
+            edgeFadeSeconds: 0.03
+        )
+
+        XCTAssertEqual(cleaned.count, 400)
+        XCTAssertLessThan(abs(cleaned.first ?? 1.0), 0.1)
+        XCTAssertLessThan(abs(cleaned.last ?? 1.0), 0.1)
     }
 }

--- a/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
+++ b/Tests/CosyVoiceTTSTests/VoiceCloningTests.swift
@@ -224,4 +224,71 @@ final class VoiceCloningTests: XCTestCase {
         XCTAssertGreaterThan(styledPeak, 0.01, "Instructed clone must not be silence")
         XCTAssertLessThan(styledPeak, 1.0001, "Instructed clone must not overflow")
     }
+
+    /// Same gating as `testE2ECloneProducesAudio`. Exercises the long-form
+    /// multi-segment clone path end-to-end against the real model, asserting
+    /// the two contracts this path promises:
+    /// 1. Seeded runs are reproducible (same seed → same audio).
+    /// 2. Every output leaves with a faded tail (no audible end click).
+    func testE2ESeededLongFormCloneIsReproducibleAndFadesTail() async throws {
+        guard let refPath = ProcessInfo.processInfo.environment["COSY_TEST_VOICE_REF"],
+              FileManager.default.fileExists(atPath: refPath) else {
+            throw XCTSkip("Set COSY_TEST_VOICE_REF to a wav file to enable this E2E test")
+        }
+        let transcript = ProcessInfo.processInfo.environment["COSY_TEST_VOICE_TRANSCRIPT"]
+            ?? "This is a reference audio recording used for voice cloning."
+        let modelId = ProcessInfo.processInfo.environment["COSY_TEST_MODEL_ID"]
+            ?? "aufklarer/CosyVoice3-0.5B-MLX-bf16"
+        guard let tokFile = ProcessInfo.processInfo.environment["COSY_TEST_SPEECH_TOKENIZER"],
+              FileManager.default.fileExists(atPath: tokFile) else {
+            throw XCTSkip("Set COSY_TEST_SPEECH_TOKENIZER to speech_tokenizer.safetensors")
+        }
+
+        let model = try await CosyVoiceTTSModel.fromPretrained(modelId: modelId)
+        let tokenizer = try SpeechTokenizerModel.fromSafetensors(
+            at: URL(fileURLWithPath: tokFile))
+        let refSamples16k = try AudioFileLoader.load(
+            url: URL(fileURLWithPath: refPath), targetSampleRate: 16_000)
+        let profile = try model.extractVoiceProfile(
+            audio: refSamples16k, sampleRate: 16_000,
+            speechTokenizer: tokenizer,
+            referenceTranscript: transcript)
+
+        // Two sentences, each above the merge threshold, so the long-form
+        // splitter genuinely produces multiple segments.
+        let text = "The quick brown fox jumps over the lazy sleeping dog. "
+            + "Pack my box with five dozen bright liquid jugs today."
+        XCTAssertGreaterThan(
+            CosyVoiceTTSModel.splitForLongForm(text).count, 1,
+            "Fixture text must exercise the multi-segment path")
+
+        let first = model.synthesize(
+            text: text, voiceProfile: profile, language: "english", seed: 7)
+        let second = model.synthesize(
+            text: text, voiceProfile: profile, language: "english", seed: 7)
+
+        XCTAssertFalse(first.isEmpty, "Long-form clone must produce audio")
+        XCTAssertGreaterThan(first.map { abs($0) }.max() ?? 0, 0.01, "Must not be silence")
+
+        // Contract 1: reproducibility. Same seed re-seeds MLX before each
+        // segment, so both renders must match sample-for-sample (tolerate
+        // tiny numeric drift, fail on any real divergence).
+        XCTAssertEqual(first.count, second.count, "Same seed must produce same-length audio")
+        if first.count == second.count && !first.isEmpty {
+            var absDiff: Float = 0
+            var absRef: Float = 0
+            for i in 0..<first.count {
+                absDiff += abs(first[i] - second[i])
+                absRef += abs(first[i])
+            }
+            XCTAssertLessThan(
+                absDiff, max(absRef, 1) * 0.01,
+                "Same-seed renders must be near-identical")
+        }
+
+        // Contract 2: no end click. The stitcher fades every output tail,
+        // so the final samples must sit near zero.
+        let tailPeak = first.suffix(8).map { abs($0) }.max() ?? 0
+        XCTAssertLessThan(tailPeak, 0.05, "Long-form output must end faded (no end click)")
+    }
 }

--- a/docs/models/cosyvoice-tts.md
+++ b/docs/models/cosyvoice-tts.md
@@ -35,6 +35,10 @@ Three-stage pipeline: LLM → DiT Flow Matching → HiFi-GAN Vocoder → 24kHz a
 - Affine projection (192 → 80) conditions DiT flow model on target voice
 - Model: `aufklarer/CamPlusPlus-Speaker-CoreML` (~14 MB, FP16)
 - CLI: `--voice-sample reference.wav`
+- Long-form cloning splits text into sentence segments, seeds MLX before each
+  segment when `seed:` is passed (`--seed` on the CLI) so repeated runs are
+  reproducible, trims the ~300 ms prompt leak per segment, and stitches with
+  edge fades so no output path ends on an audible click
 
 ## Multi-Speaker Dialogue
 - `DialogueParser` parses `[S1] text [S2] text` speaker tags into `DialogueSegment` structs

--- a/docs/models/cosyvoice-tts.md
+++ b/docs/models/cosyvoice-tts.md
@@ -37,8 +37,9 @@ Three-stage pipeline: LLM → DiT Flow Matching → HiFi-GAN Vocoder → 24kHz a
 - CLI: `--voice-sample reference.wav`
 - Long-form cloning splits text into sentence segments, seeds MLX before each
   segment when `seed:` is passed (`--seed` on the CLI) so repeated runs are
-  reproducible, trims the ~300 ms prompt leak per segment, and stitches with
-  edge fades so no output path ends on an audible click
+  reproducible, and stitches with edge fades so no output path ends on an
+  audible click. The prompt region is sliced off in the mel domain before
+  vocoding (upstream parity), so no audio-domain prompt trim is applied
 
 ## Multi-Speaker Dialogue
 - `DialogueParser` parses `[S1] text [S2] text` speaker tags into `DialogueSegment` structs


### PR DESCRIPTION
Thread an optional random seed from the `speak` CLI through the CosyVoice long-form voice-cloning path so multi-segment synthesis is reproducible run-to-run, and fix eight inference divergences from upstream CosyVoice that degraded cloning quality (reverby, voice-unstable output with onset clicks and occasional recitation of the reference transcript).

**Parity fixes**
- `PreLookaheadLayer`: leaky_relu(0.01) + the residual connection the DiT was trained with
- The CAM++ x-vector now reaches the flow, so CFG runs speaker-conditioned as upstream always does
- Fixed flow noise — upstream's seed-0 buffer via bundle `flow_noise.bin` or `COSY_FIXED_NOISE`, keyed deterministic fallback; ODE solver state and CFG combine run float32; compiled DiT fast path for the cloning inputs
- NSF source rewritten to SineGen2-causal semantics: `%1` phase wrap, frame-rate cumsum, nearest staircase upsample, unvoiced excitation at `sine_amp/3` (uniform), no extra noise on the merged source; ISTFT magnitude clipped at `1e2`
- Mel sliced at the prompt boundary before vocoding (upstream `feat[:, :, mel_len1:]`) instead of cutting rendered audio; the 300 ms prompt-leak trim is removed — the leak it papered over no longer exists
- Zero-shot LLM text layout corrected to `"You are a helpful assistant.<|endofprompt|>" + transcript + content`; the previous transcript-first layout made the model recite the reference transcript mid-utterance
- ISTFT trims `n_fft/2` edge samples (torch `center=True` semantics) and the long-form stitcher fades every segment edge including the first head — both were audible clicks at render start

**Validation**
- ASR round-trip is word-exact across seeds (7, 42) and both segment paths
- Speaker-embedding cosine to the reference: 0.59 → 0.81
- RTF 0.45 → 0.39 (the reference is no longer re-vocoded); render onset peak 0.99 → 0.0002
- New `FlowVocoderParityTests` (7 regression tests, each fails on the pre-fix code) plus updated long-form stitch tests; full unit suite green

**Regression risk**: cloning output changes by design; text-only TTS is touched only by the PreLookaheadLayer and solver-precision corrections, both of which move it toward upstream. The seeded reproducibility contract is preserved — flow noise is now fixed by default and LLM sampling still follows `--seed`.
