### PR TITLE
Fix centroid mapping after speaker ID compaction

### DIFF
--- a/Sources/SpeechVAD/DiarizationHelpers.swift
+++ b/Sources/SpeechVAD/DiarizationHelpers.swift
@@ -44,17 +44,47 @@ enum DiarizationHelpers {
         return merged
     }
 
-    /// Remap speaker IDs to contiguous 0-based range, preserving order of first appearance.
+    /// Remap speaker IDs to a contiguous 0-based range in ascending original-ID order.
     static func compactSpeakerIds(_ segments: [DiarizedSegment]) -> [DiarizedSegment] {
+        compactSpeakerIdsWithMapping(segments).segments
+    }
+
+    /// Remap speaker IDs and their centroid embeddings together.
+    ///
+    /// Clustering can produce a centroid that has no surviving segment after
+    /// center-zone clipping and minimum-duration filtering. Compacting only the
+    /// segments would then shift their IDs while leaving the centroid array in
+    /// the old coordinate space. This helper keeps both outputs aligned.
+    static func compactSpeakerIdsAndEmbeddings(
+        _ segments: [DiarizedSegment],
+        speakerEmbeddings: [[Float]],
+        missingEmbeddingDimension: Int = 256
+    ) -> (segments: [DiarizedSegment], speakerEmbeddings: [[Float]]) {
+        let compacted = compactSpeakerIdsWithMapping(segments)
+        let dimension = speakerEmbeddings.first(where: { !$0.isEmpty })?.count
+            ?? missingEmbeddingDimension
+        let zeroEmbedding = [Float](repeating: 0, count: max(0, dimension))
+        let compactedEmbeddings = compacted.originalSpeakerIds.map { speakerId in
+            speakerEmbeddings.indices.contains(speakerId)
+                ? speakerEmbeddings[speakerId]
+                : zeroEmbedding
+        }
+        return (compacted.segments, compactedEmbeddings)
+    }
+
+    private static func compactSpeakerIdsWithMapping(
+        _ segments: [DiarizedSegment]
+    ) -> (segments: [DiarizedSegment], originalSpeakerIds: [Int]) {
         let usedIds = Set(segments.map(\.speakerId)).sorted()
         let idMap = Dictionary(uniqueKeysWithValues: usedIds.enumerated().map { ($1, $0) })
-        return segments.map {
+        let compacted = segments.map {
             DiarizedSegment(
                 startTime: $0.startTime,
                 endTime: $0.endTime,
                 speakerId: idMap[$0.speakerId] ?? $0.speakerId
             )
         }
+        return (compacted, usedIds)
     }
 
     /// Resample audio via AVAudioConverter (delegates to AudioFileLoader).

--- a/Sources/SpeechVAD/DiarizationPipeline.swift
+++ b/Sources/SpeechVAD/DiarizationPipeline.swift
@@ -526,29 +526,20 @@ public final class PyannoteDiarizationPipeline {
 
         diarizedSegments.sort { $0.startTime < $1.startTime }
 
-        // Compact speaker IDs and merge
-        diarizedSegments = DiarizationHelpers.compactSpeakerIds(diarizedSegments)
+        // Compact speaker IDs and their centroids through the same mapping.
+        // Some clusters can lose every segment during center-zone clipping or
+        // minimum-duration filtering, leaving gaps in the active IDs.
+        let compacted = DiarizationHelpers.compactSpeakerIdsAndEmbeddings(
+            diarizedSegments, speakerEmbeddings: centroids)
+        diarizedSegments = compacted.segments
         let merged = DiarizationHelpers.mergeSegments(
             diarizedSegments, minSilence: config.minSilenceDuration)
-        let numSpeakers = Set(merged.map(\.speakerId)).count
-
-        // Re-compact centroids to match compacted speaker IDs
-        let finalCentroids: [[Float]]
-        if numSpeakers <= centroids.count {
-            finalCentroids = Array(centroids.prefix(numSpeakers))
-        } else {
-            // Pad with zero embeddings for speakers that had no embedding
-            var padded = centroids
-            while padded.count < numSpeakers {
-                padded.append([Float](repeating: 0, count: 256))
-            }
-            finalCentroids = padded
-        }
+        let numSpeakers = compacted.speakerEmbeddings.count
 
         return DiarizationResult(
             segments: merged,
             numSpeakers: numSpeakers,
-            speakerEmbeddings: finalCentroids
+            speakerEmbeddings: compacted.speakerEmbeddings
         )
     }
 

--- a/Tests/SpeechVADTests/DiarizationHelpersTests.swift
+++ b/Tests/SpeechVADTests/DiarizationHelpersTests.swift
@@ -109,6 +109,38 @@ final class DiarizationHelpersTests: XCTestCase {
         XCTAssertEqual(result[0].speakerId, 0)
     }
 
+    func testCompactSpeakerIdsKeepsCentroidsAlignedAcrossGaps() {
+        let segs = [
+            DiarizedSegment(startTime: 0, endTime: 1, speakerId: 2),
+            DiarizedSegment(startTime: 1, endTime: 2, speakerId: 5),
+            DiarizedSegment(startTime: 2, endTime: 3, speakerId: 2),
+        ]
+        let embeddings: [[Float]] = (0...5).map { speakerId in
+            [Float(speakerId), Float(speakerId) + 0.5]
+        }
+
+        let result = DiarizationHelpers.compactSpeakerIdsAndEmbeddings(
+            segs, speakerEmbeddings: embeddings)
+
+        XCTAssertEqual(result.segments.map(\.speakerId), [0, 1, 0])
+        XCTAssertEqual(result.speakerEmbeddings, [embeddings[2], embeddings[5]])
+    }
+
+    func testCompactSpeakerIdsPadsOnlyMissingActiveCentroid() {
+        let segs = [
+            DiarizedSegment(startTime: 0, endTime: 1, speakerId: 1),
+            DiarizedSegment(startTime: 1, endTime: 2, speakerId: 4),
+        ]
+
+        let result = DiarizationHelpers.compactSpeakerIdsAndEmbeddings(
+            segs,
+            speakerEmbeddings: [[0, 0], [1, 1]],
+            missingEmbeddingDimension: 2)
+
+        XCTAssertEqual(result.segments.map(\.speakerId), [0, 1])
+        XCTAssertEqual(result.speakerEmbeddings, [[1, 1], [0, 0]])
+    }
+
     // MARK: - resample
 
     func testResampleSameRate() {


### PR DESCRIPTION
## Summary

- compact diarization segments and speaker embeddings through one shared ID mapping
- preserve the centroid belonging to each surviving speaker when filtered clusters leave gaps
- add regressions for non-contiguous IDs and missing active centroids

## Why

The pipeline compacted surviving segment IDs but selected the first N cluster centroids independently. If filtering removed every segment for an earlier cluster, a compacted speaker ID could point at another speaker voiceprint. Segment timing remained valid, but downstream speaker identification could receive the wrong embedding.

## Verification

- 44 focused diarization tests passed, including three model-backed pipeline tests
- repository non-E2E test run completed after building the required debug Metal library
- optimized release build and release Metal library completed
- git diff --check passed

## Benchmark

Five VoxConverse development files, 1,057.5 seconds total, Pyannote CoreML:

| Metric | Legacy | Fixed |
| --- | ---: | ---: |
| DER | 5.03% | 5.03% |
| JER | 9.28% | 9.28% |
| Speaker-count accuracy | 60% | 60% |
| Throughput | 102.0x | 104.7x |
| Peak RSS | 400 MB | 400 MB |

Twelve application debug recordings totaling 2,980 seconds and seventeen rolling 120-second windows totaling 1,380 seconds produced unchanged segments and speaker counts. Those samples already had contiguous active cluster IDs, so the fix has no observed quality or performance regression and should be treated as a defensive identity-correctness fix.