### PR TITLE
Finalize empty Qwen pipeline generations

### DIFF
--- a/Sources/Qwen3Chat/Qwen35PipelineLLM.swift
+++ b/Sources/Qwen3Chat/Qwen35PipelineLLM.swift
@@ -62,11 +62,14 @@ public final class Qwen35PipelineLLM: PipelineLLM {
                     self.onToken?(chunk)
                     onToken(chunk, false)
                 }
-            } catch { }
-
-            if !fullResponse.isEmpty {
-                onToken("", true)
+            } catch {
+                FileHandle.standardError.write(Data("Qwen35PipelineLLM: generation failed: \(error)\n".utf8))
             }
+
+            // ALWAYS send the final marker — even for an empty or failed generation. Consumers
+            // (voice pipelines) block their turn on it; skipping it on empty output left them
+            // waiting forever ("stuck thinking") with the error swallowed.
+            onToken("", true)
             semaphore.signal()
         }
 

--- a/Sources/Qwen3Chat/Qwen35PipelineLLM.swift
+++ b/Sources/Qwen3Chat/Qwen35PipelineLLM.swift
@@ -52,25 +52,25 @@ public final class Qwen35PipelineLLM: PipelineLLM {
 
         let stream = model.generateStream(messages: fullMessages, sampling: sampling)
         let semaphore = DispatchSemaphore(value: 0)
-        var fullResponse = ""
 
         Task {
+            defer {
+                // Pipeline consumers require exactly one terminal marker, including when a model
+                // emits no text, fails before its first token, or is cancelled.
+                onToken("", true)
+                semaphore.signal()
+            }
             do {
                 for try await chunk in stream {
                     guard !self.cancelled else { break }
-                    fullResponse += chunk
                     self.onToken?(chunk)
                     onToken(chunk, false)
                 }
+            } catch is CancellationError {
+                // Cancellation is an expected control-flow path.
             } catch {
                 FileHandle.standardError.write(Data("Qwen35PipelineLLM: generation failed: \(error)\n".utf8))
             }
-
-            // ALWAYS send the final marker — even for an empty or failed generation. Consumers
-            // (voice pipelines) block their turn on it; skipping it on empty output left them
-            // waiting forever ("stuck thinking") with the error swallowed.
-            onToken("", true)
-            semaphore.signal()
         }
 
         semaphore.wait()

--- a/Tests/Qwen3ChatTests/Qwen35PipelineLLMTests.swift
+++ b/Tests/Qwen3ChatTests/Qwen35PipelineLLMTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import AudioCommon
+@testable import Qwen3Chat
+
+final class Qwen35PipelineLLMTests: XCTestCase {
+    private enum StubError: Error {
+        case generationFailed
+    }
+
+    private final class StubBackend: Qwen35ChatBackend {
+        enum Behavior {
+            case chunks([String])
+            case failure(Error)
+        }
+
+        let tokenizer = ChatTokenizer()
+        let config = Qwen3ChatConfig.qwen35_08B
+        private let behavior: Behavior
+
+        init(_ behavior: Behavior) {
+            self.behavior = behavior
+        }
+
+        func generateStream(
+            messages: [ChatMessage],
+            sampling: ChatSamplingConfig
+        ) -> AsyncThrowingStream<String, Error> {
+            _ = messages
+            _ = sampling
+            return AsyncThrowingStream { continuation in
+                switch behavior {
+                case .chunks(let chunks):
+                    for chunk in chunks {
+                        continuation.yield(chunk)
+                    }
+                    continuation.finish()
+                case .failure(let error):
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+
+        func resetState() {}
+    }
+
+    func testEmptyGenerationStillFinalizesExactlyOnce() {
+        let events = run(behavior: .chunks([]))
+
+        XCTAssertEqual(events, [.init(text: "", isFinal: true)])
+    }
+
+    func testFailureBeforeFirstTokenStillFinalizesExactlyOnce() {
+        let events = run(behavior: .failure(StubError.generationFailed))
+
+        XCTAssertEqual(events, [.init(text: "", isFinal: true)])
+    }
+
+    func testTokensAreFollowedByExactlyOneFinalMarker() {
+        let events = run(behavior: .chunks(["Hello", " world"]))
+
+        XCTAssertEqual(events, [
+            .init(text: "Hello", isFinal: false),
+            .init(text: " world", isFinal: false),
+            .init(text: "", isFinal: true),
+        ])
+    }
+
+    func testCancellationStillFinalizesExactlyOnce() {
+        let llm = Qwen35PipelineLLM(model: StubBackend(.chunks(["Hello", " world"])))
+        var events: [Event] = []
+        llm.onToken = { _ in llm.cancel() }
+
+        llm.chat(messages: [(role: .user, content: "Hello")]) { text, isFinal in
+            events.append(.init(text: text, isFinal: isFinal))
+        }
+
+        XCTAssertEqual(events, [
+            .init(text: "Hello", isFinal: false),
+            .init(text: "", isFinal: true),
+        ])
+    }
+
+    private struct Event: Equatable {
+        let text: String
+        let isFinal: Bool
+    }
+
+    private func run(behavior: StubBackend.Behavior) -> [Event] {
+        let llm = Qwen35PipelineLLM(model: StubBackend(behavior))
+        var events: [Event] = []
+
+        llm.chat(messages: [(role: .user, content: "Hello")]) { text, isFinal in
+            events.append(.init(text: text, isFinal: isFinal))
+        }
+
+        return events
+    }
+}


### PR DESCRIPTION
## Summary
- always emit exactly one terminal pipeline callback, including empty, failed, and cancelled generations
- report non-cancellation stream failures instead of swallowing them
- cover empty, failure, normal-token, and cancellation paths with regression tests

## Validation
- `swift test --filter Qwen35PipelineLLMTests --disable-sandbox`
- hosted-runner-equivalent unit suite: 959 tests passed, 30 skipped