### PR TITLE
Add Chatterbox Flash voice cloning bridge

### DIFF
--- a/Sources/ChatterboxTTS/ChatterboxFlashCoreMLGraphs.swift
+++ b/Sources/ChatterboxTTS/ChatterboxFlashCoreMLGraphs.swift
@@ -163,7 +163,7 @@ public struct ChatterboxFlashT3Conditioning: Sendable {
     ) {
         self.init(
             speakerEmbedding: speakerEmbedding,
-            promptSpeechTokens: promptSpeechTokens.map(Int32.init),
+            promptSpeechTokens: promptSpeechTokens.map { Int32($0) },
             promptSpeechTokenCount: promptSpeechTokenCount,
             emotionAdv: emotionAdv
         )
@@ -303,7 +303,7 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
             )
         }
 
-        var positionIds = (0..<fixedPrefixLen).map(Int32.init)
+        var positionIds = (0..<fixedPrefixLen).map { Int32($0) }
         positionIds[fixedPrefixLen - 1] = Int32(compactPrefixLen - 1)
 
         var keyPaddingMask = Array(repeating: Float(-1.0e4), count: fixedPrefixLen)
@@ -445,7 +445,7 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
             )
         }
         let padding = Array(repeating: config.stopTextToken, count: config.textLen - encodedTextIds.count)
-        let textTokenIds = (encodedTextIds + padding).map(Int32.init)
+        let textTokenIds = (encodedTextIds + padding).map { Int32($0) }
         let prefixLen = try Self.makePrefixPlan(config: config, encodedTextCount: encodedTextIds.count).compactPrefixLen
         let maxByCache = max(0, config.maxSeq - prefixLen)
         let requested = options.maxSpeechTokens ?? max(300, encodedTextIds.count * 6)

