### PR TITLE
Add Community-1 CoreML diarization runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 | [Silero VAD](https://soniqo.audio/guides/vad) | Voice Activity Detection | MLX, CoreML | 309K | Agnostic |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarization | MLX | 1.5M | Agnostic |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarization + speaker embeddings | CoreML (ANE) + Swift VBx | 8.35M | Agnostic |
 | [Sortformer](https://soniqo.audio/guides/diarize) | Diarization (E2E) | CoreML (ANE) | — | Agnostic |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Speech Enhancement | CoreML | 2.1M | Agnostic |
 | [Sidon](https://soniqo.audio/guides/restore) | Speech Restoration (denoise + dereverb, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostic |

--- a/README_ar.md
+++ b/README_ar.md
@@ -234,6 +234,7 @@ struct DictateView: View {
 | [Silero VAD](https://soniqo.audio/ar/guides/vad) | اكتشاف النشاط الصوتي | MLX, CoreML | 309K | محايد للغة |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ar/guides/diarize) | VAD + تمييز | MLX | 1.5M | محايد للغة |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | فرز المتحدثين + تضمينات المتحدث | CoreML (ANE) + Swift VBx | 8.35M | محايد للغة |
 | [Sortformer](https://soniqo.audio/ar/guides/diarize) | تمييز (E2E) | CoreML (ANE) | — | محايد للغة |
 | [DeepFilterNet3](https://soniqo.audio/ar/guides/denoise) | تحسين الكلام | CoreML | 2.1M | محايد للغة |
 | [Sidon](https://soniqo.audio/ar/guides/restore) | استعادة الكلام (إزالة الضوضاء + إزالة الصدى، 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | محايد للغة |

--- a/README_de.md
+++ b/README_de.md
@@ -190,6 +190,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 | [Silero VAD](https://soniqo.audio/de/guides/vad) | Sprachaktivitätserkennung | MLX, CoreML | 309K | Sprachunabhängig |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/de/guides/diarize) | VAD + Diarisierung | MLX | 1.5M | Sprachunabhängig |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarisierung + Sprechereinbettungen | CoreML (ANE) + Swift VBx | 8.35M | Sprachunabhängig |
 | [Sortformer](https://soniqo.audio/de/guides/diarize) | Diarisierung (E2E) | CoreML (ANE) | — | Sprachunabhängig |
 | [DeepFilterNet3](https://soniqo.audio/de/guides/denoise) | Sprachverbesserung | CoreML | 2.1M | Sprachunabhängig |
 | [Sidon](https://soniqo.audio/de/guides/restore) | Sprachwiederherstellung (Rauschunterdrückung + Enthallung, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Sprachunabhängig |

--- a/README_es.md
+++ b/README_es.md
@@ -190,6 +190,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 | [Silero VAD](https://soniqo.audio/es/guides/vad) | Detección de actividad vocal | MLX, CoreML | 309K | Agnóstico |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/es/guides/diarize) | VAD + Diarización | MLX | 1.5M | Agnóstico |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarización + embeddings de hablante | CoreML (ANE) + Swift VBx | 8.35M | Agnóstico |
 | [Sortformer](https://soniqo.audio/es/guides/diarize) | Diarización (E2E) | CoreML (ANE) | — | Agnóstico |
 | [DeepFilterNet3](https://soniqo.audio/es/guides/denoise) | Mejora de voz | CoreML | 2.1M | Agnóstico |
 | [Sidon](https://soniqo.audio/es/guides/restore) | Restauración de voz (supresión de ruido + dereverberación, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnóstico |

--- a/README_fr.md
+++ b/README_fr.md
@@ -190,6 +190,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 | [Silero VAD](https://soniqo.audio/fr/guides/vad) | Detection d'activite vocale | MLX, CoreML | 309K | Agnostique |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/fr/guides/diarize) | VAD + Diarisation | MLX | 1.5M | Agnostique |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarisation + empreintes de locuteur | CoreML (ANE) + Swift VBx | 8.35M | Agnostique |
 | [Sortformer](https://soniqo.audio/fr/guides/diarize) | Diarisation (E2E) | CoreML (ANE) | — | Agnostique |
 | [DeepFilterNet3](https://soniqo.audio/fr/guides/denoise) | Amelioration de la parole | CoreML | 2.1M | Agnostique |
 | [Sidon](https://soniqo.audio/fr/guides/restore) | Restauration de la parole (debruitage + dereverberation, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostique |

--- a/README_hi.md
+++ b/README_hi.md
@@ -190,6 +190,7 @@ struct DictateView: View {
 | [Silero VAD](https://soniqo.audio/hi/guides/vad) | वॉयस एक्टिविटी डिटेक्शन | MLX, CoreML | 309K | भाषा-तटस्थ |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/hi/guides/diarize) | VAD + Diarization | MLX | 1.5M | भाषा-तटस्थ |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarization + स्पीकर embeddings | CoreML (ANE) + Swift VBx | 8.35M | भाषा-तटस्थ |
 | [Sortformer](https://soniqo.audio/hi/guides/diarize) | Diarization (E2E) | CoreML (ANE) | — | भाषा-तटस्थ |
 | [DeepFilterNet3](https://soniqo.audio/hi/guides/denoise) | स्पीच एन्हांसमेंट | CoreML | 2.1M | भाषा-तटस्थ |
 | [Sidon](https://soniqo.audio/hi/guides/restore) | स्पीच रिस्टोरेशन (नॉइज़ हटाना + डीरीवर्ब, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | भाषा-तटस्थ |

--- a/README_ja.md
+++ b/README_ja.md
@@ -190,6 +190,7 @@ struct DictateView: View {
 | [Silero VAD](https://soniqo.audio/ja/guides/vad) | 音声区間検出 | MLX、CoreML | 309K | 言語非依存 |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ja/guides/diarize) | VAD + ダイアライゼーション | MLX | 1.5M | 言語非依存 |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | ダイアライゼーション + 話者embedding | CoreML (ANE) + Swift VBx | 8.35M | 言語非依存 |
 | [Sortformer](https://soniqo.audio/ja/guides/diarize) | ダイアライゼーション（E2E） | CoreML (ANE) | — | 言語非依存 |
 | [DeepFilterNet3](https://soniqo.audio/ja/guides/denoise) | 音声強調 | CoreML | 2.1M | 言語非依存 |
 | [Sidon](https://soniqo.audio/ja/guides/restore) | 音声修復（ノイズ抑制 + 残響除去、48 kHz） | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 言語非依存 |

--- a/README_ko.md
+++ b/README_ko.md
@@ -190,6 +190,7 @@ struct DictateView: View {
 | [Silero VAD](https://soniqo.audio/ko/guides/vad) | 음성 활동 감지 | MLX, CoreML | 309K | 언어 무관 |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ko/guides/diarize) | VAD + 화자 분리 | MLX | 1.5M | 언어 무관 |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | 화자 분리 + 화자 임베딩 | CoreML (ANE) + Swift VBx | 8.35M | 언어 무관 |
 | [Sortformer](https://soniqo.audio/ko/guides/diarize) | 화자 분리 (E2E) | CoreML (ANE) | — | 언어 무관 |
 | [DeepFilterNet3](https://soniqo.audio/ko/guides/denoise) | 음성 향상 | CoreML | 2.1M | 언어 무관 |
 | [Sidon](https://soniqo.audio/ko/guides/restore) | 음성 복원 (노이즈 제거 + 잔향 제거, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 언어 무관 |

--- a/README_pt.md
+++ b/README_pt.md
@@ -190,6 +190,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 | [Silero VAD](https://soniqo.audio/pt/guides/vad) | Deteccao de atividade de voz | MLX, CoreML | 309K | Agnostico |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/pt/guides/diarize) | VAD + Diarizacao | MLX | 1.5M | Agnostico |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarizacao + embeddings de falante | CoreML (ANE) + Swift VBx | 8.35M | Agnostico |
 | [Sortformer](https://soniqo.audio/pt/guides/diarize) | Diarizacao (E2E) | CoreML (ANE) | — | Agnostico |
 | [DeepFilterNet3](https://soniqo.audio/pt/guides/denoise) | Aprimoramento de fala | CoreML | 2.1M | Agnostico |
 | [Sidon](https://soniqo.audio/pt/guides/restore) | Restauracao de fala (denoise + dereverb, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostico |

--- a/README_ru.md
+++ b/README_ru.md
@@ -190,6 +190,7 @@ struct DictateView: View {
 | [Silero VAD](https://soniqo.audio/ru/guides/vad) | Детектор речи | MLX, CoreML | 309K | Универсальный |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ru/guides/diarize) | VAD + Диаризация | MLX | 1.5M | Универсальный |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Диаризация + эмбеддинги спикеров | CoreML (ANE) + Swift VBx | 8.35M | Универсальный |
 | [Sortformer](https://soniqo.audio/ru/guides/diarize) | Диаризация (E2E) | CoreML (ANE) | — | Универсальный |
 | [DeepFilterNet3](https://soniqo.audio/ru/guides/denoise) | Улучшение речи | CoreML | 2.1M | Универсальный |
 | [Sidon](https://soniqo.audio/ru/guides/restore) | Восстановление речи (подавление шума + дереверберация, 48 кГц) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Универсальный |

--- a/README_th.md
+++ b/README_th.md
@@ -190,6 +190,7 @@ struct DictateView: View {
 | [Silero VAD](https://soniqo.audio/guides/vad) | การตรวจจับเสียงพูด | MLX, CoreML | 309K | ไม่จำกัดภาษา |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + การแยกผู้พูด | MLX | 1.5M | ไม่จำกัดภาษา |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | การแยกผู้พูด + เอ็มเบดดิงผู้พูด | CoreML (ANE) + Swift VBx | 8.35M | ไม่จำกัดภาษา |
 | [Sortformer](https://soniqo.audio/guides/diarize) | การแยกผู้พูด (E2E) | CoreML (ANE) | — | ไม่จำกัดภาษา |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | การปรับปรุงเสียงพูด | CoreML | 2.1M | ไม่จำกัดภาษา |
 | [Sidon](https://soniqo.audio/guides/restore) | การฟื้นฟูเสียงพูด (ลดเสียงรบกวน + ลดเสียงก้อง, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | ไม่จำกัดภาษา |

--- a/README_tr.md
+++ b/README_tr.md
@@ -190,6 +190,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 | [Silero VAD](https://soniqo.audio/guides/vad) | Ses Etkinlik Algılama | MLX, CoreML | 309K | Bağımsız |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Konuşmacı Ayrımı | MLX | 1.5M | Bağımsız |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Konuşmacı ayrıştırma + konuşmacı gömmeleri | CoreML (ANE) + Swift VBx | 8.35M | Bağımsız |
 | [Sortformer](https://soniqo.audio/guides/diarize) | Konuşmacı Ayrımı (E2E) | CoreML (ANE) | — | Bağımsız |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Konuşma İyileştirme | CoreML | 2.1M | Bağımsız |
 | [Sidon](https://soniqo.audio/guides/restore) | Konuşma Onarımı (gürültü bastırma + yankı giderme, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Bağımsız |

--- a/README_vi.md
+++ b/README_vi.md
@@ -190,6 +190,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 | [Silero VAD](https://soniqo.audio/guides/vad) | Phát hiện hoạt động giọng nói | MLX, CoreML | 309K | Không phụ thuộc ngôn ngữ |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Phân tách người nói | MLX | 1.5M | Không phụ thuộc ngôn ngữ |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Phân tách người nói + embedding người nói | CoreML (ANE) + Swift VBx | 8.35M | Không phụ thuộc ngôn ngữ |
 | [Sortformer](https://soniqo.audio/guides/diarize) | Phân tách người nói (E2E) | CoreML (ANE) | — | Không phụ thuộc ngôn ngữ |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Cải thiện chất lượng giọng nói | CoreML | 2.1M | Không phụ thuộc ngôn ngữ |
 | [Sidon](https://soniqo.audio/guides/restore) | Phục hồi giọng nói (khử nhiễu + khử vang, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Không phụ thuộc ngôn ngữ |

--- a/README_zh.md
+++ b/README_zh.md
@@ -190,6 +190,7 @@ struct DictateView: View {
 | [Silero VAD](https://soniqo.audio/zh/guides/vad) | 语音活动检测 | MLX、CoreML | 309K | 语言无关 |
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/zh/guides/diarize) | VAD + 说话人分离 | MLX | 1.5M | 语言无关 |
+| [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | 说话人分离 + 说话人嵌入 | CoreML (ANE) + Swift VBx | 8.35M | 语言无关 |
 | [Sortformer](https://soniqo.audio/zh/guides/diarize) | 说话人分离（端到端） | CoreML (ANE) | — | 语言无关 |
 | [DeepFilterNet3](https://soniqo.audio/zh/guides/denoise) | 语音增强 | CoreML | 2.1M | 语言无关 |
 | [Sidon](https://soniqo.audio/zh/guides/restore) | 语音修复（降噪 + 去混响，48 kHz） | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 语言无关 |

--- a/Sources/AudioCLILib/DiarizeCommand.swift
+++ b/Sources/AudioCLILib/DiarizeCommand.swift
@@ -18,7 +18,7 @@ public struct DiarizeCommand: ParsableCommand {
     @Option(name: .long, help: "Enrollment audio for target speaker extraction")
     public var targetSpeaker: String?
 
-    @Option(name: .long, help: "Diarization engine: pyannote (default) or sortformer")
+    @Option(name: .long, help: "Diarization engine: pyannote (default), community1, or sortformer")
     public var engine: String = "pyannote"
 
     @Option(name: .long, help: "Sortformer variant: default (offline, ~125x RTF), balanced (faster first-load, ~hundreds-x RTF), or streaming (low-latency)")
@@ -26,6 +26,18 @@ public struct DiarizeCommand: ParsableCommand {
 
     @Option(name: .long, help: "Sortformer CoreML compute units: ane (default, ANE+CPU), cpu (instant first-load, ~20x RTF), gpu (cpu+gpu), all (every backend; rarely needed)")
     public var sortformerComputeUnits: String = "ane"
+
+    @Option(name: .long, help: "Community-1 CoreML compute units: ane (default), cpu, gpu, or all")
+    public var community1ComputeUnits: String = "ane"
+
+    @Option(name: .long, help: "Known exact speaker count for Community-1")
+    public var numSpeakers: Int?
+
+    @Option(name: .long, help: "Minimum speaker count for Community-1 (default 1)")
+    public var minSpeakers: Int = 1
+
+    @Option(name: .long, help: "Maximum speaker count for Community-1")
+    public var maxSpeakers: Int?
 
     @Option(name: .long, help: "Speaker embedding engine: mlx (default) or coreml")
     public var embeddingEngine: String = "mlx"
@@ -68,10 +80,16 @@ public struct DiarizeCommand: ParsableCommand {
                 #else
                 print("Error: Sortformer requires CoreML (not available on this platform).")
                 #endif
+            } else if engine == "community1" {
+                #if canImport(CoreML)
+                try await runCommunity1(audio: audio)
+                #else
+                print("Error: Community-1 requires CoreML (not available on this platform).")
+                #endif
             } else if engine == "pyannote" {
                 try await runPyannote(audio: audio, config: config)
             } else {
-                print("Error: unknown engine '\(engine)'. Use 'pyannote' or 'sortformer'.")
+                print("Error: unknown engine '\(engine)'. Use 'pyannote', 'community1', or 'sortformer'.")
             }
         }
     }
@@ -119,6 +137,51 @@ public struct DiarizeCommand: ParsableCommand {
         let result = diarizer.diarize(audio: audio, sampleRate: 16000, config: config)
         let elapsed = Date().timeIntervalSince(start)
 
+        outputResult(result, elapsed: elapsed)
+
+        if let refFile = scoreAgainst {
+            try scoreDER(result: result, refFile: refFile)
+        }
+    }
+
+    private func runCommunity1(audio: [Float]) async throws {
+        if targetSpeaker != nil {
+            print("Warning: --target-speaker is not supported with Community-1. Ignoring.")
+        }
+
+        let computeUnits: MLComputeUnits
+        switch community1ComputeUnits.lowercased() {
+        case "ane", "cpuandneuralengine", "neuralengine":
+            computeUnits = .cpuAndNeuralEngine
+        case "cpu", "cpuonly":
+            computeUnits = .cpuOnly
+        case "gpu", "cpuandgpu":
+            computeUnits = .cpuAndGPU
+        case "all":
+            computeUnits = .all
+        default:
+            print("Error: unknown Community-1 compute units '\(community1ComputeUnits)'. Use 'ane', 'cpu', 'gpu', or 'all'.")
+            return
+        }
+
+        print("Loading Community-1 CoreML + native VBx pipeline...")
+        let pipeline = try await Community1DiarizationPipeline.fromPretrained(
+            computeUnits: computeUnits,
+            progressHandler: reportProgress
+        )
+        let bounds = Community1SpeakerBounds(
+            exact: numSpeakers,
+            minimum: minSpeakers,
+            maximum: maxSpeakers
+        )
+        print("Running diarization (Community-1)...")
+        let start = Date()
+        let result = try pipeline.diarize(
+            audio: audio,
+            sampleRate: 16000,
+            speakerBounds: bounds
+        )
+        let elapsed = Date().timeIntervalSince(start)
         outputResult(result, elapsed: elapsed)
 
         if let refFile = scoreAgainst {

--- a/Sources/DiarizationBenchmark/DiarizationBench.swift
+++ b/Sources/DiarizationBenchmark/DiarizationBench.swift
@@ -19,7 +19,7 @@ struct DiarizationBench: AsyncParsableCommand {
     var manifest: String
 
     @Option(name: .shortAndLong, parsing: .upToNextOption,
-            help: "Engines: sortformer-default, sortformer-balanced, sortformer-streaming, pyannote-mlx, pyannote-coreml.")
+            help: "Engines: community1-coreml, sortformer-default, sortformer-balanced, sortformer-streaming, pyannote-mlx, pyannote-coreml.")
     var engines: [String] = ["sortformer-default", "pyannote-mlx"]
 
     @Option(name: .shortAndLong, help: "Max files to process.")
@@ -204,6 +204,8 @@ private protocol DiarizationBenchEngine: AnyObject {
 
 private func makeDiarizationEngine(_ id: String) -> DiarizationBenchEngine? {
     switch id.lowercased() {
+    case "community1-coreml":
+        return Community1DiarizationBenchEngine()
     case "sortformer-default":
         return SortformerBenchEngine(name: "sortformer-default", variant: .default)
     case "sortformer-balanced":
@@ -218,6 +220,37 @@ private func makeDiarizationEngine(_ id: String) -> DiarizationBenchEngine? {
         return nil
     }
 }
+
+#if canImport(CoreML)
+private final class Community1DiarizationBenchEngine: DiarizationBenchEngine {
+    let name = "community1-coreml"
+    var pipeline: Community1DiarizationPipeline?
+
+    func load() async throws {
+        pipeline = try await Community1DiarizationPipeline.fromPretrained(
+            computeUnits: .cpuAndNeuralEngine
+        )
+        try pipeline?.prewarm()
+    }
+
+    func diarize(audio: [Float], sampleRate: Int) throws -> DiarizationResult {
+        guard let pipeline else {
+            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        }
+        return try pipeline.diarize(audio: audio, sampleRate: sampleRate)
+    }
+}
+#else
+private final class Community1DiarizationBenchEngine: DiarizationBenchEngine {
+    let name = "community1-coreml"
+    func load() async throws {
+        throw BenchmarkSupportError.unsupportedReference("Community-1 requires CoreML")
+    }
+    func diarize(audio: [Float], sampleRate: Int) throws -> DiarizationResult {
+        DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+    }
+}
+#endif
 
 private final class PyannoteDiarizationBenchEngine: DiarizationBenchEngine {
     let name: String

--- a/Sources/SpeechVAD/Community1Clustering.swift
+++ b/Sources/SpeechVAD/Community1Clustering.swift
@@ -1,0 +1,794 @@
+#if canImport(CoreML)
+import Foundation
+
+/// Exported x-vector and PLDA transforms used by Community-1's VBx stage.
+struct Community1PLDA {
+    let xvectorMean1: [Float]
+    let xvectorMean2: [Float]
+    /// Row-major `[256, 128]` matrix.
+    let xvectorLDA: [Float]
+    let pldaMean: [Float]
+    /// Row-major `[128, 128]` matrix.
+    let pldaTransform: [Float]
+    let phi: [Float]
+
+    static func load(from url: URL) throws -> Community1PLDA {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url, options: .mappedIfSafe)
+        } catch {
+            throw Community1Error.invalidBundle(
+                "could not load \(url.lastPathComponent): \(error.localizedDescription)"
+            )
+        }
+
+        guard data.count >= 8 else {
+            throw Community1Error.invalidBundle("PLDA safetensors header is truncated")
+        }
+        let headerLength = data.prefix(8).enumerated().reduce(UInt64(0)) { result, pair in
+            result | UInt64(pair.element) << UInt64(pair.offset * 8)
+        }
+        guard headerLength <= UInt64(data.count - 8),
+              headerLength <= UInt64(Int.max) else {
+            throw Community1Error.invalidBundle("PLDA safetensors header length is invalid")
+        }
+        let headerEnd = 8 + Int(headerLength)
+        let headerObject: [String: Any]
+        do {
+            guard let object = try JSONSerialization.jsonObject(
+                with: data[8..<headerEnd]
+            ) as? [String: Any] else {
+                throw Community1Error.invalidBundle("PLDA safetensors header is not an object")
+            }
+            headerObject = object
+        } catch let error as Community1Error {
+            throw error
+        } catch {
+            throw Community1Error.invalidBundle(
+                "could not decode PLDA safetensors header: \(error.localizedDescription)"
+            )
+        }
+
+        func tensor(_ key: String, shape: [Int]) throws -> [Float] {
+            guard let descriptor = headerObject[key] as? [String: Any] else {
+                throw Community1Error.invalidBundle("PLDA weights are missing '\(key)'")
+            }
+            guard descriptor["dtype"] as? String == "F32",
+                  let storedShape = descriptor["shape"] as? [Int],
+                  let offsets = descriptor["data_offsets"] as? [Int],
+                  offsets.count == 2 else {
+                throw Community1Error.invalidBundle("PLDA tensor '\(key)' metadata is invalid")
+            }
+            guard storedShape == shape else {
+                throw Community1Error.invalidBundle(
+                    "PLDA tensor '\(key)' has shape \(storedShape), expected \(shape)"
+                )
+            }
+            let elementCount = shape.reduce(1, *)
+            let byteCount = elementCount * MemoryLayout<UInt32>.size
+            guard offsets[0] >= 0,
+                  offsets[1] - offsets[0] == byteCount,
+                  headerEnd + offsets[1] <= data.count else {
+                throw Community1Error.invalidBundle("PLDA tensor '\(key)' data range is invalid")
+            }
+            return data.withUnsafeBytes { rawBuffer in
+                let bytes = rawBuffer.bindMemory(to: UInt8.self)
+                let start = headerEnd + offsets[0]
+                return (0..<elementCount).map { index in
+                    let position = start + index * 4
+                    let bits = UInt32(bytes[position])
+                        | UInt32(bytes[position + 1]) << 8
+                        | UInt32(bytes[position + 2]) << 16
+                        | UInt32(bytes[position + 3]) << 24
+                    return Float(bitPattern: bits)
+                }
+            }
+        }
+
+        return try Community1PLDA(
+            xvectorMean1: tensor("xvector.mean1", shape: [256]),
+            xvectorMean2: tensor("xvector.mean2", shape: [128]),
+            xvectorLDA: tensor("xvector.lda", shape: [256, 128]),
+            pldaMean: tensor("plda.mean", shape: [128]),
+            pldaTransform: tensor("plda.transform", shape: [128, 128]),
+            phi: tensor("plda.phi", shape: [128])
+        )
+    }
+
+    /// Center, normalize, apply LDA, and project into diagonal PLDA space.
+    func transform(_ embeddings: [[Float]]) -> [[Double]] {
+        let inputDimension = Community1Config.embeddingDimension
+        let outputDimension = Community1Config.pldaDimension
+        let firstScale = sqrt(Double(inputDimension))
+        let secondScale = sqrt(Double(outputDimension))
+
+        return embeddings.map { embedding in
+            var centered = [Double](repeating: 0, count: inputDimension)
+            for index in 0..<inputDimension {
+                centered[index] = Double(embedding[index] - xvectorMean1[index])
+            }
+            Self.normalize(&centered)
+
+            var xvector = [Double](repeating: 0, count: outputDimension)
+            for output in 0..<outputDimension {
+                var sum = 0.0
+                for input in 0..<inputDimension {
+                    sum += firstScale * centered[input]
+                        * Double(xvectorLDA[input * outputDimension + output])
+                }
+                xvector[output] = sum - Double(xvectorMean2[output])
+            }
+            Self.normalize(&xvector)
+            for index in xvector.indices {
+                xvector[index] *= secondScale
+            }
+
+            var projected = [Double](repeating: 0, count: outputDimension)
+            for output in 0..<outputDimension {
+                var sum = 0.0
+                let row = output * outputDimension
+                for input in 0..<outputDimension {
+                    sum += (xvector[input] - Double(pldaMean[input]))
+                        * Double(pldaTransform[row + input])
+                }
+                projected[output] = sum
+            }
+            return projected
+        }
+    }
+
+    private static func normalize(_ vector: inout [Double]) {
+        let norm = sqrt(vector.reduce(0) { $0 + $1 * $1 })
+        guard norm > 0 else { return }
+        for index in vector.indices {
+            vector[index] /= norm
+        }
+    }
+}
+
+struct Community1ClusterResult {
+    let hardClusters: [[Int]]
+    let centroids: [[Float]]
+}
+
+private struct Community1DistanceCandidate {
+    let squaredDistance: Double
+    let left: Int
+    let right: Int
+
+    static func orderedBefore(
+        _ lhs: Community1DistanceCandidate,
+        _ rhs: Community1DistanceCandidate
+    ) -> Bool {
+        if lhs.squaredDistance != rhs.squaredDistance {
+            return lhs.squaredDistance < rhs.squaredDistance
+        }
+        if lhs.left != rhs.left { return lhs.left < rhs.left }
+        return lhs.right < rhs.right
+    }
+}
+
+private struct Community1DistanceHeap {
+    private var storage = [Community1DistanceCandidate]()
+
+    mutating func reserveCapacity(_ capacity: Int) {
+        storage.reserveCapacity(capacity)
+    }
+
+    mutating func push(_ candidate: Community1DistanceCandidate) {
+        storage.append(candidate)
+        var child = storage.count - 1
+        while child > 0 {
+            let parent = (child - 1) / 2
+            guard Community1DistanceCandidate.orderedBefore(
+                storage[child], storage[parent]
+            ) else { break }
+            storage.swapAt(child, parent)
+            child = parent
+        }
+    }
+
+    mutating func pop() -> Community1DistanceCandidate? {
+        guard !storage.isEmpty else { return nil }
+        if storage.count == 1 { return storage.removeLast() }
+        let result = storage[0]
+        storage[0] = storage.removeLast()
+        var parent = 0
+        while true {
+            let left = parent * 2 + 1
+            guard left < storage.count else { break }
+            let right = left + 1
+            let child: Int
+            if right < storage.count,
+               Community1DistanceCandidate.orderedBefore(storage[right], storage[left]) {
+                child = right
+            } else {
+                child = left
+            }
+            guard Community1DistanceCandidate.orderedBefore(
+                storage[child], storage[parent]
+            ) else { break }
+            storage.swapAt(parent, child)
+            parent = child
+        }
+        return result
+    }
+}
+
+/// Native host implementation of Community-1's AHC initialization and VBx loop.
+enum Community1Clustering {
+    static func cluster(
+        embeddings: [[[Float]]],
+        segmentations: [[[Float]]],
+        plda: Community1PLDA,
+        config: Community1Config,
+        bounds: Community1SpeakerBounds
+    ) throws -> Community1ClusterResult {
+        guard embeddings.count == segmentations.count else {
+            throw Community1Error.inference(
+                stage: "clustering", reason: "embedding and segmentation chunk counts differ"
+            )
+        }
+        try validate(bounds)
+
+        var trainEmbeddings = [[Float]]()
+        for chunk in embeddings.indices {
+            for speaker in 0..<Community1Config.localSpeakers {
+                var cleanFrames = 0
+                for frame in 0..<Community1Config.framesPerChunk {
+                    if segmentations[chunk][frame].reduce(0, +) == 1,
+                       segmentations[chunk][frame][speaker] > 0 {
+                        cleanFrames += 1
+                    }
+                }
+                let activeEnough = Float(cleanFrames)
+                    >= config.minimumActiveRatio * Float(Community1Config.framesPerChunk)
+                let valid = embeddings[chunk][speaker].allSatisfy(\.isFinite)
+                if activeEnough, valid {
+                    trainEmbeddings.append(embeddings[chunk][speaker])
+                }
+            }
+        }
+
+        guard !trainEmbeddings.isEmpty else {
+            return Community1ClusterResult(
+                hardClusters: Array(
+                    repeating: [Int](repeating: -2, count: Community1Config.localSpeakers),
+                    count: embeddings.count
+                ),
+                centroids: []
+            )
+        }
+
+        let centroids: [[Float]]
+        if trainEmbeddings.count < 2 {
+            centroids = [trainEmbeddings[0]]
+        } else {
+            let initial = centroidLinkageLabels(
+                trainEmbeddings, threshold: config.clusteringThreshold
+            )
+            let features = plda.transform(trainEmbeddings)
+            let (responsibilities, priors) = vbx(
+                initialLabels: initial,
+                features: features,
+                phi: plda.phi.map(Double.init),
+                config: config
+            )
+
+            let kept = priors.indices.filter { priors[$0] > Double(config.speakerPriorCutoff) }
+            let retained = kept.isEmpty ? [priors.indices.max(by: { priors[$0] < priors[$1] })!] : kept
+            centroids = weightedCentroids(
+                embeddings: trainEmbeddings,
+                responsibilities: responsibilities,
+                retained: retained
+            )
+        }
+
+        let requestedCount = resolvedCount(
+            automatic: centroids.count,
+            available: trainEmbeddings.count,
+            bounds: bounds
+        )
+        let finalCentroids: [[Float]]
+        if requestedCount != centroids.count {
+            finalCentroids = kMeansCentroids(trainEmbeddings, count: requestedCount)
+        } else {
+            finalCentroids = centroids
+        }
+
+        let hard = assign(
+            embeddings: embeddings,
+            segmentations: segmentations,
+            centroids: finalCentroids,
+            constrained: requestedCount == centroids.count
+        )
+        return Community1ClusterResult(hardClusters: hard, centroids: finalCentroids)
+    }
+
+    private static func validate(_ bounds: Community1SpeakerBounds) throws {
+        if let exact = bounds.exact, exact < 1 {
+            throw Community1Error.invalidSpeakerBounds("exact must be at least one")
+        }
+        guard bounds.minimum >= 1 else {
+            throw Community1Error.invalidSpeakerBounds("minimum must be at least one")
+        }
+        if let maximum = bounds.maximum, maximum < bounds.minimum {
+            throw Community1Error.invalidSpeakerBounds("maximum must not be below minimum")
+        }
+    }
+
+    private static func resolvedCount(
+        automatic: Int,
+        available: Int,
+        bounds: Community1SpeakerBounds
+    ) -> Int {
+        if let exact = bounds.exact {
+            return max(1, min(available, exact))
+        }
+        let maximum = min(available, bounds.maximum ?? available)
+        return max(1, min(maximum, max(bounds.minimum, automatic)))
+    }
+
+    /// SciPy-compatible centroid linkage cut over L2-normalized embeddings.
+    static func centroidLinkageLabels(
+        _ embeddings: [[Float]], threshold: Float
+    ) -> [Int] {
+        guard embeddings.count > 1 else { return [0] }
+
+        let count = embeddings.count
+        let nodeCount = 2 * count - 1
+        let normalized = embeddings.map { embedding -> [Double] in
+            var value = embedding.map(Double.init)
+            normalize(&value)
+            return value
+        }
+        var sizes = [Int](repeating: 0, count: nodeCount)
+        for index in 0..<count { sizes[index] = 1 }
+        var maximumSubtreeDistanceSquared = [Double](repeating: 0, count: nodeCount)
+        var representative = Array(repeating: 0, count: nodeCount)
+        for index in 0..<count { representative[index] = index }
+        var active = [Bool](repeating: false, count: nodeCount)
+        for index in 0..<count { active[index] = true }
+
+        // Centroid linkage can be updated exactly from the previous squared
+        // distances. Keeping a lazy min-heap avoids the O(n^3) full scan that
+        // otherwise dominates long recordings with one embedding per second.
+        var distances = [Double](
+            repeating: .infinity,
+            count: nodeCount * nodeCount
+        )
+        func distanceIndex(_ left: Int, _ right: Int) -> Int {
+            left * nodeCount + right
+        }
+        func setDistance(_ value: Double, _ left: Int, _ right: Int) {
+            distances[distanceIndex(left, right)] = value
+            distances[distanceIndex(right, left)] = value
+        }
+
+        var candidates = Community1DistanceHeap()
+        candidates.reserveCapacity(count * (count - 1) / 2)
+        for left in 0..<(count - 1) {
+            for right in (left + 1)..<count {
+                let distance = squaredDistance(normalized[left], normalized[right])
+                setDistance(distance, left, right)
+                candidates.push(.init(
+                    squaredDistance: distance,
+                    left: left,
+                    right: right
+                ))
+            }
+        }
+
+        var parent = Array(0..<count)
+        func root(_ value: Int, _ parent: inout [Int]) -> Int {
+            var current = value
+            while parent[current] != current { current = parent[current] }
+            var node = value
+            while parent[node] != node {
+                let next = parent[node]
+                parent[node] = current
+                node = next
+            }
+            return current
+        }
+        func unite(_ left: Int, _ right: Int, _ parent: inout [Int]) {
+            let a = root(left, &parent)
+            let b = root(right, &parent)
+            if a != b { parent[b] = a }
+        }
+
+        for mergeIndex in 0..<(count - 1) {
+            var best: Community1DistanceCandidate?
+            while let candidate = candidates.pop() {
+                if active[candidate.left], active[candidate.right] {
+                    best = candidate
+                    break
+                }
+            }
+            guard let best else { break }
+            let bestLeft = best.left
+            let bestRight = best.right
+
+            let merged = count + mergeIndex
+            let leftSize = Double(sizes[bestLeft])
+            let rightSize = Double(sizes[bestRight])
+            let total = leftSize + rightSize
+            sizes[merged] = Int(total)
+            representative[merged] = representative[bestLeft]
+            maximumSubtreeDistanceSquared[merged] = max(
+                best.squaredDistance,
+                max(
+                    maximumSubtreeDistanceSquared[bestLeft],
+                    maximumSubtreeDistanceSquared[bestRight]
+                )
+            )
+            if maximumSubtreeDistanceSquared[merged]
+                <= Double(threshold) * Double(threshold) {
+                unite(
+                    representative[bestLeft],
+                    representative[bestRight],
+                    &parent
+                )
+            }
+
+            for other in 0..<merged where active[other]
+                && other != bestLeft && other != bestRight {
+                // Lance-Williams update for UPGMC (centroid linkage), applied
+                // to squared Euclidean distances.
+                let leftDistance = distances[distanceIndex(bestLeft, other)]
+                let rightDistance = distances[distanceIndex(bestRight, other)]
+                let mergedDistance = max(
+                    0,
+                    leftSize / total * leftDistance
+                        + rightSize / total * rightDistance
+                        - leftSize * rightSize / (total * total)
+                            * best.squaredDistance
+                )
+                setDistance(mergedDistance, merged, other)
+                candidates.push(.init(
+                    squaredDistance: mergedDistance,
+                    left: min(merged, other),
+                    right: max(merged, other)
+                ))
+            }
+            active[bestLeft] = false
+            active[bestRight] = false
+            active[merged] = true
+        }
+
+        var compact = [Int: Int]()
+        var labels = [Int](repeating: 0, count: count)
+        for index in 0..<count {
+            let representative = root(index, &parent)
+            if compact[representative] == nil {
+                compact[representative] = compact.count
+            }
+            labels[index] = compact[representative]!
+        }
+        return labels
+    }
+
+    static func vbx(
+        initialLabels: [Int],
+        features: [[Double]],
+        phi: [Double],
+        config: Community1Config
+    ) -> (responsibilities: [[Double]], priors: [Double]) {
+        let frames = features.count
+        let dimension = phi.count
+        let speakers = (initialLabels.max() ?? 0) + 1
+        var gamma = Array(
+            repeating: [Double](repeating: 0, count: speakers), count: frames
+        )
+        for frame in 0..<frames {
+            let logits = (0..<speakers).map {
+                $0 == initialLabels[frame] ? Double(config.initialSmoothing) : 0
+            }
+            gamma[frame] = softmax(logits)
+        }
+        var priors = [Double](repeating: 1 / Double(speakers), count: speakers)
+        let fa = Double(config.fa)
+        let fb = Double(config.fb)
+        let ratio = fa / fb
+        let sqrtPhi = phi.map(sqrt)
+        let logConstant = Double(dimension) * log(2 * Double.pi)
+        let rho = features.map { feature in
+            zip(feature, sqrtPhi).map(*)
+        }
+        let frameConstant = features.map { feature in
+            -0.5 * (feature.reduce(0) { $0 + $1 * $1 } + logConstant)
+        }
+
+        var previousELBO: Double?
+        for _ in 0..<config.maxIterations {
+            var speakerMass = [Double](repeating: 0, count: speakers)
+            for frame in 0..<frames {
+                for speaker in 0..<speakers {
+                    speakerMass[speaker] += gamma[frame][speaker]
+                }
+            }
+
+            var inverseL = Array(
+                repeating: [Double](repeating: 0, count: dimension), count: speakers
+            )
+            var alpha = inverseL
+            for speaker in 0..<speakers {
+                for dim in 0..<dimension {
+                    inverseL[speaker][dim] = 1 / (1 + ratio * speakerMass[speaker] * phi[dim])
+                    var weighted = 0.0
+                    for frame in 0..<frames {
+                        weighted += gamma[frame][speaker] * rho[frame][dim]
+                    }
+                    alpha[speaker][dim] = ratio * inverseL[speaker][dim] * weighted
+                }
+            }
+
+            var logProbability = Array(
+                repeating: [Double](repeating: 0, count: speakers), count: frames
+            )
+            var logMarginal = [Double](repeating: 0, count: frames)
+            for frame in 0..<frames {
+                for speaker in 0..<speakers {
+                    var first = 0.0
+                    var second = 0.0
+                    for dim in 0..<dimension {
+                        first += rho[frame][dim] * alpha[speaker][dim]
+                        second += (inverseL[speaker][dim]
+                            + alpha[speaker][dim] * alpha[speaker][dim]) * phi[dim]
+                    }
+                    logProbability[frame][speaker] = fa
+                        * (first - 0.5 * second + frameConstant[frame])
+                        + log(priors[speaker] + 1e-8)
+                }
+                logMarginal[frame] = logSumExp(logProbability[frame])
+                for speaker in 0..<speakers {
+                    gamma[frame][speaker] = exp(
+                        logProbability[frame][speaker] - logMarginal[frame]
+                    )
+                }
+            }
+
+            priors = [Double](repeating: 0, count: speakers)
+            for frame in 0..<frames {
+                for speaker in 0..<speakers {
+                    priors[speaker] += gamma[frame][speaker]
+                }
+            }
+            let priorTotal = priors.reduce(0, +)
+            for speaker in priors.indices { priors[speaker] /= priorTotal }
+
+            var regularization = 0.0
+            for speaker in 0..<speakers {
+                for dim in 0..<dimension {
+                    regularization += log(inverseL[speaker][dim])
+                        - inverseL[speaker][dim]
+                        - alpha[speaker][dim] * alpha[speaker][dim] + 1
+                }
+            }
+            let elbo = logMarginal.reduce(0, +) + fb * 0.5 * regularization
+            if let previousELBO,
+               elbo - previousELBO < Double(config.convergenceEpsilon) {
+                break
+            }
+            previousELBO = elbo
+        }
+        return (gamma, priors)
+    }
+
+    private static func weightedCentroids(
+        embeddings: [[Float]],
+        responsibilities: [[Double]],
+        retained: [Int]
+    ) -> [[Float]] {
+        retained.map { speaker in
+            var centroid = [Double](repeating: 0, count: Community1Config.embeddingDimension)
+            var total = 0.0
+            for frame in embeddings.indices {
+                let weight = responsibilities[frame][speaker]
+                total += weight
+                for dimension in 0..<Community1Config.embeddingDimension {
+                    centroid[dimension] += weight * Double(embeddings[frame][dimension])
+                }
+            }
+            return centroid.map { Float($0 / max(total, 1e-12)) }
+        }
+    }
+
+    private static func assign(
+        embeddings: [[[Float]]],
+        segmentations: [[[Float]]],
+        centroids: [[Float]],
+        constrained: Bool
+    ) -> [[Int]] {
+        guard !centroids.isEmpty else {
+            return Array(
+                repeating: [Int](repeating: -2, count: Community1Config.localSpeakers),
+                count: embeddings.count
+            )
+        }
+
+        return embeddings.indices.map { chunk in
+            var scores = Array(
+                repeating: [Double](repeating: 0, count: centroids.count),
+                count: Community1Config.localSpeakers
+            )
+            for speaker in 0..<Community1Config.localSpeakers {
+                for cluster in centroids.indices {
+                    scores[speaker][cluster] = 2 - cosineDistance(
+                        embeddings[chunk][speaker], centroids[cluster]
+                    )
+                }
+            }
+            let finiteMinimum = scores.flatMap { $0 }.filter(\.isFinite).min() ?? -1
+            for speaker in 0..<Community1Config.localSpeakers {
+                if segmentations[chunk].allSatisfy({ $0[speaker] == 0 }) {
+                    scores[speaker] = [Double](
+                        repeating: finiteMinimum - 1, count: centroids.count
+                    )
+                }
+                for cluster in centroids.indices where !scores[speaker][cluster].isFinite {
+                    scores[speaker][cluster] = finiteMinimum
+                }
+            }
+            if constrained {
+                return constrainedArgmax(scores)
+            }
+            return scores.map { row in
+                row.indices.max(by: { row[$0] < row[$1] }) ?? 0
+            }
+        }
+    }
+
+    /// Exact maximum-weight assignment for three local speakers.
+    static func constrainedArgmax(_ scores: [[Double]]) -> [Int] {
+        let speakers = scores.count
+        let clusters = scores.first?.count ?? 0
+        guard speakers > 0, clusters > 0 else { return [Int](repeating: -2, count: speakers) }
+        let assignmentCount = min(speakers, clusters)
+        var bestScore = -Double.infinity
+        var best = [Int](repeating: -2, count: speakers)
+
+        func search(
+            speaker: Int,
+            assigned: Int,
+            used: Set<Int>,
+            currentScore: Double,
+            current: [Int]
+        ) {
+            if speaker == speakers {
+                guard assigned == assignmentCount else { return }
+                if currentScore > bestScore {
+                    bestScore = currentScore
+                    best = current
+                }
+                return
+            }
+
+            let remainingSpeakers = speakers - speaker
+            if assigned + remainingSpeakers > assignmentCount {
+                search(
+                    speaker: speaker + 1,
+                    assigned: assigned,
+                    used: used,
+                    currentScore: currentScore,
+                    current: current
+                )
+            }
+            guard assigned < assignmentCount else { return }
+            for cluster in 0..<clusters where !used.contains(cluster) {
+                var next = current
+                next[speaker] = cluster
+                var nextUsed = used
+                nextUsed.insert(cluster)
+                search(
+                    speaker: speaker + 1,
+                    assigned: assigned + 1,
+                    used: nextUsed,
+                    currentScore: currentScore + scores[speaker][cluster],
+                    current: next
+                )
+            }
+        }
+        search(
+            speaker: 0,
+            assigned: 0,
+            used: [],
+            currentScore: 0,
+            current: [Int](repeating: -2, count: speakers)
+        )
+        return best
+    }
+
+    private static func kMeansCentroids(_ embeddings: [[Float]], count: Int) -> [[Float]] {
+        let normalized = embeddings.map { embedding -> [Double] in
+            var value = embedding.map(Double.init)
+            normalize(&value)
+            return value
+        }
+        var centers = [normalized[0]]
+        while centers.count < count {
+            let next = normalized.indices.max { left, right in
+                nearestSquaredDistance(normalized[left], centers)
+                    < nearestSquaredDistance(normalized[right], centers)
+            }!
+            centers.append(normalized[next])
+        }
+
+        var labels = [Int](repeating: 0, count: embeddings.count)
+        for _ in 0..<100 {
+            let nextLabels = normalized.map { point in
+                centers.indices.min(by: {
+                    squaredDistance(point, centers[$0]) < squaredDistance(point, centers[$1])
+                })!
+            }
+            if nextLabels == labels { break }
+            labels = nextLabels
+            for cluster in 0..<count {
+                let members = normalized.indices.filter { labels[$0] == cluster }
+                guard !members.isEmpty else { continue }
+                for dimension in centers[cluster].indices {
+                    centers[cluster][dimension] = members.reduce(0) {
+                        $0 + normalized[$1][dimension]
+                    } / Double(members.count)
+                }
+            }
+        }
+
+        return (0..<count).map { cluster in
+            let members = embeddings.indices.filter { labels[$0] == cluster }
+            guard !members.isEmpty else { return embeddings[cluster % embeddings.count] }
+            return (0..<Community1Config.embeddingDimension).map { dimension in
+                members.reduce(Float(0)) { $0 + embeddings[$1][dimension] }
+                    / Float(members.count)
+            }
+        }
+    }
+
+    private static func softmax(_ values: [Double]) -> [Double] {
+        let maximum = values.max() ?? 0
+        let exponentials = values.map { exp($0 - maximum) }
+        let total = exponentials.reduce(0, +)
+        return exponentials.map { $0 / total }
+    }
+
+    private static func logSumExp(_ values: [Double]) -> Double {
+        let maximum = values.max() ?? 0
+        return maximum + log(values.reduce(0) { $0 + exp($1 - maximum) })
+    }
+
+    private static func normalize(_ vector: inout [Double]) {
+        let norm = sqrt(vector.reduce(0) { $0 + $1 * $1 })
+        guard norm > 0 else { return }
+        for index in vector.indices { vector[index] /= norm }
+    }
+
+    private static func squaredDistance(_ left: [Double], _ right: [Double]) -> Double {
+        zip(left, right).reduce(0) { result, pair in
+            let difference = pair.0 - pair.1
+            return result + difference * difference
+        }
+    }
+
+    private static func nearestSquaredDistance(
+        _ point: [Double], _ centers: [[Double]]
+    ) -> Double {
+        centers.map { squaredDistance(point, $0) }.min() ?? .infinity
+    }
+
+    private static func cosineDistance(_ left: [Float], _ right: [Float]) -> Double {
+        var dot = 0.0
+        var leftNorm = 0.0
+        var rightNorm = 0.0
+        for index in 0..<min(left.count, right.count) {
+            let a = Double(left[index])
+            let b = Double(right[index])
+            dot += a * b
+            leftNorm += a * a
+            rightNorm += b * b
+        }
+        let denominator = sqrt(leftNorm * rightNorm)
+        guard denominator > 0 else { return .nan }
+        return 1 - dot / denominator
+    }
+}
+#endif

--- a/Sources/SpeechVAD/Community1Configuration.swift
+++ b/Sources/SpeechVAD/Community1Configuration.swift
@@ -1,0 +1,175 @@
+#if canImport(CoreML)
+import Foundation
+
+/// Runtime settings encoded by the published Community-1 Core ML bundle.
+///
+/// Community-1 is a complete diarization pipeline rather than a single neural
+/// network. The segmentation and masked speaker-embedding stages run through
+/// Core ML; PLDA, VBx clustering, and timeline reconstruction run as native
+/// Swift host code.
+public struct Community1Config: Sendable {
+    public static let sampleRate = 16_000
+    public static let chunkSamples = 160_000
+    public static let chunkDuration: Float = 10.0
+    public static let chunkStep: Float = 1.0
+    public static let framesPerChunk = 589
+    public static let localSpeakers = 3
+    public static let embeddingDimension = 256
+    public static let pldaDimension = 128
+
+    /// Receptive-field geometry reported by the original PyanNet model.
+    public static let frameDuration: Float = 0.0619375
+    public static let frameStep: Float = 0.016875
+
+    /// Euclidean cut applied to centroid linkage over L2-normalized embeddings.
+    public var clusteringThreshold: Float
+    /// VBx sufficient-statistics scale.
+    public var fa: Float
+    /// VBx speaker regularization coefficient.
+    public var fb: Float
+    /// Initial posterior smoothing applied to the AHC labels.
+    public var initialSmoothing: Float
+    /// Maximum VBx iterations.
+    public var maxIterations: Int
+    /// VBx convergence threshold.
+    public var convergenceEpsilon: Float
+    /// Minimum ratio of clean, single-speaker frames used to train clustering.
+    public var minimumActiveRatio: Float
+    /// Speaker-prior cutoff below which a VBx component is discarded.
+    public var speakerPriorCutoff: Float
+
+    public init(
+        clusteringThreshold: Float = 0.6,
+        fa: Float = 0.07,
+        fb: Float = 0.8,
+        initialSmoothing: Float = 7.0,
+        maxIterations: Int = 20,
+        convergenceEpsilon: Float = 1e-4,
+        minimumActiveRatio: Float = 0.2,
+        speakerPriorCutoff: Float = 1e-7
+    ) {
+        self.clusteringThreshold = clusteringThreshold
+        self.fa = fa
+        self.fb = fb
+        self.initialSmoothing = initialSmoothing
+        self.maxIterations = maxIterations
+        self.convergenceEpsilon = convergenceEpsilon
+        self.minimumActiveRatio = minimumActiveRatio
+        self.speakerPriorCutoff = speakerPriorCutoff
+    }
+
+    public static let `default` = Community1Config()
+}
+
+/// Optional bounds for Community-1 speaker-count inference.
+public struct Community1SpeakerBounds: Sendable {
+    public var exact: Int?
+    public var minimum: Int
+    public var maximum: Int?
+
+    public init(exact: Int? = nil, minimum: Int = 1, maximum: Int? = nil) {
+        self.exact = exact
+        self.minimum = minimum
+        self.maximum = maximum
+    }
+
+    public static let inferred = Community1SpeakerBounds()
+}
+
+struct Community1BundleManifest: Decodable {
+    struct Segmentation: Decodable {
+        let model: String
+        let inputName: String
+        let outputName: String
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case inputName = "input_name"
+            case outputName = "output_name"
+        }
+    }
+
+    struct Embedding: Decodable {
+        let model: String
+        let waveformInputName: String
+        let weightsInputName: String
+        let outputName: String
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case waveformInputName = "waveform_input_name"
+            case weightsInputName = "weights_input_name"
+            case outputName = "output_name"
+        }
+    }
+
+    struct PLDA: Decodable {
+        let dimension: Int
+        let weights: String
+    }
+
+    let modelType: String
+    let sampleRate: Int
+    let segmentation: Segmentation
+    let embedding: Embedding
+    let plda: PLDA
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case sampleRate = "sample_rate"
+        case segmentation
+        case embedding
+        case plda
+    }
+
+    static func load(from directory: URL) throws -> Community1BundleManifest {
+        let url = directory.appendingPathComponent("config.json")
+        do {
+            let manifest = try JSONDecoder().decode(
+                Community1BundleManifest.self,
+                from: Data(contentsOf: url)
+            )
+            guard manifest.modelType == "pyannote-community-1-coreml" else {
+                throw Community1Error.invalidBundle(
+                    "config.json has model_type '\(manifest.modelType)'"
+                )
+            }
+            guard manifest.sampleRate == Community1Config.sampleRate else {
+                throw Community1Error.invalidBundle(
+                    "expected \(Community1Config.sampleRate) Hz, got \(manifest.sampleRate) Hz"
+                )
+            }
+            guard manifest.plda.dimension == Community1Config.pldaDimension else {
+                throw Community1Error.invalidBundle(
+                    "expected \(Community1Config.pldaDimension)-dimensional PLDA"
+                )
+            }
+            return manifest
+        } catch let error as Community1Error {
+            throw error
+        } catch {
+            throw Community1Error.invalidBundle(
+                "could not decode \(url.path): \(error.localizedDescription)"
+            )
+        }
+    }
+}
+
+/// Errors raised by the Community-1 native runtime.
+public enum Community1Error: Error, LocalizedError {
+    case invalidBundle(String)
+    case invalidSpeakerBounds(String)
+    case inference(stage: String, reason: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidBundle(let reason):
+            return "Invalid Community-1 bundle: \(reason)"
+        case .invalidSpeakerBounds(let reason):
+            return "Invalid Community-1 speaker bounds: \(reason)"
+        case .inference(let stage, let reason):
+            return "Community-1 \(stage) inference failed: \(reason)"
+        }
+    }
+}
+#endif

--- a/Sources/SpeechVAD/Community1CoreML.swift
+++ b/Sources/SpeechVAD/Community1CoreML.swift
@@ -1,0 +1,226 @@
+#if canImport(CoreML)
+import AudioCommon
+import CoreML
+import Foundation
+
+/// The two fixed-shape neural stages from the Community-1 bundle.
+final class Community1CoreMLModels {
+    private let segmentation: MLModel
+    private let embedding: MLModel
+    private let manifest: Community1BundleManifest
+
+    init(
+        directory: URL,
+        manifest: Community1BundleManifest,
+        computeUnits: MLComputeUnits
+    ) throws {
+        self.manifest = manifest
+
+        let configuration = MLModelConfiguration()
+        configuration.computeUnits = CoreMLComputeUnitsResolver.resolved(default: computeUnits)
+        configuration.allowLowPrecisionAccumulationOnGPU = true
+
+        segmentation = try Self.loadModel(
+            directory.appendingPathComponent(manifest.segmentation.model, isDirectory: true),
+            stage: "segmentation",
+            configuration: configuration
+        )
+        embedding = try Self.loadModel(
+            directory.appendingPathComponent(manifest.embedding.model, isDirectory: true),
+            stage: "embedding",
+            configuration: configuration
+        )
+    }
+
+    private static func loadModel(
+        _ url: URL,
+        stage: String,
+        configuration: MLModelConfiguration
+    ) throws -> MLModel {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw Community1Error.invalidBundle("missing \(stage) model at \(url.path)")
+        }
+        do {
+            return try MLModel(contentsOf: url, configuration: configuration)
+        } catch {
+            throw Community1Error.invalidBundle(
+                "could not load \(stage) model: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// Hard powerset decoding from `[1, 589, 7]` logits to three binary tracks.
+    func segment(waveform: [Float]) throws -> [[Float]] {
+        guard waveform.count == Community1Config.chunkSamples else {
+            throw Community1Error.inference(
+                stage: "segmentation",
+                reason: "expected \(Community1Config.chunkSamples) samples, got \(waveform.count)"
+            )
+        }
+
+        let input = try Self.multiArray(waveform, shape: [1, 1, Community1Config.chunkSamples])
+        let output: MLMultiArray = try autoreleasepool {
+            let provider = try MLDictionaryFeatureProvider(dictionary: [
+                manifest.segmentation.inputName: MLFeatureValue(multiArray: input)
+            ])
+            let prediction = try segmentation.prediction(from: provider)
+            guard let values = prediction.featureValue(
+                for: manifest.segmentation.outputName
+            )?.multiArrayValue else {
+                throw Community1Error.inference(
+                    stage: "segmentation",
+                    reason: "missing '\(manifest.segmentation.outputName)' output"
+                )
+            }
+            return values
+        }
+
+        let logits = try Self.floatValues(
+            output,
+            expectedCount: Community1Config.framesPerChunk * 7,
+            stage: "segmentation"
+        )
+        let powerset: [[Int]] = [
+            [], [0], [1], [2], [0, 1], [0, 2], [1, 2]
+        ]
+        var tracks = Array(
+            repeating: [Float](repeating: 0, count: Community1Config.localSpeakers),
+            count: Community1Config.framesPerChunk
+        )
+        for frame in 0..<Community1Config.framesPerChunk {
+            let offset = frame * 7
+            var bestClass = 0
+            var bestLogit = logits[offset]
+            for candidate in 1..<7 where logits[offset + candidate] > bestLogit {
+                bestClass = candidate
+                bestLogit = logits[offset + candidate]
+            }
+            for speaker in powerset[bestClass] {
+                tracks[frame][speaker] = 1
+            }
+        }
+        return tracks
+    }
+
+    /// Extract the three raw, unnormalized 256-dimensional embeddings for a chunk.
+    func embed(waveform: [Float], masks: [[Float]]) throws -> [[Float]] {
+        guard waveform.count == Community1Config.chunkSamples else {
+            throw Community1Error.inference(
+                stage: "embedding",
+                reason: "expected \(Community1Config.chunkSamples) samples, got \(waveform.count)"
+            )
+        }
+        guard masks.count == Community1Config.framesPerChunk,
+              masks.allSatisfy({ $0.count == Community1Config.localSpeakers }) else {
+            throw Community1Error.inference(
+                stage: "embedding",
+                reason: "expected masks shaped [589, 3]"
+            )
+        }
+
+        var speakerMajorMasks = [Float]()
+        speakerMajorMasks.reserveCapacity(
+            Community1Config.localSpeakers * Community1Config.framesPerChunk
+        )
+        let minimumCleanFrames = 2
+        for speaker in 0..<Community1Config.localSpeakers {
+            var clean = [Float](repeating: 0, count: Community1Config.framesPerChunk)
+            var full = [Float](repeating: 0, count: Community1Config.framesPerChunk)
+            var cleanCount = 0
+            for frame in 0..<Community1Config.framesPerChunk {
+                let active = masks[frame][speaker]
+                full[frame] = active
+                if active > 0, masks[frame].reduce(0, +) < 2 {
+                    clean[frame] = active
+                    cleanCount += 1
+                }
+            }
+            // pyannote uses the overlap-inclusive mask when fewer than three
+            // clean frames are available for the 400-sample minimum input.
+            speakerMajorMasks.append(contentsOf: cleanCount > minimumCleanFrames ? clean : full)
+        }
+
+        let waveformInput = try Self.multiArray(
+            waveform, shape: [1, 1, Community1Config.chunkSamples]
+        )
+        let weightsInput = try Self.multiArray(
+            speakerMajorMasks,
+            shape: [1, Community1Config.localSpeakers, Community1Config.framesPerChunk]
+        )
+        let output: MLMultiArray = try autoreleasepool {
+            let provider = try MLDictionaryFeatureProvider(dictionary: [
+                manifest.embedding.waveformInputName: MLFeatureValue(multiArray: waveformInput),
+                manifest.embedding.weightsInputName: MLFeatureValue(multiArray: weightsInput),
+            ])
+            let prediction = try embedding.prediction(from: provider)
+            guard let values = prediction.featureValue(
+                for: manifest.embedding.outputName
+            )?.multiArrayValue else {
+                throw Community1Error.inference(
+                    stage: "embedding",
+                    reason: "missing '\(manifest.embedding.outputName)' output"
+                )
+            }
+            return values
+        }
+
+        let flat = try Self.floatValues(
+            output,
+            expectedCount: Community1Config.localSpeakers * Community1Config.embeddingDimension,
+            stage: "embedding"
+        )
+        return (0..<Community1Config.localSpeakers).map { speaker in
+            let start = speaker * Community1Config.embeddingDimension
+            return Array(flat[start..<(start + Community1Config.embeddingDimension)])
+        }
+    }
+
+    private static func multiArray(_ values: [Float], shape: [Int]) throws -> MLMultiArray {
+        let array = try MLMultiArray(
+            shape: shape.map(NSNumber.init(value:)),
+            dataType: .float32
+        )
+        guard array.count == values.count else {
+            throw Community1Error.invalidBundle(
+                "Core ML input shape has \(array.count) values; received \(values.count)"
+            )
+        }
+        values.withUnsafeBufferPointer { source in
+            guard let base = source.baseAddress else { return }
+            array.dataPointer.assumingMemoryBound(to: Float.self).update(
+                from: base, count: values.count
+            )
+        }
+        return array
+    }
+
+    private static func floatValues(
+        _ array: MLMultiArray,
+        expectedCount: Int,
+        stage: String
+    ) throws -> [Float] {
+        guard array.count == expectedCount else {
+            throw Community1Error.inference(
+                stage: stage,
+                reason: "expected \(expectedCount) output values, got \(array.count)"
+            )
+        }
+        switch array.dataType {
+        case .float32:
+            let pointer = array.dataPointer.assumingMemoryBound(to: Float.self)
+            return Array(UnsafeBufferPointer(start: pointer, count: expectedCount))
+        case .float16:
+            let pointer = array.dataPointer.assumingMemoryBound(to: Float16.self)
+            return (0..<expectedCount).map { Float(pointer[$0]) }
+        case .double:
+            let pointer = array.dataPointer.assumingMemoryBound(to: Double.self)
+            return (0..<expectedCount).map { Float(pointer[$0]) }
+        default:
+            throw Community1Error.inference(
+                stage: stage,
+                reason: "unsupported Core ML output type \(array.dataType.rawValue)"
+            )
+        }
+    }
+}
+#endif

--- a/Sources/SpeechVAD/Community1DiarizationPipeline.swift
+++ b/Sources/SpeechVAD/Community1DiarizationPipeline.swift
@@ -1,0 +1,360 @@
+#if canImport(CoreML)
+import AudioCommon
+import CoreML
+import Foundation
+
+/// Native Apple runtime for pyannote `speaker-diarization-community-1`.
+///
+/// The published bundle contains Core ML segmentation and masked WeSpeaker
+/// stages plus the PLDA tensors required by native VBx clustering. Unlike the
+/// lightweight ``PyannoteDiarizationPipeline``, this class reproduces the full
+/// Community-1 host pipeline: 1-second sliding chunks, hard powerset decoding,
+/// overlap-aware embeddings, speaker counting, VBx, constrained assignment,
+/// and overlap-add timeline reconstruction.
+///
+/// - Important: This class is not thread-safe. Create one instance per
+///   concurrent diarization stream.
+public final class Community1DiarizationPipeline {
+    public static let defaultModelId = "aufklarer/Pyannote-Community-1-CoreML"
+
+    private let models: Community1CoreMLModels
+    private let plda: Community1PLDA
+    public let config: Community1Config
+
+    private init(
+        models: Community1CoreMLModels,
+        plda: Community1PLDA,
+        config: Community1Config
+    ) {
+        self.models = models
+        self.plda = plda
+        self.config = config
+    }
+
+    /// Download and load the complete Community-1 Core ML bundle.
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        config: Community1Config = .default,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> Community1DiarizationPipeline {
+        progressHandler?(0, "Downloading Community-1 bundle...")
+        let directory = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: directory,
+            additionalFiles: [
+                "segmentation.mlmodelc/**",
+                "embedding.mlmodelc/**",
+                "plda.safetensors",
+                "config.json",
+            ],
+            offlineMode: offlineMode,
+            progressHandler: { progress in
+                progressHandler?(progress * 0.75, "Downloading Community-1 bundle...")
+            }
+        )
+        return try fromLocal(
+            directory: directory,
+            config: config,
+            computeUnits: computeUnits,
+            progressHandler: { progress, message in
+                progressHandler?(0.75 + progress * 0.25, message)
+            }
+        )
+    }
+
+    /// Load a previously downloaded or locally exported Community-1 bundle.
+    public static func fromLocal(
+        directory: URL,
+        config: Community1Config = .default,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) throws -> Community1DiarizationPipeline {
+        progressHandler?(0, "Validating Community-1 bundle...")
+        let manifest = try Community1BundleManifest.load(from: directory)
+
+        let pldaURL = directory.appendingPathComponent(manifest.plda.weights)
+        guard FileManager.default.fileExists(atPath: pldaURL.path) else {
+            throw Community1Error.invalidBundle("missing PLDA weights at \(pldaURL.path)")
+        }
+        let plda = try Community1PLDA.load(from: pldaURL)
+        progressHandler?(0.25, "Loading Community-1 Core ML models...")
+        let models = try Community1CoreMLModels(
+            directory: directory,
+            manifest: manifest,
+            computeUnits: computeUnits
+        )
+        _ = progressHandler?(1, "Ready")
+        return Community1DiarizationPipeline(models: models, plda: plda, config: config)
+    }
+
+    /// Run both fixed-shape Core ML graphs once to populate their execution caches.
+    public func prewarm() throws {
+        let silence = [Float](repeating: 0, count: Community1Config.chunkSamples)
+        let segmentation = try models.segment(waveform: silence)
+        _ = try models.embed(waveform: silence, masks: segmentation)
+    }
+
+    public func diarize(
+        audio: [Float],
+        sampleRate: Int,
+        speakerBounds: Community1SpeakerBounds = .inferred
+    ) throws -> DiarizationResult {
+        try diarize(
+            audio: audio,
+            sampleRate: sampleRate,
+            speakerBounds: speakerBounds,
+            progressHandler: nil
+        )
+    }
+
+    /// Diarize complete audio with stage progress and cooperative cancellation.
+    ///
+    /// The progress callback returns `true` to continue or `false` to stop. A
+    /// cancelled run returns an empty result, matching the other diarizers.
+    public func diarize(
+        audio: [Float],
+        sampleRate: Int,
+        speakerBounds: Community1SpeakerBounds = .inferred,
+        progressHandler: ((Float, String) -> Bool)?
+    ) throws -> DiarizationResult {
+        let empty = DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        guard !audio.isEmpty else { return empty }
+        let samples = DiarizationHelpers.resample(
+            audio, from: sampleRate, to: Community1Config.sampleRate
+        )
+        guard !samples.isEmpty else { return empty }
+
+        let starts = Self.chunkStarts(sampleCount: samples.count)
+        let totalWork = max(1, starts.count * 2 + 1)
+        var completed = 0
+        var segmentations = [[[Float]]]()
+        segmentations.reserveCapacity(starts.count)
+
+        for (index, start) in starts.enumerated() {
+            if progressHandler?(
+                Float(completed) / Float(totalWork),
+                "Community-1 segmentation \(index + 1)/\(starts.count)"
+            ) == false { return empty }
+            let waveform = Self.chunk(samples, start: start)
+            segmentations.append(try models.segment(waveform: waveform))
+            completed += 1
+        }
+
+        let count = Self.speakerCount(segmentations)
+        guard count.max() ?? 0 > 0 else { return empty }
+
+        var embeddings = [[[Float]]]()
+        embeddings.reserveCapacity(starts.count)
+        for (index, start) in starts.enumerated() {
+            if progressHandler?(
+                Float(completed) / Float(totalWork),
+                "Community-1 embeddings \(index + 1)/\(starts.count)"
+            ) == false { return empty }
+            let waveform = Self.chunk(samples, start: start)
+            embeddings.append(try models.embed(
+                waveform: waveform,
+                masks: segmentations[index]
+            ))
+            completed += 1
+        }
+
+        if progressHandler?(
+            Float(completed) / Float(totalWork), "Community-1 VBx clustering"
+        ) == false { return empty }
+        let clustered = try Community1Clustering.cluster(
+            embeddings: embeddings,
+            segmentations: segmentations,
+            plda: plda,
+            config: config,
+            bounds: speakerBounds
+        )
+        guard !clustered.centroids.isEmpty else { return empty }
+
+        // Local speakers with no active frame are never allowed to contribute
+        // to reconstruction, even if constrained assignment gave them a slot.
+        var hardClusters = clustered.hardClusters
+        for chunk in segmentations.indices {
+            for speaker in 0..<Community1Config.localSpeakers
+            where segmentations[chunk].allSatisfy({ $0[speaker] == 0 }) {
+                hardClusters[chunk][speaker] = -2
+            }
+        }
+
+        let binary = Self.reconstruct(
+            segmentations: segmentations,
+            hardClusters: hardClusters,
+            speakerCount: count,
+            clusterCount: clustered.centroids.count
+        )
+        let rawSegments = Self.toSegments(binary)
+        let compacted = DiarizationHelpers.compactSpeakerIdsAndEmbeddings(
+            rawSegments,
+            speakerEmbeddings: clustered.centroids,
+            missingEmbeddingDimension: Community1Config.embeddingDimension
+        )
+        _ = progressHandler?(1, "Ready")
+        return DiarizationResult(
+            segments: compacted.segments,
+            numSpeakers: compacted.speakerEmbeddings.count,
+            speakerEmbeddings: compacted.speakerEmbeddings
+        )
+    }
+
+    /// Start sample for every official 10-second / 1-second sliding chunk.
+    static func chunkStarts(sampleCount: Int) -> [Int] {
+        guard sampleCount > 0 else { return [] }
+        let window = Community1Config.chunkSamples
+        let step = Int(Community1Config.chunkStep * Float(Community1Config.sampleRate))
+        let complete = sampleCount >= window ? (sampleCount - window) / step + 1 : 0
+        var starts = (0..<complete).map { $0 * step }
+        let hasLast = sampleCount < window || (sampleCount - window) % step > 0
+        if hasLast { starts.append(complete * step) }
+        return starts
+    }
+
+    private static func chunk(_ samples: [Float], start: Int) -> [Float] {
+        var result = [Float](repeating: 0, count: Community1Config.chunkSamples)
+        guard start < samples.count else { return result }
+        let count = min(Community1Config.chunkSamples, samples.count - start)
+        result.replaceSubrange(0..<count, with: samples[start..<(start + count)])
+        return result
+    }
+
+    /// pyannote's overlap-averaged instantaneous speaker count.
+    static func speakerCount(_ segmentations: [[[Float]]]) -> [Int] {
+        guard !segmentations.isEmpty else { return [] }
+        let outputFrames = aggregateFrameCount(chunkCount: segmentations.count)
+        var totals = [Double](repeating: 0, count: outputFrames)
+        var contributors = [Int](repeating: 0, count: outputFrames)
+        for chunk in segmentations.indices {
+            let start = closestFrame(
+                Double(chunk) * Double(Community1Config.chunkStep)
+                    + Double(Community1Config.frameDuration) / 2
+            )
+            for frame in 0..<Community1Config.framesPerChunk {
+                let output = start + frame
+                guard output >= 0, output < outputFrames else { continue }
+                totals[output] += Double(segmentations[chunk][frame].reduce(0, +))
+                contributors[output] += 1
+            }
+        }
+        return totals.indices.map { frame in
+            guard contributors[frame] > 0 else { return 0 }
+            return Int((totals[frame] / Double(contributors[frame])).rounded(.toNearestOrEven))
+        }
+    }
+
+    static func reconstruct(
+        segmentations: [[[Float]]],
+        hardClusters: [[Int]],
+        speakerCount: [Int],
+        clusterCount: Int
+    ) -> [[Float]] {
+        let maximumCount = speakerCount.max() ?? 0
+        let outputSpeakers = max(clusterCount, maximumCount)
+        var activations = Array(
+            repeating: [Double](repeating: 0, count: outputSpeakers),
+            count: speakerCount.count
+        )
+        for chunk in segmentations.indices {
+            let start = closestFrame(
+                Double(chunk) * Double(Community1Config.chunkStep)
+                    + Double(Community1Config.frameDuration) / 2
+            )
+            for frame in 0..<Community1Config.framesPerChunk {
+                let output = start + frame
+                guard output >= 0, output < speakerCount.count else { continue }
+                var chunkActivations = [Double](
+                    repeating: -.infinity, count: outputSpeakers
+                )
+                for localSpeaker in 0..<Community1Config.localSpeakers {
+                    let cluster = hardClusters[chunk][localSpeaker]
+                    guard cluster >= 0, cluster < outputSpeakers else { continue }
+                    let value = Double(segmentations[chunk][frame][localSpeaker])
+                    chunkActivations[cluster] = max(chunkActivations[cluster], value)
+                }
+                for cluster in 0..<outputSpeakers where chunkActivations[cluster].isFinite {
+                    // First take the maximum across local tracks assigned to
+                    // this cluster, then sum overlapping chunk activations.
+                    activations[output][cluster] += chunkActivations[cluster]
+                }
+            }
+        }
+
+        var binary = Array(
+            repeating: [Float](repeating: 0, count: outputSpeakers),
+            count: speakerCount.count
+        )
+        for frame in speakerCount.indices {
+            let ordered = activations[frame].indices.sorted {
+                if activations[frame][$0] == activations[frame][$1] { return $0 < $1 }
+                return activations[frame][$0] > activations[frame][$1]
+            }
+            for speaker in ordered.prefix(min(speakerCount[frame], outputSpeakers)) {
+                binary[frame][speaker] = 1
+            }
+        }
+        return binary
+    }
+
+    /// Convert frame-center state transitions with pyannote's strict 0.5 rules.
+    static func toSegments(_ binary: [[Float]]) -> [DiarizedSegment] {
+        guard let speakerCount = binary.first?.count,
+              speakerCount > 0,
+              !binary.isEmpty else { return [] }
+        let firstTimestamp = Community1Config.frameDuration / 2
+        func timestamp(_ frame: Int) -> Float {
+            firstTimestamp + Float(frame) * Community1Config.frameStep
+        }
+
+        var segments = [DiarizedSegment]()
+        for speaker in 0..<speakerCount {
+            var start = firstTimestamp
+            var active = binary[0][speaker] > 0.5
+            for frame in 1..<binary.count {
+                let time = timestamp(frame)
+                if active, binary[frame][speaker] < 0.5 {
+                    if time > start {
+                        segments.append(DiarizedSegment(
+                            startTime: start, endTime: time, speakerId: speaker
+                        ))
+                    }
+                    start = time
+                    active = false
+                } else if !active, binary[frame][speaker] > 0.5 {
+                    start = time
+                    active = true
+                }
+            }
+            if active {
+                let end = timestamp(binary.count - 1)
+                if end > start {
+                    segments.append(DiarizedSegment(
+                        startTime: start, endTime: end, speakerId: speaker
+                    ))
+                }
+            }
+        }
+        return segments.sorted {
+            if $0.startTime == $1.startTime { return $0.speakerId < $1.speakerId }
+            return $0.startTime < $1.startTime
+        }
+    }
+
+    private static func aggregateFrameCount(chunkCount: Int) -> Int {
+        let end = Double(Community1Config.chunkDuration)
+            + Double(chunkCount - 1) * Double(Community1Config.chunkStep)
+        return closestFrame(end + Double(Community1Config.frameDuration) / 2) + 1
+    }
+
+    private static func closestFrame(_ time: Double) -> Int {
+        let centered = (time - Double(Community1Config.frameDuration) / 2)
+            / Double(Community1Config.frameStep)
+        return Int(centered.rounded(.toNearestOrEven))
+    }
+}
+#endif

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -377,6 +377,40 @@ final class AlignCommandTests: XCTestCase {
     }
 }
 
+// MARK: - DiarizeCommand
+
+final class DiarizeCommandTests: XCTestCase {
+
+    func testCommunity1Defaults() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "diarize", "meeting.wav", "--engine", "community1",
+        ])
+        let diarize = try XCTUnwrap(cmd as? DiarizeCommand)
+        XCTAssertEqual(diarize.audioFile, "meeting.wav")
+        XCTAssertEqual(diarize.engine, "community1")
+        XCTAssertEqual(diarize.community1ComputeUnits, "ane")
+        XCTAssertNil(diarize.numSpeakers)
+        XCTAssertEqual(diarize.minSpeakers, 1)
+        XCTAssertNil(diarize.maxSpeakers)
+    }
+
+    func testCommunity1SpeakerBoundsAndComputeUnitsParse() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "diarize", "meeting.wav",
+            "--engine", "community1",
+            "--community1-compute-units", "cpu",
+            "--num-speakers", "3",
+            "--min-speakers", "2",
+            "--max-speakers", "5",
+        ])
+        let diarize = try XCTUnwrap(cmd as? DiarizeCommand)
+        XCTAssertEqual(diarize.community1ComputeUnits, "cpu")
+        XCTAssertEqual(diarize.numSpeakers, 3)
+        XCTAssertEqual(diarize.minSpeakers, 2)
+        XCTAssertEqual(diarize.maxSpeakers, 5)
+    }
+}
+
 // MARK: - SpeakCommand
 
 final class SpeakCommandTests: XCTestCase {

--- a/Tests/SpeechVADTests/Community1DiarizationTests.swift
+++ b/Tests/SpeechVADTests/Community1DiarizationTests.swift
@@ -1,0 +1,172 @@
+#if canImport(CoreML)
+import AudioCommon
+import CoreML
+import XCTest
+@testable import SpeechVAD
+
+final class Community1DiarizationTests: XCTestCase {
+    func testPublishedDefaults() {
+        let config = Community1Config.default
+        XCTAssertEqual(Community1Config.sampleRate, 16_000)
+        XCTAssertEqual(Community1Config.chunkSamples, 160_000)
+        XCTAssertEqual(Community1Config.framesPerChunk, 589)
+        XCTAssertEqual(config.clusteringThreshold, 0.6, accuracy: 1e-7)
+        XCTAssertEqual(config.fa, 0.07, accuracy: 1e-7)
+        XCTAssertEqual(config.fb, 0.8, accuracy: 1e-7)
+        XCTAssertEqual(config.minimumActiveRatio, 0.2, accuracy: 1e-7)
+    }
+
+    func testOfficialChunkStartsIncludePaddedOrphan() {
+        XCTAssertEqual(
+            Community1DiarizationPipeline.chunkStarts(sampleCount: 80_000),
+            [0]
+        )
+        XCTAssertEqual(
+            Community1DiarizationPipeline.chunkStarts(sampleCount: 160_000),
+            [0]
+        )
+        XCTAssertEqual(
+            Community1DiarizationPipeline.chunkStarts(sampleCount: 168_000),
+            [0, 16_000]
+        )
+        XCTAssertEqual(
+            Community1DiarizationPipeline.chunkStarts(sampleCount: 176_000),
+            [0, 16_000]
+        )
+    }
+
+    func testSpeakerCountUsesOverlapAverageAndNearestEvenRounding() {
+        var chunk = Array(
+            repeating: [Float](repeating: 0, count: 3),
+            count: Community1Config.framesPerChunk
+        )
+        chunk[0][0] = 1
+        chunk[1][0] = 1
+        chunk[1][1] = 1
+        let count = Community1DiarizationPipeline.speakerCount([chunk])
+        XCTAssertEqual(count.count, 594)
+        XCTAssertEqual(count[0], 1)
+        XCTAssertEqual(count[1], 2)
+        XCTAssertEqual(count[588], 0)
+        XCTAssertEqual(count[593], 0)
+    }
+
+    func testConstrainedAssignmentUsesEachClusterAtMostOnce() {
+        let scores = [
+            [0.9, 0.8],
+            [0.85, 0.1],
+            [0.2, 0.7],
+        ]
+        let assignment = Community1Clustering.constrainedArgmax(scores)
+        XCTAssertEqual(assignment, [1, 0, -2])
+    }
+
+    func testCentroidLinkageCut() {
+        let embeddings: [[Float]] = [
+            [1, 0], [0.98, 0.02],
+            [-1, 0], [-0.98, 0.02],
+        ]
+        XCTAssertEqual(
+            Community1Clustering.centroidLinkageLabels(embeddings, threshold: 0.2),
+            [0, 0, 1, 1]
+        )
+    }
+
+    func testCentroidLinkageScalesToRollingWindowEmbeddingCounts() {
+        let embeddings: [[Float]] = (0..<300).map { sample in
+            var embedding = [Float](
+                repeating: 0,
+                count: Community1Config.embeddingDimension
+            )
+            embedding[sample % 3] = 1
+            for dimension in 3..<embedding.count {
+                embedding[dimension] = Float((sample * 17 + dimension * 13) % 11) * 0.0001
+            }
+            return embedding
+        }
+
+        let start = Date()
+        let labels = Community1Clustering.centroidLinkageLabels(
+            embeddings,
+            threshold: 0.1
+        )
+
+        XCTAssertEqual(Set(labels).count, 3)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5.0)
+    }
+
+    func testVBxMatchesReferenceFixture() {
+        let labels = [0, 0, 1, 1]
+        let features = [
+            [1.0, 0.2], [0.9, 0.1], [-0.8, 0.1], [-1.0, 0.3],
+        ]
+        let result = Community1Clustering.vbx(
+            initialLabels: labels,
+            features: features,
+            phi: [2.0, 0.5],
+            config: .default
+        )
+        let expectedPriors = [0.500150422801, 0.499849577199]
+        XCTAssertEqual(result.priors[0], expectedPriors[0], accuracy: 1e-9)
+        XCTAssertEqual(result.priors[1], expectedPriors[1], accuracy: 1e-9)
+        XCTAssertEqual(result.responsibilities[0][0], 0.500152474379, accuracy: 1e-9)
+        XCTAssertEqual(result.responsibilities[3][1], 0.499851716677, accuracy: 1e-9)
+    }
+
+    func testTimelineUsesReceptiveFieldCenters() {
+        var binary = Array(repeating: [Float](repeating: 0, count: 1), count: 5)
+        binary[1][0] = 1
+        binary[2][0] = 1
+        let segments = Community1DiarizationPipeline.toSegments(binary)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(
+            segments[0].startTime,
+            Community1Config.frameDuration / 2 + Community1Config.frameStep,
+            accuracy: 1e-7
+        )
+        XCTAssertEqual(
+            segments[0].endTime,
+            Community1Config.frameDuration / 2 + 3 * Community1Config.frameStep,
+            accuracy: 1e-7
+        )
+    }
+}
+
+final class E2ECommunity1DiarizationTests: XCTestCase {
+    func testPublishedBundleOnVoxConverseProbe() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let bundlePath = environment["COMMUNITY1_COREML_BUNDLE"],
+              let audioPath = environment["COMMUNITY1_TEST_AUDIO"],
+              let referencePath = environment["COMMUNITY1_TEST_RTTM"] else {
+            throw XCTSkip(
+                "set COMMUNITY1_COREML_BUNDLE, COMMUNITY1_TEST_AUDIO, and COMMUNITY1_TEST_RTTM"
+            )
+        }
+        let bundle = URL(fileURLWithPath: bundlePath)
+        let audioURL = URL(fileURLWithPath: audioPath)
+        let referenceURL = URL(fileURLWithPath: referencePath)
+        guard FileManager.default.fileExists(atPath: bundle.path),
+              FileManager.default.fileExists(atPath: audioURL.path),
+              FileManager.default.fileExists(atPath: referenceURL.path) else {
+            throw XCTSkip("set COMMUNITY1_COREML_BUNDLE, COMMUNITY1_TEST_AUDIO, and COMMUNITY1_TEST_RTTM")
+        }
+
+        let pipeline = try Community1DiarizationPipeline.fromLocal(
+            directory: bundle,
+            computeUnits: .cpuAndNeuralEngine
+        )
+        let audio = try AudioFileLoader.load(url: audioURL, targetSampleRate: 16_000)
+        let result = try pipeline.diarize(audio: audio, sampleRate: 16_000)
+        let reference = parseRTTM(try String(contentsOf: referenceURL, encoding: .utf8))
+        let score = computeDERWithOptimalMapping(
+            reference: reference,
+            hypothesis: result.segments,
+            collar: 0.25,
+            resolution: 0.01
+        )
+
+        XCTAssertEqual(result.numSpeakers, 3)
+        XCTAssertLessThan(score.derPercent, 8.0)
+    }
+}
+#endif

--- a/docs/inference/cache-and-offline.md
+++ b/docs/inference/cache-and-offline.md
@@ -34,6 +34,16 @@ let pipeline = try await PyannoteDiarizationPipeline.fromPretrained(
 // VAD (opt.)   → appModels/models/aufklarer/Silero-VAD-v6.2.1-MLX/
 ```
 
+Community-1 is one self-contained bundle, so it uses the regular `cacheDir`
+parameter:
+
+```swift
+let community1 = try await Community1DiarizationPipeline.fromPretrained(
+    cacheDir: appModels.appendingPathComponent("community1"),
+    offlineMode: true
+)
+```
+
 ## HuggingFace Mirror (`HF_ENDPOINT`)
 
 Downloads default to `https://huggingface.co`. Users in regions where that host is slow or blocked — notably mainland China — can point the downloader at a mirror by setting the `HF_ENDPOINT` environment variable (the same name Python's `huggingface_hub` uses):
@@ -92,6 +102,7 @@ All models support both parameters:
 | `WeSpeakerModel` | `cacheDir`, `offlineMode` |
 | `SpeechEnhancer` | `cacheDir`, `offlineMode` |
 | `SortformerDiarizer` | `cacheDir`, `offlineMode` |
+| `Community1DiarizationPipeline` | `cacheDir`, `offlineMode` |
 | `PyannoteDiarizationPipeline` | `cacheBaseDir`, `offlineMode` |
 | `Qwen35CoreMLChat` | `cacheDir`, `offlineMode` |
 | `Qwen35MLXChat` | `cacheDir`, `offlineMode` |

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -2,10 +2,11 @@
 
 ## Overview
 
-Speaker diarization identifies **who spoke when** in an audio recording. Two engines are available:
+Speaker diarization identifies **who spoke when** in an audio recording. Three engines are available:
 
 1. **Pyannote** (default) — two-stage pipeline: segmentation + activity-based speaker chaining → post-hoc WeSpeaker embedding
-2. **Sortformer** (CoreML) — NVIDIA's end-to-end neural diarization model, runs on Neural Engine
+2. **Community-1** (CoreML) — Pyannote segmentation + masked WeSpeaker embeddings + native PLDA/VBx clustering
+3. **Sortformer** (CoreML) — NVIDIA's end-to-end neural diarization model, runs on Neural Engine
 
 ## Architecture
 
@@ -13,8 +14,39 @@ Speaker diarization identifies **who spoke when** in an audio recording. Two eng
 
 ```bash
 speech diarize meeting.wav                    # Pyannote (default)
+speech diarize meeting.wav --engine community1  # Community-1 (CoreML + VBx)
 speech diarize meeting.wav --engine sortformer  # Sortformer (CoreML)
 ```
+
+### Community-1 (CoreML + Native VBx)
+
+Community-1 is the accuracy-oriented, embedding-capable CoreML pipeline. Its
+two neural stages run through Core ML; powerset decoding, PLDA transforms, VBx,
+constrained assignment, and timeline reconstruction are native Swift. It does
+not load MLX or require a Metal shader library.
+
+```
+Audio → 10 s / 1 s-hop PyanNet → hard powerset tracks
+      → overlap-masked WeSpeaker embeddings → centroid AHC
+      → 256→128 PLDA transform → VBx → constrained assignment
+      → overlap-add speaker counting → diarized segments + 256-d centroids
+```
+
+- **Segmentation context**: 10 seconds, advanced by 1 second
+- **Local speakers**: up to three powerset tracks per chunk
+- **Embedding masks**: clean single-speaker frames, with the upstream
+  overlap-inclusive fallback for very short tracks
+- **AHC initialization**: centroid linkage over L2-normalized embeddings,
+  Euclidean threshold 0.6
+- **VBx defaults**: `Fa=0.07`, `Fb=0.8`, at most 20 iterations
+- **Assignment**: maximum-weight one-to-one matching inside each chunk
+- **Speaker bounds**: inferred by default; exact, minimum, and maximum counts
+  can be supplied by API or CLI
+
+The bundle is
+[`aufklarer/Pyannote-Community-1-CoreML`](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML),
+derived from `pyannote/speaker-diarization-community-1` and distributed under
+CC BY 4.0. Preserve its attribution when redistributing the weights.
 
 ### Sortformer (End-to-End, CoreML)
 
@@ -115,6 +147,28 @@ for seg in result.segments {
 print("\(result.numSpeakers) speakers detected")
 ```
 
+### Community-1 Swift API
+
+```swift
+let diarizer = try await Community1DiarizationPipeline.fromPretrained()
+try diarizer.prewarm()
+
+let result = try diarizer.diarize(
+    audio: samples,
+    sampleRate: 16_000,
+    speakerBounds: Community1SpeakerBounds(minimum: 2, maximum: 6)
+)
+
+for segment in result.segments {
+    print("Speaker \(segment.speakerId): \(segment.startTime)s–\(segment.endTime)s")
+}
+// result.speakerEmbeddings contains one 256-d centroid per returned speaker.
+```
+
+Use `Community1SpeakerBounds(exact: 2)` when the number of speakers is known.
+Speaker IDs are local to one result; use the returned centroids to match them
+to a recording-local or persistent voice registry.
+
 #### Progress Reporting & Cancellation
 
 For long audio files, use the `progressHandler` overload to track progress.
@@ -190,6 +244,11 @@ let result = diarizer.diarize(audio: samples, sampleRate: 16000) { progress, sta
 # Pyannote diarization (default)
 speech diarize meeting.wav
 
+# Community-1 (CoreML + native PLDA/VBx)
+speech diarize meeting.wav --engine community1
+speech diarize meeting.wav --engine community1 --num-speakers 2
+speech diarize meeting.wav --engine community1 --min-speakers 2 --max-speakers 6
+
 # Sortformer diarization (CoreML, Neural Engine)
 speech diarize meeting.wav --engine sortformer
 
@@ -207,8 +266,27 @@ speech embed-speaker enrollment.wav
 speech embed-speaker enrollment.wav --engine coreml --json
 ```
 
+Community-1 compute units can be selected with
+`--community1-compute-units ane|cpu|gpu|all` (`ane` is the default).
+
+## Community-1 Parity Check
+
+On the fixed five-file VoxConverse release subset (1,057.49 seconds, 0.25 s
+collar, overlap included), the Swift output rescored with `pyannote.metrics`
+measured **4.66% DER / 21.43% JER**. The published CoreML export measured
+**4.65% / 21.42%** with the same scorer. The residual difference is 0.02
+percentage points of DER and comes from floating-point/tie behavior; detected
+speaker counts match on all five files.
+
+This is a small release parity check, not a dataset-wide quality claim. Do not
+compare these percentages directly with the package's frame-grid benchmark,
+whose collar and boundary accounting are intentionally different.
+
 ## Model Weights
 
+- **Community-1 bundle (CoreML + PLDA/VBx)**:
+  [`aufklarer/Pyannote-Community-1-CoreML`](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML)
+  (~32 MiB)
 - **Segmentation**: `aufklarer/Pyannote-Segmentation-MLX` (~5.7 MB)
 - **Speaker Embedding (MLX)**: `aufklarer/WeSpeaker-ResNet34-LM-MLX` (~25 MB)
 - **Speaker Embedding (CoreML)**: `aufklarer/WeSpeaker-ResNet34-LM-CoreML` (~13 MB)
@@ -250,6 +328,10 @@ Sources/SpeechVAD/
 ├── PowersetDecoder.swift              7-class powerset → per-speaker probs
 ├── DiarizationHelpers.swift            Merge segments, compact IDs, constrained clustering
 ├── DiarizationPipeline.swift          Pyannote pipeline (embedding clustering + speaker extraction)
+├── Community1Configuration.swift      Published pipeline constants + speaker-count bounds
+├── Community1CoreML.swift             PyanNet + masked WeSpeaker CoreML wrappers
+├── Community1Clustering.swift         PLDA loading, centroid AHC, VBx, assignment
+├── Community1DiarizationPipeline.swift  Community-1 orchestration + reconstruction
 ├── SortformerConfig.swift             Sortformer model configuration
 ├── SortformerMelExtractor.swift       128-dim log-mel for Sortformer (Hann window)
 ├── SortformerModel.swift              CoreML wrapper for Sortformer inference


### PR DESCRIPTION
## Summary

- add a native Swift runtime for the published Pyannote Community-1 CoreML bundle
- run PyanNet segmentation and masked WeSpeaker embeddings through CoreML, with native powerset decoding, PLDA, VBx, constrained assignment, and timeline reconstruction
- expose exact/minimum/maximum speaker bounds and return one 256-dimensional centroid per detected speaker
- add CLI and diarization-benchmark engine selection, offline-cache support, tests, package docs, and all README translations

## Architecture

This is an additive SpeechVAD engine. The existing Pyannote engine remains the CLI default and Sortformer remains available; no existing pipeline or model selection changes. Model weights stay outside Git and download through the shared Hugging Face cache/offline path. CoreML-only code is platform-gated.

## Verification

- optimized release build and release Metal library completed
- complete non-E2E suite: 1,441 passed, 31 expected skips, 0 failures
- isolated real-model E2E: published 32 MiB bundle plus VoxConverse ampme audio/reference, 1 passed, 0 skipped, 7.58 seconds
- git diff --check passed

## Benchmark

Five fixed VoxConverse development files, 1,057.5 seconds total, 0.25-second collar, overlap included. The table below uses speech-swift's frame-grid scorer; engines were measured in isolated processes.

| Engine | DER | JER | Speaker-count accuracy | Throughput | Peak RSS |
| --- | ---: | ---: | ---: | ---: | ---: |
| Community-1 CoreML | 9.31% | 16.20% | 60% | 25.5x | 1,540 MB |
| Existing Pyannote CoreML | 5.03% | 9.28% | 60% | 105.7x | 393 MB |

The existing engine's 5.03% DER exactly matches its pre-branch baseline, so the additive runtime does not regress the current path.

For export parity, the same Community-1 Swift RTTM output rescored with pyannote.metrics measured 4.66% DER / 21.43% JER; the published CoreML reference measured 4.65% / 21.42%. These numbers use a different boundary/collar implementation and are not directly comparable with the frame-grid table. This is a small release parity set, not a dataset-wide quality claim.

Community-1 is useful when callers need the full upstream pipeline, bounded speaker counts, and returned voice centroids. It is not presented as a universal quality or latency improvement over the package default.
