### PR TITLE
Cache and batch the IndexTTS2 semantic GPT decode

### DIFF
--- a/Sources/IndexTTS2TTS/IndexTTS2SemanticGPT.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2SemanticGPT.swift
@@ -134,9 +134,9 @@ final class IndexTTS2SemanticGPT {
         generated.reserveCapacity(options.maxSemanticTokens)
         var rng = IndexTTS2SeededRNG(seed: options.seed)
 
+        var cache = GPTKVCache(layerCount: config.gpt.layers)
+        var logits = prefillMelLogits(prefixText: prefixText, cache: &cache)
         for _ in 0..<options.maxSemanticTokens {
-            let melInput = [Int32(config.gpt.startMelToken)] + generated
-            let logits = nextMelLogits(prefixText: prefixText, melInput: melInput)
             let next = sampleToken(logits, previousTokens: generated, options: options, rng: &rng)
             if next == Int32(config.gpt.stopMelToken) {
                 break
@@ -145,9 +145,7 @@ final class IndexTTS2SemanticGPT {
                 break
             }
             generated.append(next)
-            if generated.count % 16 == 0 {
-                eval(logits)
-            }
+            logits = stepMelLogits(token: next, melIndex: generated.count, cache: &cache)
         }
         return generated
     }
@@ -158,62 +156,78 @@ final class IndexTTS2SemanticGPT {
     ) -> [Int32] {
         let width = max(1, options.beamWidth)
         let stop = Int32(config.gpt.stopMelToken)
-        var beams = [SemanticBeam(tokens: [], score: 0, ended: false)]
+        // Invariant: a state's cache covers the prefix, the start-mel token,
+        // and all of the beam's tokens (each fed exactly once); children fork
+        // the parent's cache by value.
+        var states = [(beam: SemanticBeam(tokens: [], score: 0, ended: false),
+                       cache: GPTKVCache(layerCount: config.gpt.layers),
+                       prefilled: false)]
 
         for _ in 0..<options.maxSemanticTokens {
-            var candidates: [SemanticBeam] = []
+            var candidates: [(beam: SemanticBeam, cache: GPTKVCache, prefilled: Bool)] = []
             candidates.reserveCapacity(width * width * 2)
 
-            for beam in beams {
-                if beam.ended {
-                    candidates.append(beam)
+            for state in states {
+                if state.beam.ended {
+                    candidates.append(state)
                     continue
                 }
 
-                let melInput = [Int32(config.gpt.startMelToken)] + beam.tokens
-                let logits = nextMelLogits(prefixText: prefixText, melInput: melInput)
+                var cache = state.cache
+                let logits: MLXArray
+                if !state.prefilled {
+                    logits = prefillMelLogits(prefixText: prefixText, cache: &cache)
+                } else {
+                    logits = stepMelLogits(
+                        token: state.beam.tokens[state.beam.tokens.count - 1],
+                        melIndex: state.beam.tokens.count,
+                        cache: &cache)
+                }
                 var values = logits.asType(.float32).asArray(Float.self)
-                applyRepetitionPenalty(&values, previousTokens: beam.tokens, penalty: options.repetitionPenalty)
+                applyRepetitionPenalty(&values, previousTokens: state.beam.tokens, penalty: options.repetitionPenalty)
                 let logProbs = Self.logSoftmax(values)
                 for (token, logProb) in Self.topLogProbs(logProbs, count: width * 2) {
                     if token == stop {
-                        candidates.append(SemanticBeam(
-                            tokens: beam.tokens,
-                            score: beam.score + logProb,
-                            ended: true))
+                        candidates.append((
+                            beam: SemanticBeam(
+                                tokens: state.beam.tokens,
+                                score: state.beam.score + logProb,
+                                ended: true),
+                            cache: cache,
+                            prefilled: true))
                     } else if token >= 0, token < Int32(config.semanticCodec.codebookSize) {
-                        candidates.append(SemanticBeam(
-                            tokens: beam.tokens + [token],
-                            score: beam.score + logProb,
-                            ended: false))
+                        candidates.append((
+                            beam: SemanticBeam(
+                                tokens: state.beam.tokens + [token],
+                                score: state.beam.score + logProb,
+                                ended: false),
+                            cache: cache,
+                            prefilled: true))
                     }
-                }
-                if beam.tokens.count % 16 == 0 {
-                    eval(logits)
                 }
             }
 
-            beams = candidates
+            states = candidates
                 .sorted { lhs, rhs in
-                    let lhsScore = lhs.rankingScore(lengthPenalty: options.lengthPenalty)
-                    let rhsScore = rhs.rankingScore(lengthPenalty: options.lengthPenalty)
+                    let lhsScore = lhs.beam.rankingScore(lengthPenalty: options.lengthPenalty)
+                    let rhsScore = rhs.beam.rankingScore(lengthPenalty: options.lengthPenalty)
                     if lhsScore != rhsScore { return lhsScore > rhsScore }
-                    return lhs.tokens.count > rhs.tokens.count
+                    return lhs.beam.tokens.count > rhs.beam.tokens.count
                 }
                 .prefix(width)
                 .map { $0 }
-            if beams.allSatisfy(\.ended) {
+            if states.allSatisfy(\.beam.ended) {
                 break
             }
         }
 
-        return beams
+        return states
             .sorted {
-                $0.rankingScore(lengthPenalty: options.lengthPenalty) >
-                    $1.rankingScore(lengthPenalty: options.lengthPenalty)
+                $0.beam.rankingScore(lengthPenalty: options.lengthPenalty) >
+                    $1.beam.rankingScore(lengthPenalty: options.lengthPenalty)
             }
             .first?
-            .tokens ?? []
+            .beam.tokens ?? []
     }
 
     private func beamSampleSemanticCodes(
@@ -224,16 +238,22 @@ final class IndexTTS2SemanticGPT {
         let stop = Int32(config.gpt.stopMelToken)
         let samplesPerStep = max(2, width * 2)
         var rng = IndexTTS2SeededRNG(seed: options.seed)
+        // All active beams share one batched cache: row i continues beam i's
+        // sequence (equal lengths by construction). Beam selection reorders
+        // rows with a gather instead of forking per-beam caches.
         var active = [SemanticBeam(tokens: [], score: 0, ended: false)]
+        var cache = GPTKVCache(layerCount: config.gpt.layers)
+        var batchedLogits = prefillMelLogits(prefixText: prefixText, cache: &cache)
         var completed: [SemanticBeam] = []
 
         for _ in 0..<options.maxSemanticTokens {
             var candidates: [SemanticCandidate] = []
+            let vocab = batchedLogits.dim(-1)
+            let allScores = batchedLogits.asType(.float32).asArray(Float.self)
 
             for (beamIndex, beam) in active.enumerated() {
-                let melInput = [Int32(config.gpt.startMelToken)] + beam.tokens
-                let logits = nextMelLogits(prefixText: prefixText, melInput: melInput)
-                var scores = Self.logSoftmax(logits.asType(.float32).asArray(Float.self))
+                var scores = Self.logSoftmax(
+                    Array(allScores[(beamIndex * vocab)..<((beamIndex + 1) * vocab)]))
                 applyRepetitionPenalty(&scores, previousTokens: beam.tokens, penalty: options.repetitionPenalty)
                 applyTemperature(&scores, temperature: options.temperature)
                 applyTopK(&scores, k: options.topK, minTokensToKeep: 2)
@@ -244,9 +264,6 @@ final class IndexTTS2SemanticGPT {
                         beamIndex: beamIndex,
                         token: Int32(token),
                         score: beam.score + scores[token]))
-                }
-                if beam.tokens.count % 16 == 0 {
-                    eval(logits)
                 }
             }
 
@@ -268,6 +285,8 @@ final class IndexTTS2SemanticGPT {
             sampled.sort { $0.score > $1.score }
 
             var nextActive: [SemanticBeam] = []
+            var parents: [Int] = []
+            var stepTokens: [Int32] = []
             nextActive.reserveCapacity(width)
             for (rank, candidate) in sampled.enumerated() {
                 let source = active[candidate.beamIndex]
@@ -287,6 +306,8 @@ final class IndexTTS2SemanticGPT {
                     tokens: source.tokens + [candidate.token],
                     score: candidate.score,
                     ended: false))
+                parents.append(candidate.beamIndex)
+                stepTokens.append(candidate.token)
                 if nextActive.count == width {
                     break
                 }
@@ -302,6 +323,12 @@ final class IndexTTS2SemanticGPT {
             ) {
                 break
             }
+
+            cache = gatherCache(cache, parents: parents)
+            batchedLogits = batchedStepMelLogits(
+                tokens: stepTokens,
+                melIndex: active[0].tokens.count,
+                cache: &cache)
         }
 
         let final = bestBeams(
@@ -705,12 +732,126 @@ final class IndexTTS2SemanticGPT {
 
     // MARK: - GPT
 
-    private func nextMelLogits(prefixText: MLXArray, melInput: [Int32]) -> MLXArray {
-        let mel = melGenerationEmbeddings(melInput)
-        let hidden = gpt(concatenated([prefixText, mel], axis: 1))
+    /// Per-layer key/value cache for incremental GPT decoding. Value
+    /// semantics: copying the struct shares the immutable arrays, so beam
+    /// branches can fork a parent's cache for free.
+    struct GPTKVCache {
+        var layers: [(keys: MLXArray, values: MLXArray)?]
+
+        init(layerCount: Int) {
+            layers = Array(repeating: nil, count: layerCount)
+        }
+    }
+
+    private func melLogits(fromHidden hidden: MLXArray) -> MLXArray {
         let last = hidden[0..., (hidden.dim(1) - 1)..<hidden.dim(1), 0...]
         let normalized = layerNorm(last, prefix: "final_norm")
         return linear(normalized, prefix: "mel_head").squeezed(axis: 1)
+    }
+
+    /// Embedding for one mel token at its melInput index, preserving the
+    /// generation-time position mapping (index 0 -> position 0, index i -> i + 1).
+    private func melTokenEmbedding(_ token: Int32, melIndex: Int) -> MLXArray {
+        let tok = embed([token], key: "mel_embedding.weight")
+        let position = melIndex == 0 ? 0 : melIndex + 1
+        let pos = weights["mel_pos_embedding.emb.weight"]!
+            .take(MLXArray([Int32(position)], [1]), axis: 0)
+            .expandedDimensions(axis: 0)
+            .asType(tok.dtype)
+        return tok + pos
+    }
+
+    /// Prefills the cache with the conditioning/text prefix plus the start-mel
+    /// token and returns logits for the first generated token.
+    private func prefillMelLogits(prefixText: MLXArray, cache: inout GPTKVCache) -> MLXArray {
+        let start = melTokenEmbedding(Int32(config.gpt.startMelToken), melIndex: 0)
+        let hidden = gptCachedForward(concatenated([prefixText, start], axis: 1), cache: &cache)
+        return melLogits(fromHidden: hidden)
+    }
+
+    /// Feeds one generated token through the cached GPT and returns logits
+    /// for the next token. `melIndex` is the token's index in the mel input
+    /// (`[start] + generated`).
+    private func stepMelLogits(token: Int32, melIndex: Int, cache: inout GPTKVCache) -> MLXArray {
+        let hidden = gptCachedForward(melTokenEmbedding(token, melIndex: melIndex), cache: &cache)
+        return melLogits(fromHidden: hidden)
+    }
+
+    /// Reorders/duplicates the cache's batch rows so row `i` of the result
+    /// continues `parents[i]`'s sequence — the beam-search shuffle.
+    private func gatherCache(_ cache: GPTKVCache, parents: [Int]) -> GPTKVCache {
+        var result = cache
+        let ids = MLXArray(parents.map(Int32.init))
+        for layer in cache.layers.indices {
+            if let entry = cache.layers[layer] {
+                result.layers[layer] = (
+                    keys: take(entry.keys, ids, axis: 0),
+                    values: take(entry.values, ids, axis: 0))
+            }
+        }
+        return result
+    }
+
+    /// Feeds one token per beam (all at the same mel index) through the
+    /// cached GPT as a single batched forward; returns `[beams, vocab]` logits.
+    private func batchedStepMelLogits(
+        tokens: [Int32], melIndex: Int, cache: inout GPTKVCache
+    ) -> MLXArray {
+        let tok = embed(tokens, key: "mel_embedding.weight").transposed(1, 0, 2)
+        let position = melIndex == 0 ? 0 : melIndex + 1
+        let pos = weights["mel_pos_embedding.emb.weight"]!
+            .take(MLXArray([Int32(position)], [1]), axis: 0)
+            .expandedDimensions(axis: 0)
+            .asType(tok.dtype)
+        let hidden = gptCachedForward(tok + pos, cache: &cache)
+        return melLogits(fromHidden: hidden)
+    }
+
+    private func gptCachedForward(_ x: MLXArray, cache: inout GPTKVCache) -> MLXArray {
+        var h = x
+        for i in 0..<config.gpt.layers {
+            h = gptBlockCached(h, prefix: "gpt.h.\(i)", layer: i, cache: &cache)
+        }
+        return layerNorm(h, prefix: "gpt.ln_f")
+    }
+
+    private func gptBlockCached(
+        _ x: MLXArray, prefix: String, layer: Int, cache: inout GPTKVCache
+    ) -> MLXArray {
+        var h = x + gptAttentionCached(
+            layerNorm(x, prefix: "\(prefix).ln_1"),
+            prefix: "\(prefix).attn", layer: layer, cache: &cache)
+        h = h + gptMLP(layerNorm(h, prefix: "\(prefix).ln_2"), prefix: "\(prefix).mlp")
+        return h
+    }
+
+    private func gptAttentionCached(
+        _ x: MLXArray, prefix: String, layer: Int, cache: inout GPTKVCache
+    ) -> MLXArray {
+        let b = x.dim(0)
+        let t = x.dim(1)
+        let qkv = conv1DLinear(x, prefix: "\(prefix).c_attn")
+        let parts = split(qkv, parts: 3, axis: -1)
+        let q = parts[0].reshaped([b, t, heads, headDim]).transposed(0, 2, 1, 3)
+        var k = parts[1].reshaped([b, t, heads, headDim]).transposed(0, 2, 1, 3)
+        var v = parts[2].reshaped([b, t, heads, headDim]).transposed(0, 2, 1, 3)
+        if let past = cache.layers[layer] {
+            k = concatenated([past.keys, k], axis: 2)
+            v = concatenated([past.values, v], axis: 2)
+        }
+        cache.layers[layer] = (k, v)
+        // Prefill runs with an empty cache (square causal mask); incremental
+        // steps are single-token and attend to everything.
+        let mask: MLXFast.ScaledDotProductAttentionMaskMode =
+            t <= 1 ? .none : causalMask(length: t, dtype: x.dtype)
+        let out = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: 1.0 / Foundation.sqrt(Float(headDim)),
+            mask: mask)
+        let merged = out.transposed(0, 2, 1, 3).reshaped([b, t, modelDim])
+        return conv1DLinear(merged, prefix: "\(prefix).c_proj")
     }
 
     private func gpt(_ embeddings: MLXArray) -> MLXArray {

--- a/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
@@ -2,6 +2,19 @@ import AudioCommon
 import Foundation
 import MLX
 
+
+enum IndexTTS2StageTimer {
+    static let enabled = ProcessInfo.processInfo.environment["INDEXTTS2_TIMING"] == "1"
+
+    static func report(_ stage: String, since start: inout CFAbsoluteTime) {
+        let now = CFAbsoluteTimeGetCurrent()
+        if enabled {
+            FileHandle.standardError.write(Data("[itts2] \(stage): \(String(format: "%.2f", now - start))s\n".utf8))
+        }
+        start = now
+    }
+}
+
 public struct IndexTTS2SynthesisOptions: Equatable, Sendable {
     public var speakingRate: Float
     public var maxInternalPauseDuration: Float?
@@ -123,10 +136,12 @@ extension IndexTTS2NativeRuntime {
         semanticOptions: IndexTTS2SemanticGenerationOptions = IndexTTS2SemanticGenerationOptions(),
         synthesisOptions: IndexTTS2SynthesisOptions = .default
     ) throws -> [Float] {
+        var stageStart = CFAbsoluteTimeGetCurrent()
         let semantic = try semanticGPT.generateSemanticCodes(
             textTokens: textTokens,
             conditioning: conditioning,
             options: semanticOptions)
+        IndexTTS2StageTimer.report("semantic-gpt (\(semantic.codeCount) codes)", since: &stageStart)
         return try synthesize(
             textTokens: textTokens,
             conditioning: conditioning,
@@ -180,14 +195,20 @@ extension IndexTTS2NativeRuntime {
         let generatedCondition = lengthRegulator(semanticPrompt, targetLength: targetLength)
         let condition = concatenated([conditioning.promptCondition, generatedCondition], axis: 1)
 
+        var stageStart = CFAbsoluteTimeGetCurrent()
+        eval(condition)
+        IndexTTS2StageTimer.report("s2mel-prep", since: &stageStart)
         let mel = s2MelFlow.inference(
             condition: condition,
             promptMel: conditioning.promptMel,
             style: conditioning.styleEmbedding)
+        eval(mel)
+        IndexTTS2StageTimer.report("s2mel-flow", since: &stageStart)
         let promptFrames = conditioning.promptMel.dim(2)
         let generatedMel = mel[0..., 0..., promptFrames..<mel.dim(2)]
         let waveform = vocoder(generatedMel.transposed(0, 2, 1)).asType(.float32)
         eval(waveform)
+        IndexTTS2StageTimer.report("bigvgan", since: &stageStart)
         var samples = waveform.asArray(Float.self)
         if let maxPauseDuration = synthesisOptions.maxInternalPauseDuration {
             samples = IndexTTS2PauseCompressor.compress(

--- a/Sources/IndexTTS2TTS/IndexTTS2TTSModel.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2TTSModel.swift
@@ -320,11 +320,14 @@ public final class IndexTTS2TTSModel: SpeechGenerationModel, ModelMemoryManageab
                 reason: "Tokenizer could not be initialized from bpe.model.")
         }
         let textTokens = try tokenizer.encode(text)
+        var stageStart = CFAbsoluteTimeGetCurrent()
         let runtime = try runtime()
+        IndexTTS2StageTimer.report("runtime-load", since: &stageStart)
         let conditioning = try runtime.prepareReferenceConditioning(
             referenceAudio: referenceAudio,
             emotionReferenceAudio: emotionReferenceAudio,
             emotionControl: emotionControl)
+        IndexTTS2StageTimer.report("reference-conditioning", since: &stageStart)
         return try runtime.synthesize(
             textTokens: textTokens,
             conditioning: conditioning,

--- a/docs/benchmarks/voice-cloning-tts.md
+++ b/docs/benchmarks/voice-cloning-tts.md
@@ -17,15 +17,14 @@ afternoon sun."
 | F5-TTS (clone, 16 steps, default) | 336M fp16 | 0.8 GB | 5.09 s | 2.91 s | **0.57** | 1-word sub |
 | F5-TTS (clone, 32 steps) | 336M fp16 | 0.8 GB | 5.09 s | 5.75 s | 1.13 | 1-word sub |
 | F5-TTS (clone, 12 steps) | 336M fp16 | 0.8 GB | 5.09 s | 2.19 s | 0.43 | 1-word sub |
-| IndexTTS2 (clone) | 1.5B-class fp16 | 2.8 GB | 5.27 s | ~45 s * | ~9 * | exact |
+| IndexTTS2 (clone) | 1.5B-class fp16 | 2.8 GB | 5.39 s | 19.6 s | 3.6 | exact |
 
 **Machine**: Apple M5 Pro, 48 GB, release build with compiled metallib.
 Synth time excludes model load (Higgs/F5 report it directly); RSS from
 `/usr/bin/time -l`, includes weights.
 
-\* IndexTTS2's CLI does not report synthesis-only timing; the figure is wall
-clock minus an estimated ~10 s load of its expanded multi-stage bundle
-(GPT + S2Mel + BigVGAN + w2v-BERT/MaskGCT/CAMPPlus auxiliaries).
+IndexTTS2 stage timing (via `INDEXTTS2_TIMING=1`): reference conditioning
+0.6 s, semantic GPT 13.3 s, S2Mel flow 1.8 s, BigVGAN 3.9 s.
 
 ## Notes
 
@@ -42,8 +41,13 @@ clock minus an estimated ~10 s load of its expanded multi-stage bundle
   found them indistinguishable, so the default moved from 32 to **16**
   (`--f5-steps 32` remains for maximum fidelity). Steps run over the full
   reference+target sequence, so RTF also improves on longer utterances.
-- **IndexTTS2** is the heavyweight path (multi-stage GPT + diffusion +
-  vocoder); prefer it for its emotion-control surface rather than latency.
+- **IndexTTS2 dropped from ~9 to 3.6 RTF** by giving the semantic GPT a KV
+  cache (decode was quadratic — every token re-ran the full sequence) and
+  batching the three sampling beams into one forward per step with
+  gather-based beam reordering. Remaining cost: GPT kernel-launch overhead
+  (~46 ms/step), BigVGAN (fp32 by design — Snake activations are
+  fp16-fragile), and S2Mel's 25 upstream-default flow steps. Still the
+  heavyweight path; prefer it for its emotion-control surface.
 - Cloned-voice quality gates for Higgs and F5 (ASR roundtrips en/zh, plus
   es/de/ja for the Python reference) live in the E2E suites; see
   `docs/models/higgs-tts.md` and `docs/models/f5-tts.md`.


### PR DESCRIPTION
## What changed

- **KV cache for the semantic GPT.** Decoding re-ran the full prefix + generated sequence through every layer for each token — quadratic in sequence length, and the dominant cost of IndexTTS2 synthesis. All three decode paths (sampling, beam search, beam sampling) now prefill the conditioning/text prefix once and step one token at a time, preserving the exact generation-time positional mapping (index 0 → position 0, index i → i + 1) and the CPU-side sampling semantics.
- **Batched beam stepping.** The default beam-sample path keeps one batched cache for all active beams (equal lengths by construction), steps them in a single forward, and reorders cache rows with a gather when beams are selected. Beam search forks value-semantics caches per branch (immutable arrays make the fork free).
- **Stage timing** behind `INDEXTTS2_TIMING=1`: runtime load, reference conditioning, semantic GPT, S2Mel flow, BigVGAN.
- Benchmark doc updated with measured stage times.

## Measured

| | before | after |
|---|---|---|
| End-to-end (5.4 s sentence, M5 Pro release) | ~55 s | **~20 s** |
| Synthesis RTF | ~9 | **3.6** |
| Semantic GPT stage | quadratic (~35 s+) | 13.3 s |

Stage profile after: conditioning 0.6 s · GPT 13.3 s · S2Mel 1.8 s · BigVGAN 3.9 s. Remaining headroom is GPT kernel-launch overhead, BigVGAN (kept fp32 deliberately — Snake activations are fp16-fragile), and S2Mel's upstream-default 25 steps; all noted in the benchmark doc.

## Validation

- E2E bundle suite passes with **roundtrip WER 0.000** (`INDEXTTS2_E2E_BUNDLE` + `INDEXTTS2_E2E_ROUNDTRIP=1`).
- CLI synthesis roundtrips exactly; listening check on the optimized output passed.
- 13 unit tests unchanged and green.

## Regression risk

Low-medium: the decode math is unchanged (cached attention is algebraically identical; fp16 accumulation order shifts can flip near-tie samples, as with any such change — gated functionally above). Sampling/candidate logic, RNG, and beam semantics are untouched.