### PR TITLE
Expose IndexTTS2 S2Mel flow steps

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -172,6 +172,9 @@ public struct SpeakCommand: ParsableCommand {
     @Option(name: .long, help: "[indextts2] Optional cap for long internal pauses, in seconds, from 0.05 to 2.0. Omit to keep raw model timing.")
     public var indextts2MaxPause: Float?
 
+    @Option(name: .customLong("indextts2-s2mel-steps"), help: "[indextts2] S2Mel flow steps (default 25; lower is faster)")
+    public var indextts2S2MelSteps: Int = 25
+
     // MARK: - F5-TTS-specific options
 
     @Option(name: .long, help: "[f5] HuggingFace model ID for the exported MLX bundle")
@@ -1093,7 +1096,8 @@ public struct SpeakCommand: ParsableCommand {
         do {
             return try IndexTTS2SynthesisOptions(
                 speakingRate: indextts2SpeakingRate,
-                maxInternalPauseDuration: indextts2MaxPause)
+                maxInternalPauseDuration: indextts2MaxPause,
+                s2MelSteps: indextts2S2MelSteps)
         } catch let error as AudioModelError {
             throw ValidationError(error.localizedDescription)
         }

--- a/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
@@ -18,10 +18,12 @@ enum IndexTTS2StageTimer {
 public struct IndexTTS2SynthesisOptions: Equatable, Sendable {
     public var speakingRate: Float
     public var maxInternalPauseDuration: Float?
+    public var s2MelSteps: Int
 
     public init(
         speakingRate: Float = 1.0,
-        maxInternalPauseDuration: Float? = nil
+        maxInternalPauseDuration: Float? = nil,
+        s2MelSteps: Int = 25
     ) throws {
         guard speakingRate.isFinite, speakingRate >= 0.5, speakingRate <= 1.5 else {
             throw AudioModelError.invalidConfiguration(
@@ -37,8 +39,14 @@ public struct IndexTTS2SynthesisOptions: Equatable, Sendable {
                     reason: "maxInternalPauseDuration must be finite and in [0.05, 2.0].")
             }
         }
+        guard s2MelSteps >= 4, s2MelSteps <= 100 else {
+            throw AudioModelError.invalidConfiguration(
+                model: "IndexTTS2",
+                reason: "s2MelSteps must be in [4, 100].")
+        }
         self.speakingRate = speakingRate
         self.maxInternalPauseDuration = maxInternalPauseDuration
+        self.s2MelSteps = s2MelSteps
     }
 
     public static let `default` = try! IndexTTS2SynthesisOptions()
@@ -201,7 +209,8 @@ extension IndexTTS2NativeRuntime {
         let mel = s2MelFlow.inference(
             condition: condition,
             promptMel: conditioning.promptMel,
-            style: conditioning.styleEmbedding)
+            style: conditioning.styleEmbedding,
+            steps: synthesisOptions.s2MelSteps)
         eval(mel)
         IndexTTS2StageTimer.report("s2mel-flow", since: &stageStart)
         let promptFrames = conditioning.promptMel.dim(2)

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -592,6 +592,7 @@ final class SpeakCommandTests: XCTestCase {
             "--indextts2-emotion-weight", "0.75",
             "--indextts2-speaking-rate", "1.15",
             "--indextts2-max-pause", "0.18",
+            "--indextts2-s2mel-steps", "15",
         ])
         let speak = try XCTUnwrap(cmd as? SpeakCommand)
         XCTAssertEqual(speak.indextts2ModelId, "org/IndexTTS2-MLX-fp16")
@@ -600,6 +601,7 @@ final class SpeakCommandTests: XCTestCase {
         XCTAssertEqual(speak.indextts2EmotionWeight, 0.75, accuracy: 0.001)
         XCTAssertEqual(speak.indextts2SpeakingRate, 1.15, accuracy: 0.001)
         XCTAssertEqual(try XCTUnwrap(speak.indextts2MaxPause), 0.18, accuracy: 0.001)
+        XCTAssertEqual(speak.indextts2S2MelSteps, 15)
     }
 
     func testIndexTTS2EmotionVectorOption() throws {

--- a/docs/benchmarks/voice-cloning-tts.md
+++ b/docs/benchmarks/voice-cloning-tts.md
@@ -25,6 +25,8 @@ Synth time excludes model load (Higgs/F5 report it directly); RSS from
 
 IndexTTS2 stage timing (via `INDEXTTS2_TIMING=1`): reference conditioning
 0.6 s, semantic GPT 12.9 s, S2Mel flow 1.8 s, BigVGAN 0.7 s.
+S2Mel step sweep (`--indextts2-s2mel-steps`, word-identical roundtrips):
+25 steps 1.95 s, 15 steps 1.14 s, 10 steps 0.73 s.
 
 ## Notes
 

--- a/docs/inference/indextts2.md
+++ b/docs/inference/indextts2.md
@@ -75,6 +75,7 @@ mels with S2Mel, and vocodes the result with BigVGAN.
 | `--indextts2-emotion <preset-or-vector>` | Optional upstream-style emotion vector control. Presets: `eager`, `happy`, `excited`, `angry`, `sad`, `afraid`, `disgusted`, `melancholic`, `surprised`, `calm`. Custom vectors use the 8-value order `happy,angry,sad,afraid,disgusted,melancholic,surprised,calm` and must sum to `<= 0.8`. Mutually exclusive with `--indextts2-emotion-audio`. |
 | `--indextts2-emotion-weight <0...1>` | Scales `--indextts2-emotion`; defaults to `1.0`. Keep this modest when speaker identity matters. |
 | `--indextts2-speaking-rate <0.5...1.5>` | Shortens or lengthens generated speech by changing the S2Mel frame expansion. Values above `1.0` are faster. Defaults to `1.0`. |
+| `--indextts2-s2mel-steps <4...100>` | S2Mel flow steps. Defaults to the upstream `25`; `15` halves the S2Mel stage with word-identical ASR roundtrips in local testing. |
 | `--indextts2-max-pause <0.05...2.0>` | Optional post-vocoder cap for long internal low-energy spans. Omit to keep raw model timing; use small values such as `0.05` only when generated speech has audible dead pauses. |
 
 Default semantic generation uses upstream-style beam sampling with `beams=3`,


### PR DESCRIPTION
## What changed

- `IndexTTS2SynthesisOptions` gains `s2MelSteps` (validated 4–100, default the upstream 25), wired through synthesis and exposed as `--indextts2-s2mel-steps`.
- Sweep results (same sentence, cloned voice, ASR roundtrips word-identical at every setting): 25 steps → 1.95 s, 15 → 1.14 s, 10 → 0.73 s for the S2Mel stage. Default stays upstream-faithful; the docs record the fast settings.
- Parser test for the new flag; IndexTTS2 inference doc and the voice-cloning benchmark updated.

## Also investigated (not shipped)

A fixed-shape compiled GPT decode step (preallocated KV + single `compile` trace, mlx-lm style) measured within 3% of the current path: without MLX buffer donation, the per-step scatter rewrites the whole cache and spends the traffic the fused launches save. Parked until in-place cache updates are available in MLX; noted in the benchmark doc.

## Validation

150 tests green (CLI + IndexTTS2 suites); CLI roundtrips exact at 25/15/10 steps.

## Regression risk

Minimal: additive option, default preserves current behavior exactly.