### PR TITLE
Skip system audio tap E2E on hosted nightly runner

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -101,7 +101,11 @@ jobs:
             # tests themselves are correct; the runner is the constraint.
             # Skip them in Nightly until we either move S2S E2E off cpuOnly or
             # speed up the cold-cache load.
-            skip: 'testS2SHibikiTranslatesAudio|testS2SPersonaPlexProducesAudio'
+            # The system-audio tap E2E needs physical audio output and an
+            # interactive Screen & System Audio Recording permission grant,
+            # neither of which is available on the virtualized hosted runner.
+            # Keep it enabled in local/physical-Mac isolated E2E runs.
+            skip: 'testS2SHibikiTranslatesAudio|testS2SPersonaPlexProducesAudio|E2ESystemAudioTapTests'
           - name: qwen3-chat-coreml
             filter: 'Qwen3ChatTests'
             skip: ''


### PR DESCRIPTION
## Summary

- exclude `E2ESystemAudioTapTests` from the hosted nightly `audio-infra` shard
- retain the real-hardware test for local and physical-Mac isolated E2E runs
- document the hosted runner hardware and permission limitation in the workflow

## Why

The virtualized macOS runner cannot provide physical audio output or an interactive Screen & System Audio Recording permission grant. The tap therefore receives no buffers and fails assertions unrelated to product behavior.

## Validation

- `actionlint .github/workflows/nightly-e2e.yml`
- `git diff --check`
- `make debug`
- `swift test --skip E2E`
- exact filter/skip simulation confirmed `E2ESystemAudioTapTests` is not selected