### PR TITLE
Harden downloader against large-shard stalls and partial bundles

### DIFF
--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -82,7 +82,26 @@ public enum HuggingFaceDownloader {
             AudioLog.download.debug("Could not list directory \(directory.path): \(error)")
             contents = []
         }
-        return contents.contains { weightFileExtensions.contains($0.pathExtension) }
+        guard contents.contains(where: { weightFileExtensions.contains($0.pathExtension) }) else {
+            return false
+        }
+        // A multi-shard bundle is only complete when every shard named in
+        // its index is present — a stalled download can leave later shards
+        // fully written while earlier ones are missing, and a half-loaded
+        // model runs with random weights (observed as near-silent TTS).
+        let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
+        if fm.fileExists(atPath: indexURL.path),
+            let data = try? Data(contentsOf: indexURL),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let weightMap = json["weight_map"] as? [String: String]
+        {
+            for shard in Set(weightMap.values)
+            where !fm.fileExists(atPath: directory.appendingPathComponent(shard).path) {
+                AudioLog.download.debug("weightsExist: missing shard \(shard) in \(directory.path)")
+                return false
+            }
+        }
+        return true
     }
 
     // MARK: - Download
@@ -147,7 +166,7 @@ public enum HuggingFaceDownloader {
         var lastError: Error?
         for attempt in 1...maxAttempts {
             do {
-                try await withDownloadStallGuard(modelId: modelId) { reportProgress in
+                try await withDownloadStallGuard(modelId: modelId, watchDirectory: directory) { reportProgress in
                     try await hub.snapshot(from: repo, matching: globs) { progress in
                         reportProgress(progress.fractionCompleted)
                         progressHandler?(progress.fractionCompleted)
@@ -194,7 +213,7 @@ public enum HuggingFaceDownloader {
         var lastError: Error?
         for attempt in 1...maxAttempts {
             do {
-                try await withDownloadStallGuard(modelId: modelId) { reportProgress in
+                try await withDownloadStallGuard(modelId: modelId, watchDirectory: directory) { reportProgress in
                     try await hub.snapshot(from: repo, matching: globs) { progress in
                         reportProgress(progress.fractionCompleted)
                         progressHandler?(progress.fractionCompleted)
@@ -369,6 +388,23 @@ public enum HuggingFaceDownloader {
         }
     }
 
+    /// Total bytes under `directory`, including in-flight partial files in
+    /// hidden subdirectories (HubApi writes `.incomplete` files under
+    /// `.cache/huggingface/download/`).
+    private static func directorySize(of directory: URL) -> Int64 {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: directory, includingPropertiesForKeys: [.fileSizeKey], options: [])
+        else { return 0 }
+        var total: Int64 = 0
+        for case let url as URL in enumerator {
+            if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+
     /// Run a download `operation` that reports fractional progress, and
     /// abort it if progress stalls for `downloadStallTimeoutSeconds`.
     /// On stall the in-flight `hub.snapshot` task is cancelled (URLSession
@@ -377,6 +413,7 @@ public enum HuggingFaceDownloader {
     static func withDownloadStallGuard(
         modelId: String,
         stallTimeoutSeconds: Int? = nil,
+        watchDirectory: URL? = nil,
         _ operation: @escaping (@escaping @Sendable (Double) -> Void) async throws -> Void
     ) async throws {
         let stall = stallTimeoutSeconds ?? downloadStallTimeoutSeconds
@@ -389,9 +426,26 @@ public enum HuggingFaceDownloader {
             group.addTask {
                 // Poll on a fraction of the window so we detect a stall
                 // within ~stall..stall+pollStep seconds.
+                //
+                // `hub.snapshot` only fires its progress callback at file
+                // completion, so a single shard that takes longer than the
+                // stall window to transfer produces zero callbacks and a
+                // healthy download would be killed (a 4.3 GB shard at
+                // ~10 MB/s needs ~430 s against a 300 s window — VoxCPM2
+                // bf16 could never finish). Bytes appearing on disk are
+                // download progress, so also tick whenever the destination
+                // directory grows.
                 let pollStep = max(1, stall / 3)
+                var lastSize = watchDirectory.map(Self.directorySize(of:)) ?? 0
                 while true {
                     try await Task.sleep(for: .seconds(pollStep))
+                    if let dir = watchDirectory {
+                        let size = Self.directorySize(of: dir)
+                        if size != lastSize {
+                            lastSize = size
+                            clock.tick()
+                        }
+                    }
                     if clock.idleSeconds() >= Double(stall) {
                         throw DownloadError.stalled(modelId: modelId, seconds: stall)
                     }

--- a/Tests/AudioCommonTests/DownloaderRobustnessTests.swift
+++ b/Tests/AudioCommonTests/DownloaderRobustnessTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import AudioCommon
+
+/// Regression tests for two large-bundle download failure modes observed
+/// with VoxCPM2 bf16 (4.3 GB shard):
+/// 1. `weightsExist` accepted a partial multi-shard bundle (stall left
+///    shard 1 missing, shard 2 complete) → model loaded half-initialized
+///    and synthesized near-silence.
+/// 2. The stall guard only ticked on `hub.snapshot` progress callbacks,
+///    which fire at file completion — any shard needing longer than the
+///    stall window produced zero ticks and a healthy transfer was killed
+///    on every retry.
+final class DownloaderRobustnessTests: XCTestCase {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dl-robust-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    private func write(_ name: String, _ contents: String, in dir: URL) throws {
+        try contents.data(using: .utf8)!.write(to: dir.appendingPathComponent(name))
+    }
+
+    func testWeightsExistRejectsMissingShard() throws {
+        let dir = try makeTempDir()
+        try write("model.safetensors.index.json",
+                  #"{"weight_map": {"a.w": "model-00001.safetensors", "b.w": "model-00002.safetensors"}}"#,
+                  in: dir)
+        try write("model-00002.safetensors", "shard2", in: dir)
+        XCTAssertFalse(HuggingFaceDownloader.weightsExist(in: dir),
+                       "partial multi-shard bundle must not count as cached")
+    }
+
+    func testWeightsExistAcceptsCompleteShardedBundle() throws {
+        let dir = try makeTempDir()
+        try write("model.safetensors.index.json",
+                  #"{"weight_map": {"a.w": "model-00001.safetensors", "b.w": "model-00002.safetensors"}}"#,
+                  in: dir)
+        try write("model-00001.safetensors", "shard1", in: dir)
+        try write("model-00002.safetensors", "shard2", in: dir)
+        XCTAssertTrue(HuggingFaceDownloader.weightsExist(in: dir))
+    }
+
+    func testWeightsExistAcceptsSingleFileWithoutIndex() throws {
+        let dir = try makeTempDir()
+        try write("model.safetensors", "weights", in: dir)
+        XCTAssertTrue(HuggingFaceDownloader.weightsExist(in: dir))
+    }
+
+    /// A download that reports no fractional progress but keeps writing
+    /// bytes to the destination must survive the stall guard.
+    func testStallGuardTicksOnDiskGrowth() async throws {
+        let dir = try makeTempDir()
+        let file = dir.appendingPathComponent("model.safetensors.incomplete")
+        FileManager.default.createFile(atPath: file.path, contents: Data())
+
+        try await HuggingFaceDownloader.withDownloadStallGuard(
+            modelId: "test/growing", stallTimeoutSeconds: 2, watchDirectory: dir
+        ) { _ in
+            // 5s of transfer with zero progress callbacks, but the file grows.
+            for _ in 0..<10 {
+                try await Task.sleep(for: .milliseconds(500))
+                let handle = try FileHandle(forWritingTo: file)
+                try handle.seekToEnd()
+                try handle.write(contentsOf: Data(repeating: 7, count: 64))
+                try handle.close()
+            }
+        }
+    }
+
+    /// No progress callbacks and no disk growth is a genuine stall.
+    func testStallGuardStillFiresWithoutGrowth() async throws {
+        let dir = try makeTempDir()
+        do {
+            try await HuggingFaceDownloader.withDownloadStallGuard(
+                modelId: "test/stalled", stallTimeoutSeconds: 1, watchDirectory: dir
+            ) { _ in
+                try await Task.sleep(for: .seconds(10))
+            }
+            XCTFail("expected stall")
+        } catch let error as DownloadError {
+            guard case .stalled = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Two `HuggingFaceDownloader` failure modes, both surfaced by the VoxCPM2 bf16 bundle's 4.3 GB shard during the full E2E regression:

1. **Stall guard killed healthy large transfers.** It only ticked on `hub.snapshot` progress callbacks, which fire at file completion — a shard needing longer than the 300 s window produced zero callbacks and got aborted on every retry. The poller now also ticks whenever the destination directory grows on disk, so bytes flowing count as progress regardless of callback granularity.

2. **`weightsExist` accepted partial multi-shard bundles.** A stalled download that completed only the small shard counted as cached; the model then loaded half-initialized and synthesized near-silence (the regression's mystery VoxCPM2 "quality failure"). It now parses `model.safetensors.index.json` and requires every mapped shard.

## Validation

- 5 new regression tests (index-aware completeness ×3, growth-tick survival, genuine-stall detection); all 32 AudioCommon downloader tests green.
- `E2EVoxCPM2TTSTests` passes both variants with the complete bundle.

## Known follow-up (separate issue)

The specific VoxCPM2 wedge is deeper: swift-transformers 1.3.1 never begins transferring that 4.286 GB blob at all — no partial file appears across five 300 s windows, while plain `curl` streams the same URL at ~10 MB/s. These fixes are correct independently of that client bug; it will be tracked separately.

## Regression risk

Low: the growth watcher only *adds* tick sources (a genuine stall still fires — covered by test); the completeness check only *tightens* what counts as cached, forcing a re-download where it previously loaded garbage.