### PR TITLE
Add SystemAudioTap: system-output capture via Core Audio process taps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,7 @@ docs/
   audio/                        Audio I/O, playback, voice pipeline
     playback.md                 Streaming playback, pre-buffer, Apple audio architecture
     voice-pipeline.md           VoicePipeline state machine, events, config
+    system-audio-tap.md         System-output capture via Core Audio process taps
   benchmarks/                   WER, DER, RTF results
   shared-protocols.md       Protocol reference (cross-cutting)
 ```

--- a/Sources/AudioCommon/SystemAudioTap.swift
+++ b/Sources/AudioCommon/SystemAudioTap.swift
@@ -1,0 +1,585 @@
+#if os(macOS)
+import AVFoundation
+import AudioToolbox
+import CoreAudio
+import Foundation
+import os
+
+/// Errors thrown by `SystemAudioTap`. Every case carries the failing `OSStatus`
+/// so callers can report the real Core Audio failure instead of a generic message.
+public enum SystemAudioTapError: Error, LocalizedError {
+    case alreadyRunning
+    case processTranslationFailed(pid: pid_t, status: OSStatus)
+    case tapCreationFailed(status: OSStatus)
+    case formatReadFailed(status: OSStatus)
+    case aggregateCreationFailed(status: OSStatus)
+    case ioProcCreationFailed(status: OSStatus)
+    case startFailed(status: OSStatus)
+    case resamplerUnavailable(from: Double, to: Double)
+
+    public var errorDescription: String? {
+        switch self {
+        case .alreadyRunning:
+            return "System audio capture is already running."
+        case .processTranslationFailed(let pid, let status):
+            return "Cannot translate pid \(pid) to a Core Audio process object (\(SystemAudioTap.describeOSStatus(status))). The process may not have registered with the audio HAL yet."
+        case .tapCreationFailed(let status):
+            return "Creating the system audio process tap failed (\(SystemAudioTap.describeOSStatus(status))). System audio capture requires the host app to declare NSAudioCaptureUsageDescription and the user to grant the macOS audio-recording permission."
+        case .formatReadFailed(let status):
+            return "Reading the tap stream format failed (\(SystemAudioTap.describeOSStatus(status)))."
+        case .aggregateCreationFailed(let status):
+            return "Creating the private aggregate device for the tap failed (\(SystemAudioTap.describeOSStatus(status)))."
+        case .ioProcCreationFailed(let status):
+            return "Creating the aggregate device IO proc failed (\(SystemAudioTap.describeOSStatus(status)))."
+        case .startFailed(let status):
+            return "Starting the aggregate device failed (\(SystemAudioTap.describeOSStatus(status)))."
+        case .resamplerUnavailable(let from, let to):
+            return "Cannot create a resampler from \(from) Hz to \(to) Hz."
+        }
+    }
+}
+
+/// Captures the system output mix — "what the Mac is playing" — via a Core Audio
+/// process tap (macOS 14.4+ tapping API), mirroring `AudioIO`'s microphone API.
+///
+/// ```swift
+/// let tap = SystemAudioTap()                       // excludes this process by default
+/// try tap.start(targetSampleRate: 16000) { samples in
+///     pipeline.pushAudio(samples)                  // mono Float32 @ 16 kHz
+/// }
+/// tap.stop()
+/// ```
+///
+/// Design notes:
+/// - The tap is a **mono global tap** over all processes, minus an exclusion list.
+///   By default the current process is excluded so the app's own playback (for
+///   example a TTS voice) is not re-captured.
+/// - The tap is wrapped in a **private aggregate device that contains only the
+///   tap** — no sub-devices. Including the output device's own streams can pull
+///   its input channels (for example a Bluetooth headset microphone) into the
+///   capture and duplicate audio.
+/// - A global tap follows processes, not a specific device, so it keeps
+///   capturing across default-output-device switches. The delivered sample rate
+///   can change on such a switch; a property listener re-reads the tap format
+///   and the internal resampler is rebuilt on the fly. `onSamples` always
+///   receives mono Float32 at `targetSampleRate`.
+///
+/// Permission: the host app must declare `NSAudioCaptureUsageDescription`;
+/// macOS prompts on first tap creation. **If the permission is denied, Core
+/// Audio may still create a working tap that delivers only silence.** Callers
+/// that need to fail closed should watch `framesCaptured` grow while
+/// `nonSilentFrames` stays at zero and surface an explicit status.
+public final class SystemAudioTap {
+    /// Capture state, mirroring `AudioIO.MicrophoneState`.
+    public enum CaptureState: Sendable {
+        case stopped, running, error(String)
+    }
+
+    /// Current capture state.
+    public private(set) var captureState: CaptureState = .stopped
+
+    /// Whether the current process is excluded from the tap (default true).
+    public let excludeCurrentProcess: Bool
+
+    /// Additional pids excluded from the tap.
+    public let excludedPIDs: [pid_t]
+
+    /// Amplitude threshold below which a sample counts as silence.
+    public static let silenceThreshold: Float = 1e-6
+
+    private static let log = Logger(subsystem: "audio.soniqo", category: "SystemAudioTap")
+
+    // Core Audio objects owned while running.
+    private var tapID = AudioObjectID(kAudioObjectUnknown)
+    private var aggregateID = AudioObjectID(kAudioObjectUnknown)
+    private var ioProcID: AudioDeviceIOProcID?
+    private var tapDescription: CATapDescription?
+
+    // Listener bookkeeping so the exact registered blocks can be removed.
+    private var formatListener: AudioObjectPropertyListenerBlock?
+    private var defaultDeviceListener: AudioObjectPropertyListenerBlock?
+
+    // IO-block-confined resampling state (touched only on `ioQueue`).
+    private var resampler: AVAudioConverter?
+    private var resamplerInputRate: Double = 0
+    private var targetSampleRate: Double = 16000
+    private var onSamples: (([Float]) -> Void)?
+
+    // Shared counters (IO queue writes, any thread reads).
+    private var statsLock = os_unfair_lock()
+    private var _tapSampleRate: Double = 0
+    private var _framesCaptured: UInt64 = 0
+    private var _nonSilentFrames: UInt64 = 0
+    private var _audioLevel: Float = 0
+    private var _deviceChanges: UInt64 = 0
+
+    private let ioQueue = DispatchQueue(label: "audio.soniqo.system-audio-tap.io")
+    private let controlQueue = DispatchQueue(label: "audio.soniqo.system-audio-tap.control")
+
+    public init(excludeCurrentProcess: Bool = true, excludedPIDs: [pid_t] = []) {
+        self.excludeCurrentProcess = excludeCurrentProcess
+        self.excludedPIDs = excludedPIDs
+    }
+
+    deinit {
+        stop()
+    }
+
+    // MARK: - Public capture surface
+
+    /// Sample rate the tap currently delivers before resampling. 0 when stopped.
+    public var tapSampleRate: Double {
+        os_unfair_lock_lock(&statsLock)
+        defer { os_unfair_lock_unlock(&statsLock) }
+        return _tapSampleRate
+    }
+
+    /// Total frames delivered by the tap since `start`. Note that the HAL may
+    /// deliver no callbacks at all while every audible process is excluded from
+    /// the tap (nothing contributes to the mixdown), so 0 can also mean "no
+    /// non-excluded audio has played yet".
+    public var framesCaptured: UInt64 {
+        os_unfair_lock_lock(&statsLock)
+        defer { os_unfair_lock_unlock(&statsLock) }
+        return _framesCaptured
+    }
+
+    /// Frames above the silence threshold since `start`. A capture where
+    /// `framesCaptured` grows while this stays 0 usually means the audio-capture
+    /// permission is missing (the tap exists but delivers silence).
+    public var nonSilentFrames: UInt64 {
+        os_unfair_lock_lock(&statsLock)
+        defer { os_unfair_lock_unlock(&statsLock) }
+        return _nonSilentFrames
+    }
+
+    /// RMS level (0.0–1.0) of the most recent capture buffer, for UI meters.
+    public var audioLevel: Float {
+        os_unfair_lock_lock(&statsLock)
+        defer { os_unfair_lock_unlock(&statsLock) }
+        return _audioLevel
+    }
+
+    /// Number of default-output-device changes observed while capturing.
+    public var deviceChanges: UInt64 {
+        os_unfair_lock_lock(&statsLock)
+        defer { os_unfair_lock_unlock(&statsLock) }
+        return _deviceChanges
+    }
+
+    /// Start capturing the system output mix.
+    ///
+    /// - Parameters:
+    ///   - targetSampleRate: Output rate for `onSamples` (default 16 kHz for VAD/ASR).
+    ///   - onSamples: Mono Float32 samples at `targetSampleRate`, called on the
+    ///     capture queue. Keep the callback fast; long work belongs on another queue.
+    public func start(
+        targetSampleRate: Int = 16000,
+        onSamples: @escaping ([Float]) -> Void
+    ) throws {
+        guard case .stopped = captureState else {
+            throw SystemAudioTapError.alreadyRunning
+        }
+
+        do {
+            try activate(targetSampleRate: Double(targetSampleRate), onSamples: onSamples)
+            captureState = .running
+            Self.log.info("System audio tap started, tap rate \(self.tapSampleRate) Hz → \(targetSampleRate) Hz")
+        } catch {
+            stop()
+            captureState = .error(error.localizedDescription)
+            throw error
+        }
+    }
+
+    /// Stop capturing and destroy the tap, aggregate device, and listeners.
+    /// Idempotent. Must not be called from inside `onSamples` — teardown joins
+    /// the capture queue that the callback runs on.
+    public func stop() {
+        if let listener = formatListener, tapID != kAudioObjectUnknown {
+            var address = Self.tapFormatAddress
+            AudioObjectRemovePropertyListenerBlock(tapID, &address, controlQueue, listener)
+            formatListener = nil
+        }
+        if let listener = defaultDeviceListener {
+            var address = Self.defaultOutputDeviceAddress
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject), &address, controlQueue, listener)
+            defaultDeviceListener = nil
+        }
+        if let procID = ioProcID, aggregateID != kAudioObjectUnknown {
+            AudioDeviceStop(aggregateID, procID)
+            AudioDeviceDestroyIOProcID(aggregateID, procID)
+        }
+        ioProcID = nil
+        if aggregateID != kAudioObjectUnknown {
+            AudioHardwareDestroyAggregateDevice(aggregateID)
+            aggregateID = AudioObjectID(kAudioObjectUnknown)
+        }
+        if tapID != kAudioObjectUnknown {
+            AudioHardwareDestroyProcessTap(tapID)
+            tapID = AudioObjectID(kAudioObjectUnknown)
+        }
+        tapDescription = nil
+        ioQueue.sync {
+            resampler = nil
+            resamplerInputRate = 0
+            onSamples = nil
+        }
+        os_unfair_lock_lock(&statsLock)
+        _tapSampleRate = 0
+        _audioLevel = 0
+        os_unfair_lock_unlock(&statsLock)
+        captureState = .stopped
+    }
+
+    // MARK: - Capture pipeline
+
+    private func activate(targetSampleRate: Double, onSamples: @escaping ([Float]) -> Void) throws {
+        os_unfair_lock_lock(&statsLock)
+        _framesCaptured = 0
+        _nonSilentFrames = 0
+        _deviceChanges = 0
+        os_unfair_lock_unlock(&statsLock)
+
+        ioQueue.sync {
+            self.targetSampleRate = targetSampleRate
+            self.onSamples = onSamples
+        }
+
+        // 1. Translate the exclusion pids to HAL process objects. Excluding a
+        // process requires it to be registered with the HAL; failing closed here
+        // beats silently re-capturing the caller's own playback later.
+        let excludedObjects = try effectiveExcludedPIDs().map { pid -> AudioObjectID in
+            try Self.processObject(for: pid)
+        }
+
+        // 2. Mono global tap over everything except the excluded processes.
+        let description = CATapDescription(monoGlobalTapButExcludeProcesses: excludedObjects)
+        description.name = "audio.soniqo.system-audio-tap"
+        description.isPrivate = true
+        description.muteBehavior = .unmuted
+        self.tapDescription = description
+
+        var newTapID = AudioObjectID(kAudioObjectUnknown)
+        let tapStatus = AudioHardwareCreateProcessTap(description, &newTapID)
+        guard tapStatus == noErr, newTapID != kAudioObjectUnknown else {
+            throw SystemAudioTapError.tapCreationFailed(status: tapStatus)
+        }
+        tapID = newTapID
+
+        try refreshTapFormat()
+
+        // 3. Private aggregate device containing only the tap (no sub-devices).
+        let composition = Self.aggregateComposition(
+            tapUUID: description.uuid, aggregateUID: UUID().uuidString)
+        var newAggregateID = AudioObjectID(kAudioObjectUnknown)
+        let aggregateStatus = AudioHardwareCreateAggregateDevice(
+            composition as CFDictionary, &newAggregateID)
+        guard aggregateStatus == noErr, newAggregateID != kAudioObjectUnknown else {
+            throw SystemAudioTapError.aggregateCreationFailed(status: aggregateStatus)
+        }
+        aggregateID = newAggregateID
+
+        // 4. Track tap format changes (device switches can change the mix rate).
+        let formatListener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            guard let self else { return }
+            do {
+                try self.refreshTapFormat()
+            } catch {
+                Self.log.error("Tap format re-read failed: \(error.localizedDescription)")
+            }
+        }
+        var formatAddress = Self.tapFormatAddress
+        AudioObjectAddPropertyListenerBlock(tapID, &formatAddress, controlQueue, formatListener)
+        self.formatListener = formatListener
+
+        let deviceListener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            guard let self else { return }
+            os_unfair_lock_lock(&self.statsLock)
+            self._deviceChanges += 1
+            os_unfair_lock_unlock(&self.statsLock)
+            do {
+                try self.refreshTapFormat()
+            } catch {
+                Self.log.error("Tap format re-read after device change failed: \(error.localizedDescription)")
+            }
+        }
+        var deviceAddress = Self.defaultOutputDeviceAddress
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &deviceAddress, controlQueue, deviceListener)
+        self.defaultDeviceListener = deviceListener
+
+        // 5. IO proc on the aggregate: the tap arrives as the input buffer list.
+        var newIOProcID: AudioDeviceIOProcID?
+        let ioStatus = AudioDeviceCreateIOProcIDWithBlock(&newIOProcID, aggregateID, ioQueue) {
+            [weak self] _, inInputData, _, _, _ in
+            self?.handleInput(inInputData)
+        }
+        guard ioStatus == noErr, let procID = newIOProcID else {
+            throw SystemAudioTapError.ioProcCreationFailed(status: ioStatus)
+        }
+        ioProcID = procID
+
+        let startStatus = AudioDeviceStart(aggregateID, procID)
+        guard startStatus == noErr else {
+            throw SystemAudioTapError.startFailed(status: startStatus)
+        }
+    }
+
+    /// Runs on `ioQueue`. Downmixes the tap buffers to mono, updates counters,
+    /// resamples to the target rate, and delivers the batch.
+    private func handleInput(_ list: UnsafePointer<AudioBufferList>) {
+        let buffers = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: list))
+        guard buffers.count > 0 else { return }
+
+        var mono: [Float]
+        if buffers.count == 1, buffers[0].mNumberChannels <= 1 {
+            guard let data = buffers[0].mData else { return }
+            let frames = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.size
+            guard frames > 0 else { return }
+            mono = Array(UnsafeBufferPointer(start: data.assumingMemoryBound(to: Float.self), count: frames))
+        } else if buffers.count == 1 {
+            guard let data = buffers[0].mData else { return }
+            let channels = Int(buffers[0].mNumberChannels)
+            let values = Int(buffers[0].mDataByteSize) / MemoryLayout<Float>.size
+            let interleaved = Array(UnsafeBufferPointer(start: data.assumingMemoryBound(to: Float.self), count: values))
+            mono = Self.monoMixdown(interleaved: interleaved, channels: channels)
+        } else {
+            var planar: [[Float]] = []
+            planar.reserveCapacity(buffers.count)
+            for buffer in buffers {
+                guard let data = buffer.mData else { continue }
+                let frames = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
+                planar.append(Array(UnsafeBufferPointer(
+                    start: data.assumingMemoryBound(to: Float.self), count: frames)))
+            }
+            mono = Self.monoMixdown(planar: planar)
+        }
+        guard !mono.isEmpty else { return }
+
+        let nonSilent = Self.nonSilentCount(mono, threshold: Self.silenceThreshold)
+        var sum: Float = 0
+        for sample in mono { sum += sample * sample }
+        let rms = (sum / Float(mono.count)).squareRoot()
+
+        os_unfair_lock_lock(&statsLock)
+        _framesCaptured += UInt64(mono.count)
+        _nonSilentFrames += UInt64(nonSilent)
+        _audioLevel = rms
+        let inputRate = _tapSampleRate
+        os_unfair_lock_unlock(&statsLock)
+
+        guard inputRate > 0 else { return }
+        guard let delivery = onSamples else { return }
+
+        if inputRate == targetSampleRate {
+            delivery(mono)
+            return
+        }
+        guard let resampled = resampleOnIOQueue(mono, from: inputRate) else { return }
+        if !resampled.isEmpty {
+            delivery(resampled)
+        }
+    }
+
+    /// Stateful streaming resample on `ioQueue`; the converter is rebuilt when the
+    /// tap rate changes (for example after a default-output-device switch).
+    private func resampleOnIOQueue(_ samples: [Float], from inputRate: Double) -> [Float]? {
+        if resampler == nil || resamplerInputRate != inputRate {
+            guard
+                let inputFormat = AVAudioFormat(
+                    commonFormat: .pcmFormatFloat32, sampleRate: inputRate,
+                    channels: 1, interleaved: false),
+                let outputFormat = AVAudioFormat(
+                    commonFormat: .pcmFormatFloat32, sampleRate: targetSampleRate,
+                    channels: 1, interleaved: false),
+                let converter = AVAudioConverter(from: inputFormat, to: outputFormat)
+            else {
+                Self.log.error("Resampler unavailable: \(inputRate) Hz → \(self.targetSampleRate) Hz")
+                return nil
+            }
+            resampler = converter
+            resamplerInputRate = inputRate
+        }
+        guard let resampler else { return nil }
+
+        guard let inputBuffer = AVAudioPCMBuffer(
+            pcmFormat: resampler.inputFormat, frameCapacity: AVAudioFrameCount(samples.count))
+        else { return nil }
+        inputBuffer.frameLength = AVAudioFrameCount(samples.count)
+        samples.withUnsafeBufferPointer { source in
+            inputBuffer.floatChannelData![0].update(from: source.baseAddress!, count: samples.count)
+        }
+
+        let capacity = AVAudioFrameCount(
+            (Double(samples.count) * targetSampleRate / inputRate).rounded(.up) + 16)
+        guard let outputBuffer = AVAudioPCMBuffer(
+            pcmFormat: resampler.outputFormat, frameCapacity: capacity)
+        else { return nil }
+
+        var conversionError: NSError?
+        var consumed = false
+        resampler.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
+            if consumed {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            outStatus.pointee = .haveData
+            return inputBuffer
+        }
+        if conversionError != nil { return nil }
+
+        let frames = Int(outputBuffer.frameLength)
+        guard frames > 0, let data = outputBuffer.floatChannelData else { return [] }
+        return Array(UnsafeBufferPointer(start: data[0], count: frames))
+    }
+
+    /// Re-read the tap's stream format and publish the current sample rate.
+    private func refreshTapFormat() throws {
+        var address = Self.tapFormatAddress
+        var asbd = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        let status = AudioObjectGetPropertyData(tapID, &address, 0, nil, &size, &asbd)
+        guard status == noErr, asbd.mSampleRate > 0 else {
+            throw SystemAudioTapError.formatReadFailed(status: status)
+        }
+        os_unfair_lock_lock(&statsLock)
+        let previous = _tapSampleRate
+        _tapSampleRate = asbd.mSampleRate
+        os_unfair_lock_unlock(&statsLock)
+        if previous != 0, previous != asbd.mSampleRate {
+            Self.log.info("Tap sample rate changed: \(previous) Hz → \(asbd.mSampleRate) Hz")
+        }
+    }
+
+    // MARK: - Pure helpers (unit-tested)
+
+    /// Exclusion list actually applied to the tap: the explicit pids plus the
+    /// current process (unless opted out), deduplicated, in stable order.
+    func effectiveExcludedPIDs() -> [pid_t] {
+        var pids = excludedPIDs
+        if excludeCurrentProcess {
+            pids.append(getpid())
+        }
+        var seen = Set<pid_t>()
+        return pids.filter { seen.insert($0).inserted }
+    }
+
+    /// Composition dictionary for the tap's aggregate device. Deliberately
+    /// contains **no sub-device list**: aggregating the output device alongside
+    /// the tap can import that device's input streams (for example a Bluetooth
+    /// headset microphone) and duplicate audio into the capture.
+    static func aggregateComposition(tapUUID: UUID, aggregateUID: String) -> [String: Any] {
+        [
+            kAudioAggregateDeviceNameKey: "soniqo system audio tap",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceIsStackedKey: false,
+            kAudioAggregateDeviceTapAutoStartKey: true,
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapUIDKey: tapUUID.uuidString,
+                    kAudioSubTapDriftCompensationKey: true,
+                ]
+            ],
+        ]
+    }
+
+    /// Average interleaved frames down to mono. `channels <= 1` returns the input.
+    static func monoMixdown(interleaved samples: [Float], channels: Int) -> [Float] {
+        guard channels > 1 else { return samples }
+        let frames = samples.count / channels
+        guard frames > 0 else { return [] }
+        var mono = [Float](repeating: 0, count: frames)
+        let scale = 1 / Float(channels)
+        for frame in 0..<frames {
+            var sum: Float = 0
+            let base = frame * channels
+            for channel in 0..<channels {
+                sum += samples[base + channel]
+            }
+            mono[frame] = sum * scale
+        }
+        return mono
+    }
+
+    /// Average planar channel buffers down to mono, tolerating length mismatches.
+    static func monoMixdown(planar channels: [[Float]]) -> [Float] {
+        guard let longest = channels.map(\.count).max(), longest > 0 else { return [] }
+        guard channels.count > 1 else { return channels.first ?? [] }
+        var mono = [Float](repeating: 0, count: longest)
+        for channel in channels {
+            for index in 0..<channel.count {
+                mono[index] += channel[index]
+            }
+        }
+        let scale = 1 / Float(channels.count)
+        for index in 0..<longest {
+            mono[index] *= scale
+        }
+        return mono
+    }
+
+    /// Count of samples whose magnitude exceeds `threshold`.
+    static func nonSilentCount(_ samples: [Float], threshold: Float) -> Int {
+        var count = 0
+        for sample in samples where abs(sample) > threshold {
+            count += 1
+        }
+        return count
+    }
+
+    /// Render an `OSStatus` as its four-character code when printable
+    /// (for example 1852797029 → "'nope'"), otherwise as a decimal.
+    static func describeOSStatus(_ status: OSStatus) -> String {
+        let value = UInt32(bitPattern: status)
+        let bytes = [
+            UInt8((value >> 24) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8(value & 0xFF),
+        ]
+        let printable = bytes.allSatisfy { $0 >= 0x20 && $0 < 0x7F }
+        if printable, let code = String(bytes: bytes, encoding: .ascii) {
+            return "'\(code)' (\(status))"
+        }
+        return "\(status)"
+    }
+
+    // MARK: - Core Audio plumbing
+
+    private static var tapFormatAddress: AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+    }
+
+    private static var defaultOutputDeviceAddress: AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+    }
+
+    /// Translate a pid to its HAL process object.
+    static func processObject(for pid: pid_t) throws -> AudioObjectID {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var qualifier = pid
+        var object = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address,
+            UInt32(MemoryLayout<pid_t>.size), &qualifier, &size, &object)
+        guard status == noErr, object != kAudioObjectUnknown else {
+            throw SystemAudioTapError.processTranslationFailed(pid: pid, status: status)
+        }
+        return object
+    }
+}
+#endif

