### PR TITLE
Cut IndexTTS2 GPT step overhead, default S2Mel to 15 steps

### DIFF
--- a/Sources/AudioCLILib/SpeakCommand.swift
+++ b/Sources/AudioCLILib/SpeakCommand.swift
@@ -172,8 +172,8 @@ public struct SpeakCommand: ParsableCommand {
     @Option(name: .long, help: "[indextts2] Optional cap for long internal pauses, in seconds, from 0.05 to 2.0. Omit to keep raw model timing.")
     public var indextts2MaxPause: Float?
 
-    @Option(name: .customLong("indextts2-s2mel-steps"), help: "[indextts2] S2Mel flow steps (default 25; lower is faster)")
-    public var indextts2S2MelSteps: Int = 25
+    @Option(name: .customLong("indextts2-s2mel-steps"), help: "[indextts2] S2Mel flow steps (default 15, ear-validated; 25 matches upstream exactly)")
+    public var indextts2S2MelSteps: Int = 15
 
     // MARK: - F5-TTS-specific options
 

--- a/Sources/IndexTTS2TTS/IndexTTS2SemanticGPT.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2SemanticGPT.swift
@@ -249,11 +249,12 @@ final class IndexTTS2SemanticGPT {
         for _ in 0..<options.maxSemanticTokens {
             var candidates: [SemanticCandidate] = []
             let vocab = batchedLogits.dim(-1)
-            let allScores = batchedLogits.asType(.float32).asArray(Float.self)
+            let floatLogits = batchedLogits.asType(.float32)
+            let logProbs = floatLogits - floatLogits.logSumExp(axis: -1, keepDims: true)
+            let allScores = logProbs.asArray(Float.self)
 
             for (beamIndex, beam) in active.enumerated() {
-                var scores = Self.logSoftmax(
-                    Array(allScores[(beamIndex * vocab)..<((beamIndex + 1) * vocab)]))
+                var scores = Array(allScores[(beamIndex * vocab)..<((beamIndex + 1) * vocab)])
                 applyRepetitionPenalty(&scores, previousTokens: beam.tokens, penalty: options.repetitionPenalty)
                 applyTemperature(&scores, temperature: options.temperature)
                 applyTopK(&scores, k: options.topK, minTokensToKeep: 2)
@@ -780,6 +781,12 @@ final class IndexTTS2SemanticGPT {
     /// Reorders/duplicates the cache's batch rows so row `i` of the result
     /// continues `parents[i]`'s sequence — the beam-search shuffle.
     private func gatherCache(_ cache: GPTKVCache, parents: [Int]) -> GPTKVCache {
+        if let entry = cache.layers.compactMap({ $0 }).first,
+            entry.keys.dim(0) == parents.count,
+            parents.enumerated().allSatisfy({ $0.offset == $0.element })
+        {
+            return cache
+        }
         var result = cache
         let ids = MLXArray(parents.map(Int32.init))
         for layer in cache.layers.indices {
@@ -1114,34 +1121,26 @@ final class IndexTTS2SemanticGPT {
 
     private func linear(_ x: MLXArray, prefix: String, bias: Bool = true) -> MLXArray {
         let weight = weights["\(prefix).weight"]!.asType(x.dtype)
-        var y = matmul(x, weight.transposed(1, 0))
         if bias, let b = weights["\(prefix).bias"] {
-            y = y + b.asType(y.dtype)
+            return addMM(b.asType(x.dtype), x, weight.transposed(1, 0))
         }
-        return y
+        return matmul(x, weight.transposed(1, 0))
     }
 
     private func conv1DLinear(_ x: MLXArray, prefix: String) -> MLXArray {
         let weight = weights["\(prefix).weight"]!.asType(x.dtype)
-        var y = matmul(x, weight)
         if let b = weights["\(prefix).bias"] {
-            y = y + b.asType(y.dtype)
+            return addMM(b.asType(x.dtype), x, weight)
         }
-        return y
+        return matmul(x, weight)
     }
 
     private func layerNorm(_ x: MLXArray, prefix: String, eps: Float = 1e-5) -> MLXArray {
-        let mean = x.mean(axis: -1, keepDims: true)
-        let centered = x - mean
-        let variance = (centered * centered).mean(axis: -1, keepDims: true)
-        var y = centered / sqrt(variance + MLXArray(eps).asType(x.dtype))
-        if let weight = weights["\(prefix).weight"] {
-            y = y * weight.asType(y.dtype)
-        }
-        if let bias = weights["\(prefix).bias"] {
-            y = y + bias.asType(y.dtype)
-        }
-        return y
+        MLX.layerNorm(
+            x,
+            weight: weights["\(prefix).weight"]?.asType(x.dtype),
+            bias: weights["\(prefix).bias"]?.asType(x.dtype),
+            eps: eps)
     }
 
     private func embed(_ ids: [Int32], key: String) -> MLXArray {

--- a/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
@@ -23,7 +23,7 @@ public struct IndexTTS2SynthesisOptions: Equatable, Sendable {
     public init(
         speakingRate: Float = 1.0,
         maxInternalPauseDuration: Float? = nil,
-        s2MelSteps: Int = 25
+        s2MelSteps: Int = 15
     ) throws {
         guard speakingRate.isFinite, speakingRate >= 0.5, speakingRate <= 1.5 else {
             throw AudioModelError.invalidConfiguration(

--- a/docs/benchmarks/voice-cloning-tts.md
+++ b/docs/benchmarks/voice-cloning-tts.md
@@ -17,16 +17,23 @@ afternoon sun."
 | F5-TTS (clone, 16 steps, default) | 336M fp16 | 0.8 GB | 5.09 s | 2.91 s | **0.57** | 1-word sub |
 | F5-TTS (clone, 32 steps) | 336M fp16 | 0.8 GB | 5.09 s | 5.75 s | 1.13 | 1-word sub |
 | F5-TTS (clone, 12 steps) | 336M fp16 | 0.8 GB | 5.09 s | 2.19 s | 0.43 | 1-word sub |
-| IndexTTS2 (clone) | 1.5B-class fp16 | 2.8 GB | 5.39 s | 16.0 s | 3.0 | exact |
+| IndexTTS2 (clone) | 1.5B-class fp16 | 2.8 GB | 5.49 s | 14.9 s | **2.7** | exact |
 
 **Machine**: Apple M5 Pro, 48 GB, release build with compiled metallib.
 Synth time excludes model load (Higgs/F5 report it directly); RSS from
 `/usr/bin/time -l`, includes weights.
 
 IndexTTS2 stage timing (via `INDEXTTS2_TIMING=1`): reference conditioning
-0.6 s, semantic GPT 12.9 s, S2Mel flow 1.8 s, BigVGAN 0.7 s.
-S2Mel step sweep (`--indextts2-s2mel-steps`, word-identical roundtrips):
-25 steps 1.95 s, 15 steps 1.14 s, 10 steps 0.73 s.
+0.6 s, semantic GPT 12.7 s, S2Mel flow 1.0 s (15 steps, the default),
+BigVGAN 0.7 s. The GPT step floor improved ~15% (interleaved min-of-5,
+41.9 -> 35.6 ms/step) from fusing the hand-rolled layer norms into
+`MLX.layerNorm`, fusing matmul+bias via `addMM`, skipping the beam-cache
+gather when every beam continues its own row, and computing log-softmax
+on GPU so the host receives ready log-probs; wall-clock runs vary with
+thermal state, so per-step minima are the comparable metric.
+S2Mel step sweep (`--indextts2-s2mel-steps`, word-identical roundtrips,
+ear-validated): 25 steps 1.7 s, 15 steps 1.0 s, 10 steps 0.7 s —
+**default is now 15**; use 25 for upstream-exact flow.
 
 ## Notes
 

--- a/docs/inference/indextts2.md
+++ b/docs/inference/indextts2.md
@@ -75,7 +75,7 @@ mels with S2Mel, and vocodes the result with BigVGAN.
 | `--indextts2-emotion <preset-or-vector>` | Optional upstream-style emotion vector control. Presets: `eager`, `happy`, `excited`, `angry`, `sad`, `afraid`, `disgusted`, `melancholic`, `surprised`, `calm`. Custom vectors use the 8-value order `happy,angry,sad,afraid,disgusted,melancholic,surprised,calm` and must sum to `<= 0.8`. Mutually exclusive with `--indextts2-emotion-audio`. |
 | `--indextts2-emotion-weight <0...1>` | Scales `--indextts2-emotion`; defaults to `1.0`. Keep this modest when speaker identity matters. |
 | `--indextts2-speaking-rate <0.5...1.5>` | Shortens or lengthens generated speech by changing the S2Mel frame expansion. Values above `1.0` are faster. Defaults to `1.0`. |
-| `--indextts2-s2mel-steps <4...100>` | S2Mel flow steps. Defaults to the upstream `25`; `15` halves the S2Mel stage with word-identical ASR roundtrips in local testing. |
+| `--indextts2-s2mel-steps <4...100>` | S2Mel flow steps. Defaults to `15` (ear-validated, word-identical ASR roundtrips); `25` matches the upstream flow exactly. |
 | `--indextts2-max-pause <0.05...2.0>` | Optional post-vocoder cap for long internal low-energy spans. Omit to keep raw model timing; use small values such as `0.05` only when generated speech has audible dead pauses. |
 
 Default semantic generation uses upstream-style beam sampling with `beams=3`,


### PR DESCRIPTION
## What changed

Four numerics-neutral cuts to the semantic GPT decode step, which was dominated by kernel-launch/graph overhead rather than compute:

- Hand-rolled layer norm (6 kernels, 2× per layer + logits head) → fused `MLX.layerNorm`.
- matmul + separate bias add on every linear → fused `addMM`.
- Beam-cache gather (2 kernels × layers × steps) skipped when every beam continues its own row — the common case.
- Beam scoring log-softmax moved to GPU; the host receives ready log-probs instead of exp/log over the full `[beams, vocab]` logits per step.

Plus: `--indextts2-s2mel-steps` defaults to **15** (from upstream 25). The sweep is word-identical through ASR at 25/15/10 on seed-deterministic codes, and an A/B listen approved all three — same precedent as F5's halved default, with the upstream value one flag away.

## Measured

- GPT step floor: **41.9 → 35.6 ms/step** (interleaved min-of-5; wall-clock drifts with thermal state, so per-step minima are the comparable metric).
- S2Mel stage: 1.7 s → 1.0 s at the new default.
- End-to-end default path measured RTF 2.7 on a thermally-warm machine (was 3.0 in the fresh-machine table run); benchmark doc updated with methodology notes.

## Validation

CLI cloning roundtrip word-exact at the new defaults; 21 IndexTTS2 tests green (unit + E2E); cloned-voice listening check passed.

## Regression risk

Low: fused ops are mathematically identical to the replaced sequences (log-softmax moves the same computation to GPU float32); the gather skip is behavior-preserving by construction. The S2Mel default change is user-visible but reversible via flag.