### PR TITLE
Add Parakeet language steering

### DIFF
--- a/Sources/ParakeetASR/ParakeetASR.swift
+++ b/Sources/ParakeetASR/ParakeetASR.swift
@@ -85,7 +85,9 @@ public class ParakeetASRModel {
     /// - Parameters:
     ///   - audio: PCM Float32 audio samples
     ///   - sampleRate: Sample rate of the input audio in Hz
-    ///   - language: Language hint (unused, Parakeet auto-detects from 25 European languages)
+    ///   - language: Language steering — a comma-separated shortlist of ISO codes ("en", or
+    ///     "en,ru" for bilingual). The decoder is masked so it can only emit these languages'
+    ///     tags. Empty/nil (default) lets the model auto-detect natively.
     /// - Returns: Transcribed text
     /// - Throws: `AudioModelError` on CoreML inference failure
     public func transcribeAudio(_ audio: [Float], sampleRate: Int, language: String? = nil) throws -> String {
@@ -110,12 +112,16 @@ public class ParakeetASRModel {
         // has no EnumeratedShapes) transcribe arbitrarily long audio instead
         // of truncating to the tail.
         let maxWindow = supportedMelLengths.last ?? melLength
+        // Language steering: a per-call language wins; otherwise fall back to the persistent
+        // override (a host settings toggle). Empty/nil both mean auto-detect.
+        let effectiveLanguage = (language?.isEmpty == false) ? language : languageOverride
+        let masked = maskedLanguageTokens(for: effectiveLanguage)
         let tInfer0 = CFAbsoluteTimeGetCurrent()
         var tokenIds: [Int] = []
         var tokenLogProbs: [Float] = []
 
         if melLength <= maxWindow {
-            let r = try encodeAndDecodeWindow(mel: mel, actualLength: melLength)
+            let r = try encodeAndDecodeWindow(mel: mel, actualLength: melLength, maskedTokenIds: masked)
             tokenIds = r.tokens; tokenLogProbs = r.tokenLogProbs
         } else {
             // The mel buffer is [1, 128, bufferFrames] where bufferFrames
@@ -128,7 +134,7 @@ public class ParakeetASRModel {
             while start < melLength {
                 let win = min(maxWindow, melLength - start)
                 let windowMel = try sliceMel(mel: mel, start: start, length: win, totalFrames: bufferFrames)
-                let r = try encodeAndDecodeWindow(mel: windowMel, actualLength: win)
+                let r = try encodeAndDecodeWindow(mel: windowMel, actualLength: win, maskedTokenIds: masked)
                 tokenIds += r.tokens; tokenLogProbs += r.tokenLogProbs
                 start += maxWindow; windows += 1
             }
@@ -155,15 +161,36 @@ public class ParakeetASRModel {
     }
 
     /// Encode one mel window and run TDT greedy decode on it.
-    private func encodeAndDecodeWindow(mel: MLMultiArray, actualLength: Int)
+    private func encodeAndDecodeWindow(mel: MLMultiArray, actualLength: Int, maskedTokenIds: Set<Int> = [])
         throws -> (tokens: [Int], tokenLogProbs: [Float], confidence: Float)
     {
         let (paddedMel, effectiveLength) = try padMelToSupportedShape(mel: mel, actualLength: actualLength)
         let encoderOutput = try runEncoder(mel: paddedMel, length: effectiveLength)
         let encoded = encoderOutput.featureValue(for: "encoded")!.multiArrayValue!
         let encodedLength = encoderOutput.featureValue(for: "encoded_length")!.multiArrayValue![0].intValue
-        let tdtDecoder = TDTGreedyDecoder(config: config, decoder: decoder!, joint: joint!)
+        let tdtDecoder = TDTGreedyDecoder(config: config, decoder: decoder!, joint: joint!, maskedTokenIds: maskedTokenIds)
         return try tdtDecoder.decode(encoded: encoded, encodedLength: encodedLength)
+    }
+
+    /// Persistent language steering applied when a per-call `language` isn't given. Lets a host
+    /// pick the ASR language at runtime (a settings toggle) without rebuilding the pipeline — an
+    /// ISO code / shortlist ("en", "en,ru"), or nil for auto-detect.
+    public var languageOverride: String?
+
+    /// Resolve which language-tag tokens to suppress so the decoder can only emit an allowed
+    /// language. `language` is a comma-separated shortlist ("en", "en,ru"); empty/nil → no masking
+    /// (native auto-detect). Unknown codes are ignored; if none resolve, masking is skipped so a
+    /// bad hint never silently breaks transcription.
+    private func maskedLanguageTokens(for language: String?) -> Set<Int> {
+        guard let language, !language.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
+        let requested = language.lowercased()
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        let tagIds = vocabulary.languageTagIds
+        let allowedIds = Set(requested.compactMap { tagIds[$0] })
+        guard !allowedIds.isEmpty else { return [] }
+        return Set(tagIds.values).subtracting(allowedIds)
     }
 
     /// Copy frames `[start, start+length)` out of a `[1, 128, totalFrames]`

--- a/Sources/ParakeetASR/ParakeetASR.swift
+++ b/Sources/ParakeetASR/ParakeetASR.swift
@@ -113,9 +113,11 @@ public class ParakeetASRModel {
         // of truncating to the tail.
         let maxWindow = supportedMelLengths.last ?? melLength
         // Language steering: a per-call language wins; otherwise fall back to the persistent
-        // override (a host settings toggle). Empty/nil both mean auto-detect.
-        let effectiveLanguage = (language?.isEmpty == false) ? language : languageOverride
-        let masked = maskedLanguageTokens(for: effectiveLanguage)
+        // override. Empty/nil both mean auto-detect.
+        let effectiveLanguage = Self.effectiveLanguageHint(
+            perCall: language,
+            override: languageOverride)
+        let masked = vocabulary.maskedLanguageTokenIds(allowing: effectiveLanguage)
         let tInfer0 = CFAbsoluteTimeGetCurrent()
         var tokenIds: [Int] = []
         var tokenLogProbs: [Float] = []
@@ -172,25 +174,13 @@ public class ParakeetASRModel {
         return try tdtDecoder.decode(encoded: encoded, encodedLength: encodedLength)
     }
 
-    /// Persistent language steering applied when a per-call `language` isn't given. Lets a host
-    /// pick the ASR language at runtime (a settings toggle) without rebuilding the pipeline — an
+    /// Persistent language steering applied when a per-call `language` isn't given. Accepts an
     /// ISO code / shortlist ("en", "en,ru"), or nil for auto-detect.
     public var languageOverride: String?
 
-    /// Resolve which language-tag tokens to suppress so the decoder can only emit an allowed
-    /// language. `language` is a comma-separated shortlist ("en", "en,ru"); empty/nil → no masking
-    /// (native auto-detect). Unknown codes are ignored; if none resolve, masking is skipped so a
-    /// bad hint never silently breaks transcription.
-    private func maskedLanguageTokens(for language: String?) -> Set<Int> {
-        guard let language, !language.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
-        let requested = language.lowercased()
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-        let tagIds = vocabulary.languageTagIds
-        let allowedIds = Set(requested.compactMap { tagIds[$0] })
-        guard !allowedIds.isEmpty else { return [] }
-        return Set(tagIds.values).subtracting(allowedIds)
+    static func effectiveLanguageHint(perCall: String?, override: String?) -> String? {
+        let trimmed = perCall?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : override
     }
 
     /// Copy frames `[start, start+length)` out of a `[1, 128, totalFrames]`

--- a/Sources/ParakeetASR/TDTGreedyDecoder.swift
+++ b/Sources/ParakeetASR/TDTGreedyDecoder.swift
@@ -35,6 +35,16 @@ struct TDTGreedyDecoder {
     let config: ParakeetConfig
     let decoder: MLModel
     let joint: MLModel
+    /// Language-tag token IDs to suppress during argmax, so the decoder can only emit an allowed
+    /// language and the transcription follows it. Empty = no steering (native auto-detect).
+    let maskedTokenIds: Set<Int>
+
+    init(config: ParakeetConfig, decoder: MLModel, joint: MLModel, maskedTokenIds: Set<Int> = []) {
+        self.config = config
+        self.decoder = decoder
+        self.joint = joint
+        self.maskedTokenIds = maskedTokenIds
+    }
 
     /// Decode encoded audio representations into token IDs with per-token log-probabilities.
     ///
@@ -97,7 +107,7 @@ struct TDTGreedyDecoder {
             let tokenLogits = jointOut.featureValue(for: "token_logits")!.multiArrayValue!
             let durationLogits = jointOut.featureValue(for: "duration_logits")!.multiArrayValue!
 
-            let tokenId = argmax(tokenLogits, count: config.vocabSize + 1, floatBuf: argmaxBuf)
+            let tokenId = argmax(tokenLogits, count: config.vocabSize + 1, floatBuf: argmaxBuf, masked: maskedTokenIds)
 
             if tokenId == config.blankTokenId {
                 t += 1
@@ -177,10 +187,10 @@ struct TDTGreedyDecoder {
 
     /// Find the index of the maximum value in the first `count` elements.
     /// Uses vDSP for large arrays (token logits); scalar for small arrays (duration logits).
-    private func argmax(_ array: MLMultiArray, count: Int, floatBuf: UnsafeMutablePointer<Float>?) -> Int {
+    private func argmax(_ array: MLMultiArray, count: Int, floatBuf: UnsafeMutablePointer<Float>?, masked: Set<Int> = []) -> Int {
         let ptr = array.dataPointer.assumingMemoryBound(to: Float16.self)
 
-        // Small arrays or no buffer: scalar path
+        // Small arrays or no buffer: scalar path (duration logits; never masked)
         if count <= 16 || floatBuf == nil {
             var maxIdx = 0
             var maxVal = ptr[0]
@@ -195,6 +205,9 @@ struct TDTGreedyDecoder {
 
         // Large arrays: convert Float16→Float, then vDSP_maxvi
         for i in 0..<count { floatBuf![i] = Float(ptr[i]) }
+        // Language steering: knock out disallowed language-tag logits so they can never win argmax,
+        // forcing the model to emit an allowed language tag (which conditions the rest of decode).
+        for id in masked where id < count { floatBuf![id] = -Float.greatestFiniteMagnitude }
         var maxVal: Float = 0
         var maxIdx: vDSP_Length = 0
         vDSP_maxvi(floatBuf!, 1, &maxVal, &maxIdx, vDSP_Length(count))

--- a/Sources/ParakeetASR/TDTGreedyDecoder.swift
+++ b/Sources/ParakeetASR/TDTGreedyDecoder.swift
@@ -205,9 +205,10 @@ struct TDTGreedyDecoder {
 
         // Large arrays: convert Float16→Float, then vDSP_maxvi
         for i in 0..<count { floatBuf![i] = Float(ptr[i]) }
-        // Language steering: knock out disallowed language-tag logits so they can never win argmax,
-        // forcing the model to emit an allowed language tag (which conditions the rest of decode).
-        for id in masked where id < count { floatBuf![id] = -Float.greatestFiniteMagnitude }
+        // Suppress disallowed tags so only requested language tags can condition the decode.
+        for id in masked where id >= 0 && id < count {
+            floatBuf![id] = -Float.greatestFiniteMagnitude
+        }
         var maxVal: Float = 0
         var maxIdx: vDSP_Length = 0
         vDSP_maxvi(floatBuf!, 1, &maxVal, &maxIdx, vDSP_Length(count))

--- a/Sources/ParakeetASR/Vocabulary.swift
+++ b/Sources/ParakeetASR/Vocabulary.swift
@@ -12,9 +12,31 @@ public struct ParakeetVocabulary: Sendable {
     /// Number of tokens in the vocabulary (excluding blank).
     public var count: Int { idToToken.count }
 
+    /// Token IDs of language tags (`<|xx|>` for ISO codes, id >= 24 so control tokens like
+    /// `<|pnc|>` / `<|timestamp|>` / `<|predict_lang|>` at 0..23 are excluded), keyed by
+    /// lowercase language code. Used to steer greedy decoding to a chosen language by masking
+    /// the others.
+    public let languageTagIds: [String: Int]
+
     /// Initialize from a pre-loaded dictionary.
     public init(idToToken: [Int: String]) {
         self.idToToken = idToToken
+        self.languageTagIds = Self.extractLanguageTags(from: idToToken)
+    }
+
+    /// Pull `<|xx|>` language tags out of the vocab. Control tokens (`<|pnc|>`, `<|emo:...|>`,
+    /// `<|predict_lang|>`, …) all sit below id 24, so an id + shape filter isolates the
+    /// per-language tags cleanly.
+    private static func extractLanguageTags(from idToToken: [Int: String]) -> [String: Int] {
+        var map = [String: Int]()
+        for (id, token) in idToToken where id >= 24 {
+            guard token.hasPrefix("<|"), token.hasSuffix("|>") else { continue }
+            let code = token.dropFirst(2).dropLast(2)
+            guard (2...3).contains(code.count), code.allSatisfy({ $0.isLetter && $0.isLowercase })
+            else { continue }
+            map[String(code)] = id
+        }
+        return map
     }
 
     /// Load vocabulary from a `vocab.json` file.

--- a/Sources/ParakeetASR/Vocabulary.swift
+++ b/Sources/ParakeetASR/Vocabulary.swift
@@ -39,6 +39,21 @@ public struct ParakeetVocabulary: Sendable {
         return map
     }
 
+    /// Resolve the language-tag IDs that should be suppressed for a comma-separated allowlist.
+    /// Unknown-only input leaves native auto-detection unchanged instead of masking every tag.
+    func maskedLanguageTokenIds(allowing language: String?) -> Set<Int> {
+        guard let language else { return [] }
+        let requested = language.lowercased()
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !requested.isEmpty else { return [] }
+
+        let allowedIds = Set(requested.compactMap { languageTagIds[$0] })
+        guard !allowedIds.isEmpty else { return [] }
+        return Set(languageTagIds.values).subtracting(allowedIds)
+    }
+
     /// Load vocabulary from a `vocab.json` file.
     ///
     /// Expected format: `{"0": "▁the", "1": "▁a", ...}`

--- a/Tests/ParakeetASRTests/ParakeetASRTests.swift
+++ b/Tests/ParakeetASRTests/ParakeetASRTests.swift
@@ -446,4 +446,30 @@ final class ParakeetASRUnitTests: XCTestCase {
         XCTAssertGreaterThan(words[0].confidence, words[1].confidence)
         XCTAssertGreaterThan(words[1].confidence, words[2].confidence)
     }
+
+    // MARK: - Language-Tag Steering
+
+    func testLanguageTagExtraction() {
+        // Control tokens live at ids 0..23; per-language `<|xx|>` tags start at 24.
+        let vocab = ParakeetVocabulary(idToToken: [
+            0: "<unk>",
+            5: "<|pnc|>",             // control token (id < 24) — not a language
+            16: "<|emo:neutral|>",    // colon — not a language
+            21: "<|unklang|>",        // control token — not a language
+            24: "<|aa|>",
+            26: "<|af|>",
+            100: "<|en|>",
+            150: "<|ru|>",
+            274: "\u{2581}the",       // text token
+        ])
+        let tags = vocab.languageTagIds
+        XCTAssertEqual(tags["en"], 100)
+        XCTAssertEqual(tags["ru"], 150)
+        XCTAssertEqual(tags["aa"], 24)
+        XCTAssertEqual(tags["af"], 26)
+        // Only the four `<|xx|>` tags at id >= 24 qualify; controls and text tokens are excluded.
+        XCTAssertEqual(tags.count, 4)
+        XCTAssertNil(tags["pnc"])      // id 5 < 24
+        XCTAssertNil(tags["unklang"])  // control + too long
+    }
 }

--- a/Tests/ParakeetASRTests/ParakeetASRTests.swift
+++ b/Tests/ParakeetASRTests/ParakeetASRTests.swift
@@ -200,6 +200,30 @@ final class E2EParakeetASRTests: XCTestCase {
         print("German transcription: \(result)")
     }
 
+    func testLanguageSteeringPreservesEnglishAndGermanTranscription() async throws {
+        let model = try await ParakeetASRModel.fromPretrained(modelId: Self.modelId)
+
+        guard
+            let englishURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav"),
+            let germanURL = Bundle.module.url(forResource: "test_audio_german", withExtension: "wav")
+        else {
+            throw XCTSkip("Parakeet language-steering fixtures not found")
+        }
+
+        let englishAudio = try AudioFileLoader.load(url: englishURL, targetSampleRate: 16000)
+        let english = try model.transcribeAudio(englishAudio, sampleRate: 16000, language: "en")
+        let englishLower = english.lowercased()
+        XCTAssertTrue(englishLower.contains("guarantee"), "English steering lost 'guarantee': \(english)")
+        XCTAssertTrue(englishLower.contains("replacement"), "English steering lost 'replacement': \(english)")
+        XCTAssertTrue(englishLower.contains("shipped"), "English steering lost 'shipped': \(english)")
+
+        let germanAudio = try AudioFileLoader.load(url: germanURL, targetSampleRate: 16000)
+        let german = try model.transcribeAudio(germanAudio, sampleRate: 16000, language: "de")
+        XCTAssertTrue(
+            german.lowercased().contains("guten tag"),
+            "German steering lost 'guten tag': \(german)")
+    }
+
     func testWarmup() async throws {
         let model = try await ParakeetASRModel.fromPretrained(modelId: Self.modelId)
 
@@ -471,5 +495,33 @@ final class ParakeetASRUnitTests: XCTestCase {
         XCTAssertEqual(tags.count, 4)
         XCTAssertNil(tags["pnc"])      // id 5 < 24
         XCTAssertNil(tags["unklang"])  // control + too long
+    }
+
+    func testLanguageMaskAllowsOnlyRequestedTags() {
+        let vocab = ParakeetVocabulary(idToToken: [
+            64: "<|en|>",
+            78: "<|de|>",
+            157: "<|ru|>",
+            274: "en",
+        ])
+
+        XCTAssertEqual(vocab.maskedLanguageTokenIds(allowing: "en"), [78, 157])
+        XCTAssertEqual(vocab.maskedLanguageTokenIds(allowing: " EN, de "), [157])
+        XCTAssertEqual(vocab.maskedLanguageTokenIds(allowing: "unknown"), [])
+        XCTAssertEqual(vocab.maskedLanguageTokenIds(allowing: "  "), [])
+        XCTAssertEqual(vocab.maskedLanguageTokenIds(allowing: nil), [])
+    }
+
+    func testPerCallLanguagePrecedesOverrideUnlessItIsBlank() {
+        XCTAssertEqual(
+            ParakeetASRModel.effectiveLanguageHint(perCall: "en", override: "de"),
+            "en")
+        XCTAssertEqual(
+            ParakeetASRModel.effectiveLanguageHint(perCall: "  ", override: "de"),
+            "de")
+        XCTAssertEqual(
+            ParakeetASRModel.effectiveLanguageHint(perCall: nil, override: "de"),
+            "de")
+        XCTAssertNil(ParakeetASRModel.effectiveLanguageHint(perCall: nil, override: nil))
     }
 }


### PR DESCRIPTION
## Summary
- steer Parakeet decoding with a per-call or persistent language allowlist
- preserve native auto-detection for blank or unknown-only hints
- bounds-check masked vocabulary IDs and cover language resolution with unit tests
- verify English and German steering against real CoreML inference

## Validation
- focused language unit tests: 3 passed
- Parakeet language-steering E2E with `aufklarer/Parakeet-TDT-v3-CoreML-INT8-iOS-5s`: passed
- existing English, German, and latency E2E probes: passed
- hosted-runner-equivalent unit suite: 955 tests passed, 30 skipped