--- a/Tests/AudioCommonTests/E2ESystemAudioTapTests.swift
+++ b/Tests/AudioCommonTests/E2ESystemAudioTapTests.swift
@@ -1,0 +1,118 @@
+#if os(macOS)
+import AVFoundation
+import XCTest
+@testable import AudioCommon
+
+/// Real-hardware capture test: plays a tone through the default output and
+/// asserts the system tap hears it, then that excluding the current process
+/// silences the capture again.
+///
+/// Requirements: audio output hardware and the macOS audio-recording permission
+/// for the test host (macOS prompts on the first run). Run without other audio
+/// playing — the tap captures the whole system mix, so background music would
+/// leak into the exclusion phase and skew the comparison.
+final class E2ESystemAudioTapTests: XCTestCase {
+
+    private final class CaptureSink {
+        private let lock = NSLock()
+        private var samples: [Float] = []
+
+        func append(_ chunk: [Float]) {
+            lock.lock()
+            samples.append(contentsOf: chunk)
+            lock.unlock()
+        }
+
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return samples.count
+        }
+
+        var rms: Float {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !samples.isEmpty else { return 0 }
+            var sum: Float = 0
+            for sample in samples { sum += sample * sample }
+            return (sum / Float(samples.count)).squareRoot()
+        }
+    }
+
+    private func makeToneEngine(frequency: Double = 440) throws -> AVAudioEngine {
+        let engine = AVAudioEngine()
+        let outputFormat = engine.outputNode.outputFormat(forBus: 0)
+        let sampleRate = outputFormat.sampleRate
+        var phase = 0.0
+        let increment = 2.0 * Double.pi * frequency / sampleRate
+
+        let source = AVAudioSourceNode { _, _, frameCount, audioBufferList -> OSStatus in
+            let buffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+            for frame in 0..<Int(frameCount) {
+                let value = Float(sin(phase)) * 0.4
+                phase += increment
+                if phase > 2.0 * Double.pi { phase -= 2.0 * Double.pi }
+                for buffer in buffers {
+                    guard let data = buffer.mData else { continue }
+                    data.assumingMemoryBound(to: Float.self)[frame] = value
+                }
+            }
+            return noErr
+        }
+
+        engine.attach(source)
+        let monoFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: sampleRate,
+            channels: 1, interleaved: false)!
+        engine.connect(source, to: engine.mainMixerNode, format: monoFormat)
+        engine.mainMixerNode.outputVolume = 0.6
+        try engine.start()
+        return engine
+    }
+
+    private func capture(excludeCurrentProcess: Bool, seconds: TimeInterval) throws -> (
+        sink: CaptureSink, framesCaptured: UInt64, nonSilentFrames: UInt64, tapRate: Double
+    ) {
+        let tap = SystemAudioTap(excludeCurrentProcess: excludeCurrentProcess)
+        let sink = CaptureSink()
+        try tap.start(targetSampleRate: 16000) { sink.append($0) }
+        defer { tap.stop() }
+        Thread.sleep(forTimeInterval: seconds)
+        return (sink, tap.framesCaptured, tap.nonSilentFrames, tap.tapSampleRate)
+    }
+
+    func testCapturesOwnToneAndExcludingOwnProcessSilencesIt() throws {
+        let engine = try makeToneEngine()
+        defer { engine.stop() }
+
+        // Give the output engine a moment to actually start rendering.
+        Thread.sleep(forTimeInterval: 0.3)
+
+        // Phase 1: the tap includes this process, so it must hear the tone.
+        let included = try capture(excludeCurrentProcess: false, seconds: 1.5)
+
+        XCTAssertGreaterThan(included.framesCaptured, 0, "the tap delivered no buffers at all")
+        XCTAssertGreaterThan(included.tapRate, 0, "tap sample rate was never published")
+        XCTAssertGreaterThan(
+            included.nonSilentFrames, 0,
+            "tap delivered only silence — if this persists, the audio-recording permission is "
+                + "likely missing for the test host (macOS Privacy & Security → Screen & System "
+                + "Audio Recording)")
+        XCTAssertGreaterThan(
+            included.sink.rms, 0.02,
+            "captured level too low for the played tone (rms \(included.sink.rms))")
+        // 1.5 s at 16 kHz minus startup latency should still exceed one second of audio.
+        XCTAssertGreaterThan(included.sink.count, 16_000, "resampled capture is shorter than 1 s")
+
+        // Phase 2: excluding the current process must remove our own tone. When
+        // every audible process is excluded the HAL may deliver no callbacks at
+        // all, so zero buffers is a valid pass — what matters is that no
+        // meaningful energy from our tone reaches the capture.
+        let excluded = try capture(excludeCurrentProcess: true, seconds: 1.5)
+        XCTAssertLessThan(
+            excluded.sink.rms, max(included.sink.rms * 0.2, 0.005),
+            "self-exclusion still captured this process's tone (rms \(excluded.sink.rms) vs "
+                + "included \(included.sink.rms)) — was other audio playing during the test?")
+    }
+}
+#endif