--- a/Sources/ChatterboxTTS/ChatterboxFlashCoreMLGraphs.swift
+++ b/Sources/ChatterboxTTS/ChatterboxFlashCoreMLGraphs.swift
@@ -52,24 +52,44 @@ enum ChatterboxFlashCoreMLBridge {
 
     static func toFloat32(_ arr: MLMultiArray) throws -> [Float] {
         let count = arr.count
+        let shape = arr.shape.map(\.intValue)
+        let strides = arr.strides.map(\.intValue)
+        func logicalOffsets() -> [Int] {
+            guard !shape.isEmpty else { return [0] }
+            var offsets: [Int] = []
+            offsets.reserveCapacity(count)
+            func appendOffsets(dim: Int, base: Int) {
+                if dim == shape.count {
+                    offsets.append(base)
+                    return
+                }
+                for index in 0..<shape[dim] {
+                    appendOffsets(dim: dim + 1, base: base + index * strides[dim])
+                }
+            }
+            appendOffsets(dim: 0, base: 0)
+            return offsets
+        }
+        let offsets = logicalOffsets()
+        let storageCount = (offsets.max() ?? 0) + 1
         if arr.dataType.rawValue == int8DataTypeRawValue {
-            let ptr = arr.dataPointer.bindMemory(to: Int8.self, capacity: count)
-            return (0..<count).map { Float(ptr[$0]) }
+            let ptr = arr.dataPointer.bindMemory(to: Int8.self, capacity: storageCount)
+            return offsets.map { Float(ptr[$0]) }
         }
 
         switch arr.dataType {
         case .float32:
-            let ptr = arr.dataPointer.bindMemory(to: Float.self, capacity: count)
-            return Array(UnsafeBufferPointer(start: ptr, count: count))
+            let ptr = arr.dataPointer.bindMemory(to: Float.self, capacity: storageCount)
+            return offsets.map { ptr[$0] }
         case .float16:
-            let ptr = arr.dataPointer.bindMemory(to: UInt16.self, capacity: count)
-            return (0..<count).map { Float(Float16(bitPattern: ptr[$0])) }
+            let ptr = arr.dataPointer.bindMemory(to: UInt16.self, capacity: storageCount)
+            return offsets.map { Float(Float16(bitPattern: ptr[$0])) }
         case .double:
-            let ptr = arr.dataPointer.bindMemory(to: Double.self, capacity: count)
-            return (0..<count).map { Float(ptr[$0]) }
+            let ptr = arr.dataPointer.bindMemory(to: Double.self, capacity: storageCount)
+            return offsets.map { Float(ptr[$0]) }
         case .int32:
-            let ptr = arr.dataPointer.bindMemory(to: Int32.self, capacity: count)
-            return (0..<count).map { Float(ptr[$0]) }
+            let ptr = arr.dataPointer.bindMemory(to: Int32.self, capacity: storageCount)
+            return offsets.map { Float(ptr[$0]) }
         default:
             throw ChatterboxFlashCoreMLError.unsupportedConfiguration("Unsupported MLMultiArray data type \(arr.dataType)")
         }
@@ -120,27 +140,48 @@ public struct ChatterboxFlashS3GenReference: Sendable {
 public struct ChatterboxFlashT3Conditioning: Sendable {
     public let speakerEmbedding: [Float]
     public let promptSpeechTokens: [Int32]
+    public let promptSpeechTokenCount: Int
     public let emotionAdv: Float
 
-    public init(speakerEmbedding: [Float], promptSpeechTokens: [Int32], emotionAdv: Float = 0.5) {
+    public init(
+        speakerEmbedding: [Float],
+        promptSpeechTokens: [Int32],
+        promptSpeechTokenCount: Int? = nil,
+        emotionAdv: Float = 0.5
+    ) {
         self.speakerEmbedding = speakerEmbedding
         self.promptSpeechTokens = promptSpeechTokens
+        self.promptSpeechTokenCount = promptSpeechTokenCount ?? promptSpeechTokens.count
         self.emotionAdv = emotionAdv
     }
 
-    public init(speakerEmbedding: [Float], promptSpeechTokens: [Int], emotionAdv: Float = 0.5) {
+    public init(
+        speakerEmbedding: [Float],
+        promptSpeechTokens: [Int],
+        promptSpeechTokenCount: Int? = nil,
+        emotionAdv: Float = 0.5
+    ) {
         self.init(
             speakerEmbedding: speakerEmbedding,
             promptSpeechTokens: promptSpeechTokens.map(Int32.init),
+            promptSpeechTokenCount: promptSpeechTokenCount,
             emotionAdv: emotionAdv
         )
     }
+}
+
+struct ChatterboxFlashT3PrefixPlan: Sendable {
+    let compactPrefixLen: Int
+    let positionIds: [Int32]
+    let keyPaddingMask: [Float]
+    let prefixCacheMap: [Float]
 }
 
 public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
     public let config: ChatterboxFlashT3Config
     private let conditioningEncoder: MLModel
     private let textPrefill: MLModel
+    private let nullTextPrefill: MLModel?
     private let blockDecoder: MLModel
     public let tokenizerURL: URL
     public let unconditionalBlockPriorURL: URL
@@ -165,6 +206,17 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
             computeUnits: computeUnits,
             name: "ChatterboxFlash.TextPrefill"
         )
+        let nullTextPrefillPath = directory.appendingPathComponent("t3/NullTextPrefill.mlmodelc")
+        if FileManager.default.fileExists(atPath: nullTextPrefillPath.path) {
+            self.nullTextPrefill = try ChatterboxFlashCoreMLBridge.loadCompiledModel(
+                relativePath: "t3/NullTextPrefill.mlmodelc",
+                in: directory,
+                computeUnits: computeUnits,
+                name: "ChatterboxFlash.NullTextPrefill"
+            )
+        } else {
+            self.nullTextPrefill = nil
+        }
         self.blockDecoder = try ChatterboxFlashCoreMLBridge.loadCompiledModel(
             relativePath: "t3/BlockDecoder.mlmodelc",
             in: directory,
@@ -197,6 +249,16 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
         guard conditioning.promptSpeechTokens.count == 150 else {
             throw ChatterboxFlashCoreMLError.invalidShape("prompt speech tokens must contain 150 ids")
         }
+        guard conditioning.promptSpeechTokenCount >= 0,
+              conditioning.promptSpeechTokenCount <= conditioning.promptSpeechTokens.count else {
+            throw ChatterboxFlashCoreMLError.invalidShape(
+                "prompt speech token count must be in 0...\(conditioning.promptSpeechTokens.count)"
+            )
+        }
+        var promptMask = Array(repeating: Float(0), count: conditioning.promptSpeechTokens.count)
+        for index in 0..<conditioning.promptSpeechTokenCount {
+            promptMask[index] = 1
+        }
 
         let provider = try ChatterboxFlashCoreMLBridge.predict(
             conditioningEncoder,
@@ -216,22 +278,100 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
                     shape: [1, 1, 1],
                     label: "emotion_adv"
                 ),
+                "prompt_speech_mask": ChatterboxFlashCoreMLBridge.float32(
+                    promptMask,
+                    shape: [1, conditioning.promptSpeechTokens.count],
+                    label: "prompt_speech_mask"
+                ),
             ]
         )
         return try ChatterboxFlashCoreMLBridge.output(provider, named: "cond_emb")
     }
 
-    public func prefill(textTokenIds: [Int32], conditioningEmbedding: MLMultiArray) throws -> MLFeatureProvider {
+    static func makePrefixPlan(config: ChatterboxFlashT3Config, encodedTextCount: Int) throws -> ChatterboxFlashT3PrefixPlan {
+        guard encodedTextCount > 0, encodedTextCount <= config.textLen else {
+            throw ChatterboxFlashCoreMLError.invalidShape(
+                "encoded text count \(encodedTextCount) must be in 1...\(config.textLen)"
+            )
+        }
+
+        let fixedPrefixLen = config.prefixLen
+        let compactPrefixLen = config.condLen + encodedTextCount + 1
+        guard compactPrefixLen <= config.maxSeq else {
+            throw ChatterboxFlashCoreMLError.invalidShape(
+                "compact prefix length \(compactPrefixLen) exceeds max_seq \(config.maxSeq)"
+            )
+        }
+
+        var positionIds = (0..<fixedPrefixLen).map(Int32.init)
+        positionIds[fixedPrefixLen - 1] = Int32(compactPrefixLen - 1)
+
+        var keyPaddingMask = Array(repeating: Float(-1.0e4), count: fixedPrefixLen)
+        let visiblePrefixWithoutSOS = config.condLen + encodedTextCount
+        for index in 0..<visiblePrefixWithoutSOS {
+            keyPaddingMask[index] = 0
+        }
+        keyPaddingMask[fixedPrefixLen - 1] = 0
+
+        var prefixCacheMap = Array(repeating: Float(0), count: fixedPrefixLen * config.maxSeq)
+        for row in 0..<visiblePrefixWithoutSOS {
+            prefixCacheMap[row * config.maxSeq + row] = 1
+        }
+        prefixCacheMap[(fixedPrefixLen - 1) * config.maxSeq + compactPrefixLen - 1] = 1
+
+        return ChatterboxFlashT3PrefixPlan(
+            compactPrefixLen: compactPrefixLen,
+            positionIds: positionIds,
+            keyPaddingMask: keyPaddingMask,
+            prefixCacheMap: prefixCacheMap
+        )
+    }
+
+    static func makeBlockPositionIds(prefixLen: Int, blockStart: Int, blockSize: Int) -> [Int32] {
+        (0..<blockSize).map { Int32(prefixLen + blockStart + $0) }
+    }
+
+    public func prefill(
+        textTokenIds: [Int32],
+        encodedTextCount: Int,
+        conditioningEmbedding: MLMultiArray,
+        nullBranch: Bool = false
+    ) throws -> MLFeatureProvider {
         guard textTokenIds.count == config.textLen else {
             throw ChatterboxFlashCoreMLError.invalidShape("text tokens must contain \(config.textLen) ids")
         }
+        let model: MLModel
+        if nullBranch {
+            guard let nullTextPrefill else {
+                throw ChatterboxFlashCoreMLError.missingFile("t3/NullTextPrefill.mlmodelc")
+            }
+            model = nullTextPrefill
+        } else {
+            model = textPrefill
+        }
+        let plan = try Self.makePrefixPlan(config: config, encodedTextCount: encodedTextCount)
         return try ChatterboxFlashCoreMLBridge.predict(
-            textPrefill,
+            model,
             inputs: [
                 "text_token_ids": ChatterboxFlashCoreMLBridge.int32(
                     textTokenIds,
                     shape: [1, config.textLen],
                     label: "text_token_ids"
+                ),
+                "position_ids": ChatterboxFlashCoreMLBridge.int32(
+                    plan.positionIds,
+                    shape: [1, config.prefixLen],
+                    label: "position_ids"
+                ),
+                "key_padding_mask": ChatterboxFlashCoreMLBridge.float32(
+                    plan.keyPaddingMask,
+                    shape: [1, config.prefixLen],
+                    label: "key_padding_mask"
+                ),
+                "prefix_cache_map": ChatterboxFlashCoreMLBridge.float32(
+                    plan.prefixCacheMap,
+                    shape: [config.prefixLen, config.maxSeq],
+                    label: "prefix_cache_map"
                 ),
                 "cond_emb": conditioningEmbedding,
             ]
@@ -298,18 +438,44 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
         options: ChatterboxFlashGenerationOptions = ChatterboxFlashGenerationOptions()
     ) throws -> [Int] {
         try validateGenerationOptions(options)
-        let textTokenIds = try tokenizer.encodePadded(text, config: config)
-        let encodedTextCount = tokenizer.encode(text, addSpecialTokens: true, config: config).count
-        let maxByCache = max(0, config.maxSeq - config.prefixLen)
-        let requested = options.maxSpeechTokens ?? max(300, encodedTextCount * 6)
+        let encodedTextIds = tokenizer.encode(text, addSpecialTokens: true, config: config)
+        guard encodedTextIds.count <= config.textLen else {
+            throw ChatterboxFlashCoreMLError.unsupportedConfiguration(
+                "text encodes to \(encodedTextIds.count) tokens, exceeding exported text_len \(config.textLen)"
+            )
+        }
+        let padding = Array(repeating: config.stopTextToken, count: config.textLen - encodedTextIds.count)
+        let textTokenIds = (encodedTextIds + padding).map(Int32.init)
+        let prefixLen = try Self.makePrefixPlan(config: config, encodedTextCount: encodedTextIds.count).compactPrefixLen
+        let maxByCache = max(0, config.maxSeq - prefixLen)
+        let requested = options.maxSpeechTokens ?? max(300, encodedTextIds.count * 6)
         let totalSpeechLen = min(maxByCache, requested)
         guard totalSpeechLen > 0 else { return [] }
 
         let conditioningEmbedding = try encodeConditioning(conditioning)
-        let prefillProvider = try prefill(textTokenIds: textTokenIds, conditioningEmbedding: conditioningEmbedding)
+        let prefillProvider = try prefill(
+            textTokenIds: textTokenIds,
+            encodedTextCount: encodedTextIds.count,
+            conditioningEmbedding: conditioningEmbedding
+        )
         var shiftContext = try ChatterboxFlashCoreMLBridge.output(prefillProvider, named: "shift_ctx")
         var keyCache = try ChatterboxFlashCoreMLBridge.output(prefillProvider, named: "key_cache")
         var valueCache = try ChatterboxFlashCoreMLBridge.output(prefillProvider, named: "value_cache")
+        let usesCFG = options.cfgScale > 0
+        var nullShiftContext: MLMultiArray?
+        var nullKeyCache: MLMultiArray?
+        var nullValueCache: MLMultiArray?
+        if usesCFG {
+            let nullPrefillProvider = try prefill(
+                textTokenIds: textTokenIds,
+                encodedTextCount: encodedTextIds.count,
+                conditioningEmbedding: conditioningEmbedding,
+                nullBranch: true
+            )
+            nullShiftContext = try ChatterboxFlashCoreMLBridge.output(nullPrefillProvider, named: "shift_ctx")
+            nullKeyCache = try ChatterboxFlashCoreMLBridge.output(nullPrefillProvider, named: "key_cache")
+            nullValueCache = try ChatterboxFlashCoreMLBridge.output(nullPrefillProvider, named: "value_cache")
+        }
 
         var rng = ChatterboxFlashGaussianRNG(seed: options.seed)
         var speech = Array(repeating: config.maskTokenId, count: totalSpeechLen)
@@ -325,14 +491,22 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
 
             var rowHitEOS = false
             for step in 0..<options.numSteps {
+                let speechTokenIds = blockTokenIds(speech, start: blockStart, length: blockLen)
+                let speechPositionIds = Self.makeBlockPositionIds(
+                    prefixLen: prefixLen,
+                    blockStart: blockStart,
+                    blockSize: config.blockSize
+                )
+                let paddingMask = keyPaddingMask(blockStart: blockStart, blockLen: blockLen, prefixLen: prefixLen)
+                let cacheMap = blockCacheMap(blockStart: blockStart, blockLen: blockLen, prefixLen: prefixLen)
                 let provider = try decodeBlock(
-                    speechTokenIds: blockTokenIds(speech, start: blockStart, length: blockLen),
-                    speechPositionIds: blockPositionIds(start: blockStart),
+                    speechTokenIds: speechTokenIds,
+                    speechPositionIds: speechPositionIds,
                     shiftContext: shiftContext,
                     keyCache: keyCache,
                     valueCache: valueCache,
-                    keyPaddingMask: keyPaddingMask(blockStart: blockStart, blockLen: blockLen),
-                    blockCacheMap: blockCacheMap(blockStart: blockStart, blockLen: blockLen)
+                    keyPaddingMask: paddingMask,
+                    blockCacheMap: cacheMap
                 )
                 let logits = try ChatterboxFlashCoreMLBridge.toFloat32(
                     ChatterboxFlashCoreMLBridge.output(provider, named: "logits")
@@ -342,8 +516,34 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
                         "logits expected \(config.blockSize * config.speechVocabSize) values, got \(logits.count)"
                     )
                 }
+                var nullLogits: [Float]?
+                if usesCFG {
+                    guard let currentNullShiftContext = nullShiftContext,
+                          let currentNullKeyCache = nullKeyCache,
+                          let currentNullValueCache = nullValueCache else {
+                        throw ChatterboxFlashCoreMLError.invalidShape("missing null CFG cache state")
+                    }
+                    let nullProvider = try decodeBlock(
+                        speechTokenIds: speechTokenIds,
+                        speechPositionIds: speechPositionIds,
+                        shiftContext: currentNullShiftContext,
+                        keyCache: currentNullKeyCache,
+                        valueCache: currentNullValueCache,
+                        keyPaddingMask: paddingMask,
+                        blockCacheMap: cacheMap
+                    )
+                    nullLogits = try ChatterboxFlashCoreMLBridge.toFloat32(
+                        ChatterboxFlashCoreMLBridge.output(nullProvider, named: "logits")
+                    )
+                    guard nullLogits?.count == config.blockSize * config.speechVocabSize else {
+                        throw ChatterboxFlashCoreMLError.invalidShape(
+                            "null logits expected \(config.blockSize * config.speechVocabSize) values"
+                        )
+                    }
+                }
                 let result = try denoiseBlockStep(
                     logits: logits,
+                    nullLogits: nullLogits,
                     tokens: Array(speech[blockStart ..< blockStart + blockLen]),
                     blockLen: blockLen,
                     step: step,
@@ -351,6 +551,7 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
                     scheduleCount: schedule[step],
                     temperature: options.temperature,
                     timeShiftTau: options.timeShiftTau,
+                    cfgScale: options.cfgScale,
                     positionTemperature: options.positionTemperature,
                     rng: &rng
                 )
@@ -373,19 +574,56 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
 
             let isLastBlock = blockStart + blockLen >= totalSpeechLen
             if !isLastBlock {
+                let speechTokenIds = blockTokenIds(speech, start: blockStart, length: blockLen)
+                let speechPositionIds = Self.makeBlockPositionIds(
+                    prefixLen: prefixLen,
+                    blockStart: blockStart,
+                    blockSize: config.blockSize
+                )
+                let paddingMask = keyPaddingMask(blockStart: blockStart, blockLen: blockLen, prefixLen: prefixLen)
+                let cacheMap = blockCacheMap(blockStart: blockStart, blockLen: blockLen, prefixLen: prefixLen)
                 let finalizeProvider = try decodeBlock(
-                    speechTokenIds: blockTokenIds(speech, start: blockStart, length: blockLen),
-                    speechPositionIds: blockPositionIds(start: blockStart),
+                    speechTokenIds: speechTokenIds,
+                    speechPositionIds: speechPositionIds,
                     shiftContext: shiftContext,
                     keyCache: keyCache,
                     valueCache: valueCache,
-                    keyPaddingMask: keyPaddingMask(blockStart: blockStart, blockLen: blockLen),
-                    blockCacheMap: blockCacheMap(blockStart: blockStart, blockLen: blockLen)
+                    keyPaddingMask: paddingMask,
+                    blockCacheMap: cacheMap
                 )
                 keyCache = try ChatterboxFlashCoreMLBridge.output(finalizeProvider, named: "new_key_cache")
                 valueCache = try ChatterboxFlashCoreMLBridge.output(finalizeProvider, named: "new_value_cache")
                 let blockHidden = try ChatterboxFlashCoreMLBridge.output(finalizeProvider, named: "block_hidden")
                 shiftContext = try sliceHidden(blockHidden, row: blockLen - 1)
+                if usesCFG {
+                    guard let currentNullShiftContext = nullShiftContext,
+                          let currentNullKeyCache = nullKeyCache,
+                          let currentNullValueCache = nullValueCache else {
+                        throw ChatterboxFlashCoreMLError.invalidShape("missing null CFG cache state")
+                    }
+                    let nullFinalizeProvider = try decodeBlock(
+                        speechTokenIds: speechTokenIds,
+                        speechPositionIds: speechPositionIds,
+                        shiftContext: currentNullShiftContext,
+                        keyCache: currentNullKeyCache,
+                        valueCache: currentNullValueCache,
+                        keyPaddingMask: paddingMask,
+                        blockCacheMap: cacheMap
+                    )
+                    nullKeyCache = try ChatterboxFlashCoreMLBridge.output(
+                        nullFinalizeProvider,
+                        named: "new_key_cache"
+                    )
+                    nullValueCache = try ChatterboxFlashCoreMLBridge.output(
+                        nullFinalizeProvider,
+                        named: "new_value_cache"
+                    )
+                    let nullBlockHidden = try ChatterboxFlashCoreMLBridge.output(
+                        nullFinalizeProvider,
+                        named: "block_hidden"
+                    )
+                    nullShiftContext = try sliceHidden(nullBlockHidden, row: blockLen - 1)
+                }
             }
 
             blockStart += blockLen
@@ -401,9 +639,12 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
         guard options.temperature >= 0 else {
             throw ChatterboxFlashCoreMLError.unsupportedConfiguration("temperature must be non-negative")
         }
-        guard options.cfgScale == 0 else {
+        guard options.cfgScale >= 0 else {
+            throw ChatterboxFlashCoreMLError.unsupportedConfiguration("cfgScale must be non-negative")
+        }
+        if options.cfgScale > 0, nullTextPrefill == nil {
             throw ChatterboxFlashCoreMLError.unsupportedConfiguration(
-                "cfgScale > 0 requires a zero-text null prefill graph that is not included in this export"
+                "cfgScale > 0 requires t3/NullTextPrefill.mlmodelc in the Core ML bundle"
             )
         }
     }
@@ -416,12 +657,8 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
         return ids
     }
 
-    private func blockPositionIds(start: Int) -> [Int32] {
-        (0..<config.blockSize).map { Int32(start + $0) }
-    }
-
-    private func keyPaddingMask(blockStart: Int, blockLen: Int) -> [Float] {
-        let validCount = min(config.maxSeq, config.prefixLen + blockStart + blockLen)
+    private func keyPaddingMask(blockStart: Int, blockLen: Int, prefixLen: Int) -> [Float] {
+        let validCount = min(config.maxSeq, prefixLen + blockStart + blockLen)
         var mask = Array(repeating: Float(-1.0e4), count: config.maxSeq)
         for index in 0..<validCount {
             mask[index] = 0
@@ -429,10 +666,10 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
         return mask
     }
 
-    private func blockCacheMap(blockStart: Int, blockLen: Int) -> [Float] {
+    private func blockCacheMap(blockStart: Int, blockLen: Int, prefixLen: Int) -> [Float] {
         var cacheMap = Array(repeating: Float(0), count: config.blockSize * config.maxSeq)
         for row in 0..<blockLen {
-            let column = config.prefixLen + blockStart + row
+            let column = prefixLen + blockStart + row
             if column < config.maxSeq {
                 cacheMap[row * config.maxSeq + column] = 1
             }
@@ -448,6 +685,7 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
 
     private func denoiseBlockStep(
         logits: [Float],
+        nullLogits: [Float]?,
         tokens: [Int],
         blockLen: Int,
         step: Int,
@@ -455,18 +693,38 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
         scheduleCount: Int,
         temperature: Float,
         timeShiftTau: Float,
+        cfgScale: Float,
         positionTemperature: Float,
         rng: inout ChatterboxFlashGaussianRNG
     ) throws -> DenoiseResult {
+        let useCFG = cfgScale > 0
+        if useCFG {
+            guard let nullLogits, nullLogits.count == logits.count else {
+                throw ChatterboxFlashCoreMLError.invalidShape("null logits must match conditional logits")
+            }
+        }
         var sampled = Array(repeating: 0, count: blockLen)
-        var probabilities = Array(repeating: Array<Float>(), count: blockLen)
+        var conditionalProbabilities = Array(repeating: Array<Float>(), count: blockLen)
+        var unconditionalProbabilities = Array(repeating: Array<Float>(), count: blockLen)
 
         for row in 0..<blockLen {
             let start = row * config.speechVocabSize
             let end = start + config.speechVocabSize
             let rowLogits = Array(logits[start..<end])
-            probabilities[row] = Self.softmax(rowLogits)
-            sampled[row] = Self.sample(logits: rowLogits, temperature: temperature, rng: &rng)
+            conditionalProbabilities[row] = Self.softmax(rowLogits)
+            let samplingLogits: [Float]
+            if useCFG, let nullLogits {
+                let rowNullLogits = Array(nullLogits[start..<end])
+                unconditionalProbabilities[row] = Self.softmax(rowNullLogits)
+                let condLogProbs = Self.logSoftmax(rowLogits)
+                let nullLogProbs = Self.logSoftmax(rowNullLogits)
+                samplingLogits = zip(condLogProbs, nullLogProbs).map { cond, uncond in
+                    cond + cfgScale * (cond - uncond)
+                }
+            } else {
+                samplingLogits = rowLogits
+            }
+            sampled[row] = Self.sample(logits: samplingLogits, temperature: temperature, rng: &rng)
         }
 
         let maskedIndexes = (0..<blockLen).filter { tokens[$0] == config.maskTokenId }
@@ -477,9 +735,14 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
         var pmi = Array(repeating: -Float.greatestFiniteMagnitude, count: blockLen)
         for row in maskedIndexes {
             let token = sampled[row]
-            let probability = probabilities[row][token]
             let prior = unconditionalBlockPrior[token]
-            pmi[row] = log(max(probability, 1.0e-8)) - log(max(prior, 1.0e-8))
+            let condPMI = log(max(conditionalProbabilities[row][token], 1.0e-8)) - log(max(prior, 1.0e-8))
+            if useCFG {
+                let uncondPMI = log(max(unconditionalProbabilities[row][token], 1.0e-8)) - log(max(prior, 1.0e-8))
+                pmi[row] = (1 + cfgScale) * condPMI - cfgScale * uncondPMI
+            } else {
+                pmi[row] = condPMI
+            }
             if positionTemperature > 0 {
                 pmi[row] += Self.gumbel(rng: &rng)
             }
@@ -592,6 +855,20 @@ public final class ChatterboxFlashT3Graphs: @unchecked Sendable {
             values[index] /= total
         }
         return values
+    }
+
+    private static func logSoftmax(_ logits: [Float]) -> [Float] {
+        let maxLogit = logits.max() ?? 0
+        var total = Float(0)
+        for value in logits {
+            total += exp(value - maxLogit)
+        }
+        guard total > 0, total.isFinite else {
+            let fallback = -log(Float(max(1, logits.count)))
+            return Array(repeating: fallback, count: logits.count)
+        }
+        let logTotal = log(total) + maxLogit
+        return logits.map { $0 - logTotal }
     }
 
     private static func sample(

--- a/Sources/ChatterboxTTS/ChatterboxFlashCoreMLModel.swift
+++ b/Sources/ChatterboxTTS/ChatterboxFlashCoreMLModel.swift
@@ -115,7 +115,7 @@ public final class ChatterboxFlashCoreMLModel: @unchecked Sendable {
         let maxByTokenBuffer = audio.config.tokenLen - reference.promptToken.count
         let maxTotalTokensByMel = audio.config.melLen / audio.config.tokenMelRatio
         let maxByMel = maxTotalTokensByMel - reference.promptToken.count
-        let maxByT3Cache = t3.config.maxSeq - t3.config.prefixLen
+        let maxByT3Cache = t3.config.maxSeq - t3.config.condLen - 1
         return max(0, min(maxByTokenBuffer, maxByMel, maxByT3Cache))
     }
 }

--- a/Sources/ChatterboxTTS/ChatterboxFlashTokenizer.swift
+++ b/Sources/ChatterboxTTS/ChatterboxFlashTokenizer.swift
@@ -68,7 +68,7 @@ public final class ChatterboxFlashTokenizer: @unchecked Sendable {
                 "text encodes to \(ids.count) tokens, exceeding exported text_len \(config.textLen)"
             )
         }
-        return (ids + Array(repeating: config.stopTextToken, count: config.textLen - ids.count)).map(Int32.init)
+        return (ids + Array(repeating: config.stopTextToken, count: config.textLen - ids.count)).map { Int32($0) }
     }
 
     public func decode(_ ids: [Int]) -> String {

--- a/Sources/ChatterboxTTS/ChatterboxFlashTokenizer.swift
+++ b/Sources/ChatterboxTTS/ChatterboxFlashTokenizer.swift
@@ -76,7 +76,7 @@ public final class ChatterboxFlashTokenizer: @unchecked Sendable {
     }
 
     private func tokenize(_ text: String) -> [Int] {
-        let chars = Array(text)
+        let chars = Array(text.replacingOccurrences(of: " ", with: "[SPACE]"))
         var ids: [Int] = []
         var buffer: [Character] = []
 

--- a/Sources/ChatterboxTTS/ChatterboxMemoryOptions.swift
+++ b/Sources/ChatterboxTTS/ChatterboxMemoryOptions.swift
@@ -1,0 +1,65 @@
+import Foundation
+import MLX
+
+public struct ChatterboxMemoryOptions: Sendable, Equatable {
+    /// Temporary MLX cache limit while running Chatterbox generation.
+    /// `nil` preserves the caller's existing global cache limit.
+    public var cacheLimitBytes: Int?
+
+    /// Clear reusable MLX buffers between the autoregressive T3 stage, S3Gen
+    /// flow stage, and vocoder stage. Active tensors are retained.
+    public var clearCacheBetweenStages: Bool
+
+    /// Clear reusable MLX buffers before returning generated audio.
+    public var clearCacheOnCompletion: Bool
+
+    public init(
+        cacheLimitBytes: Int? = 512 * 1024 * 1024,
+        clearCacheBetweenStages: Bool = true,
+        clearCacheOnCompletion: Bool = true
+    ) {
+        self.cacheLimitBytes = cacheLimitBytes
+        self.clearCacheBetweenStages = clearCacheBetweenStages
+        self.clearCacheOnCompletion = clearCacheOnCompletion
+    }
+
+    /// Memory-conscious default for app/runtime use.
+    public static let balanced = ChatterboxMemoryOptions()
+
+    /// Preserve MLX's default cache behavior for maximum-throughput experiments.
+    public static let unrestricted = ChatterboxMemoryOptions(
+        cacheLimitBytes: nil,
+        clearCacheBetweenStages: false,
+        clearCacheOnCompletion: false
+    )
+}
+
+enum ChatterboxMemory {
+    private static let lock = NSRecursiveLock()
+
+    static func withOptions<T>(_ options: ChatterboxMemoryOptions, _ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let previousCacheLimit = options.cacheLimitBytes == nil ? nil : Memory.cacheLimit
+        if let cacheLimitBytes = options.cacheLimitBytes {
+            Memory.cacheLimit = min(Memory.cacheLimit, max(0, cacheLimitBytes))
+            Memory.clearCache()
+        }
+        defer {
+            if let previousCacheLimit {
+                Memory.cacheLimit = previousCacheLimit
+            }
+            if options.clearCacheOnCompletion {
+                Memory.clearCache()
+            }
+        }
+        return try body()
+    }
+
+    static func clearStageCache(_ options: ChatterboxMemoryOptions) {
+        if options.clearCacheBetweenStages {
+            Memory.clearCache()
+        }
+    }
+}

--- a/Sources/ChatterboxTTS/ChatterboxS3Gen.swift
+++ b/Sources/ChatterboxTTS/ChatterboxS3Gen.swift
@@ -194,23 +194,30 @@ public final class ChatterboxS3Gen {
     /// Full synthesis: speech tokens + reference → 24 kHz waveform `[Float]`.
     ///
     /// Mirrors `S3Token2Wav.__call__`: flow mel → HiFTGenerator → 20 ms fade-in.
-    public func synthesize(speechTokens: [Int], ref: ChatterboxS3GenRef) -> [Float] {
-        let mel = flowMel(speechTokens: speechTokens, ref: ref)     // [1, 80, T]
-        var wav = vocoder.inference(mel: mel.asType(.float32))      // [1, samples]
+    public func synthesize(
+        speechTokens: [Int],
+        ref: ChatterboxS3GenRef,
+        memoryOptions: ChatterboxMemoryOptions = .balanced
+    ) -> [Float] {
+        ChatterboxMemory.withOptions(memoryOptions) {
+            let mel = flowMel(speechTokens: speechTokens, ref: ref)     // [1, 80, T]
+            ChatterboxMemory.clearStageCache(memoryOptions)
+            var wav = vocoder.inference(mel: mel.asType(.float32))      // [1, samples]
 
-        // trim_fade: zero the first 20 ms, raised-cosine fade-in over the next
-        // 20 ms. n_trim = sr/50 = 480; window length = 960.
-        let nTrim = Self.sampleRate / 50
-        let fadeLen = 2 * nTrim
-        if wav.dim(1) >= fadeLen {
-            let fade = Self.trimFade(nTrim: nTrim).asType(wav.dtype)  // [960]
-            let head = wav[0..., 0 ..< fadeLen] * fade.reshaped([1, fadeLen])
-            let tail = wav[0..., fadeLen...]
-            wav = concatenated([head, tail], axis: 1)
+            // trim_fade: zero the first 20 ms, raised-cosine fade-in over the next
+            // 20 ms. n_trim = sr/50 = 480; window length = 960.
+            let nTrim = Self.sampleRate / 50
+            let fadeLen = 2 * nTrim
+            if wav.dim(1) >= fadeLen {
+                let fade = Self.trimFade(nTrim: nTrim).asType(wav.dtype)  // [960]
+                let head = wav[0..., 0 ..< fadeLen] * fade.reshaped([1, fadeLen])
+                let tail = wav[0..., fadeLen...]
+                wav = concatenated([head, tail], axis: 1)
+            }
+            eval(wav)
+            let flat = wav.reshaped([wav.size]).asType(.float32).asArray(Float.self)
+            return flat
         }
-        eval(wav)
-        let flat = wav.reshaped([wav.size]).asType(.float32).asArray(Float.self)
-        return flat
     }
 
     /// The reference `trim_fade` window: `n_trim` zeros followed by an

--- a/Sources/ChatterboxTTS/ChatterboxTTSModel.swift
+++ b/Sources/ChatterboxTTS/ChatterboxTTSModel.swift
@@ -389,6 +389,7 @@ public final class ChatterboxTTSModel {
     ///   - exaggeration: emotion-advance scalar (T3 `emotion_adv`).
     ///   - cfgWeight: T3 classifier-free-guidance weight.
     ///   - temperature: T3 sampling temperature (0 = greedy).
+    ///   - memoryOptions: temporary MLX cache policy for this generation.
     /// - Returns: 24 kHz mono waveform.
     public func clone(
         referenceSamples: [Float],
@@ -401,68 +402,72 @@ public final class ChatterboxTTSModel {
         topP: Float = 1.0,
         minP: Float = 0.05,
         repetitionPenalty: Float = 1.2,
-        cfgWeight: Float = 0.5
+        cfgWeight: Float = 0.5,
+        memoryOptions: ChatterboxMemoryOptions = .balanced
     ) throws -> [Float] {
-        let lang = languageId.lowercased()
-        guard MTLTokenizer.supportedLanguages.contains(lang) else {
-            throw ChatterboxModelError.unsupportedLanguage(lang)
-        }
+        try ChatterboxMemory.withOptions(memoryOptions) {
+            let lang = languageId.lowercased()
+            guard MTLTokenizer.supportedLanguages.contains(lang) else {
+                throw ChatterboxModelError.unsupportedLanguage(lang)
+            }
 
-        // --- prepare_conditionals: reference at the required sample rates ---
-        // 24 kHz (truncated to 10 s) for the S3Gen prompt mel.
-        let ref24kFull = sampleRate == ChatterboxS3Gen.sampleRate
-            ? referenceSamples
-            : AudioFileLoader.resample(
-                referenceSamples, from: sampleRate, to: ChatterboxS3Gen.sampleRate,
+            // --- prepare_conditionals: reference at the required sample rates ---
+            // 24 kHz (truncated to 10 s) for the S3Gen prompt mel.
+            let ref24kFull = sampleRate == ChatterboxS3Gen.sampleRate
+                ? referenceSamples
+                : AudioFileLoader.resample(
+                    referenceSamples, from: sampleRate, to: ChatterboxS3Gen.sampleRate,
+                    quality: .mastering)
+            let ref24k = Array(ref24kFull.prefix(Self.decCondLen))
+            // 24 kHz -> 16 kHz for the S3Gen tokenizer + CAMPPlus.
+            let ref16kFromRef24k = AudioFileLoader.resample(
+                ref24k, from: ChatterboxS3Gen.sampleRate, to: ChatterboxS3Gen.tokenSampleRate,
                 quality: .mastering)
-        let ref24k = Array(ref24kFull.prefix(Self.decCondLen))
-        // 24 kHz -> 16 kHz for the S3Gen tokenizer + CAMPPlus.
-        let ref16kFromRef24k = AudioFileLoader.resample(
-            ref24k, from: ChatterboxS3Gen.sampleRate, to: ChatterboxS3Gen.tokenSampleRate,
-            quality: .mastering)
-        // original -> 16 kHz (untruncated) for the VoiceEncoder; 6 s slice for T3 cond tokens.
-        let ref16kFull = sampleRate == ChatterboxS3Gen.tokenSampleRate
-            ? referenceSamples
-            : AudioFileLoader.resample(
-                referenceSamples, from: sampleRate, to: ChatterboxS3Gen.tokenSampleRate,
-                quality: .mastering)
-        let ref16kEnc = Array(ref16kFull.prefix(Self.encCondLen))
+            // original -> 16 kHz (untruncated) for the VoiceEncoder; 6 s slice for T3 cond tokens.
+            let ref16kFull = sampleRate == ChatterboxS3Gen.tokenSampleRate
+                ? referenceSamples
+                : AudioFileLoader.resample(
+                    referenceSamples, from: sampleRate, to: ChatterboxS3Gen.tokenSampleRate,
+                    quality: .mastering)
+            let ref16kEnc = Array(ref16kFull.prefix(Self.encCondLen))
 
-        // S3Gen conditioning (x-vector, prompt tokens, prompt mel).
-        let s3Ref = s3gen.embedRef(refWav24k: ref24k, refWav16k: ref16kFromRef24k)
+            // S3Gen conditioning (x-vector, prompt tokens, prompt mel).
+            let s3Ref = s3gen.embedRef(refWav24k: ref24k, refWav16k: ref16kFromRef24k)
 
-        // T3 conditioning: speaker emb (full 16 kHz) + prompt-speech tokens (6 s).
-        let speakerEmb = voiceEncoder.embed(samples: ref16kFull)  // [256]
-        let t3PromptTokens = Array(s3gen.tokenizer.encode(ref16kEnc).prefix(Self.speechCondPromptLen))
+            // T3 conditioning: speaker emb (full 16 kHz) + prompt-speech tokens (6 s).
+            let speakerEmb = voiceEncoder.embed(samples: ref16kFull)  // [256]
+            let t3PromptTokens = Array(s3gen.tokenizer.encode(ref16kEnc).prefix(Self.speechCondPromptLen))
 
-        // --- text tokenization: [sot] + ids + [eot] ---
-        let ids: [Int]
-        do {
-            ids = try tokenizer.encodeStrict(text, languageId: lang)
-        } catch ChatterboxTokenizerError.hebrewRequiresDiacritics {
-            throw ChatterboxModelError.invalidText(
-                "Hebrew input must include niqqud/diacritics; automatic Dicta diacritization is not bundled yet")
+            // --- text tokenization: [sot] + ids + [eot] ---
+            let ids: [Int]
+            do {
+                ids = try tokenizer.encodeStrict(text, languageId: lang)
+            } catch ChatterboxTokenizerError.hebrewRequiresDiacritics {
+                throw ChatterboxModelError.invalidText(
+                    "Hebrew input must include niqqud/diacritics; automatic Dicta diacritization is not bundled yet")
+            }
+            let textTokens = [Self.startTextToken] + ids + [Self.stopTextToken]
+
+            // --- T3: text -> speech tokens ---
+            let rawSpeech = t3.inference(
+                textTokens: textTokens,
+                speakerEmb: speakerEmb,
+                promptSpeechTokens: t3PromptTokens,
+                emotionAdv: exaggeration,
+                maxNewTokens: maxNewTokens,
+                temperature: temperature,
+                topP: topP,
+                minP: minP,
+                repetitionPenalty: repetitionPenalty,
+                cfgWeight: cfgWeight)
+
+            // drop SOS/EOS, then keep only valid codes (< SPEECH_VOCAB_SIZE), order-preserving.
+            let dropped = Self.dropInvalidTokens(rawSpeech)
+            let speechTokens = dropped.filter { $0 < Self.speechVocabSize }
+            ChatterboxMemory.clearStageCache(memoryOptions)
+
+            // --- S3Gen: speech tokens -> waveform ---
+            return s3gen.synthesize(speechTokens: speechTokens, ref: s3Ref, memoryOptions: memoryOptions)
         }
-        let textTokens = [Self.startTextToken] + ids + [Self.stopTextToken]
-
-        // --- T3: text -> speech tokens ---
-        let rawSpeech = t3.inference(
-            textTokens: textTokens,
-            speakerEmb: speakerEmb,
-            promptSpeechTokens: t3PromptTokens,
-            emotionAdv: exaggeration,
-            maxNewTokens: maxNewTokens,
-            temperature: temperature,
-            topP: topP,
-            minP: minP,
-            repetitionPenalty: repetitionPenalty,
-            cfgWeight: cfgWeight)
-
-        // drop SOS/EOS, then keep only valid codes (< SPEECH_VOCAB_SIZE), order-preserving.
-        let dropped = Self.dropInvalidTokens(rawSpeech)
-        let speechTokens = dropped.filter { $0 < Self.speechVocabSize }
-
-        // --- S3Gen: speech tokens -> waveform ---
-        return s3gen.synthesize(speechTokens: speechTokens, ref: s3Ref)
     }
 }

--- a/Sources/ChatterboxTTS/ChatterboxTTSModel.swift
+++ b/Sources/ChatterboxTTS/ChatterboxTTSModel.swift
@@ -47,16 +47,24 @@ public extension ChatterboxTTSModel {
     ) throws -> ChatterboxFlashConditioning {
         let ref24kFull = sampleRate == ChatterboxS3Gen.sampleRate
             ? referenceSamples
-            : AudioFileLoader.resample(referenceSamples, from: sampleRate, to: ChatterboxS3Gen.sampleRate)
-        let ref24k = Array(ref24kFull.prefix(Self.decCondLen))
+            : AudioFileLoader.resample(
+                referenceSamples, from: sampleRate, to: ChatterboxS3Gen.sampleRate,
+                quality: .mastering)
+        // The public Flash audio graph has a shorter mel buffer than full MLX
+        // S3Gen. Use the 6 s conditioning window so the prompt leaves room for
+        // generated speech frames.
+        let ref24k = Array(ref24kFull.prefix(Self.flashDecCondLen))
         let ref16kFromRef24k = AudioFileLoader.resample(
             ref24k,
             from: ChatterboxS3Gen.sampleRate,
-            to: ChatterboxS3Gen.tokenSampleRate
+            to: ChatterboxS3Gen.tokenSampleRate,
+            quality: .mastering
         )
         let ref16kFull = sampleRate == ChatterboxS3Gen.tokenSampleRate
             ? referenceSamples
-            : AudioFileLoader.resample(referenceSamples, from: sampleRate, to: ChatterboxS3Gen.tokenSampleRate)
+            : AudioFileLoader.resample(
+                referenceSamples, from: sampleRate, to: ChatterboxS3Gen.tokenSampleRate,
+                quality: .mastering)
         let ref16kEnc = Array(ref16kFull.prefix(Self.encCondLen))
 
         let s3Ref = s3gen.embedRef(refWav24k: ref24k, refWav16k: ref16kFromRef24k)
@@ -64,6 +72,7 @@ public extension ChatterboxTTSModel {
         MLX.eval(speakerArray)
         let speakerEmbedding = speakerArray.asArray(Float.self)
         var promptTokens = Array(s3gen.tokenizer.encode(ref16kEnc).prefix(Self.speechCondPromptLen))
+        let promptTokenCount = promptTokens.count
         if promptTokens.count < Self.speechCondPromptLen {
             promptTokens.append(contentsOf: Array(repeating: 0, count: Self.speechCondPromptLen - promptTokens.count))
         }
@@ -72,6 +81,7 @@ public extension ChatterboxTTSModel {
             t3: ChatterboxFlashT3Conditioning(
                 speakerEmbedding: speakerEmbedding,
                 promptSpeechTokens: promptTokens,
+                promptSpeechTokenCount: promptTokenCount,
                 emotionAdv: exaggeration
             ),
             audio: ChatterboxFlashS3GenReference(s3Ref)
@@ -101,6 +111,8 @@ public final class ChatterboxTTSModel {
     public static let encCondLen = 6 * 16000
     /// 10 s at 24 kHz — the S3Gen-conditioning reference window.
     public static let decCondLen = 10 * 24000
+    /// 6 s at 24 kHz — Flash Core ML S3Gen conditioning window.
+    private static let flashDecCondLen = 6 * 24000
 
     public init(
         tokenizer: MTLTokenizer,
@@ -128,7 +140,8 @@ public final class ChatterboxTTSModel {
     /// - Parameters:
     ///   - bundleDir: directory with `model.safetensors` + `tokenizer.json`.
     ///   - s3TokenizerWeights: `model.safetensors` for S3TokenizerV2 (encoder /
-    ///     quantizer). Required — the bundle does not carry tokenizer weights.
+    ///     quantizer), or Flash `s3gen.safetensors` with `tokenizer.*` keys.
+    ///     Required — the bundle does not carry tokenizer weights.
     ///   - conformerWeights: optional checkpoint carrying the flow-encoder
     ///     conformer blocks (`flow.encoder.encoders.* / up_encoders.*`). The
     ///     the bundle ships these as `conformer.safetensors`, which is used by
@@ -221,9 +234,10 @@ public final class ChatterboxTTSModel {
         let matcha = MatchaCFM()
         try matcha.update(parameters: ModuleParameters.unflattened(cfm), verify: .all)
 
-        // S3TokenizerV2 weights (separate repo).
-        let tokRaw = try MLX.loadArrays(url: s3TokenizerWeights)
-        let tokW = tokRaw.mapValues { $0.asType(.float32) }
+        // S3TokenizerV2 weights. Accept the converted standalone tokenizer repo
+        // and Flash's raw s3gen.safetensors, whose tokenizer submodule is stored
+        // with PyTorch Conv1d layouts and upstream Sequential/FSQ key names.
+        let tokW = try Self.s3TokenizerWeights(from: s3TokenizerWeights)
         let s3Tokenizer = S3TokenizerV2()
         try s3Tokenizer.update(parameters: ModuleParameters.unflattened(tokW), verify: .all)
 
@@ -317,6 +331,39 @@ public final class ChatterboxTTSModel {
         return out
     }
 
+    /// Load S3TokenizerV2 weights from either the converted standalone MLX
+    /// safetensors (`encoder.*`, `quantizer.*`) or Chatterbox Flash's raw
+    /// `s3gen.safetensors` (`tokenizer.*` in PyTorch Conv1d layout).
+    private static func s3TokenizerWeights(from url: URL) throws -> [String: MLXArray] {
+        let raw = try MLX.loadArrays(url: url)
+        let flashPrefix = "tokenizer."
+        let hasFlashTokenizer = raw.keys.contains { $0.hasPrefix(flashPrefix) }
+        guard hasFlashTokenizer else {
+            return raw.mapValues { $0.asType(.float32) }
+        }
+
+        var out: [String: MLXArray] = [:]
+        for (rawKey, rawValue) in raw where rawKey.hasPrefix(flashPrefix) {
+            var key = String(rawKey.dropFirst(flashPrefix.count))
+            if key.hasPrefix("_") || key == "window" { continue }
+            key = key.replacingOccurrences(of: ".mlp.0.", with: ".mlp.layers.0.")
+            key = key.replacingOccurrences(of: ".mlp.2.", with: ".mlp.layers.2.")
+            key = key.replacingOccurrences(
+                of: "quantizer._codebook.",
+                with: "quantizer.fsq_codebook.")
+
+            var value = rawValue.asType(.float32)
+            if key == "encoder.conv1.weight"
+                || key == "encoder.conv2.weight"
+                || key.hasSuffix(".attn.fsmn_block.weight")
+            {
+                value = value.transposed(0, 2, 1)
+            }
+            out[key] = value
+        }
+        return out
+    }
+
     // MARK: - Inference
 
     /// Drop the SOS(6561)/EOS(6562) boundary markers from a flat token sequence,
@@ -365,15 +412,20 @@ public final class ChatterboxTTSModel {
         // 24 kHz (truncated to 10 s) for the S3Gen prompt mel.
         let ref24kFull = sampleRate == ChatterboxS3Gen.sampleRate
             ? referenceSamples
-            : AudioFileLoader.resample(referenceSamples, from: sampleRate, to: ChatterboxS3Gen.sampleRate)
+            : AudioFileLoader.resample(
+                referenceSamples, from: sampleRate, to: ChatterboxS3Gen.sampleRate,
+                quality: .mastering)
         let ref24k = Array(ref24kFull.prefix(Self.decCondLen))
         // 24 kHz -> 16 kHz for the S3Gen tokenizer + CAMPPlus.
         let ref16kFromRef24k = AudioFileLoader.resample(
-            ref24k, from: ChatterboxS3Gen.sampleRate, to: ChatterboxS3Gen.tokenSampleRate)
+            ref24k, from: ChatterboxS3Gen.sampleRate, to: ChatterboxS3Gen.tokenSampleRate,
+            quality: .mastering)
         // original -> 16 kHz (untruncated) for the VoiceEncoder; 6 s slice for T3 cond tokens.
         let ref16kFull = sampleRate == ChatterboxS3Gen.tokenSampleRate
             ? referenceSamples
-            : AudioFileLoader.resample(referenceSamples, from: sampleRate, to: ChatterboxS3Gen.tokenSampleRate)
+            : AudioFileLoader.resample(
+                referenceSamples, from: sampleRate, to: ChatterboxS3Gen.tokenSampleRate,
+                quality: .mastering)
         let ref16kEnc = Array(ref16kFull.prefix(Self.encCondLen))
 
         // S3Gen conditioning (x-vector, prompt tokens, prompt mel).

--- a/Sources/ChatterboxTTS/S3TokenizerV2.swift
+++ b/Sources/ChatterboxTTS/S3TokenizerV2.swift
@@ -53,7 +53,8 @@ enum S3Mel {
     /// `torch.stft(center=True)`. We drop the trailing frame after the call.
     static let melConfig = SlaneyMelConfig(
         sampleRate: sampleRate, nFft: nFft, hop: hop, win: win, nMels: nMels,
-        fmin: 0, fmax: Float(sampleRate) / 2, power: 2.0, logMel: false, centerPad: true)
+        fmin: 0, fmax: Float(sampleRate) / 2, power: 2.0, logMel: false,
+        centerPad: true, periodicHann: true)
 
     /// 16 kHz mono samples → log-mel `(nMels, T)` MLX float32, where
     /// `T = samples.count / hop`.
@@ -201,8 +202,8 @@ final class S3ResidualAttentionBlock: Module {
 
     init(nState: Int, nHead: Int, freqs: S3Freqs) {
         self._attn.wrappedValue = S3FSMNAttention(nState: nState, nHead: nHead, freqs: freqs)
-        // attn_ln uses eps 1e-6 in the reference; mlp_ln uses the default (1e-5).
-        self._attnLN.wrappedValue = LayerNorm(dimensions: nState, eps: 1e-6, affine: true)
+        // s3tokenizer.model_v2 uses eps=1e-5 for both layer norms.
+        self._attnLN.wrappedValue = LayerNorm(dimensions: nState, eps: 1e-5, affine: true)
         let nMLP = nState * 4
         self._mlp.wrappedValue = Sequential(layers: [
             Linear(nState, nMLP), GELU(), Linear(nMLP, nState),

--- a/Sources/MLXCommon/SlaneyMel.swift
+++ b/Sources/MLXCommon/SlaneyMel.swift
@@ -19,11 +19,15 @@ public struct SlaneyMelConfig: Sendable {
     public var logFloor: Float
     /// If true, reflect-pad the signal by `nFft/2` each side (librosa `center=True`).
     public var centerPad: Bool
+    /// If true, use PyTorch's default periodic Hann window. The default remains
+    /// symmetric for existing mel front-ends that were validated that way.
+    public var periodicHann: Bool
 
     public init(
         sampleRate: Int, nFft: Int, hop: Int, win: Int, nMels: Int,
         fmin: Float, fmax: Float, power: Float = 1.0,
-        logMel: Bool = false, logFloor: Float = 1e-5, centerPad: Bool = true
+        logMel: Bool = false, logFloor: Float = 1e-5, centerPad: Bool = true,
+        periodicHann: Bool = false
     ) {
         self.sampleRate = sampleRate
         self.nFft = nFft
@@ -36,6 +40,7 @@ public struct SlaneyMelConfig: Sendable {
         self.logMel = logMel
         self.logFloor = logFloor
         self.centerPad = centerPad
+        self.periodicHann = periodicHann
     }
 }
 
@@ -62,7 +67,7 @@ public enum SlaneyMel {
         let frames = max(0, (sig.count - c.nFft) / c.hop + 1)
 
         // Windowed frames [frames, nFft] (built on host; one rfft on the backend).
-        let window = hannWindow(length: c.win, nFft: c.nFft)
+        let window = hannWindow(length: c.win, nFft: c.nFft, periodic: c.periodicHann)
         var framed = [Float](repeating: 0, count: frames * c.nFft)
         for t in 0 ..< frames {
             let start = t * c.hop
@@ -86,11 +91,9 @@ public enum SlaneyMel {
 
     // MARK: - Internals (lifted from FlashSR/Mel.swift)
 
-    private static func hannWindow(length: Int, nFft: Int) -> [Float] {
+    private static func hannWindow(length: Int, nFft: Int, periodic: Bool) -> [Float] {
         var w = [Float](repeating: 0, count: nFft)
-        // Symmetric Hann (denominator length-1), matching the reference implementation's
-        // `hanning(size, periodic=False)` used by its STFT.
-        let denom = Float(max(length - 1, 1))
+        let denom = Float(max(periodic ? length : length - 1, 1))
         for i in 0 ..< length {
             w[i] = 0.5 * (1.0 - cos(2.0 * Float.pi * Float(i) / denom))
         }

--- a/Tests/ChatterboxTTSTests/ChatterboxFlashCoreMLTests.swift
+++ b/Tests/ChatterboxTTSTests/ChatterboxFlashCoreMLTests.swift
@@ -139,6 +139,10 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
         XCTAssertFalse(a.allSatisfy { $0 == 0 })
     }
 
+    func testGenerationOptionsDefaultKeepsNullPrefillOptional() {
+        XCTAssertEqual(ChatterboxFlashGenerationOptions().cfgScale, 0)
+    }
+
     func testFlashTokenizerUsesWhitespaceBPEAndSpecialTokens() throws {
         let directory = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -150,6 +154,7 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
             "vocab": {
               "[STOP]": 0,
               "[UNK]": 1,
+              "[SPACE]": 2,
               "[START]": 255,
               "C": 10,
               "o": 11,
@@ -166,6 +171,7 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
           "added_tokens": [
             {"id": 0, "content": "[STOP]"},
             {"id": 1, "content": "[UNK]"},
+            {"id": 2, "content": "[SPACE]"},
             {"id": 255, "content": "[START]"}
           ]
         }
@@ -173,7 +179,7 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
         try json.write(to: url, atomically: true, encoding: .utf8)
         let tokenizer = try ChatterboxFlashTokenizer(tokenizerURL: url)
 
-        XCTAssertEqual(tokenizer.encode("Core ML."), [255, 12, 15, 16, 17, 18, 0])
+        XCTAssertEqual(tokenizer.encode("Core ML."), [255, 12, 15, 2, 16, 17, 18, 0])
         let padded = try tokenizer.encodePadded(
             "Core",
             config: ChatterboxFlashT3Config(
@@ -200,14 +206,45 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
         XCTAssertEqual(padded, [255, 12, 15, 0, 0, 0, 0, 0])
     }
 
-    func testNumpyFloat32VectorReader() throws {
-        let values: [Float] = [0.25, -1.5, 3.0]
-        let parsed = try ChatterboxFlashNumpy.parseFloat32Vector(makeNpy(values), label: "fixture.npy")
+    func testT3PrefixPlanCompactsPaddedText() throws {
+        let config = ChatterboxFlashT3Config(
+            textLen: 8,
+            maxSeq: 32,
+            blockSize: 4,
+            condLen: 2,
+            promptSpeechLen: 4,
+            hiddenSize: 8,
+            numLayers: 1,
+            numAttentionHeads: 1,
+            numKeyValueHeads: 1,
+            headDim: 8,
+            kvCacheShape: [1, 8, 1, 32],
+            textVocabSize: 256,
+            speechVocabSize: 16,
+            maskTokenId: 16,
+            startSpeechToken: 10,
+            stopSpeechToken: 11,
+            startTextToken: 255,
+            stopTextToken: 0
+        )
 
-        XCTAssertEqual(parsed.count, values.count)
-        for (lhs, rhs) in zip(parsed, values) {
-            XCTAssertEqual(lhs, rhs, accuracy: 1e-6)
-        }
+        let plan = try ChatterboxFlashT3Graphs.makePrefixPlan(config: config, encodedTextCount: 3)
+
+        XCTAssertEqual(plan.compactPrefixLen, 6)
+        XCTAssertEqual(plan.positionIds.count, config.prefixLen)
+        XCTAssertEqual(plan.positionIds.last, 5)
+        XCTAssertEqual(plan.keyPaddingMask[0..<5], Array(repeating: Float(0), count: 5)[...])
+        XCTAssertEqual(plan.keyPaddingMask[5..<10], Array(repeating: Float(-1.0e4), count: 5)[...])
+        XCTAssertEqual(plan.keyPaddingMask[10], 0)
+        XCTAssertEqual(plan.prefixCacheMap[0 * config.maxSeq + 0], 1)
+        XCTAssertEqual(plan.prefixCacheMap[4 * config.maxSeq + 4], 1)
+        XCTAssertEqual(plan.prefixCacheMap[10 * config.maxSeq + 5], 1)
+        XCTAssertEqual(plan.prefixCacheMap[(5 * config.maxSeq)..<(6 * config.maxSeq)].reduce(0, +), 0)
+    }
+
+    func testT3BlockPositionsUseCacheOffset() {
+        let ids = ChatterboxFlashT3Graphs.makeBlockPositionIds(prefixLen: 39, blockStart: 16, blockSize: 4)
+        XCTAssertEqual(ids, [55, 56, 57, 58])
     }
 
     func testToFloat32ReadsInt8MultiArrayWithoutSDKCaseReference() throws {
@@ -230,6 +267,16 @@ final class ChatterboxFlashCoreMLTests: XCTestCase {
         pointer.update(from: values, count: values.count)
 
         XCTAssertEqual(try ChatterboxFlashCoreMLBridge.toFloat32(array), [-8, -1, 0, 127])
+    }
+
+    func testNumpyFloat32VectorReader() throws {
+        let values: [Float] = [0.25, -1.5, 3.0]
+        let parsed = try ChatterboxFlashNumpy.parseFloat32Vector(makeNpy(values), label: "fixture.npy")
+
+        XCTAssertEqual(parsed.count, values.count)
+        for (lhs, rhs) in zip(parsed, values) {
+            XCTAssertEqual(lhs, rhs, accuracy: 1e-6)
+        }
     }
 
     private func makeTempDirectory() throws -> URL {

--- a/Tests/ChatterboxTTSTests/ChatterboxMemoryOptionsTests.swift
+++ b/Tests/ChatterboxTTSTests/ChatterboxMemoryOptionsTests.swift
@@ -1,0 +1,51 @@
+import MLX
+import XCTest
+
+@testable import ChatterboxTTS
+
+final class ChatterboxMemoryOptionsTests: XCTestCase {
+    func testBalancedDefaultsBoundCacheAndClearStages() {
+        let options = ChatterboxMemoryOptions.balanced
+
+        XCTAssertEqual(options.cacheLimitBytes, 512 * 1024 * 1024)
+        XCTAssertTrue(options.clearCacheBetweenStages)
+        XCTAssertTrue(options.clearCacheOnCompletion)
+    }
+
+    func testUnrestrictedPreservesMLXCacheBehavior() {
+        let options = ChatterboxMemoryOptions.unrestricted
+
+        XCTAssertNil(options.cacheLimitBytes)
+        XCTAssertFalse(options.clearCacheBetweenStages)
+        XCTAssertFalse(options.clearCacheOnCompletion)
+    }
+
+    func testWithOptionsRestoresPriorMLXCacheLimit() {
+        let priorCap = Memory.cacheLimit
+        defer { Memory.cacheLimit = priorCap }
+
+        let initialCap = 3 * 1024 * 1024 * 1024
+        let boundedCap = 512 * 1024 * 1024
+        Memory.cacheLimit = initialCap
+
+        ChatterboxMemory.withOptions(.balanced) {
+            XCTAssertEqual(Memory.cacheLimit, boundedCap)
+        }
+
+        XCTAssertEqual(Memory.cacheLimit, initialCap)
+    }
+
+    func testWithOptionsDoesNotRaiseStricterCallerCacheLimit() {
+        let priorCap = Memory.cacheLimit
+        defer { Memory.cacheLimit = priorCap }
+
+        let stricterCap = 256 * 1024 * 1024
+        Memory.cacheLimit = stricterCap
+
+        ChatterboxMemory.withOptions(.balanced) {
+            XCTAssertEqual(Memory.cacheLimit, stricterCap)
+        }
+
+        XCTAssertEqual(Memory.cacheLimit, stricterCap)
+    }
+}

--- a/Tests/ChatterboxTTSTests/E2EChatterboxFlashCoreMLTests.swift
+++ b/Tests/ChatterboxTTSTests/E2EChatterboxFlashCoreMLTests.swift
@@ -12,7 +12,8 @@ final class E2EChatterboxFlashCoreMLTests: XCTestCase {
         XCTAssertEqual(model.sampleRate, 24_000)
         XCTAssertEqual(model.t3.config.speechLen, 1024)
         XCTAssertEqual(model.t3.config.speechVocabSize, 8194)
-        XCTAssertEqual(model.audio.config.melLen, 384)
+        XCTAssertGreaterThanOrEqual(model.audio.config.tokenLen, 192)
+        XCTAssertEqual(model.audio.config.melLen, model.audio.config.tokenLen * model.audio.config.tokenMelRatio)
     }
 
     func testExportedTokenizerMatchesReferenceIds() throws {
@@ -20,12 +21,13 @@ final class E2EChatterboxFlashCoreMLTests: XCTestCase {
 
         XCTAssertEqual(
             tokenizer.encode("Core ML speech test."),
-            [255, 279, 28, 46, 289, 288, 32, 124, 18, 71, 33, 218, 9, 0]
+            [255, 279, 28, 46, 2, 289, 288, 2, 32, 124, 18, 71, 2, 33, 218, 9, 0]
         )
     }
 
     func testT3SpeechTokenSmoke() throws {
-        let model = try ChatterboxFlashCoreMLModel(directory: try localBundleURL(), computeUnits: .all)
+        let bundle = try localBundleURL()
+        let model = try ChatterboxFlashCoreMLModel(directory: bundle, computeUnits: .all)
         let conditioning = ChatterboxFlashT3Conditioning(
             speakerEmbedding: deterministicValues(count: 256, scale: 0.01),
             promptSpeechTokens: Array(repeating: Int32(0), count: model.t3.config.promptSpeechLen),
@@ -47,11 +49,42 @@ final class E2EChatterboxFlashCoreMLTests: XCTestCase {
         XCTAssertTrue(tokens.allSatisfy { $0 >= 0 && $0 < model.t3.config.startSpeechToken })
     }
 
+    func testT3SpeechTokenSmokeWithCFGWhenNullPrefillExists() throws {
+        let bundle = try localBundleURL()
+        guard FileManager.default.fileExists(
+            atPath: bundle.appendingPathComponent("t3/NullTextPrefill.mlmodelc").path)
+        else {
+            throw XCTSkip("Core ML bundle does not include t3/NullTextPrefill.mlmodelc")
+        }
+
+        let model = try ChatterboxFlashCoreMLModel(directory: bundle, computeUnits: .all)
+        let conditioning = ChatterboxFlashT3Conditioning(
+            speakerEmbedding: deterministicValues(count: 256, scale: 0.01),
+            promptSpeechTokens: Array(repeating: Int32(0), count: model.t3.config.promptSpeechLen),
+            emotionAdv: 0.5
+        )
+        let tokens = try model.generateSpeechTokens(
+            text: "Core ML speech test.",
+            conditioning: conditioning,
+            options: ChatterboxFlashGenerationOptions(
+                maxSpeechTokens: 16,
+                numSteps: 2,
+                temperature: 0,
+                cfgScale: 1.0,
+                positionTemperature: 0,
+                seed: 1234
+            )
+        )
+
+        XCTAssertLessThanOrEqual(tokens.count, 16)
+        XCTAssertTrue(tokens.allSatisfy { $0 >= 0 && $0 < model.t3.config.startSpeechToken })
+    }
+
     func testAudioBackHalfSmoke() throws {
         let bundle = try localBundleURL()
         let audio = try ChatterboxFlashAudioGraphs(
             directory: bundle,
-            config: ChatterboxFlashAudioConfig.fallback,
+            config: ChatterboxFlashAudioConfig.load(from: bundle),
             computeUnits: .cpuOnly
         )
 
@@ -73,6 +106,51 @@ final class E2EChatterboxFlashCoreMLTests: XCTestCase {
         XCTAssertGreaterThan(waveform.map { abs($0) }.max() ?? 0, 0)
     }
 
+    func testReferenceCloneThroughFlashCoreML() throws {
+        let fm = FileManager.default
+        let mlxBundle = ProcessInfo.processInfo.environment["CHATTERBOX_MLX_PATH"] ?? "/tmp/cbx-fp16"
+        let refPath = ProcessInfo.processInfo.environment["CHATTERBOX_REFERENCE_WAV"] ?? "/tmp/clone_reference.wav"
+        for path in [mlxBundle + "/model.safetensors", refPath] where !fm.fileExists(atPath: path) {
+            throw XCTSkip("missing \(path); set CHATTERBOX_MLX_PATH and CHATTERBOX_REFERENCE_WAV")
+        }
+        guard let s3Tokenizer = Self.cachedSnapshotFile(
+            repo: "models--mlx-community--S3TokenizerV2",
+            file: "model.safetensors"
+        ) else {
+            throw XCTSkip("S3TokenizerV2 weights not cached")
+        }
+
+        let conditioningModel = try ChatterboxTTSModel.fromPretrained(
+            localDir: URL(fileURLWithPath: mlxBundle, isDirectory: true),
+            s3TokenizerWeights: s3Tokenizer
+        )
+        let (samples, sampleRate) = try Self.loadWav(refPath)
+        let conditioning = try conditioningModel.prepareFlashConditioning(
+            referenceSamples: samples,
+            sampleRate: sampleRate
+        )
+
+        let flash = try ChatterboxFlashCoreMLModel(directory: try localBundleURL(), computeUnits: .all)
+        let waveform = try flash.generate(
+            text: "Hello there, this is a Chatterbox Flash voice clone.",
+            conditioning: conditioning,
+            options: ChatterboxFlashGenerationOptions(
+                maxSpeechTokens: 96,
+                numSteps: 4,
+                temperature: 0,
+                positionTemperature: 0,
+                seed: 1234
+            )
+        )
+
+        XCTAssertFalse(waveform.isEmpty, "synthesized audio is empty")
+        XCTAssertTrue(waveform.allSatisfy { $0.isFinite })
+        let rms = (waveform.reduce(0.0) { $0 + Double($1) * Double($1) } / Double(waveform.count)).squareRoot()
+        XCTAssertGreaterThan(rms, 1e-3, "synthesized audio is silent (rms=\(rms))")
+        try Self.writeWav(waveform, sampleRate: flash.sampleRate, to: "/tmp/cbx_flash_clone.wav")
+        print("[FlashClone] wrote /tmp/cbx_flash_clone.wav: \(waveform.count) samples, rms=\(rms)")
+    }
+
     private func localBundleURL() throws -> URL {
         if let override = ProcessInfo.processInfo.environment["CHATTERBOX_FLASH_COREML_PATH"], !override.isEmpty {
             return URL(fileURLWithPath: override, isDirectory: true)
@@ -89,6 +167,102 @@ final class E2EChatterboxFlashCoreMLTests: XCTestCase {
         (0..<count).map { index in
             sin(Float(index) * 0.17) * scale
         }
+    }
+
+    private static func cachedSnapshotFile(repo: String, file: String) -> URL? {
+        let base = ("~/.cache/huggingface/hub/\(repo)/snapshots" as NSString).expandingTildeInPath
+        let fm = FileManager.default
+        guard let snapshots = try? fm.contentsOfDirectory(atPath: base) else { return nil }
+        for snapshot in snapshots {
+            let path = URL(fileURLWithPath: base)
+                .appendingPathComponent(snapshot)
+                .appendingPathComponent(file)
+            if fm.fileExists(atPath: path.path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    private static func loadWav(_ path: String) throws -> (samples: [Float], sampleRate: Int) {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        return data.withUnsafeBytes { raw -> (samples: [Float], sampleRate: Int) in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            func u32(_ offset: Int) -> UInt32 {
+                UInt32(bytes[offset])
+                    | UInt32(bytes[offset + 1]) << 8
+                    | UInt32(bytes[offset + 2]) << 16
+                    | UInt32(bytes[offset + 3]) << 24
+            }
+            func u16(_ offset: Int) -> UInt16 {
+                UInt16(bytes[offset]) | UInt16(bytes[offset + 1]) << 8
+            }
+
+            var position = 12
+            var sampleRate = 24_000
+            var audioFormat: UInt16 = 1
+            var bitsPerSample: UInt16 = 16
+            var samples: [Float] = []
+            while position + 8 <= bytes.count {
+                let id = String(bytes: (0..<4).map { bytes[position + $0] }, encoding: .ascii) ?? ""
+                let size = Int(u32(position + 4))
+                let body = position + 8
+                if id == "fmt " {
+                    audioFormat = u16(body)
+                    sampleRate = Int(u32(body + 4))
+                    bitsPerSample = u16(body + 14)
+                } else if id == "data" {
+                    let end = min(body + size, bytes.count)
+                    if audioFormat == 3 || bitsPerSample == 32 {
+                        var offset = body
+                        while offset + 4 <= end {
+                            samples.append(Float(bitPattern: u32(offset)))
+                            offset += 4
+                        }
+                    } else {
+                        var offset = body
+                        while offset + 2 <= end {
+                            samples.append(Float(Int16(bitPattern: u16(offset))) / 32768.0)
+                            offset += 2
+                        }
+                    }
+                }
+                position = body + size + (size & 1)
+            }
+            return (samples, sampleRate)
+        }
+    }
+
+    private static func writeWav(_ samples: [Float], sampleRate: Int, to path: String) throws {
+        var data = Data()
+        func u32(_ value: UInt32) {
+            var v = value.littleEndian
+            withUnsafeBytes(of: &v) { data.append(contentsOf: $0) }
+        }
+        func u16(_ value: UInt16) {
+            var v = value.littleEndian
+            withUnsafeBytes(of: &v) { data.append(contentsOf: $0) }
+        }
+
+        let byteCount = samples.count * 2
+        data.append(contentsOf: Array("RIFF".utf8))
+        u32(UInt32(36 + byteCount))
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        u32(16)
+        u16(1)
+        u16(1)
+        u32(UInt32(sampleRate))
+        u32(UInt32(sampleRate * 2))
+        u16(2)
+        u16(16)
+        data.append(contentsOf: Array("data".utf8))
+        u32(UInt32(byteCount))
+        for sample in samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            u16(UInt16(bitPattern: Int16((clamped * 32767.0).rounded())))
+        }
+        try data.write(to: URL(fileURLWithPath: path))
     }
 }
 #endif

--- a/docs/models/chatterbox-tts.md
+++ b/docs/models/chatterbox-tts.md
@@ -63,6 +63,17 @@ Zero-shot: a single reference clip is encoded to a speaker embedding (VoiceEncod
 and to S3Gen reference features (S3TokenizerV2 + CAM++). No fine-tuning. The
 reference is resampled to 16 kHz and silence-trimmed before the speaker encoder.
 
+The MLX clone path uses `ChatterboxMemoryOptions.balanced` by default. During
+`clone(...)` and standalone `ChatterboxS3Gen.synthesize(...)`, the runtime
+temporarily caps MLX cache memory at up to 512 MB without raising a stricter
+caller cap, clears reusable buffers between T3, S3Gen flow, and vocoder stages,
+then restores the caller's previous cache limit. This keeps long-form synthesis
+from retaining large stage-local Metal buffers. A 72 s Russian clone on the
+local M-series test machine dropped from ~39.0 GB process footprint to ~7.4 GB
+with this policy. Pass
+`memoryOptions: .unrestricted` to preserve MLX's default cache behavior for
+maximum-throughput experiments.
+
 ## Chatterbox Flash Core ML
 
 `ChatterboxFlashCoreMLModel` loads the published

--- a/docs/models/chatterbox-tts.md
+++ b/docs/models/chatterbox-tts.md
@@ -72,6 +72,7 @@ and the S3Gen audio back half as compiled Core ML graphs:
 
 - `t3/ConditioningEncoder.mlmodelc`
 - `t3/TextPrefill.mlmodelc`
+- `t3/NullTextPrefill.mlmodelc` (optional; required only for `cfgScale > 0`)
 - `t3/BlockDecoder.mlmodelc`
 - `audio/FlowSpeakerProjector.mlmodelc`
 - `audio/FlowEncoder.mlmodelc`
@@ -79,8 +80,9 @@ and the S3Gen audio back half as compiled Core ML graphs:
 - `audio/HiFTVocoder.mlmodelc`
 
 The Swift runtime owns the host-side Flash loop: BPE text tokenization,
-fixed-length text padding, PMI ranking against `uncond_block_prior.npy`,
-block unmask scheduling, EOS trimming, and S3Gen waveform synthesis.
+compact T3 prefix planning, optional classifier-free guidance through
+`NullTextPrefill`, PMI ranking against `uncond_block_prior.npy`, block unmask
+scheduling, EOS trimming, and S3Gen waveform synthesis.
 
 ```swift
 import ChatterboxTTS
@@ -103,18 +105,31 @@ let audio24k = try flash.generate(
 Voice cloning is supported when the caller provides reference conditioning
 tensors. The convenience bridge above uses the existing MLX VoiceEncoder,
 S3Tokenizer, and S3Gen reference encoder to create those tensors from a
-reference waveform. Fully Core ML `ref.wav -> cloned wav` is not complete yet
-because the reference-audio encoders are not included in the Flash Core ML
-bundle.
+reference waveform. `ChatterboxTTSModel.fromPretrained(localDir:
+s3TokenizerWeights:)` accepts either the standalone converted S3TokenizerV2
+weights or Flash `s3gen.safetensors`; for the latter it extracts and converts
+the `tokenizer.*` tensors.
 
-The exact Chatterbox Flash CFG null branch requires a separate zero-text prefill
-graph, so the Swift Core ML path currently supports `cfgScale == 0`. Passing a
-positive CFG scale fails fast instead of using an approximate null branch.
+Fully Core ML `ref.wav -> cloned wav` is not complete yet because the
+reference-audio encoders are not included in the Flash Core ML bundle.
+Generated speech defaults to `cfgScale: 0.0` for compatibility with bundles
+that do not include a null-branch graph. Passing a positive `cfgScale` requires
+`t3/NullTextPrefill.mlmodelc` in the bundle.
+
+Voice-cloning quality also depends on the exported S3Gen audio bucket. The
+audio graph consumes `prompt_token + generated_speech_tokens`; the full MLX
+path gives S3Gen up to 10 seconds of prompt audio, while Flash Core ML caps the
+reference prompt to 6 seconds so the public 192-token audio export still leaves
+room for generated speech. A 192-token audio export is enough for smoke tests,
+but it forces short utterances and limited prompt audio. Use a larger audio
+export, for example `token_len=512` and `mel_len=1024`, when validating speaker
+similarity.
 
 Opt-in E2E tests:
 
 ```bash
 CHATTERBOX_FLASH_COREML_PATH=/path/to/Chatterbox-Flash-CoreML \
+CHATTERBOX_REFERENCE_WAV=/path/to/reference.wav \
   swift test --filter E2EChatterboxFlashCoreMLTests
 ```
 


### PR DESCRIPTION
## What changed

- Adds a Chatterbox Flash Core ML voice-cloning bridge that uses the MLX Chatterbox front end to build reference conditioning, then runs the exported Flash T3/S3Gen Core ML graphs.
- Keeps CFG optional so public bundles without `t3/NullTextPrefill.mlmodelc` still run by default.
- Caps Flash S3Gen reference conditioning to 6 seconds so the public 192-token audio export leaves room for generated speech.
- Adds `ChatterboxMemoryOptions` for the MLX clone/S3Gen path. The default `.balanced` policy caps reusable MLX cache memory at up to 512 MB, does not raise a stricter caller cap, clears reusable buffers between T3/S3Gen/vocoder stages, and restores the caller cache limit afterward.
- Uses explicit Chatterbox Flash integer casts so older CI toolchains do not hit ambiguous `Int32.init` overloads.
- Adds local E2E coverage that synthesizes cloned audio through the Flash Core ML path and writes `/tmp/cbx_flash_clone.wav`.
- Updates the Chatterbox model docs for Flash conditioning, CFG requirements, audio-bucket limits, and MLX cache behavior.

## Why

The Flash Core ML export starts after reference-audio encoding. This change makes the Swift package prepare the required speaker embedding, prompt speech tokens, and S3Gen reference tensors from a real reference waveform, while preserving compatibility with the currently published Core ML bundle.

The full MLX clone path was also retaining large stage-local Metal buffers during longer synthesis. The new memory policy keeps the default runtime path bounded while leaving `.unrestricted` available for throughput experiments.

## Validation

- `swift build --build-tests --disable-sandbox`
  - local debug build passed
- `swift test --filter ChatterboxTTSTests`
  - 39 tests executed
  - 8 expected local-golden/Core ML optional skips
  - 0 failures
- `swift test --filter ChatterboxFlashCoreML`
  - 17 tests executed
  - 1 expected optional CFG skip
  - 0 failures
- 72 s Russian full MLX clone local measurement:
  - before policy: ~39.0 GB peak process footprint
  - after policy: 7.37 GB peak process footprint, 1.64 GB max RSS, RTF 0.88
  - output: `/tmp/cbx_swift_ru_long.wav`
- Regenerated listenable local outputs with Ivan reference audio:
  - `/tmp/cbx_swift_en.wav` from the full MLX clone path
  - `/tmp/cbx_flash_clone.wav` from the Flash Core ML bridge

## Notes

The public 192-token Flash audio export is suitable for smoke testing but limits reference prompt length and generated utterance length. Larger audio exports, for example `token_len=512` and `mel_len=1024`, should be used when validating speaker similarity.