### PR TITLE
Add isolated E2E regression runner

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -11,16 +11,19 @@ allowed-tools: Bash
 Run unit and/or E2E tests.
 
 - `unit` (default): Quick tests, no model downloads. CI-safe.
-- `e2e`: Full pipeline tests with real models. Requires metallib + cached weights.
-- `all`: Both unit and E2E.
+- `e2e`: Full pipeline tests with real models, via `scripts/test_e2e_isolated.sh`
+  — one process per E2E suite. Never use plain `swift test` for the full E2E
+  suite: models accumulate in a single xctest process and can exhaust system
+  memory (observed: machine reboot).
+- `all`: Both unit and E2E (unit phase once, then isolated E2E suites).
 - Any other argument: passed as `--filter` to swift test.
 
 ```bash
 arg="${ARGUMENTS:-unit}"
 case "$arg" in
   unit) swift test --skip E2E 2>&1 | tail -20 ;;
-  e2e)  swift test 2>&1 | tail -30 ;;
-  all)  swift test 2>&1 | tail -30 ;;
+  e2e)  swift build --build-tests --disable-sandbox && ./scripts/build_mlx_metallib.sh debug && E2E_SKIP_UNIT=1 scripts/test_e2e_isolated.sh 2>&1 | tail -40 ;;
+  all)  swift build --build-tests --disable-sandbox && ./scripts/build_mlx_metallib.sh debug && scripts/test_e2e_isolated.sh 2>&1 | tail -40 ;;
   *)    swift test --filter "$arg" 2>&1 | tail -20 ;;
 esac
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,12 +165,23 @@ Run a single test:
 swift test --filter TestClassName/testMethodName --disable-sandbox
 ```
 
-Full local suite including E2E. Build the debug metallib first; tests may
-download models and require Apple Silicon GPU/ANE support:
+Full local suite including E2E — **never run it as a single `swift test`
+invocation**. All suites share one xctest process, each E2E suite loads
+multi-GB model weights, and nothing is released between suites, so a
+single-process run accumulates every model in RSS and can exhaust system
+memory (observed: hard machine reboot mid-suite). Use the isolated runner,
+which runs the unit phase once (CI semantics) and then each E2E class in
+its own process, bounding peak memory to the largest single suite:
 ```bash
-make debug
-swift test --disable-sandbox
+swift build --build-tests --disable-sandbox
+./scripts/build_mlx_metallib.sh debug
+scripts/test_e2e_isolated.sh
 ```
+Per-suite logs and a pass/fail summary land in `.e2e-logs/`. Knobs:
+`E2E_ONLY_FILTER=<substring>` runs matching E2E classes only,
+`E2E_SKIP_FILE=<file of Module.Class lines>` resumes an interrupted run,
+`E2E_SKIP_UNIT=1` skips the unit phase. Tests may download models and
+require Apple Silicon GPU/ANE support.
 
 ### Testing requirements for new code
 