--- a/Tests/AudioCommonTests/SystemAudioTapTests.swift
+++ b/Tests/AudioCommonTests/SystemAudioTapTests.swift
@@ -1,0 +1,119 @@
+#if os(macOS)
+import CoreAudio
+import XCTest
+@testable import AudioCommon
+
+final class SystemAudioTapTests: XCTestCase {
+
+    // MARK: Exclusion list
+
+    func testOwnProcessExcludedByDefault() {
+        let tap = SystemAudioTap()
+        XCTAssertEqual(tap.effectiveExcludedPIDs(), [getpid()])
+    }
+
+    func testExplicitPIDsPrecedeOwnProcessAndDeduplicate() {
+        let tap = SystemAudioTap(excludeCurrentProcess: true, excludedPIDs: [42, 42, getpid(), 7])
+        XCTAssertEqual(tap.effectiveExcludedPIDs(), [42, getpid(), 7])
+    }
+
+    func testOptOutOfOwnProcessExclusion() {
+        let tap = SystemAudioTap(excludeCurrentProcess: false, excludedPIDs: [])
+        XCTAssertEqual(tap.effectiveExcludedPIDs(), [])
+    }
+
+    // MARK: Aggregate composition
+
+    func testAggregateContainsOnlyTheTap() {
+        let uuid = UUID()
+        let composition = SystemAudioTap.aggregateComposition(
+            tapUUID: uuid, aggregateUID: "agg-uid")
+
+        // The whole point of the tap-only aggregate: no sub-device list, so the
+        // output device's own input streams can never leak into the capture.
+        XCTAssertNil(composition[kAudioAggregateDeviceSubDeviceListKey])
+        XCTAssertNil(composition[kAudioAggregateDeviceMainSubDeviceKey])
+
+        XCTAssertEqual(composition[kAudioAggregateDeviceUIDKey] as? String, "agg-uid")
+        XCTAssertEqual(composition[kAudioAggregateDeviceIsPrivateKey] as? Bool, true)
+        XCTAssertEqual(composition[kAudioAggregateDeviceIsStackedKey] as? Bool, false)
+        XCTAssertEqual(composition[kAudioAggregateDeviceTapAutoStartKey] as? Bool, true)
+
+        let tapList = composition[kAudioAggregateDeviceTapListKey] as? [[String: Any]]
+        XCTAssertEqual(tapList?.count, 1)
+        XCTAssertEqual(tapList?.first?[kAudioSubTapUIDKey] as? String, uuid.uuidString)
+        XCTAssertEqual(tapList?.first?[kAudioSubTapDriftCompensationKey] as? Bool, true)
+    }
+
+    // MARK: Mono mixdown
+
+    func testInterleavedStereoMixdownAveragesFrames() {
+        let mono = SystemAudioTap.monoMixdown(interleaved: [1, 3, -2, 2, 0.5, 0.5], channels: 2)
+        XCTAssertEqual(mono, [2, 0, 0.5])
+    }
+
+    func testInterleavedMonoPassesThrough() {
+        let samples: [Float] = [0.1, -0.2, 0.3]
+        XCTAssertEqual(SystemAudioTap.monoMixdown(interleaved: samples, channels: 1), samples)
+    }
+
+    func testInterleavedDropsTrailingPartialFrame() {
+        let mono = SystemAudioTap.monoMixdown(interleaved: [1, 1, 1], channels: 2)
+        XCTAssertEqual(mono, [1])
+    }
+
+    func testPlanarMixdownAveragesChannels() {
+        let mono = SystemAudioTap.monoMixdown(planar: [[1, 2], [3, 4]])
+        XCTAssertEqual(mono, [2, 3])
+    }
+
+    func testPlanarMixdownToleratesLengthMismatch() {
+        let mono = SystemAudioTap.monoMixdown(planar: [[2, 2, 2], [4]])
+        XCTAssertEqual(mono, [3, 1, 1])
+    }
+
+    func testPlanarSingleChannelPassesThrough() {
+        XCTAssertEqual(SystemAudioTap.monoMixdown(planar: [[5, 6]]), [5, 6])
+    }
+
+    func testEmptyInputsProduceEmptyMono() {
+        XCTAssertEqual(SystemAudioTap.monoMixdown(interleaved: [], channels: 2), [])
+        XCTAssertEqual(SystemAudioTap.monoMixdown(planar: []), [])
+    }
+
+    // MARK: Silence accounting
+
+    func testNonSilentCountUsesThreshold() {
+        let samples: [Float] = [0, 1e-7, -1e-7, 0.01, -0.5, 0]
+        XCTAssertEqual(SystemAudioTap.nonSilentCount(samples, threshold: 1e-6), 2)
+        XCTAssertEqual(SystemAudioTap.nonSilentCount([], threshold: 1e-6), 0)
+    }
+
+    // MARK: OSStatus rendering
+
+    func testDescribeOSStatusRendersFourCharCode() {
+        // kAudioHardwareIllegalOperationError = 'nope' — the classic status when
+        // tap creation is rejected.
+        XCTAssertEqual(SystemAudioTap.describeOSStatus(1_852_797_029), "'nope' (1852797029)")
+    }
+
+    func testDescribeOSStatusFallsBackToDecimal() {
+        XCTAssertEqual(SystemAudioTap.describeOSStatus(-50), "-50")
+        XCTAssertEqual(SystemAudioTap.describeOSStatus(0), "0")
+    }
+
+    // MARK: Lifecycle guards (no hardware touched)
+
+    func testStopWithoutStartIsIdempotent() {
+        let tap = SystemAudioTap()
+        tap.stop()
+        tap.stop()
+        if case .stopped = tap.captureState {} else {
+            XCTFail("expected stopped state, got \(tap.captureState)")
+        }
+        XCTAssertEqual(tap.framesCaptured, 0)
+        XCTAssertEqual(tap.nonSilentFrames, 0)
+        XCTAssertEqual(tap.tapSampleRate, 0)
+    }
+}
+#endif

