### PR TITLE
Add voice cloning candidate runtimes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,22 @@ let package = Package(
             targets: ["FishAudioTTS"]
         ),
         .library(
+            name: "VoiceCloneTTSCommon",
+            targets: ["VoiceCloneTTSCommon"]
+        ),
+        .library(
+            name: "IndexTTS2TTS",
+            targets: ["IndexTTS2TTS"]
+        ),
+        .library(
+            name: "HiggsAudioTTS",
+            targets: ["HiggsAudioTTS"]
+        ),
+        .library(
+            name: "F5TTS",
+            targets: ["F5TTS"]
+        ),
+        .library(
             name: "PersonaPlex",
             targets: ["PersonaPlex"]
         ),
@@ -304,6 +320,33 @@ let package = Package(
             ]
         ),
         .target(
+            name: "VoiceCloneTTSCommon",
+            dependencies: [
+                "AudioCommon",
+            ]
+        ),
+        .target(
+            name: "IndexTTS2TTS",
+            dependencies: [
+                "AudioCommon",
+                "VoiceCloneTTSCommon",
+            ]
+        ),
+        .target(
+            name: "HiggsAudioTTS",
+            dependencies: [
+                "AudioCommon",
+                "VoiceCloneTTSCommon",
+            ]
+        ),
+        .target(
+            name: "F5TTS",
+            dependencies: [
+                "AudioCommon",
+                "VoiceCloneTTSCommon",
+            ]
+        ),
+        .target(
             name: "PersonaPlex",
             dependencies: [
                 "AudioCommon",
@@ -563,6 +606,7 @@ let package = Package(
                 "KokoroTTS",
                 "VibeVoiceTTS",
                 "VoxCPM2TTS",
+                "IndexTTS2TTS",
                 "IndicMioTTS",
                 "MAGNeTMusicGen",
                 "StableAudio3MusicGen",
@@ -724,6 +768,16 @@ let package = Package(
             dependencies: [
                 "FishAudioTTS", "AudioCommon", "MLXCommon", "Qwen3ASR",
                 .product(name: "MLX", package: "mlx-swift")
+            ]
+        ),
+        .testTarget(
+            name: "VoiceCloneCandidateTTSTests",
+            dependencies: [
+                "VoiceCloneTTSCommon",
+                "IndexTTS2TTS",
+                "HiggsAudioTTS",
+                "F5TTS",
+                "AudioCommon",
             ]
         ),
         .testTarget(

--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -5,6 +5,7 @@ import MLX
 import Qwen3TTS
 import CosyVoiceTTS
 import VoxCPM2TTS
+import IndexTTS2TTS
 import IndicMioTTS
 import MagpieTTS
 import MagpieTTSCoreML
@@ -14,13 +15,13 @@ import SpeechRestoration
 public struct SpeakCommand: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "speak",
-        abstract: "Text-to-speech synthesis (Qwen3-TTS, CosyVoice, VoxCPM2, Indic-Mio, or Magpie). For CoreML, use the `qwen3-tts-coreml` subcommand."
+        abstract: "Text-to-speech synthesis (Qwen3-TTS, CosyVoice, VoxCPM2, IndexTTS2 bundle validation, Indic-Mio, or Magpie). For CoreML, use the `qwen3-tts-coreml` subcommand."
     )
 
     @Argument(help: "Text to synthesize (omit when using --list-speakers or --batch-file)")
     public var text: String?
 
-    @Option(name: .long, help: "TTS engine: qwen3 (default), cosyvoice, voxcpm2, indic-mio, magpie, or magpie-coreml")
+    @Option(name: .long, help: "TTS engine: qwen3 (default), cosyvoice, voxcpm2, indextts2, indic-mio, magpie, or magpie-coreml")
     public var engine: String = "qwen3"
 
     @Option(name: .shortAndLong, help: "Output WAV file path")
@@ -146,6 +147,17 @@ public struct SpeakCommand: ParsableCommand {
     @Option(name: .long, help: "[voxcpm2] Warmup patches to skip before emitting audio")
     public var voxcpm2WarmupPatches: Int = 0
 
+    // MARK: - IndexTTS2-specific options
+
+    @Option(name: .long, help: "[indextts2] HuggingFace model ID for the exported MLX bundle")
+    public var indextts2ModelId: String = IndexTTS2TTSModel.defaultModelId
+
+    @Option(name: .long, help: "[indextts2] Load an exported bundle from this local directory instead of HuggingFace")
+    public var indextts2BundleDir: String?
+
+    @Option(name: .long, help: "[indextts2] Optional emotion/style reference audio. Native Swift synthesis is not implemented yet.")
+    public var indextts2EmotionAudio: String?
+
     // MARK: - Indic-Mio-specific options
 
     @Option(name: .long, help: "[indic-mio] HuggingFace model ID")
@@ -201,8 +213,8 @@ public struct SpeakCommand: ParsableCommand {
     public func validate() throws {
         let eng = engine.lowercased()
         guard eng == "qwen3" || eng == "cosyvoice" || eng == "voxcpm2"
-                || eng == "indic-mio" || eng == "magpie" || eng == "magpie-coreml" else {
-            throw ValidationError("--engine must be 'qwen3', 'cosyvoice', 'voxcpm2', 'indic-mio', 'magpie', or 'magpie-coreml'. For Qwen3-TTS CoreML, use the `qwen3-tts-coreml` subcommand.")
+                || eng == "indextts2" || eng == "indic-mio" || eng == "magpie" || eng == "magpie-coreml" else {
+            throw ValidationError("--engine must be 'qwen3', 'cosyvoice', 'voxcpm2', 'indextts2', 'indic-mio', 'magpie', or 'magpie-coreml'. For Qwen3-TTS CoreML, use the `qwen3-tts-coreml` subcommand.")
         }
         if text == nil && batchFile == nil && !listSpeakers {
             throw ValidationError("Either a text argument, --batch-file, or --list-speakers must be provided")
@@ -213,6 +225,26 @@ public struct SpeakCommand: ParsableCommand {
             }
             if (voxcpm2PromptAudio == nil) != (voxcpm2PromptText == nil) {
                 throw ValidationError("--voxcpm2-prompt-audio and --voxcpm2-prompt-text must be provided together")
+            }
+        }
+        if eng == "indextts2" {
+            if batchFile != nil || listSpeakers {
+                throw ValidationError("--engine indextts2 only supports a single text input")
+            }
+            if stream {
+                throw ValidationError("--engine indextts2 does not support --stream yet")
+            }
+            if voiceSample == nil {
+                throw ValidationError("--engine indextts2 requires --voice-sample because IndexTTS2 is a zero-shot voice-cloning model")
+            }
+            if cleanReference {
+                throw ValidationError("--clean-reference is not wired for --engine indextts2 yet")
+            }
+            if speaker != nil {
+                throw ValidationError("--engine indextts2 does not support --speaker; use --voice-sample")
+            }
+            if instruct != nil {
+                throw ValidationError("--engine indextts2 does not support --instruct; use --indextts2-emotion-audio once native synthesis is implemented")
             }
         }
         if eng == "indic-mio" {
@@ -305,6 +337,8 @@ public struct SpeakCommand: ParsableCommand {
             try runCosyVoice()
         case "voxcpm2":
             try runVoxCPM2()
+        case "indextts2":
+            try runIndexTTS2()
         case "indic-mio":
             try runIndicMio()
         case "magpie":
@@ -865,6 +899,59 @@ public struct SpeakCommand: ParsableCommand {
                 }
             } else {
                 try await body()
+            }
+        }
+    }
+
+    // MARK: - IndexTTS2 engine
+
+    private func runIndexTTS2() throws {
+        try runAsync {
+            guard let inputText = text else {
+                print("Error: text argument is required for IndexTTS2")
+                throw ExitCode(1)
+            }
+            guard let voiceSample else {
+                print("Error: --voice-sample is required for IndexTTS2")
+                throw ExitCode(1)
+            }
+
+            let model: IndexTTS2TTSModel
+            if let bundleDir = indextts2BundleDir {
+                let bundleURL = URL(fileURLWithPath: bundleDir)
+                print("Loading IndexTTS2 exported bundle (\(bundleURL.path))...")
+                model = try await IndexTTS2TTSModel.fromBundle(
+                    bundleURL,
+                    progressHandler: reportProgress)
+            } else {
+                print("Loading IndexTTS2 exported bundle (\(indextts2ModelId))...")
+                model = try await IndexTTS2TTSModel.fromPretrained(
+                    modelId: indextts2ModelId,
+                    progressHandler: reportProgress)
+            }
+
+            print("  Model: \(model.manifest.displayName)")
+            print("  Source: \(model.manifest.sourceRepo)")
+            if let publishRepo = model.manifest.publishRepo {
+                print("  Bundle: \(publishRepo)")
+            }
+            print("  Params: \(model.manifest.parameterCount ?? "unknown")")
+            print("  Sample rate: \(model.sampleRate) Hz")
+            print("  Runtime status: \(model.manifest.runtimeStatus ?? "unknown")")
+
+            let voiceURL = URL(fileURLWithPath: voiceSample)
+            let emotionURL = indextts2EmotionAudio.map { URL(fileURLWithPath: $0) }
+            let audio = try await model.generate(
+                text: inputText,
+                referenceAudio: voiceURL,
+                emotionReferenceAudio: emotionURL,
+                language: effectiveLanguage)
+            let outputURL = URL(fileURLWithPath: output)
+            if play {
+                playAudio(samples: audio, sampleRate: model.sampleRate)
+            } else {
+                try WAVWriter.write(samples: audio, sampleRate: model.sampleRate, to: outputURL)
+                print("Saved audio to \(output)")
             }
         }
     }

--- a/Sources/F5TTS/F5TTSModel.swift
+++ b/Sources/F5TTS/F5TTSModel.swift
@@ -1,0 +1,93 @@
+import AudioCommon
+import Foundation
+import VoiceCloneTTSCommon
+
+public final class F5TTSModel: SpeechGenerationModel, ModelMemoryManageable, @unchecked Sendable {
+    public static let defaultModelId = "aufklarer/F5-TTS-v1-Base-MLX-fp16"
+    public static let modelKey = "f5-tts-v1"
+
+    private static let requiredFiles = [
+        "soniqo_manifest.json",
+        "README.md",
+        "config.json",
+        "F5TTS_v1_Base/model_1250000.safetensors",
+        "F5TTS_v1_Base/vocab.txt",
+    ]
+
+    public let bundleDirectory: URL
+    public let manifest: VoiceCloneExportManifest
+    public let sampleRate: Int
+
+    private let bundleInfo: VoiceCloneBundleInfo
+    private var loaded = true
+
+    private init(bundleInfo: VoiceCloneBundleInfo) {
+        self.bundleInfo = bundleInfo
+        self.bundleDirectory = bundleInfo.directory
+        self.manifest = bundleInfo.manifest
+        self.sampleRate = bundleInfo.sampleRate
+    }
+
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> F5TTSModel {
+        let directory = try await VoiceCloneBundleLoader.download(
+            modelId: modelId,
+            requiredFiles: requiredFiles,
+            cacheDir: cacheDir,
+            offlineMode: offlineMode,
+            progressHandler: progressHandler)
+        return try await fromBundle(directory) { progress, message in
+            progressHandler?(0.85 + progress * 0.15, message)
+        }
+    }
+
+    public static func fromBundle(
+        _ directory: URL,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> F5TTSModel {
+        let info = try VoiceCloneBundleLoader.load(
+            from: directory,
+            expectedModelKey: modelKey,
+            progressHandler: progressHandler)
+        return F5TTSModel(bundleInfo: info)
+    }
+
+    public var isLoaded: Bool {
+        loaded
+    }
+
+    public var memoryFootprint: Int {
+        loaded ? bundleInfo.weightMemory : 0
+    }
+
+    public func unload() {
+        loaded = false
+    }
+
+    public func generate(text: String, language: String?) async throws -> [Float] {
+        try ensureLoaded()
+        throw VoiceCloneBundleLoader.runtimeNotImplemented(modelName: "F5-TTS v1")
+    }
+
+    public func generate(
+        text: String,
+        referenceAudio: URL,
+        referenceText: String,
+        language: String? = nil
+    ) async throws -> [Float] {
+        try ensureLoaded()
+        throw VoiceCloneBundleLoader.runtimeNotImplemented(modelName: "F5-TTS v1")
+    }
+
+    private func ensureLoaded() throws {
+        guard loaded else {
+            throw AudioModelError.inferenceFailed(
+                operation: "F5-TTS v1 synthesis",
+                reason: "Model has been unloaded.")
+        }
+    }
+}

--- a/Sources/HiggsAudioTTS/HiggsAudioTTSModel.swift
+++ b/Sources/HiggsAudioTTS/HiggsAudioTTSModel.swift
@@ -1,0 +1,99 @@
+import AudioCommon
+import Foundation
+import VoiceCloneTTSCommon
+
+public final class HiggsAudioTTSModel: SpeechGenerationModel, ModelMemoryManageable, @unchecked Sendable {
+    public static let defaultModelId = "aufklarer/Higgs-Audio-v3-TTS-4B-MLX-fp16"
+    public static let modelKey = "higgs-audio-v3"
+
+    private static let requiredFiles = [
+        "soniqo_manifest.json",
+        "README.md",
+        "LICENSE",
+        "PROMPTING.md",
+        "config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+        "model.safetensors",
+        "model.safetensors.index.json",
+    ]
+
+    public let bundleDirectory: URL
+    public let manifest: VoiceCloneExportManifest
+    public let sampleRate: Int
+
+    private let bundleInfo: VoiceCloneBundleInfo
+    private var loaded = true
+
+    private init(bundleInfo: VoiceCloneBundleInfo) {
+        self.bundleInfo = bundleInfo
+        self.bundleDirectory = bundleInfo.directory
+        self.manifest = bundleInfo.manifest
+        self.sampleRate = bundleInfo.sampleRate
+    }
+
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> HiggsAudioTTSModel {
+        let directory = try await VoiceCloneBundleLoader.download(
+            modelId: modelId,
+            requiredFiles: requiredFiles,
+            cacheDir: cacheDir,
+            offlineMode: offlineMode,
+            progressHandler: progressHandler)
+        return try await fromBundle(directory) { progress, message in
+            progressHandler?(0.85 + progress * 0.15, message)
+        }
+    }
+
+    public static func fromBundle(
+        _ directory: URL,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> HiggsAudioTTSModel {
+        let info = try VoiceCloneBundleLoader.load(
+            from: directory,
+            expectedModelKey: modelKey,
+            progressHandler: progressHandler)
+        return HiggsAudioTTSModel(bundleInfo: info)
+    }
+
+    public var isLoaded: Bool {
+        loaded
+    }
+
+    public var memoryFootprint: Int {
+        loaded ? bundleInfo.weightMemory : 0
+    }
+
+    public func unload() {
+        loaded = false
+    }
+
+    public func generate(text: String, language: String?) async throws -> [Float] {
+        try ensureLoaded()
+        throw VoiceCloneBundleLoader.runtimeNotImplemented(modelName: "Higgs Audio v3")
+    }
+
+    public func generate(
+        text: String,
+        referenceAudio: URL,
+        referenceText: String? = nil,
+        voicePrompt: String? = nil,
+        language: String? = nil
+    ) async throws -> [Float] {
+        try ensureLoaded()
+        throw VoiceCloneBundleLoader.runtimeNotImplemented(modelName: "Higgs Audio v3")
+    }
+
+    private func ensureLoaded() throws {
+        guard loaded else {
+            throw AudioModelError.inferenceFailed(
+                operation: "Higgs Audio v3 synthesis",
+                reason: "Model has been unloaded.")
+        }
+    }
+}

--- a/Sources/IndexTTS2TTS/IndexTTS2TTSModel.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2TTSModel.swift
@@ -1,0 +1,171 @@
+import AudioCommon
+import Foundation
+import VoiceCloneTTSCommon
+
+public final class IndexTTS2TTSModel: SpeechGenerationModel, ModelMemoryManageable, @unchecked Sendable {
+    public static let defaultModelId = "aufklarer/IndexTTS2-MLX-fp16"
+    public static let modelKey = "indextts2"
+
+    public struct AuxiliaryModel: Equatable, Sendable {
+        public let name: String
+        public let repository: String
+        public let files: [String]
+        public let purpose: String
+
+        public init(name: String, repository: String, files: [String], purpose: String) {
+            self.name = name
+            self.repository = repository
+            self.files = files
+            self.purpose = purpose
+        }
+    }
+
+    public static let auxiliaryModels: [AuxiliaryModel] = [
+        AuxiliaryModel(
+            name: "w2v-bert-2.0",
+            repository: "facebook/w2v-bert-2.0",
+            files: [
+                "aux/w2v-bert-2.0/config.json",
+                "aux/w2v-bert-2.0/model.safetensors",
+                "aux/w2v-bert-2.0/preprocessor_config.json",
+            ],
+            purpose: "SeamlessM4T feature extraction and semantic hidden states for reference audio"),
+        AuxiliaryModel(
+            name: "MaskGCT semantic codec",
+            repository: "amphion/MaskGCT",
+            files: [
+                "aux/maskgct/config.json",
+                "aux/maskgct/README.md",
+                "aux/maskgct/semantic_codec/model.safetensors",
+            ],
+            purpose: "Quantizes semantic reference features and maps generated codes to embeddings"),
+        AuxiliaryModel(
+            name: "CAMPPlus",
+            repository: "funasr/campplus",
+            files: [
+                "aux/campplus/campplus_cn_common.safetensors",
+                "aux/campplus/configuration.json",
+                "aux/campplus/README.md",
+            ],
+            purpose: "Extracts the 192-d global style vector from the speaker reference"),
+        AuxiliaryModel(
+            name: "BigVGAN",
+            repository: "nvidia/bigvgan_v2_22khz_80band_256x",
+            files: [
+                "aux/bigvgan/bigvgan_generator.safetensors",
+                "aux/bigvgan/config.json",
+                "aux/bigvgan/LICENSE",
+                "aux/bigvgan/README.md",
+            ],
+            purpose: "Decodes generated 80-band mel spectrograms to waveform"),
+    ]
+
+    private static let baseRequiredFiles = [
+        "soniqo_manifest.json",
+        "README.md",
+        "LICENSE.txt",
+        "LICENSE_ZH.txt",
+        "config.json",
+        "config.yaml",
+        "bpe.model",
+        "gpt.safetensors",
+        "s2mel.safetensors",
+        "feat1.safetensors",
+        "feat2.safetensors",
+        "wav2vec2bert_stats.safetensors",
+        "qwen0.6bemo4-merge/config.json",
+        "qwen0.6bemo4-merge/generation_config.json",
+        "qwen0.6bemo4-merge/tokenizer.json",
+        "qwen0.6bemo4-merge/tokenizer_config.json",
+        "qwen0.6bemo4-merge/special_tokens_map.json",
+        "qwen0.6bemo4-merge/added_tokens.json",
+        "qwen0.6bemo4-merge/vocab.json",
+        "qwen0.6bemo4-merge/merges.txt",
+        "qwen0.6bemo4-merge/chat_template.jinja",
+        "qwen0.6bemo4-merge/model.safetensors",
+    ]
+
+    private static let requiredFiles =
+        baseRequiredFiles + auxiliaryModels.flatMap(\.files)
+
+    public let bundleDirectory: URL
+    public let manifest: VoiceCloneExportManifest
+    public let sampleRate: Int
+    public let tokenizer: IndexTTS2Tokenizer?
+
+    private let bundleInfo: VoiceCloneBundleInfo
+    private var loaded = true
+
+    private init(bundleInfo: VoiceCloneBundleInfo) {
+        self.bundleInfo = bundleInfo
+        self.bundleDirectory = bundleInfo.directory
+        self.manifest = bundleInfo.manifest
+        self.sampleRate = bundleInfo.sampleRate
+        self.tokenizer = try? IndexTTS2Tokenizer(
+            modelURL: bundleInfo.directory.appendingPathComponent("bpe.model"))
+    }
+
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> IndexTTS2TTSModel {
+        let directory = try await VoiceCloneBundleLoader.download(
+            modelId: modelId,
+            requiredFiles: requiredFiles,
+            cacheDir: cacheDir,
+            offlineMode: offlineMode,
+            progressHandler: progressHandler)
+        return try await fromBundle(directory) { progress, message in
+            progressHandler?(0.85 + progress * 0.15, message)
+        }
+    }
+
+    public static func fromBundle(
+        _ directory: URL,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> IndexTTS2TTSModel {
+        let info = try VoiceCloneBundleLoader.load(
+            from: directory,
+            expectedModelKey: modelKey,
+            progressHandler: progressHandler)
+        return IndexTTS2TTSModel(bundleInfo: info)
+    }
+
+    public var isLoaded: Bool {
+        loaded
+    }
+
+    public var memoryFootprint: Int {
+        loaded ? bundleInfo.weightMemory : 0
+    }
+
+    public func unload() {
+        loaded = false
+    }
+
+    public func generate(text: String, language: String?) async throws -> [Float] {
+        try ensureLoaded()
+        throw VoiceCloneBundleLoader.runtimeNotImplemented(modelName: "IndexTTS2")
+    }
+
+    public func generate(
+        text: String,
+        referenceAudio: URL,
+        referenceText: String? = nil,
+        emotionReferenceAudio: URL? = nil,
+        language: String? = nil
+    ) async throws -> [Float] {
+        try ensureLoaded()
+        throw VoiceCloneBundleLoader.runtimeNotImplemented(modelName: "IndexTTS2")
+    }
+
+    private func ensureLoaded() throws {
+        guard loaded else {
+            throw AudioModelError.inferenceFailed(
+                operation: "IndexTTS2 synthesis",
+                reason: "Model has been unloaded.")
+        }
+    }
+}

--- a/Sources/IndexTTS2TTS/IndexTTS2Tokenizer.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2Tokenizer.swift
@@ -1,0 +1,133 @@
+import AudioCommon
+import Foundation
+
+public struct IndexTTS2Token: Equatable, Sendable {
+    public let id: Int
+    public let piece: String
+
+    public init(id: Int, piece: String) {
+        self.id = id
+        self.piece = piece
+    }
+}
+
+public enum IndexTTS2TokenizerError: Error, LocalizedError, Equatable {
+    case emptyVocabulary
+    case textTooLong(maxScalars: Int)
+    case unencodableText(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyVocabulary:
+            return "IndexTTS2 tokenizer vocabulary is empty."
+        case .textTooLong(let maxScalars):
+            return "IndexTTS2 tokenizer input is too long; max \(maxScalars) Unicode scalars."
+        case .unencodableText(let text):
+            return "IndexTTS2 tokenizer could not encode text: \(text)"
+        }
+    }
+}
+
+/// SentencePiece tokenizer scaffold for IndexTTS2's `bpe.model`.
+///
+/// Upstream applies additional Chinese text normalization before SentencePiece.
+/// This Swift port starts with the model-compatible Unigram Viterbi path used
+/// by English and already gives the GPT stage stable token IDs.
+public struct IndexTTS2Tokenizer: Sendable {
+    public static let maxInputScalars = 2_048
+
+    private let pieces: [SentencePieceModel.Piece]
+    private let tokenToId: [String: Int]
+
+    public init(modelURL: URL) throws {
+        let model = try SentencePieceModel(contentsOf: modelURL)
+        try self.init(pieces: model.pieces)
+    }
+
+    init(pieces: [SentencePieceModel.Piece]) throws {
+        guard !pieces.isEmpty else {
+            throw IndexTTS2TokenizerError.emptyVocabulary
+        }
+        self.pieces = pieces
+        self.tokenToId = Dictionary(
+            uniqueKeysWithValues: pieces.enumerated().map { ($0.element.text, $0.offset) }
+        )
+    }
+
+    public func tokenize(_ text: String) throws -> [IndexTTS2Token] {
+        try encode(text).map { id in
+            IndexTTS2Token(id: id, piece: pieces[id].text)
+        }
+    }
+
+    public func encode(_ text: String) throws -> [Int] {
+        let normalized = normalizedPieceText(for: text)
+        guard !normalized.isEmpty else { return [] }
+
+        let scalars = Array(normalized.unicodeScalars)
+        guard scalars.count <= Self.maxInputScalars else {
+            throw IndexTTS2TokenizerError.textTooLong(maxScalars: Self.maxInputScalars)
+        }
+
+        var bestScores = [Float](repeating: -.infinity, count: scalars.count + 1)
+        var backPointer = [(start: Int, id: Int)?](repeating: nil, count: scalars.count + 1)
+        bestScores[0] = 0
+
+        for start in 0..<scalars.count where bestScores[start].isFinite {
+            for end in (start + 1)...scalars.count {
+                let piece = String(String.UnicodeScalarView(scalars[start..<end]))
+                guard let id = tokenToId[piece] else { continue }
+                guard !pieces[id].isControlOrUnknown else { continue }
+
+                let score = bestScores[start] + pieces[id].score
+                if score > bestScores[end] || (score == bestScores[end] && isTieBreakBetter(id, start, than: backPointer[end])) {
+                    bestScores[end] = score
+                    backPointer[end] = (start, id)
+                }
+            }
+        }
+
+        guard bestScores[scalars.count].isFinite else {
+            throw IndexTTS2TokenizerError.unencodableText(text)
+        }
+
+        var ids: [Int] = []
+        var cursor = scalars.count
+        while cursor > 0, let pointer = backPointer[cursor] {
+            ids.append(pointer.id)
+            cursor = pointer.start
+        }
+        return ids.reversed()
+    }
+
+    public func decode(_ ids: [Int]) -> String {
+        ids.compactMap { id in
+            guard id >= 0, id < pieces.count else { return nil }
+            let piece = pieces[id]
+            return piece.isControlOrUnknown ? nil : piece.text
+        }
+        .joined()
+        .replacingOccurrences(of: "▁", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func normalizedPieceText(for text: String) -> String {
+        let normalized = (text as NSString)
+            .precomposedStringWithCompatibilityMapping
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        guard !normalized.isEmpty else { return "" }
+        return "▁" + normalized.replacingOccurrences(of: " ", with: "▁")
+    }
+
+    private func isTieBreakBetter(
+        _ candidateId: Int,
+        _ candidateStart: Int,
+        than existing: (start: Int, id: Int)?
+    ) -> Bool {
+        guard let existing else { return true }
+        return candidateId < existing.id ||
+            (candidateId == existing.id && candidateStart > existing.start)
+    }
+}

--- a/Sources/VoiceCloneTTSCommon/VoiceCloneBundle.swift
+++ b/Sources/VoiceCloneTTSCommon/VoiceCloneBundle.swift
@@ -1,0 +1,232 @@
+import AudioCommon
+import Foundation
+
+public struct VoiceCloneBundleFile: Codable, Equatable, Sendable {
+    public let path: String
+    public let bytes: Int64
+
+    public init(path: String, bytes: Int64) {
+        self.path = path
+        self.bytes = bytes
+    }
+}
+
+public struct VoiceCloneAuxiliaryManifest: Codable, Equatable, Sendable {
+    public let key: String
+    public let displayName: String
+    public let sourceRepo: String
+    public let sourceRevision: String?
+    public let purpose: String
+    public let convertedFiles: [String]
+    public let copiedFiles: [String]
+    public let notes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case displayName = "display_name"
+        case sourceRepo = "source_repo"
+        case sourceRevision = "source_revision"
+        case purpose
+        case convertedFiles = "converted_files"
+        case copiedFiles = "copied_files"
+        case notes
+    }
+}
+
+public struct VoiceCloneExportManifest: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let artifactType: String
+    public let modelKey: String
+    public let displayName: String
+    public let sourceRepo: String
+    public let sourceRevision: String?
+    public let publishRepo: String?
+    public let outputName: String
+    public let license: String?
+    public let licensePosture: String?
+    public let parameterCount: String?
+    public let sampleRateHz: Int?
+    public let languages: [String]
+    public let voiceConditioning: String?
+    public let streaming: String?
+    public let format: String?
+    public let runtimeStatus: String?
+    public let convertedFiles: [String]
+    public let copiedFiles: [String]
+    public let auxiliaryModels: [VoiceCloneAuxiliaryManifest]
+    public let notes: [String]
+    public let files: [VoiceCloneBundleFile]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case artifactType = "artifact_type"
+        case modelKey = "model_key"
+        case displayName = "display_name"
+        case sourceRepo = "source_repo"
+        case sourceRevision = "source_revision"
+        case publishRepo = "publish_repo"
+        case outputName = "output_name"
+        case license
+        case licensePosture = "license_posture"
+        case parameterCount = "parameter_count"
+        case sampleRateHz = "sample_rate_hz"
+        case languages
+        case voiceConditioning = "voice_conditioning"
+        case streaming
+        case format
+        case runtimeStatus = "runtime_status"
+        case convertedFiles = "converted_files"
+        case copiedFiles = "copied_files"
+        case auxiliaryModels = "auxiliary_models"
+        case notes
+        case files
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+        artifactType = try container.decodeIfPresent(String.self, forKey: .artifactType) ?? "voice_cloning_tts_candidate"
+        modelKey = try container.decode(String.self, forKey: .modelKey)
+        displayName = try container.decodeIfPresent(String.self, forKey: .displayName) ?? modelKey
+        sourceRepo = try container.decodeIfPresent(String.self, forKey: .sourceRepo) ?? ""
+        sourceRevision = try container.decodeIfPresent(String.self, forKey: .sourceRevision)
+        publishRepo = try container.decodeIfPresent(String.self, forKey: .publishRepo)
+        outputName = try container.decodeIfPresent(String.self, forKey: .outputName) ?? displayName
+        license = try container.decodeIfPresent(String.self, forKey: .license)
+        licensePosture = try container.decodeIfPresent(String.self, forKey: .licensePosture)
+        parameterCount = try container.decodeIfPresent(String.self, forKey: .parameterCount)
+        sampleRateHz = try container.decodeIfPresent(Int.self, forKey: .sampleRateHz)
+        languages = try container.decodeIfPresent([String].self, forKey: .languages) ?? []
+        voiceConditioning = try container.decodeIfPresent(String.self, forKey: .voiceConditioning)
+        streaming = try container.decodeIfPresent(String.self, forKey: .streaming)
+        format = try container.decodeIfPresent(String.self, forKey: .format)
+        runtimeStatus = try container.decodeIfPresent(String.self, forKey: .runtimeStatus)
+        convertedFiles = try container.decodeIfPresent([String].self, forKey: .convertedFiles) ?? []
+        copiedFiles = try container.decodeIfPresent([String].self, forKey: .copiedFiles) ?? []
+        auxiliaryModels = try container.decodeIfPresent(
+            [VoiceCloneAuxiliaryManifest].self,
+            forKey: .auxiliaryModels) ?? []
+        notes = try container.decodeIfPresent([String].self, forKey: .notes) ?? []
+        files = try container.decodeIfPresent([VoiceCloneBundleFile].self, forKey: .files) ?? []
+    }
+}
+
+public struct VoiceCloneBundleInfo: Equatable, Sendable {
+    public let directory: URL
+    public let manifest: VoiceCloneExportManifest
+    public let weightMemory: Int
+
+    public var sampleRate: Int {
+        manifest.sampleRateHz ?? 24_000
+    }
+
+    public init(directory: URL, manifest: VoiceCloneExportManifest, weightMemory: Int) {
+        self.directory = directory
+        self.manifest = manifest
+        self.weightMemory = weightMemory
+    }
+}
+
+public enum VoiceCloneBundleError: Error, LocalizedError, Equatable {
+    case missingManifest(URL)
+    case invalidManifest(URL, String)
+    case unexpectedModelKey(expected: String, actual: String)
+    case missingRequiredFile(String)
+    case emptyWeightSet(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingManifest(let url):
+            return "Missing voice-cloning bundle manifest: \(url.path)"
+        case .invalidManifest(let url, let reason):
+            return "Invalid voice-cloning bundle manifest at \(url.path): \(reason)"
+        case .unexpectedModelKey(let expected, let actual):
+            return "Unexpected voice-cloning model key '\(actual)' (expected '\(expected)')"
+        case .missingRequiredFile(let path):
+            return "Voice-cloning bundle is missing required file: \(path)"
+        case .emptyWeightSet(let url):
+            return "Voice-cloning bundle has no converted safetensors weights: \(url.path)"
+        }
+    }
+}
+
+public enum VoiceCloneBundleLoader {
+    public static let manifestFileName = "soniqo_manifest.json"
+
+    public static func download(
+        modelId: String,
+        requiredFiles: [String],
+        cacheDir: URL?,
+        offlineMode: Bool,
+        progressHandler: ((Double, String) -> Void)?
+    ) async throws -> URL {
+        let directory = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        try await HuggingFaceDownloader.downloadFiles(
+            modelId: modelId,
+            to: directory,
+            files: requiredFiles,
+            offlineMode: offlineMode
+        ) { progress in
+            progressHandler?(progress * 0.85, "Downloading \(modelId)")
+        }
+        return directory
+    }
+
+    public static func load(
+        from directory: URL,
+        expectedModelKey: String,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) throws -> VoiceCloneBundleInfo {
+        progressHandler?(0.05, "Loading voice-cloning manifest")
+        let manifestURL = directory.appendingPathComponent(manifestFileName)
+        let manifest = try loadManifest(from: manifestURL)
+
+        guard manifest.modelKey == expectedModelKey else {
+            throw VoiceCloneBundleError.unexpectedModelKey(
+                expected: expectedModelKey,
+                actual: manifest.modelKey)
+        }
+
+        progressHandler?(0.35, "Validating voice-cloning bundle")
+        for path in manifest.convertedFiles + manifest.copiedFiles {
+            let fileURL = directory.appendingPathComponent(path)
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                throw VoiceCloneBundleError.missingRequiredFile(path)
+            }
+        }
+
+        let weightFiles = manifest.convertedFiles.filter { $0.hasSuffix(".safetensors") }
+        guard !weightFiles.isEmpty else {
+            throw VoiceCloneBundleError.emptyWeightSet(directory)
+        }
+
+        let memory = weightFiles.reduce(0) { total, path in
+            let fileURL = directory.appendingPathComponent(path)
+            let size = ((try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+            return total + size
+        }
+
+        progressHandler?(1.0, "Voice-cloning bundle ready")
+        return VoiceCloneBundleInfo(directory: directory, manifest: manifest, weightMemory: memory)
+    }
+
+    public static func loadManifest(from url: URL) throws -> VoiceCloneExportManifest {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw VoiceCloneBundleError.missingManifest(url)
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(VoiceCloneExportManifest.self, from: data)
+        } catch let error as VoiceCloneBundleError {
+            throw error
+        } catch {
+            throw VoiceCloneBundleError.invalidManifest(url, error.localizedDescription)
+        }
+    }
+
+    public static func runtimeNotImplemented(modelName: String) -> AudioModelError {
+        AudioModelError.inferenceFailed(
+            operation: "\(modelName) synthesis",
+            reason: "The bundle loader is implemented, but native Swift inference for this model has not been ported yet.")
+    }
+}

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -436,6 +436,17 @@ final class SpeakCommandTests: XCTestCase {
         XCTAssertEqual(speak.indicMioRepetitionPenalty, 1.0, accuracy: 0.001)
     }
 
+    func testIndexTTS2Engine() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "speak", "--engine", "indextts2", "Hello",
+            "--voice-sample", "ref.wav",
+        ])
+        let speak = try XCTUnwrap(cmd as? SpeakCommand)
+        XCTAssertEqual(speak.engine, "indextts2")
+        XCTAssertEqual(speak.voiceSample, "ref.wav")
+        XCTAssertEqual(speak.indextts2ModelId, "aufklarer/IndexTTS2-MLX-fp16")
+    }
+
     func testInvalidEngineFails() {
         XCTAssertThrowsError(try AudioCLI.parseAsRoot(["speak", "--engine", "whisper", "hi"])) { error in
             XCTAssertEqual(AudioCLI.exitCode(for: error), .validationFailure)
@@ -570,6 +581,21 @@ final class SpeakCommandTests: XCTestCase {
         XCTAssertNotNil(speak.indicMioGlobalEmbedding)
     }
 
+    func testIndexTTS2Options() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "speak", "Hello",
+            "--engine", "indextts2",
+            "--voice-sample", "ref.wav",
+            "--indextts2-model-id", "org/IndexTTS2-MLX-fp16",
+            "--indextts2-bundle-dir", "/tmp/IndexTTS2-MLX-fp16",
+            "--indextts2-emotion-audio", "style.wav",
+        ])
+        let speak = try XCTUnwrap(cmd as? SpeakCommand)
+        XCTAssertEqual(speak.indextts2ModelId, "org/IndexTTS2-MLX-fp16")
+        XCTAssertEqual(speak.indextts2BundleDir, "/tmp/IndexTTS2-MLX-fp16")
+        XCTAssertEqual(speak.indextts2EmotionAudio, "style.wav")
+    }
+
     func testIndicMioAcceptsInlineJSONEmbedding() throws {
         let embedding = "[\(Array(repeating: "0", count: 128).joined(separator: ","))]"
         XCTAssertNoThrow(try AudioCLI.parseAsRoot([
@@ -624,6 +650,24 @@ final class SpeakCommandTests: XCTestCase {
     }
 
     // MARK: - Indic-Mio engine
+
+    func testIndexTTS2RejectsMissingVoiceSample() {
+        expectSpeakReject(
+            ["speak", "Hello", "--engine", "indextts2"],
+            contains: "--voice-sample")
+    }
+
+    func testIndexTTS2RejectsUnsupportedControls() {
+        expectSpeakReject(
+            ["speak", "Hello", "--engine", "indextts2", "--voice-sample", "ref.wav", "--stream"],
+            contains: "--stream")
+        expectSpeakReject(
+            ["speak", "Hello", "--engine", "indextts2", "--voice-sample", "ref.wav", "--speaker", "someone"],
+            contains: "--speaker")
+        expectSpeakReject(
+            ["speak", "Hello", "--engine", "indextts2", "--voice-sample", "ref.wav", "--instruct", "friendly"],
+            contains: "--instruct")
+    }
 
     func testIndicMioAcceptsVoiceSampleReference() throws {
         let cmd = try AudioCLI.parseAsRoot([

--- a/Tests/VoiceCloneCandidateTTSTests/E2EIndexTTS2BundleTests.swift
+++ b/Tests/VoiceCloneCandidateTTSTests/E2EIndexTTS2BundleTests.swift
@@ -1,0 +1,57 @@
+import AudioCommon
+@testable import IndexTTS2TTS
+import XCTest
+
+final class E2EIndexTTS2BundleTests: XCTestCase {
+    func testExpandedBundleLoadsAndReportsCurrentSynthesisStatus() async throws {
+        let model = try await loadModel()
+
+        XCTAssertEqual(model.manifest.modelKey, IndexTTS2TTSModel.modelKey)
+        XCTAssertEqual(model.manifest.displayName, "IndexTTS2")
+        XCTAssertEqual(model.manifest.sampleRateHz, 24_000)
+        XCTAssertEqual(model.manifest.auxiliaryModels.map(\.sourceRepo), [
+            "facebook/w2v-bert-2.0",
+            "amphion/MaskGCT",
+            "funasr/campplus",
+            "nvidia/bigvgan_v2_22khz_80band_256x",
+        ])
+        XCTAssertGreaterThan(model.memoryFootprint, 4_000_000_000)
+        XCTAssertNotNil(model.tokenizer)
+
+        do {
+            _ = try await model.generate(
+                text: "This is an IndexTTS2 native synthesis smoke test.",
+                referenceAudio: URL(fileURLWithPath: "/tmp/index-tts2-reference.wav"),
+                referenceText: "Reference voice sample.",
+                language: "en")
+            XCTFail("IndexTTS2 native synthesis should remain explicit until the Swift/MLX graph port lands")
+        } catch let error as AudioModelError {
+            guard case .inferenceFailed(let operation, let reason) = error else {
+                return XCTFail("Unexpected AudioModelError: \(error)")
+            }
+            XCTAssertEqual(operation, "IndexTTS2 synthesis")
+            XCTAssertTrue(reason.contains("native Swift inference"))
+        }
+    }
+
+    private func loadModel() async throws -> IndexTTS2TTSModel {
+        let env = ProcessInfo.processInfo.environment
+        if let bundlePath = env["INDEXTTS2_E2E_BUNDLE"], !bundlePath.isEmpty {
+            let bundle = URL(fileURLWithPath: bundlePath, isDirectory: true)
+            guard FileManager.default.fileExists(atPath: bundle.path) else {
+                throw XCTSkip("IndexTTS2 E2E bundle not found at \(bundle.path)")
+            }
+            return try await IndexTTS2TTSModel.fromBundle(bundle)
+        }
+
+        guard env["INDEXTTS2_E2E_DOWNLOAD"] == "1" else {
+            throw XCTSkip("Set INDEXTTS2_E2E_BUNDLE or INDEXTTS2_E2E_DOWNLOAD=1 to run IndexTTS2 bundle E2E")
+        }
+
+        do {
+            return try await IndexTTS2TTSModel.fromPretrained()
+        } catch {
+            throw XCTSkip("IndexTTS2 published bundle unavailable: \(error)")
+        }
+    }
+}

--- a/Tests/VoiceCloneCandidateTTSTests/VoiceCloneCandidateTTSTests.swift
+++ b/Tests/VoiceCloneCandidateTTSTests/VoiceCloneCandidateTTSTests.swift
@@ -1,0 +1,223 @@
+import AudioCommon
+@testable import F5TTS
+@testable import HiggsAudioTTS
+@testable import IndexTTS2TTS
+@testable import VoiceCloneTTSCommon
+import XCTest
+
+final class VoiceCloneCandidateTTSTests: XCTestCase {
+    func testIndexTTS2BundleLoadsAndReportsMetadata() async throws {
+        let dir = try makeBundle(
+            modelKey: "indextts2",
+            displayName: "IndexTTS2",
+            parameterCount: "1.5B-class",
+            sampleRate: 24_000,
+            convertedFiles: ["gpt.safetensors", "s2mel.safetensors"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let model = try await IndexTTS2TTSModel.fromBundle(dir)
+
+        XCTAssertEqual(model.sampleRate, 24_000)
+        XCTAssertEqual(model.manifest.displayName, "IndexTTS2")
+        XCTAssertEqual(model.manifest.parameterCount, "1.5B-class")
+        XCTAssertEqual(model.manifest.publishRepo, "aufklarer/IndexTTS2-MLX-fp16")
+        XCTAssertEqual(model.memoryFootprint, 32)
+        XCTAssertTrue(model.isLoaded)
+    }
+
+    func testIndexTTS2DocumentsAuxiliaryModelsNeededForNativePort() {
+        let aux = IndexTTS2TTSModel.auxiliaryModels
+        XCTAssertEqual(aux.map(\.repository), [
+            "facebook/w2v-bert-2.0",
+            "amphion/MaskGCT",
+            "funasr/campplus",
+            "nvidia/bigvgan_v2_22khz_80band_256x",
+        ])
+        XCTAssertTrue(aux[0].purpose.contains("semantic"))
+        XCTAssertTrue(aux[3].files.contains("aux/bigvgan/bigvgan_generator.safetensors"))
+    }
+
+    func testManifestDecodesAuxiliaryModels() async throws {
+        let dir = try makeBundle(
+            modelKey: "indextts2",
+            displayName: "IndexTTS2",
+            parameterCount: "1.5B-class",
+            sampleRate: 24_000,
+            convertedFiles: ["gpt.safetensors"],
+            copiedFiles: ["config.json"],
+            auxiliaryModels: [[
+                "key": "bigvgan",
+                "display_name": "BigVGAN",
+                "source_repo": "nvidia/bigvgan_v2_22khz_80band_256x",
+                "source_revision": "aux-test",
+                "purpose": "vocoder",
+                "converted_files": ["aux/bigvgan/bigvgan_generator.safetensors"],
+                "copied_files": ["aux/bigvgan/config.json"],
+                "notes": ["unit test"],
+            ]])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let model = try await IndexTTS2TTSModel.fromBundle(dir)
+
+        XCTAssertEqual(model.manifest.auxiliaryModels.count, 1)
+        XCTAssertEqual(model.manifest.auxiliaryModels[0].key, "bigvgan")
+        XCTAssertEqual(model.manifest.auxiliaryModels[0].sourceRepo, "nvidia/bigvgan_v2_22khz_80band_256x")
+        XCTAssertEqual(model.manifest.auxiliaryModels[0].convertedFiles, ["aux/bigvgan/bigvgan_generator.safetensors"])
+    }
+
+    func testBundleLoaderValidatesCopiedFiles() throws {
+        let dir = try makeBundle(
+            modelKey: "indextts2",
+            displayName: "IndexTTS2",
+            parameterCount: "1.5B-class",
+            sampleRate: 24_000,
+            convertedFiles: ["gpt.safetensors"],
+            copiedFiles: ["config.json"],
+            writeCopiedFiles: false)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        XCTAssertThrowsError(
+            try VoiceCloneBundleLoader.load(from: dir, expectedModelKey: "indextts2")
+        ) { error in
+            XCTAssertEqual(error as? VoiceCloneBundleError, .missingRequiredFile("config.json"))
+        }
+    }
+
+    func testIndexTTS2TokenizerUsesSentencePieceScores() throws {
+        let pieces = [
+            SentencePieceModel.Piece(text: "<unk>", score: 0, type: SentencePieceModel.PieceType.unknown.rawValue),
+            SentencePieceModel.Piece(text: "▁", score: -10, type: SentencePieceModel.PieceType.normal.rawValue),
+            SentencePieceModel.Piece(text: "hello", score: -5, type: SentencePieceModel.PieceType.normal.rawValue),
+            SentencePieceModel.Piece(text: "world", score: -5, type: SentencePieceModel.PieceType.normal.rawValue),
+            SentencePieceModel.Piece(text: "▁hello", score: -1, type: SentencePieceModel.PieceType.normal.rawValue),
+            SentencePieceModel.Piece(text: "▁world", score: -1, type: SentencePieceModel.PieceType.normal.rawValue),
+        ]
+        let tokenizer = try IndexTTS2Tokenizer(pieces: pieces)
+
+        let ids = try tokenizer.encode("hello world")
+
+        XCTAssertEqual(ids, [4, 5])
+        XCTAssertEqual(tokenizer.decode(ids), "hello world")
+    }
+
+    func testHiggsBundleRejectsWrongManifestKey() async throws {
+        let dir = try makeBundle(
+            modelKey: "indextts2",
+            displayName: "IndexTTS2",
+            parameterCount: "1.5B-class",
+            sampleRate: 24_000,
+            convertedFiles: ["model.safetensors"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        do {
+            _ = try await HiggsAudioTTSModel.fromBundle(dir)
+            XCTFail("Expected wrong manifest key to fail")
+        } catch let error as VoiceCloneBundleError {
+            XCTAssertEqual(error, .unexpectedModelKey(expected: "higgs-audio-v3", actual: "indextts2"))
+        }
+    }
+
+    func testF5GenerationFailsWithExplicitUnsupportedRuntime() async throws {
+        let dir = try makeBundle(
+            modelKey: "f5-tts-v1",
+            displayName: "F5-TTS v1 Base",
+            parameterCount: "335M-class",
+            sampleRate: 24_000,
+            convertedFiles: ["F5TTS_v1_Base/model_1250000.safetensors"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let model = try await F5TTSModel.fromBundle(dir)
+
+        do {
+            _ = try await model.generate(text: "Hello", language: "en")
+            XCTFail("Expected unsupported native inference error")
+        } catch let error as AudioModelError {
+            guard case .inferenceFailed(let operation, let reason) = error else {
+                return XCTFail("Unexpected AudioModelError: \(error)")
+            }
+            XCTAssertEqual(operation, "F5-TTS v1 synthesis")
+            XCTAssertTrue(reason.contains("native Swift inference"))
+        }
+    }
+
+    func testUnloadClearsMemoryFootprint() async throws {
+        let dir = try makeBundle(
+            modelKey: "higgs-audio-v3",
+            displayName: "Higgs Audio v3 TTS 4B",
+            parameterCount: "4B",
+            sampleRate: 24_000,
+            convertedFiles: ["model.safetensors"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let model = try await HiggsAudioTTSModel.fromBundle(dir)
+        XCTAssertEqual(model.memoryFootprint, 16)
+
+        model.unload()
+
+        XCTAssertFalse(model.isLoaded)
+        XCTAssertEqual(model.memoryFootprint, 0)
+    }
+
+    private func makeBundle(
+        modelKey: String,
+        displayName: String,
+        parameterCount: String,
+        sampleRate: Int,
+        convertedFiles: [String],
+        copiedFiles: [String] = [],
+        auxiliaryModels: [[String: Any]] = [],
+        writeCopiedFiles: Bool = true
+    ) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        for relativePath in convertedFiles {
+            let fileURL = dir.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true)
+            try Data(repeating: 0x7f, count: 16).write(to: fileURL)
+        }
+
+        if writeCopiedFiles {
+            for relativePath in copiedFiles {
+                let fileURL = dir.appendingPathComponent(relativePath)
+                try FileManager.default.createDirectory(
+                    at: fileURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true)
+                try Data("{}".utf8).write(to: fileURL)
+            }
+        }
+
+        let manifest: [String: Any] = [
+            "schema_version": 1,
+            "artifact_type": "voice_cloning_tts_candidate",
+            "model_key": modelKey,
+            "display_name": displayName,
+            "source_repo": "example/\(displayName)",
+            "source_revision": "test",
+            "publish_repo": "aufklarer/\(displayName)-MLX-fp16",
+            "output_name": "\(displayName)-MLX-fp16",
+            "license": "test",
+            "license_posture": "test",
+            "parameter_count": parameterCount,
+            "sample_rate_hz": sampleRate,
+            "languages": ["en"],
+            "voice_conditioning": "reference audio",
+            "streaming": "test",
+            "format": "MLX fp16 safetensors",
+            "runtime_status": "artifact-export; Swift native inference not implemented",
+            "converted_files": convertedFiles,
+            "copied_files": copiedFiles,
+            "auxiliary_models": auxiliaryModels,
+            "notes": ["unit test"],
+            "files": (convertedFiles + copiedFiles).map { ["path": $0, "bytes": 16] },
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: dir.appendingPathComponent("soniqo_manifest.json"))
+        return dir
+    }
+}

--- a/docs/inference/voice-cloning-candidate-runtimes.md
+++ b/docs/inference/voice-cloning-candidate-runtimes.md
@@ -1,0 +1,96 @@
+# Voice Cloning Candidate Runtimes - Inference
+
+These modules are loadable runtime contracts, not complete synthesis engines.
+They are useful for wiring downloads, cache validation, model-size reporting,
+CLI surfacing, and native-port tests before the full inference graphs land.
+
+```swift
+import IndexTTS2TTS
+
+let bundle = URL(fileURLWithPath: "/path/to/IndexTTS2-MLX-fp16")
+let model = try await IndexTTS2TTSModel.fromBundle(bundle)
+
+print(model.manifest.parameterCount ?? "unknown")
+print(model.memoryFootprint)
+print(IndexTTS2TTSModel.auxiliaryModels.map(\.repository))
+
+let tokenIds = try model.tokenizer?.encode("Hello from IndexTTS2")
+
+// Throws until the native graph port is implemented.
+_ = try await model.generate(text: "Hello", language: "en")
+```
+
+The same shape is available for `HiggsAudioTTSModel` and `F5TTSModel`.
+
+## CLI Surface
+
+IndexTTS2 is exposed through `speech speak` as a bundle-validation engine:
+
+```bash
+speech speak "Hello from IndexTTS2" \
+  --engine indextts2 \
+  --voice-sample reference.wav \
+  --indextts2-bundle-dir /path/to/IndexTTS2-MLX-fp16
+```
+
+or, after the expanded bundle is published:
+
+```bash
+speech speak "Hello from IndexTTS2" \
+  --engine indextts2 \
+  --voice-sample reference.wav \
+  --indextts2-model-id aufklarer/IndexTTS2-MLX-fp16
+```
+
+The command downloads or loads the exported bundle, prints manifest metadata,
+then throws the same explicit unsupported-runtime error as the Swift API. This
+keeps CLI behavior honest while making the published artifact testable through
+the normal cache path.
+
+The expanded IndexTTS2 export layout contains base artifacts at the root plus
+w2v-BERT, MaskGCT semantic codec, CAMPPlus, and BigVGAN under `aux/`. Those
+paths are exposed through
+`IndexTTS2TTSModel.auxiliaryModels` for the native port, but the graph execution
+is not yet wired into `generate`.
+
+| Flag | Scope | Notes |
+|---|---|---|
+| `--engine indextts2` | `speech speak` | Selects the IndexTTS2 exported-bundle loader. |
+| `--voice-sample <wav>` | `indextts2` | Required because IndexTTS2 is a zero-shot voice-cloning model. |
+| `--indextts2-model-id <repo>` | `indextts2` | Defaults to `aufklarer/IndexTTS2-MLX-fp16`. |
+| `--indextts2-bundle-dir <path>` | `indextts2` | Loads a local exported bundle instead of Hugging Face. |
+| `--indextts2-emotion-audio <wav>` | `indextts2` | Accepted for the future native port; not used until synthesis is implemented. |
+
+## Download Defaults
+
+| Module | Default model id |
+|---|---|
+| `IndexTTS2TTSModel` | `aufklarer/IndexTTS2-MLX-fp16` |
+| `HiggsAudioTTSModel` | `aufklarer/Higgs-Audio-v3-TTS-4B-MLX-fp16` |
+| `F5TTSModel` | `aufklarer/F5-TTS-v1-Base-MLX-fp16` |
+
+The default IDs are the expected outputs of the `speech-models`
+`voice-cloning-candidates` exporter. Uploading those bundles to Hugging Face is
+a separate release step and is not performed by the runtime.
+
+## Tests
+
+Fast unit tests avoid model downloads:
+
+```bash
+swift test --filter VoiceCloneCandidateTTSTests
+```
+
+The IndexTTS2 expanded-bundle E2E test is opt-in because it validates a multi-GB
+bundle:
+
+```bash
+INDEXTTS2_E2E_BUNDLE=/path/to/IndexTTS2-MLX-fp16 \
+  swift test --filter E2EIndexTTS2BundleTests --disable-sandbox
+
+INDEXTTS2_E2E_DOWNLOAD=1 \
+  swift test --filter E2EIndexTTS2BundleTests --disable-sandbox
+```
+
+The E2E verifies bundle metadata, auxiliary model records, tokenizer loading,
+and the current explicit native-synthesis-not-ported error.

--- a/docs/models/voice-cloning-candidate-runtimes.md
+++ b/docs/models/voice-cloning-candidate-runtimes.md
@@ -1,0 +1,87 @@
+# Voice Cloning Candidate Runtimes
+
+`IndexTTS2TTS`, `HiggsAudioTTS`, and `F5TTS` are first-pass runtime surfaces for
+candidate local voice-cloning engines requested for benchmark follow-up. They
+share `VoiceCloneTTSCommon`, which loads `soniqo_manifest.json`, validates the
+exported safetensors bundle, exposes model metadata, and tracks the local weight
+footprint.
+
+## Status
+
+| Module | Upstream | Default bundle | Params | Runtime status |
+|---|---|---|---|---|
+| `IndexTTS2TTS` | `IndexTeam/IndexTTS-2` | `aufklarer/IndexTTS2-MLX-fp16` | 1.5B-class | Bundle loader + CLI validation + tokenizer scaffold |
+| `HiggsAudioTTS` | `bosonai/higgs-audio-v3-tts-4b` | `aufklarer/Higgs-Audio-v3-TTS-4B-MLX-fp16` | 4B | Bundle loader only |
+| `F5TTS` | `SWivid/F5-TTS` (`F5TTS_v1_Base`) | `aufklarer/F5-TTS-v1-Base-MLX-fp16` | 335M-class | Bundle loader only |
+
+The modules conform to `SpeechGenerationModel` so generic callers can identify
+them as TTS models, but synthesis is not available yet. Calling `generate` throws
+`AudioModelError.inferenceFailed` with a native-inference-not-ported message.
+`speech speak --engine indextts2` is wired to the same loader so an uploaded
+IndexTTS2 artifact can be downloaded, cache-validated, and inspected through the
+normal CLI path before the full Swift/MLX graph port is complete.
+
+## Publishing
+
+The intended published bundle IDs are:
+
+| Bundle | Repo |
+|---|---|
+| IndexTTS2 fp16 | `aufklarer/IndexTTS2-MLX-fp16` |
+| Higgs Audio v3 fp16 | `aufklarer/Higgs-Audio-v3-TTS-4B-MLX-fp16` |
+| F5-TTS v1 Base fp16 | `aufklarer/F5-TTS-v1-Base-MLX-fp16` |
+
+Publishing is a release operation outside this package. The exported bundle must
+include the generated model card, `soniqo_manifest.json`, fp16 safetensors, and
+copied tokenizer/config/license files.
+
+The IndexTTS2 export is an expanded synthesis bundle: GPT/S2Mel/Qwen artifacts
+at the root plus w2v-BERT, MaskGCT semantic codec, CAMPPlus, and BigVGAN under
+`aux/`. Native synthesis still needs Swift/MLX graph ports for those components.
+
+## Bundle Contract
+
+The matching exporter lives in `speech-models` under
+`models/voice-cloning-candidates/export/`. Each bundle includes:
+
+- `soniqo_manifest.json` with model key, source repo, sample rate, parameter
+  class, license posture, converted files, and runtime status.
+- fp16 `*.safetensors` files with upstream tensor names preserved.
+- tokenizer/config files copied from the upstream repository.
+
+`VoiceCloneBundleLoader` validates that the manifest model key matches the
+runtime module and that all converted and copied files listed in the manifest
+exist. It reports `memoryFootprint` as the total bytes of the converted
+safetensors.
+
+## IndexTTS2 Native Port Requirements
+
+The Swift module exposes `IndexTTS2TTSModel.auxiliaryModels` so callers and tests
+can see the complete upstream runtime surface:
+
+| Component | Upstream repo | Purpose |
+|---|---|---|
+| w2v-BERT 2.0 | `facebook/w2v-bert-2.0` | SeamlessM4T features and semantic hidden states for reference audio |
+| MaskGCT semantic codec | `amphion/MaskGCT` | Quantizes reference features and maps generated semantic codes to embeddings |
+| CAMPPlus | `funasr/campplus` | 192-d global style vector from the speaker reference |
+| BigVGAN | `nvidia/bigvgan_v2_22khz_80band_256x` | Vocoder from generated 80-band mels to waveform |
+
+`IndexTTS2Tokenizer` provides a native SentencePiece Unigram path for the
+published `bpe.model`. It currently covers the model-compatible Viterbi
+tokenization used by English text. Full parity still needs the upstream Chinese
+normalization and glossary handling.
+
+`E2EIndexTTS2BundleTests` validates either a local expanded bundle
+(`INDEXTTS2_E2E_BUNDLE`) or the published Hugging Face download path
+(`INDEXTTS2_E2E_DOWNLOAD=1`). The test confirms that the full bundle loads and
+that synthesis currently fails with the explicit native-port-pending error.
+
+## Remaining Native Runtime Work
+
+- IndexTTS2: Chinese normalizer parity, w2v-BERT encoder, MaskGCT semantic
+  codec, GPT2/Conformer/Perceiver generation loop, S2Mel diffusion decoder,
+  CAMPPlus style encoder, and BigVGAN vocoder path.
+- Higgs Audio v3: conversational prompt builder, multi-codebook generation loop,
+  inline control handling, and audio decoder path.
+- F5-TTS v1: text frontend, reference transcript alignment, flow-matching
+  sampler, and vocoder integration.

--- a/docs/shared-protocols.md
+++ b/docs/shared-protocols.md
@@ -26,6 +26,8 @@ The `AudioCommon` module defines shared protocols that provide model-agnostic in
    │CosyVoice│        │ParakeetASR│       └───────────┘       └───────────┘
    │VoxCPM2  │        │ForcedAlign│
    │Kokoro   │
+   │IndexTTS2│
+   │Higgs/F5 │
    └─────────┘        └───────────┘
 ```
 
@@ -43,7 +45,9 @@ public protocol SpeechGenerationModel: AnyObject {
 }
 ```
 
-**Conforming types:** `Qwen3TTSModel`, `CosyVoiceTTSModel`, `VoxCPM2TTSModel`, `KokoroTTSModel`
+**Conforming types:** `Qwen3TTSModel`, `CosyVoiceTTSModel`, `VoxCPM2TTSModel`, `KokoroTTSModel`, `IndexTTS2TTSModel`, `HiggsAudioTTSModel`, `F5TTSModel`
+
+`IndexTTS2TTSModel`, `HiggsAudioTTSModel`, and `F5TTSModel` currently implement bundle loading, manifest validation, metadata access, and `ModelMemoryManageable`. `speech speak --engine indextts2` routes through the IndexTTS2 loader for published-bundle validation. Their `generate` methods intentionally throw a clear unsupported-runtime error until the native Swift inference graphs are ported.
 
 ### SpeechRecognitionModel (STT)
 
@@ -413,6 +417,11 @@ Sources/
 │   ├── AudioVAE.swift         AudioVAE V2 encode/decode
 │   └── Configuration.swift    ModelArgs / config decoding for VoxCPM2 snapshots
 │
+├── VoiceCloneTTSCommon/       Shared manifest + bundle validation for candidate TTS ports
+├── IndexTTS2TTS/              IndexTTS2 bundle loader (inference not ported)
+├── HiggsAudioTTS/             Higgs Audio v3 bundle loader (inference not ported)
+├── F5TTS/                     F5-TTS v1 bundle loader (inference not ported)
+│
 ├── PersonaPlex/               Speech-to-speech (Temporal + Depformer + Mimi)
 │   ├── PersonaPlex.swift      PersonaPlexModel: SpeechToSpeechModel
 │   └── PersonaPlex+Protocols.swift
@@ -444,6 +453,7 @@ AudioCommon  ← Qwen3ASR         ─┐
              ← Qwen3TTS         │
              ← CosyVoiceTTS     │
              ← VoxCPM2TTS       │
+             ← VoiceCloneTTSCommon ← IndexTTS2TTS, HiggsAudioTTS, F5TTS
              ← KokoroTTS        ├── AudioCLILib ── AudioCLI (executable)
              ← ParakeetASR      │
              ← ParakeetStreamingASR │
@@ -467,6 +477,7 @@ All model classes are **not thread-safe** by design. ML inference is inherently 
 - `Qwen3TTSModel`
 - `CosyVoiceTTSModel`
 - `VoxCPM2TTSModel`
+- `IndexTTS2TTSModel`, `HiggsAudioTTSModel`, `F5TTSModel`
 - `PersonaPlexModel`
 - `OmnilingualASRModel` (CoreML), `OmnilingualASRMLXModel` (MLX)
 - `ParakeetASRModel`, `ParakeetStreamingASRModel`, `NemotronStreamingASRModel`


### PR DESCRIPTION
## Summary

Adds first-pass runtime surfaces for voice-cloning benchmark follow-up models: IndexTTS2, Higgs Audio v3, and F5-TTS. The PR also wires IndexTTS2 into the speak CLI as a bundle-validation engine and documents the expanded IndexTTS2 export layout.

## Details

- Adds shared voice-clone bundle manifest loading and validation.
- Adds IndexTTS2 metadata, auxiliary model contract, SentencePiece tokenizer scaffold, and explicit native-synthesis-pending errors.
- Adds Higgs Audio and F5-TTS bundle loader modules for candidate exports.
- Adds CLI flags for IndexTTS2 bundle/model loading.
- Adds unit and opt-in E2E tests for the expanded IndexTTS2 bundle.
- Updates local model/inference/shared protocol docs.

## Validation

- make build
- swift test --filter VoiceCloneCandidateTTSTests --disable-sandbox
- swift test --filter SpeakCommandTests/testIndexTTS2 --disable-sandbox
- INDEXTTS2_E2E_BUNDLE=/tmp/voice-clone-candidate-exports-full/IndexTTS2-MLX-fp16 swift test --filter E2EIndexTTS2BundleTests --disable-sandbox
- INDEXTTS2_E2E_DOWNLOAD=1 swift test --filter E2EIndexTTS2BundleTests --disable-sandbox

## Notes

The expanded IndexTTS2 Hugging Face bundle has been uploaded to aufklarer/IndexTTS2-MLX-fp16. Native Swift synthesis is not implemented yet; the runtime and CLI intentionally report that state after validating the full bundle.