### PR TITLE
Pipeline the Higgs decode loop and tune voice-cloning TTS performance

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -183,8 +183,8 @@ public struct SpeakCommand: ParsableCommand {
     @Option(name: .long, help: "[f5] Reference transcript: the text content of --voice-sample. Required for zero-shot cloning.")
     public var f5ReferenceText: String?
 
-    @Option(name: .long, help: "[f5] Flow-matching steps (default 32)")
-    public var f5Steps: Int = 32
+    @Option(name: .long, help: "[f5] Flow-matching steps (default 16; use 32 for maximum fidelity)")
+    public var f5Steps: Int = 16
 
     @Option(name: .long, help: "[f5] Classifier-free guidance strength (default 2.0)")
     public var f5CfgStrength: Float = 2.0
@@ -1187,7 +1187,7 @@ public struct SpeakCommand: ParsableCommand {
             if f5Speed != 1.0 {
                 print("  Speaking rate: \(f5Speed)x")
             }
-            if f5Steps != 32 || f5CfgStrength != 2.0 || f5Sway != -1.0 {
+            if f5Steps != 16 || f5CfgStrength != 2.0 || f5Sway != -1.0 {
                 print("  Sampling: steps \(f5Steps), cfg \(f5CfgStrength), sway \(f5Sway)")
             }
 

--- a/Sources/F5TTS/F5TTSFlow.swift
+++ b/Sources/F5TTS/F5TTSFlow.swift
@@ -12,7 +12,7 @@ public struct F5TTSSynthesisOptions: Equatable, Sendable {
     public let targetRMS: Float
 
     public init(
-        steps: Int = 32,
+        steps: Int = 16,
         cfgStrength: Float = 2.0,
         swaySamplingCoef: Float? = -1.0,
         speed: Float = 1.0,

--- a/Sources/HiggsTTS/HiggsTTSModel.swift
+++ b/Sources/HiggsTTS/HiggsTTSModel.swift
@@ -169,19 +169,47 @@ public final class HiggsTTSModel: SpeechGenerationModel, ModelMemoryManageable, 
             bocId: config.audioBOCTokenId,
             eocId: config.audioEOCTokenId)
         var rows: [[Int32]] = []
-        for step in 0..<options.maxNewTokens {
-            let logits = fused.logits(last).reshaped(
-                config.audioNumCodebooks, config.audioCodebookSize)
-            let sampled = sample(logits: logits, options: options)
-            let codes = try sampler.advance(sampled)
-            rows.append(codes)
-            if sampler.isDone { break }
+        let codebooks = config.audioNumCodebooks
+        let rampIndex = MLXArray(0..<Int32(codebooks))
 
-            let next = fused.embed(
-                MLXArray(codes).reshaped(1, 1, config.audioNumCodebooks))
-            let (h, advanced) = backbone.forward(embeddings: next, state: state)
-            state = advanced
-            last = h[0..., -1, 0...]
+        // Samples codes for a hidden state with the delay ramp masked
+        // on-device, so the result can feed back without a CPU round trip.
+        // `HiggsTTSSamplerState.advance` re-applies the same mask
+        // idempotently and keeps owning the EOC stop logic.
+        func sampleCodes(_ hidden: MLXArray, step: Int) -> MLXArray {
+            let logits = fused.logits(hidden).reshaped(codebooks, config.audioCodebookSize)
+            var codes = sampleOnDevice(logits: logits, options: options)
+            if step < codebooks - 1 {
+                codes = MLX.which(
+                    rampIndex .>= Int32(step + 1),
+                    MLXArray(config.audioBOCTokenId),
+                    codes)
+            }
+            return codes
+        }
+
+        // Software pipeline: launch step t+1's forward pass before reading
+        // step t's codes, overlapping the CPU-side state machine with GPU
+        // compute. Costs one discarded in-flight step at EOC.
+        var current = sampleCodes(last, step: 0)
+        asyncEval(current)
+        for step in 0..<options.maxNewTokens {
+            var upcoming: MLXArray?
+            if step + 1 < options.maxNewTokens {
+                let next = fused.embed(current.reshaped(1, 1, codebooks))
+                let (h, advanced) = backbone.forward(embeddings: next, state: state)
+                state = advanced
+                last = h[0..., -1, 0...]
+                let nextCodes = sampleCodes(last, step: step + 1)
+                asyncEval(nextCodes)
+                upcoming = nextCodes
+            }
+
+            let row = try sampler.advance(current.asArray(Int32.self))
+            rows.append(row)
+            if sampler.isDone { break }
+            guard let upcoming else { break }
+            current = upcoming
             if step % 64 == 63 {
                 progressHandler?(min(0.76 + Double(step) / Double(options.maxNewTokens) * 0.2, 0.95),
                                  "Sampling Higgs audio frames")
@@ -374,12 +402,10 @@ public final class HiggsTTSModel: SpeechGenerationModel, ModelMemoryManageable, 
         return concatenated(pieces, axis: 1)
     }
 
-    /// Independent per-codebook sampling over `[N, V]` logits.
-    private func sample(logits: MLXArray, options: HiggsTTSSynthesisOptions) -> [Int32] {
+    /// Independent per-codebook sampling over `[N, V]` logits, kept on-device.
+    private func sampleOnDevice(logits: MLXArray, options: HiggsTTSSynthesisOptions) -> MLXArray {
         if options.temperature <= 1e-5 || options.topK == 1 {
-            let ids = argMax(logits, axis: -1).asType(.int32)
-            eval(ids)
-            return ids.asArray(Int32.self)
+            return argMax(logits, axis: -1).asType(.int32)
         }
         var scaled = logits / options.temperature
         if let topK = options.topK, topK < config.audioCodebookSize {
@@ -400,9 +426,7 @@ public final class HiggsTTSModel: SpeechGenerationModel, ModelMemoryManageable, 
             mask = putAlong(mask, order, values: maskSorted, axis: -1)
             scaled = MLX.which(mask, -Float.infinity, scaled)
         }
-        let ids = MLXRandom.categorical(scaled, axis: -1).asType(.int32)
-        eval(ids)
-        return ids.asArray(Int32.self)
+        return MLXRandom.categorical(scaled, axis: -1).asType(.int32)
     }
 
     private func runtime(

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -736,7 +736,7 @@ final class SpeakCommandTests: XCTestCase {
         XCTAssertEqual(speak.f5ReferenceText, "Reference transcript.")
         XCTAssertEqual(speak.f5ModelId, "aufklarer/F5TTS-v1-Base-MLX-fp16")
         XCTAssertNil(speak.f5BundleDir)
-        XCTAssertEqual(speak.f5Steps, 32)
+        XCTAssertEqual(speak.f5Steps, 16)
         XCTAssertEqual(speak.f5CfgStrength, 2.0, accuracy: 0.001)
         XCTAssertEqual(speak.f5Sway, -1.0, accuracy: 0.001)
         XCTAssertEqual(speak.f5Speed, 1.0, accuracy: 0.001)

--- a/docs/benchmarks/voice-cloning-tts.md
+++ b/docs/benchmarks/voice-cloning-tts.md
@@ -1,0 +1,49 @@
+# Voice-Cloning TTS Benchmarks
+
+Single-sentence synthesis benchmark for the zero-shot voice-cloning engines,
+cloned from the same 12 s reference clip (with its transcript where the engine
+accepts one). Roundtrip = Qwen3-ASR transcription of the generated audio
+compared against the input text.
+
+Sentence: "The quick brown fox jumps over the lazy dog and rests in the
+afternoon sun."
+
+## Results
+
+| Engine | Params | Peak RSS | Audio | Synth | RTF | Roundtrip |
+|---|---|---:|---:|---:|---:|---|
+| Higgs TTS 3 (clone) | 4B bf16 | 8.6 GB | 6.04 s | 4.73 s | **0.78** | exact |
+| Higgs TTS 3 (no reference) | 4B bf16 | 8.3 GB | 4.80 s | 3.77 s | **0.78** | exact |
+| F5-TTS (clone, 16 steps, default) | 336M fp16 | 0.8 GB | 5.09 s | 2.91 s | **0.57** | 1-word sub |
+| F5-TTS (clone, 32 steps) | 336M fp16 | 0.8 GB | 5.09 s | 5.75 s | 1.13 | 1-word sub |
+| F5-TTS (clone, 12 steps) | 336M fp16 | 0.8 GB | 5.09 s | 2.19 s | 0.43 | 1-word sub |
+| IndexTTS2 (clone) | 1.5B-class fp16 | 2.8 GB | 5.27 s | ~45 s * | ~9 * | exact |
+
+**Machine**: Apple M5 Pro, 48 GB, release build with compiled metallib.
+Synth time excludes model load (Higgs/F5 report it directly); RSS from
+`/usr/bin/time -l`, includes weights.
+
+\* IndexTTS2's CLI does not report synthesis-only timing; the figure is wall
+clock minus an estimated ~10 s load of its expanded multi-stage bundle
+(GPT + S2Mel + BigVGAN + w2v-BERT/MaskGCT/CAMPPlus auxiliaries).
+
+## Notes
+
+- **Higgs RTF includes the decode-loop pipelining** landed alongside this
+  benchmark (previously 1.04 clone / 0.82 plain): sampling stays on-device
+  with the delay ramp masked on GPU, and `asyncEval` overlaps the next
+  forward pass with the CPU-side EOC state machine. Cloning now costs the
+  same RTF as plain synthesis; the remaining decode cost is the bf16
+  memory-bandwidth roofline of the 4B backbone (~32 frames/s at 25 fps).
+- **Higgs reference encoding** (12 s clip → codes) adds ~0.6 s once per
+  voice; `encodeReference` returns reusable codes for repeated generations.
+- **F5's flow-step count is the whole speed lever** (CFG is already batched):
+  the ASR roundtrip is word-identical at 32/16/12 steps and a listening A/B
+  found them indistinguishable, so the default moved from 32 to **16**
+  (`--f5-steps 32` remains for maximum fidelity). Steps run over the full
+  reference+target sequence, so RTF also improves on longer utterances.
+- **IndexTTS2** is the heavyweight path (multi-stage GPT + diffusion +
+  vocoder); prefer it for its emotion-control surface rather than latency.
+- Cloned-voice quality gates for Higgs and F5 (ASR roundtrips en/zh, plus
+  es/de/ja for the Python reference) live in the E2E suites; see
+  `docs/models/higgs-tts.md` and `docs/models/f5-tts.md`.

--- a/docs/inference/f5-tts.md
+++ b/docs/inference/f5-tts.md
@@ -19,7 +19,7 @@ let audio = try await model.generate(
     referenceAudio: URL(fileURLWithPath: "/path/to/reference.wav"),
     referenceText: "The words spoken in the reference recording.",
     options: try F5TTSSynthesisOptions(
-        steps: 32,
+        steps: 16,
         cfgStrength: 2.0,
         swaySamplingCoef: -1.0,
         speed: 1.0,
@@ -69,7 +69,7 @@ Vocos, and writes 24 kHz mono WAV.
 | `--f5-reference-text <text>` | Required transcript for the reference audio. |
 | `--f5-model-id <repo>` | Defaults to `aufklarer/F5TTS-v1-Base-MLX-fp16`. |
 | `--f5-bundle-dir <path>` | Loads a local exported bundle instead of Hugging Face. |
-| `--f5-steps <n>` | Flow-matching steps; defaults to `32`. |
+| `--f5-steps <n>` | Flow-matching steps; defaults to `16` (identical ASR roundtrips vs 32 at 2x the speed; use `32` for maximum fidelity). |
 | `--f5-cfg-strength <value>` | Classifier-free guidance strength; defaults to `2.0`. |
 | `--f5-sway <value>` | Sway sampling coefficient; defaults to `-1.0`. |
 | `--f5-speed <value>` | Speaking-rate multiplier; values above `1.0` shorten generated speech. |

--- a/docs/models/higgs-tts.md
+++ b/docs/models/higgs-tts.md
@@ -65,12 +65,20 @@ the exporter's REFERENCES.md in speech-models):
   reference takes ~0.6 s.
 - **End-to-end native gates** (Swift encoder → LM → decoder, cloned voice,
   Qwen3-ASR roundtrips at temperature 0.8): English lexical overlap 1.00,
-  Mandarin CER 0.000, RTF ≈ 1 on Apple Silicon before optimization.
+  Mandarin CER 0.000.
+- **Speed**: RTF 0.78 (release build, Apple M5 Pro) for both cloned and
+  reference-free synthesis after the pipelined decode loop — on-device
+  sampling with a GPU-masked delay ramp and `asyncEval` overlap; the
+  remaining cost is the 4B bf16 memory-bandwidth roofline. See
+  `docs/benchmarks/voice-cloning-tts.md`.
 - The CLI defaults to temperature 0.8: at the reference's 1.0, single-sentence
   roundtrips wobble (measured across two full reference gate runs).
 
 Remaining work:
 
-- Quantized bundle variant (int8/int4) behind the same roundtrip gates.
-- RTF optimization and streaming synthesis.
+- Streaming synthesis (chunked codec decode as frames arrive) and per-voice
+  prefix KV caching for repeated same-voice generations.
 - Broader language QA beyond the en/zh/es/de/ja gate set.
+
+Quantized variants are intentionally not planned: synthesis stays at
+reference precision because quantization audibly degrades speech.


### PR DESCRIPTION
## What changed

- **Higgs decode loop pipelined**: per-codebook sampling stays on-device, the delay ramp is masked on GPU so codes feed back without a CPU round trip, and `asyncEval` launches step t+1's forward pass before the CPU-side EOC state machine reads step t. `HiggsTTSSamplerState` still owns stop logic (the GPU mask is idempotent under `advance`). Cloned-synthesis RTF drops **1.04 → 0.78** (release, Apple M5 Pro), now equal to reference-free synthesis; the remaining cost is the 4B bf16 memory-bandwidth roofline.
- **F5 default flow steps 32 → 16** (API and CLI, `--f5-steps 32` still available): step sweep showed word-identical ASR roundtrips at 32/16/12 and a listening A/B could not distinguish them; RTF **1.13 → 0.57**. en/zh E2E gates re-validated at the new default (English exact; Mandarin CER 0.174, byte-identical output to the 32-step run).
- **New `docs/benchmarks/voice-cloning-tts.md`**: single-sentence cloning benchmark (RTF, peak RSS, ASR roundtrip) for Higgs, the F5 step sweep, and IndexTTS2, with methodology and machine noted.

## Validation

- Higgs gate suite on the pipelined loop: byte-identical parity numbers (teacher-forced logits max |Δ| 1.0, codec diff RMS 1e-4, encoder per-book profile) and native roundtrips en 1.00 / zh 0.000; 16/16 tests.
- F5 + CLI unit suites green (80 tests, parser default updated); F5 en/zh E2E pass at 16 steps.

## Regression risk

Low. The Higgs change is confined to the generation loop with the state machine unchanged; greedy outputs are bit-identical (verified by the parity suite). The F5 change is a default value; behavior at explicit `--f5-steps` values is untouched.

## Follow-ups

- Streaming Higgs synthesis (chunked codec decode) for sub-second first audio.
- IndexTTS2 profiling: per-voice reference-conditioning cache, GPT-loop pipelining.