--- a/docs/audio/system-audio-tap.md
+++ b/docs/audio/system-audio-tap.md
@@ -1,0 +1,69 @@
+# System Audio Tap
+
+`SystemAudioTap` (in `AudioCommon`) captures the system output mix — what the
+Mac is currently playing — as mono Float32 samples, resampled to a target rate.
+It complements `AudioIO`, which captures the microphone; together they cover
+both sides of a conversation happening on the machine.
+
+```swift
+import AudioCommon
+
+let tap = SystemAudioTap()                 // excludes this process by default
+try tap.start(targetSampleRate: 16000) { samples in
+    pipeline.pushAudio(samples)            // mono Float32 @ 16 kHz
+}
+// ...
+tap.stop()
+```
+
+## How it works
+
+The capture path is the Core Audio process-tap API (macOS 14.4+):
+
+1. A **mono global tap** (`CATapDescription`) taps the mix of all processes,
+   minus an exclusion list. The current process is excluded by default so the
+   app's own playback — for example a TTS voice — is not re-captured.
+2. The tap is wrapped in a **private aggregate device that contains only the
+   tap**. No output sub-device is aggregated: including the output device can
+   import its input streams (for example a Bluetooth headset microphone) and
+   duplicate audio into the capture.
+3. An IO proc on the aggregate device delivers the tap buffers. They are
+   downmixed to mono if needed, counted for the silence diagnostics, resampled
+   with a stateful `AVAudioConverter`, and handed to `onSamples`.
+
+Because a global tap follows processes rather than a device, capture survives
+default-output-device switches. The delivered rate can change on such a switch;
+property listeners re-read the tap format and the resampler is rebuilt on the
+fly, so `onSamples` always receives `targetSampleRate`.
+
+## Permission
+
+The host app must declare `NSAudioCaptureUsageDescription` in its Info.plist.
+macOS shows the system prompt on first tap creation, and the grant appears
+under Privacy & Security → Screen & System Audio Recording.
+
+**Known trap:** if the permission is denied, tap creation can still succeed and
+deliver pure silence. Consumers that must fail closed should watch the
+counters: `framesCaptured` growing while `nonSilentFrames` stays 0 is the
+denied-permission signature (assuming audio is actually playing).
+
+## Diagnostics
+
+| Property | Meaning |
+|---|---|
+| `captureState` | `stopped` / `running` / `error(String)` |
+| `tapSampleRate` | Rate the tap currently delivers (before resampling) |
+| `framesCaptured` | Total frames delivered since `start` |
+| `nonSilentFrames` | Frames above the silence threshold since `start` |
+| `audioLevel` | RMS (0–1) of the latest buffer, for UI meters |
+| `deviceChanges` | Default-output-device switches observed while running |
+
+## Testing
+
+Unit tests (`SystemAudioTapTests`) cover the pure logic: exclusion-list
+assembly, the tap-only aggregate composition, mono mixdown, silence counting,
+and OSStatus rendering. The hardware path is covered by
+`E2ESystemAudioTapTests`, which plays a tone through the default output,
+asserts the tap hears it, and then asserts that excluding the current process
+silences the capture. The E2E test needs the audio-recording permission and a
+quiet system (no other audio playing).


