### PR TITLE
Fix Chatterbox CoreML int8 SDK compatibility

### DIFF
--- a/Sources/ChatterboxTTS/ChatterboxFlashCoreMLGraphs.swift
+++ b/Sources/ChatterboxTTS/ChatterboxFlashCoreMLGraphs.swift
@@ -5,6 +5,8 @@ import Foundation
 import MLX
 
 enum ChatterboxFlashCoreMLBridge {
+    private static let int8DataTypeRawValue = 0x20000 | 8
+
     static func loadCompiledModel(
         relativePath: String,
         in directory: URL,
@@ -50,6 +52,11 @@ enum ChatterboxFlashCoreMLBridge {
 
     static func toFloat32(_ arr: MLMultiArray) throws -> [Float] {
         let count = arr.count
+        if arr.dataType.rawValue == int8DataTypeRawValue {
+            let ptr = arr.dataPointer.bindMemory(to: Int8.self, capacity: count)
+            return (0..<count).map { Float(ptr[$0]) }
+        }
+
         switch arr.dataType {
         case .float32:
             let ptr = arr.dataPointer.bindMemory(to: Float.self, capacity: count)
@@ -63,10 +70,7 @@ enum ChatterboxFlashCoreMLBridge {
         case .int32:
             let ptr = arr.dataPointer.bindMemory(to: Int32.self, capacity: count)
             return (0..<count).map { Float(ptr[$0]) }
-        case .int8:
-            let ptr = arr.dataPointer.bindMemory(to: Int8.self, capacity: count)
-            return (0..<count).map { Float(ptr[$0]) }
-        @unknown default:
+        default:
             throw ChatterboxFlashCoreMLError.unsupportedConfiguration("Unsupported MLMultiArray data type \(arr.dataType)")
         }
     }

--- a/Tests/ChatterboxTTSTests/ChatterboxFlashCoreMLTests.swift
+++ b/Tests/ChatterboxTTSTests/ChatterboxFlashCoreMLTests.swift
@@ -221,6 +221,9 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
         } catch {
             throw XCTSkip("CoreML runtime does not support int8 MLMultiArray allocation")
         }
+        guard array.dataType.rawValue == int8DataType.rawValue else {
+            throw XCTSkip("CoreML runtime does not preserve int8 MLMultiArray allocation")
+        }
 
         let values: [Int8] = [-8, -1, 0, 127]
         let pointer = array.dataPointer.bindMemory(to: Int8.self, capacity: values.count)

--- a/Tests/ChatterboxTTSTests/ChatterboxFlashCoreMLTests.swift
+++ b/Tests/ChatterboxTTSTests/ChatterboxFlashCoreMLTests.swift
@@ -1,4 +1,5 @@
 #if canImport(CoreML)
+import CoreML
 import Foundation
 import XCTest
 
@@ -207,6 +208,25 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
         for (lhs, rhs) in zip(parsed, values) {
             XCTAssertEqual(lhs, rhs, accuracy: 1e-6)
         }
+    }
+
+    func testToFloat32ReadsInt8MultiArrayWithoutSDKCaseReference() throws {
+        guard let int8DataType = MLMultiArrayDataType(rawValue: 0x20000 | 8) else {
+            throw XCTSkip("CoreML SDK does not expose the int8 data type raw value")
+        }
+
+        let array: MLMultiArray
+        do {
+            array = try MLMultiArray(shape: [4], dataType: int8DataType)
+        } catch {
+            throw XCTSkip("CoreML runtime does not support int8 MLMultiArray allocation")
+        }
+
+        let values: [Int8] = [-8, -1, 0, 127]
+        let pointer = array.dataPointer.bindMemory(to: Int8.self, capacity: values.count)
+        pointer.update(from: values, count: values.count)
+
+        XCTAssertEqual(try ChatterboxFlashCoreMLBridge.toFloat32(array), [-8, -1, 0, 127])
     }
 
     private func makeTempDirectory() throws -> URL {


### PR DESCRIPTION
## Summary
- Avoid a direct `MLMultiArrayDataType.int8` enum case reference in the Chatterbox Flash CoreML bridge.
- Preserve int8 array handling through the CoreML raw data type value so older SDKs can compile the package.
- Add a regression test that exercises int8 conversion without referencing the SDK-gated enum case.

## Root Cause
The `macos-15` GitHub Actions runner defaults to Xcode 16.4, whose CoreML SDK does not expose `MLMultiArrayDataType.int8`. The direct enum case reference caused `swift build --build-tests --disable-sandbox` to fail before tests ran.

## Validation
- `swift build --build-tests --disable-sandbox`
- `swift test --filter ChatterboxFlashCoreMLTests`