--- a/scripts/test_e2e_isolated.sh
+++ b/scripts/test_e2e_isolated.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Full test suite with per-suite process isolation for E2E classes.
+#
+# `swift test` runs every suite in a single xctest process. Each E2E suite
+# loads multi-GB model weights that are never released between suites, so a
+# full run accumulates every model in RSS and can exhaust system memory.
+# This runner executes the unit phase once (CI semantics: --skip E2E) and
+# then each E2E class in its own process, bounding peak memory to the
+# largest single suite.
+#
+# Usage:
+#   scripts/test_e2e_isolated.sh                 # build assumed done: swift build --build-tests + metallib
+#   E2E_SKIP_FILE=passed.txt scripts/test_e2e_isolated.sh   # resume: skip listed Module.Class entries
+#   E2E_ONLY_FILTER=Magpie scripts/test_e2e_isolated.sh     # run only E2E classes matching a substring
+#   E2E_SKIP_UNIT=1 scripts/test_e2e_isolated.sh            # skip the unit phase
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+LOG_DIR="${E2E_LOG_DIR:-.e2e-logs}"
+SKIP_FILE="${E2E_SKIP_FILE:-}"
+ONLY_FILTER="${E2E_ONLY_FILTER:-}"
+mkdir -p "$LOG_DIR"
+
+SUMMARY="$LOG_DIR/summary.txt"
+: > "$SUMMARY"
+OVERALL=0
+
+record() { # status name detail
+  printf '%-6s %-55s %s\n' "$1" "$2" "$3" | tee -a "$SUMMARY"
+}
+
+echo "== Listing tests =="
+if ! swift test list --skip-build --disable-sandbox > "$LOG_DIR/all-tests.txt" 2> "$LOG_DIR/list.err"; then
+  echo "swift test list failed (build tests first: swift build --build-tests --disable-sandbox && ./scripts/build_mlx_metallib.sh debug)" >&2
+  cat "$LOG_DIR/list.err" >&2
+  exit 2
+fi
+E2E_CLASSES=$(sed -E 's|/.*||' "$LOG_DIR/all-tests.txt" | sort -u | awk -F. '$2 ~ /^E2E/')
+
+if [[ -z "$ONLY_FILTER" && "${E2E_SKIP_UNIT:-0}" != "1" ]]; then
+  echo "== Unit phase (single process, --skip E2E) =="
+  if swift test --skip-build --disable-sandbox --skip E2E > "$LOG_DIR/unit.log" 2>&1; then
+    record PASS "unit-phase" "$(grep -cE "Test Case .* passed" "$LOG_DIR/unit.log") cases"
+  else
+    OVERALL=1
+    record FAIL "unit-phase" "see $LOG_DIR/unit.log"
+    grep -E "Test Case .* failed \(" "$LOG_DIR/unit.log" | head -20
+  fi
+fi
+
+echo "== E2E phase (one process per class) =="
+for MC in $E2E_CLASSES; do
+  CLS="${MC#*.}"
+  if [[ -n "$ONLY_FILTER" && "$MC" != *"$ONLY_FILTER"* ]]; then continue; fi
+  if [[ -n "$SKIP_FILE" ]] && grep -qxF "$MC" "$SKIP_FILE" 2>/dev/null; then
+    record SKIP "$MC" "(resume skip)"
+    continue
+  fi
+  LOG="$LOG_DIR/$CLS.log"
+  if swift test --skip-build --disable-sandbox --filter "$MC" > "$LOG" 2>&1; then
+    N=$(grep -cE "Test Case .* passed" "$LOG")
+    S=$(grep -cE "Test Case .* skipped" "$LOG" || true)
+    record PASS "$MC" "$N passed, $S skipped"
+  else
+    OVERALL=1
+    record FAIL "$MC" "see $LOG"
+    grep -E "Test Case .* failed \(|error:" "$LOG" | head -10
+  fi
+done
+
+echo "== Summary =="
+cat "$SUMMARY"
+FAILS=$(grep -c '^FAIL' "$SUMMARY" || true)
+echo "Overall: $([[ $OVERALL -eq 0 ]] && echo GREEN || echo "RED ($FAILS failing suites)")"
+exit $OVERALL


### PR DESCRIPTION
## What changed

Running the full E2E suite as one `swift test` invocation loads every engine's model weights into a single xctest process with nothing released between suites — RSS accumulates across the whole fleet and can exhaust system memory (observed as a hard machine reboot mid-run on a 48 GB M5 Pro, with system services failing around the tests in the minutes before).

- **`scripts/test_e2e_isolated.sh`** — runs the unit phase once (CI semantics, `--skip E2E`), then each E2E class in its own process, so peak memory is bounded by the largest single suite. Per-suite logs plus a pass/fail summary in `.e2e-logs/`; `E2E_SKIP_FILE` resumes an interrupted run, `E2E_ONLY_FILTER` scopes to matching suites, `E2E_SKIP_UNIT=1` skips the unit phase.
- **`/test e2e` and `/test all`** now route through the runner instead of plain `swift test`.
- **Agent instructions** (AGENTS.md, mirrored by the CLAUDE.md symlink) document the runner as the only supported way to run the full E2E suite, with the memory rationale.

## Regression risk

None to product code — script + docs + skill routing only. CI is unaffected (it already runs unit-only with `--skip E2E`).

## Validation

The runner is currently executing the post-merge full regression on main: unit phase 313+ green in one process, E2E suites running one process each with memory staying bounded. Shell syntax checked with `bash -n`.