### PR DESCRIPTION
## What changed

`AudioCommon` gains `SystemAudioTap`: capture of the system output mix — what the Mac is currently playing — as mono Float32 at a caller-chosen rate, complementing `AudioIO`'s microphone capture.

Implementation: a mono global Core Audio process tap (macOS 14.4+ tapping API) excluding configurable processes — the current process by default, so an app's own playback is never re-captured — wrapped in a **private aggregate device containing only the tap**, an IO proc, and a stateful `AVAudioConverter` resample stage. Property listeners track tap-format and default-output-device changes and rebuild the resampler on rate changes mid-capture. Frame/silence counters expose the denied-permission signature (buffers arriving, all silent) so consumers can fail closed instead of shipping dead air.

Docs: new `docs/audio/system-audio-tap.md` plus the AGENTS.md docs-tree entry.

## Architecture fit

Capture lives in `AudioCommon` beside `AudioIO` and `AudioRingBuffer`, which it reuses. No new module, no new dependency, additive-only public API. The file is `#if os(macOS)`; iOS builds are unaffected.

## Regression risk

Low. No existing source file changed (only an AGENTS.md docs line); the new code runs only when instantiated.

## Tests

- 15 unit tests: exclusion-list assembly, tap-only aggregate composition (locks in the no-sub-device invariant that prevents duplicate/echoed capture), interleaved/planar mono mixdown, silence accounting, OSStatus four-char rendering, lifecycle idempotence.
- `E2ESystemAudioTapTests` (local, real hardware): plays a tone through the default output, asserts the tap captures it, then asserts that excluding the current process silences the capture. Passing locally.
- CI-equivalent gate run locally with the debug metallib: 977 unit tests, 0 failures.

Notable behavior found while testing, now documented: the HAL delivers no IO callbacks at all while every audible process is excluded from the tap — zero frames can mean "nothing non-excluded is playing", not a broken capture.

## Follow-ups

- soniqo.audio docs page for the new capability.
- VAD-driven segmentation example and voice-pipeline integration.

Recommendation: merge.
