### PR TITLE
Run IndexTTS2 GPT attention in float32 to dodge fp16 SDPA slowdown

### DIFF
--- a/Sources/IndexTTS2TTS/IndexTTS2SemanticGPT.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2SemanticGPT.swift
@@ -782,6 +782,12 @@ final class IndexTTS2SemanticGPT {
     /// write. Reference semantics — the batched paths hold exactly one
     /// cache and reorder beam rows in place; the fork-by-value greedy beam
     /// path must stay on `GPTKVCache`.
+    ///
+    /// History is stored in float32 and attention runs in float32: the
+    /// Metal fp16 SDPA vector kernel degrades ~2.5x per step under the
+    /// buffer states real decoding produces (measured on M5 Pro; dummy
+    /// caches don't trigger it), while the fp32 kernel is immune — and
+    /// float32 attention is also strictly higher precision.
     final class BatchedGPTKVCache: GPTKeyValueCache {
         private static let chunk = 256
 
@@ -793,8 +799,10 @@ final class IndexTTS2SemanticGPT {
         }
 
         func update(
-            layer: Int, keys: MLXArray, values: MLXArray
+            layer: Int, keys rawKeys: MLXArray, values rawValues: MLXArray
         ) -> (keys: MLXArray, values: MLXArray) {
+            let keys = rawKeys.asType(.float32)
+            let values = rawValues.asType(.float32)
             let end = offset + keys.dim(2)
             let rounded = (end + Self.chunk - 1) / Self.chunk * Self.chunk
             if buffers[layer] == nil {
@@ -935,12 +943,12 @@ final class IndexTTS2SemanticGPT {
         // steps are single-token and attend to everything.
         let mask: MLXFast.ScaledDotProductAttentionMaskMode = t <= 1 ? .none : .causal
         let out = MLXFast.scaledDotProductAttention(
-            queries: q,
+            queries: q.asType(k.dtype),
             keys: k,
             values: v,
             scale: 1.0 / Foundation.sqrt(Float(headDim)),
             mask: mask)
-        let merged = out.transposed(0, 2, 1, 3).reshaped([b, t, modelDim])
+        let merged = out.asType(x.dtype).transposed(0, 2, 1, 3).reshaped([b, t, modelDim])
         return conv1DLinear(merged, prefix: "\(prefix).c_proj")
     }
 

--- a/Tests/IndexTTS2TTSTests/IndexTTS2KVCacheTests.swift
+++ b/Tests/IndexTTS2TTSTests/IndexTTS2KVCacheTests.swift
@@ -44,6 +44,19 @@ final class IndexTTS2KVCacheTests: XCTestCase {
         }
     }
 
+    func testBatchedCachePromotesHalfPrecisionHistoryToFloat32() {
+        // Attention over the cached history runs in float32 (the fp16 SDPA
+        // kernel degrades under real decode buffer states); the cache must
+        // return float32 no matter what dtype the step produces.
+        let batched = IndexTTS2SemanticGPT.BatchedGPTKVCache(layerCount: 1)
+        let (k, v) = step(2, seed: 3)
+        let out = batched.update(layer: 0, keys: k.asType(.float16), values: v.asType(.float16))
+        XCTAssertEqual(out.keys.dtype, .float32)
+        XCTAssertEqual(out.values.dtype, .float32)
+        assertSame(out.keys, k.asType(.float16).asType(.float32), "promoted keys")
+        assertSame(out.values, v.asType(.float16).asType(.float32), "promoted values")
+    }
+
     func testReorderRowsMatchesGatherAndIdentityIsNoOp() {
         let batched = IndexTTS2SemanticGPT.BatchedGPTKVCache(layerCount: 1)
         let (k0, v0) = step(3, seed: 0)

--- a/docs/benchmarks/voice-cloning-tts.md
+++ b/docs/benchmarks/voice-cloning-tts.md
@@ -17,22 +17,27 @@ afternoon sun."
 | F5-TTS (clone, 16 steps, default) | 336M fp16 | 0.8 GB | 5.09 s | 2.91 s | **0.57** | 1-word sub |
 | F5-TTS (clone, 32 steps) | 336M fp16 | 0.8 GB | 5.09 s | 5.75 s | 1.13 | 1-word sub |
 | F5-TTS (clone, 12 steps) | 336M fp16 | 0.8 GB | 5.09 s | 2.19 s | 0.43 | 1-word sub |
-| IndexTTS2 (clone) | 1.5B-class fp16 | 3.0 GB | 5.49 s | 9.4 s | **1.7** | exact |
+| IndexTTS2 (clone) | 1.5B-class fp16 | 3.0 GB | 5.80 s | 5.8 s | **1.0** | exact |
 
 **Machine**: Apple M5 Pro, 48 GB, release build with compiled metallib.
 Synth time excludes model load (Higgs/F5 report it directly); RSS from
 `/usr/bin/time -l`, includes weights.
 
 IndexTTS2 stage timing (via `INDEXTTS2_TIMING=1`): reference conditioning
-0.6 s, semantic GPT 7.1 s, S2Mel flow 1.1 s (15 steps, the default),
-BigVGAN 0.6 s. The semantic GPT decodes against a preallocated KV cache
-grown in 256-token chunks and written in place, replacing the two
-O(history) `concatenated` copies per layer per step; step eval fell from
-48.8 ms mean (min 20.8 — the mean grew with history as each step
-re-traversed the whole cache) to 21.7 ms mean (min 20.2), and the stage
-from 13.2 s to 7.1 s in same-day interleaved runs, output bit-identical.
-Wall-clock runs vary with thermal state, so per-step minima and same-day
-interleaved pairs are the comparable metrics.
+0.6 s, semantic GPT 3.4 s, S2Mel flow 1.1 s (15 steps, the default),
+BigVGAN 0.7 s. The semantic GPT decodes against a preallocated KV cache
+grown in 256-token chunks and written in place (no O(history) concat
+copies), with the history stored in **float32** and attention run in
+float32: the Metal fp16 SDPA vector kernel degrades ~2.5x per step under
+the buffer states real decoding produces (measured on M5 Pro; synthetic
+caches don't trigger it), while the fp32 kernel is immune — and float32
+attention is strictly higher precision. Step eval: 48.8 ms mean before
+the cache rework, 21.7 ms with the in-place fp16 cache, ~10 ms with
+fp32 attention. Same seed now takes a marginally different sample path
+than the fp16 build (275 → 291 codes on the benchmark sentence);
+roundtrip stays exact. Wall-clock runs vary with thermal state, so
+per-step minima and same-day interleaved pairs are the comparable
+metrics.
 S2Mel step sweep (`--indextts2-s2mel-steps`, word-identical roundtrips,
 ear-validated): 25 steps 1.7 s, 15 steps 1.0 s, 10 steps 0.7 s —
 **default is now 15**; use 25 for upstream-exact flow.
@@ -52,22 +57,22 @@ ear-validated): 25 steps 1.7 s, 15 steps 1.0 s, 10 steps 0.7 s —
   found them indistinguishable, so the default moved from 32 to **16**
   (`--f5-steps 32` remains for maximum fidelity). Steps run over the full
   reference+target sequence, so RTF also improves on longer utterances.
-- **IndexTTS2 dropped from ~9 to 1.7 RTF** in three passes: the semantic GPT
+- **IndexTTS2 dropped from ~9 to 1.0 RTF** in four passes: the semantic GPT
   gained a KV cache (decode was quadratic — every token re-ran the full
   sequence) with the three sampling beams batched into one forward per step;
   BigVGAN's anti-aliased FIR resamplers were rewritten from materialized
   sliding windows (a `[B, T, K, C]` gather around every Snake activation) to
   dense channels-as-batch `conv1d` — bit-equivalent output (diff 0.03% of
-  signal RMS), 3.9 s → 0.7 s; and the KV cache moved to preallocated
-  in-place chunks (see stage timing above), which is where most of the
-  14.9 s → 9.4 s synth cut came from. The remaining ~20 ms step floor on
-  ~5 ms of weight bandwidth is fixed dispatch cost across the ~300
-  serialized kernels per decode step — raising MLX's ops-per-command-buffer
-  limit measures *slower*, since the 40-op buffer splits pipeline CPU
-  encoding against GPU execution — so the next lever is a compiled step
-  graph or on-device sampling, both of which change numerics, unlike every
-  pass so far (all bit-identical). Still the heavyweight path; prefer it
-  for its emotion-control surface.
+  signal RMS), 3.9 s → 0.7 s; the KV cache moved to preallocated in-place
+  chunks (14.9 s → 9.4 s synth); and attention moved to a float32 KV
+  history after step-level probes isolated the dominant remaining cost as
+  a ~2.5x slowdown inside the fp16 SDPA vector kernel that only real
+  decode buffer states trigger (9.4 s → 5.8 s; see stage timing above).
+  The step is now within ~2 ms of its ~8 ms weight-bandwidth floor; what's
+  left is host-side beam sampling (~1.5 ms/step) and the S2Mel/BigVGAN
+  tail, so the practical next levers are on-device sampling and the
+  10-step S2Mel option. Still the heavyweight path; prefer it for its
+  emotion-control surface.
 - Cloned-voice quality gates for Higgs and F5 (ASR roundtrips en/zh, plus
   es/de/ja for the Python reference) live in the E2E suites; see
   `docs/models/higgs-tts.md` and `docs/models/f5-tts.md`.


### PR DESCRIPTION
## What changed

The IndexTTS2 batched KV cache now stores history in float32 and runs attention in float32 (output cast back to fp16 for the projections). The deterministic fork-by-value beam-search path keeps its fp16 concat cache and remains bit-identical to before.

## Why

Step-level probes isolated the dominant remaining decode cost as a ~2.5x slowdown inside the Metal fp16 SDPA vector kernel that only manifests under the buffer states real decoding produces:

- A step chain with the full block content (all matmuls, KV writes, SDPA, layer norms, GELU, residuals) runs at ~10 ms/step from a synthetic cache — but ~26 ms/step after a real prefill.
- Ruled out by direct experiment: history length (dummy pads of equal length are fast), K/V values (scrambling buffers to random keeps it slow), process poisoning (real prefill into a discarded cache + fresh dummy cache is fast), buffer-cache recycling (clearing the MLX buffer cache doesn't help).
- The fp32 SDPA kernel is immune in the identical configuration (bf16 is only half-immune). Mechanism inside the fp16 kernel not identified; treated as empirical and documented in the benchmark notes.

Float32 attention is also strictly higher precision than fp16 — this is the opposite of quantization.

## Performance

Same-day interleaved min-of-5 against main (M5 Pro 48 GB, benchmark sentence):

| | main | this PR |
|---|---:|---:|
| Synth | 16.3 s | **5.8 s** |
| Audio | 5.49 s | 5.80 s |
| RTF | 2.96 | **1.00** |
| Semantic GPT stage | 13.8 s | 3.4 s |
| Step eval | ~48 ms mean | ~10 ms mean |
| Peak RSS | 2.6 GiB | 3.0 GiB |

Cumulative IndexTTS2 trajectory: ~9 → 3.0 → 1.7 → **1.0 RTF** across four passes.

## Regression risk

Output is **not** bit-identical to the previous build: attention rounds at higher precision, so the same seed takes a marginally different sample path (275 → 291 codes on the benchmark sentence, audio 5.49 → 5.80 s). Mitigations:

- Same-seed output is deterministic run-to-run (verified byte-identical).
- ASR roundtrip of the benchmark sentence and of a longer paragraph are word-exact.
- E2E suite green with the roundtrip gate: WER 0.000.
- Unit tests pin the fp32 promotion and cache/beam-reorder equivalence.
- Peak KV memory doubles (float32), bounded by max mel tokens; measured peak RSS 3.0 GiB, worst case roughly +0.9 GiB on maximum-length generations.

## Tests

- `IndexTTS2KVCacheTests`: 3/3 (new float32-promotion test; equivalence and reorder tests updated paths).
- IndexTTS2 unit suite: 13/13.
- E2E `E2EIndexTTS2BundleTests` with `INDEXTTS2_E2E_DOWNLOAD=1 INDEXTTS2_E2E_ROUNDTRIP=1`: 2/2, WER 0.000.
- `docs/benchmarks/voice-cloning-tts.md` updated (table row, stage timing, notes).

## Recommendation

Merge after a listening check of the regenerated samples (sampling path shifted slightly, so an ear-check is the last gate; the fp16-kernel finding is also worth a minimal upstream repro later).