### PR TITLE
Add ReDimNet2-B6 speaker identity encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs
 - **[Wake-word](https://soniqo.audio/guides/wake-word)** — On-device keyword spotting (KWS Zipformer 3M, CoreML, 26× real-time, configurable keyword list)
 - **[VAD](https://soniqo.audio/guides/vad)** — Voice activity detection (Silero streaming, Pyannote offline, FireRedVAD 100+ languages)
 - **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — Who spoke when (Pyannote pipeline, Sortformer end-to-end on Neural Engine)
-- **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), CAM++ (192-dim)
+- **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), ReDimNet2-B6 named identity (192-dim), CAM++ (192-dim)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -203,6 +203,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | Audio super-resolution (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnostic |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Speaker Embedding | MLX, CoreML | 6.6M | Agnostic |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Named Voice Identity | CoreML | 12.3M | Agnostic |
 
 ## Installation
 

--- a/README_ar.md
+++ b/README_ar.md
@@ -88,7 +88,7 @@
 - **[كلمة التنبيه](https://soniqo.audio/ar/guides/wake-word)** — اكتشاف الكلمات المفتاحية على الجهاز (KWS Zipformer 3M، CoreML، 26× الزمن الحقيقي، قائمة كلمات مفتاحية قابلة للتهيئة)
 - **[VAD](https://soniqo.audio/ar/guides/vad)** — اكتشاف النشاط الصوتي (Silero تدفقي، Pyannote دون اتصال، FireRedVAD أكثر من 100 لغة)
 - **[تمييز المتحدثين](https://soniqo.audio/ar/guides/diarize)** — من تحدث متى (خط أنابيب Pyannote، Sortformer من طرف إلى طرف على Neural Engine)
-- **[تضمينات المتحدث](https://soniqo.audio/ar/guides/embed-speaker)** — WeSpeaker ResNet34 (256 بُعداً)، CAM++ (192 بُعداً)
+- **[تضمينات المتحدث](https://soniqo.audio/ar/guides/embed-speaker)** — WeSpeaker ResNet34 (256 بُعداً)، ReDimNet2-B6 للهوية الصوتية المسماة (192 بُعداً)، CAM++ (192 بُعداً)
 
 </div>
 
@@ -244,6 +244,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ar/guides/upsample) | رفع دقة الصوت (48 كيلوهرتز) | MLX | 363 ميغابايت / 720 ميغابايت (int4/int8) | محايد للغة |
 | [WeSpeaker](https://soniqo.audio/ar/guides/embed-speaker) | تضمين المتحدث | MLX, CoreML | 6.6M | محايد للغة |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | هوية صوتية مسماة | CoreML | 12.3M | محايد للغة |
 
 ## التثبيت
 

--- a/README_de.md
+++ b/README_de.md
@@ -78,7 +78,7 @@ Spracherkennung, -synthese und -verständnis auf dem Gerät für Mac und iOS. L�
 - **[Wake-Word](https://soniqo.audio/de/guides/wake-word)** — Schlüsselworterkennung auf dem Gerät (KWS Zipformer 3M, CoreML, 26× Echtzeit, konfigurierbare Stichwortliste)
 - **[VAD](https://soniqo.audio/de/guides/vad)** — Sprachaktivitätserkennung (Silero Streaming, Pyannote Offline, FireRedVAD 100+ Sprachen)
 - **[Sprecherdiarisierung](https://soniqo.audio/de/guides/diarize)** — Wer hat wann gesprochen (Pyannote-Pipeline, durchgängiger Sortformer auf der Neural Engine)
-- **[Sprechereinbettungen](https://soniqo.audio/de/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), CAM++ (192-dim)
+- **[Sprechereinbettungen](https://soniqo.audio/de/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), ReDimNet2-B6 für benannte Stimmidentität (192-dim), CAM++ (192-dim)
 
 Paper: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/de/guides/upsample) | Audio-Super-Resolution (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnostisch |
 | [WeSpeaker](https://soniqo.audio/de/guides/embed-speaker) | Sprechereinbettung | MLX, CoreML | 6.6M | Sprachunabhängig |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Benannte Stimmidentität | CoreML | 12.3M | Sprachunabhängig |
 
 ## Installation
 

--- a/README_es.md
+++ b/README_es.md
@@ -78,7 +78,7 @@ Reconocimiento, síntesis y comprensión de voz en el dispositivo para Mac e iOS
 - **[Palabra de activación](https://soniqo.audio/es/guides/wake-word)** — Detección de palabras clave en el dispositivo (KWS Zipformer 3M, CoreML, 26× tiempo real, lista de palabras clave configurable)
 - **[VAD](https://soniqo.audio/es/guides/vad)** — Detección de actividad vocal (Silero streaming, Pyannote offline, FireRedVAD 100+ idiomas)
 - **[Diarización de hablantes](https://soniqo.audio/es/guides/diarize)** — Quién habló cuándo (pipeline Pyannote, Sortformer de extremo a extremo en Neural Engine)
-- **[Embeddings de hablante](https://soniqo.audio/es/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), CAM++ (192 dim)
+- **[Embeddings de hablante](https://soniqo.audio/es/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), ReDimNet2-B6 para identidad de voz con nombre (192 dim), CAM++ (192 dim)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/es/guides/upsample) | Super-resolución de audio (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnóstico |
 | [WeSpeaker](https://soniqo.audio/es/guides/embed-speaker) | Embedding de hablante | MLX, CoreML | 6.6M | Agnóstico |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Identidad de voz con nombre | CoreML | 12.3M | Agnóstico |
 
 ## Instalación
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -78,7 +78,7 @@ Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'e
 - **[Mot de reveil](https://soniqo.audio/fr/guides/wake-word)** -- Detection de mots-cles sur appareil (KWS Zipformer 3M, CoreML, 26x temps reel, liste de mots-cles configurable)
 - **[VAD](https://soniqo.audio/fr/guides/vad)** -- Detection d'activite vocale (Silero streaming, Pyannote hors ligne, FireRedVAD 100+ langues)
 - **[Diarisation de locuteurs](https://soniqo.audio/fr/guides/diarize)** -- Qui a parle quand (pipeline Pyannote, Sortformer de bout en bout sur Neural Engine)
-- **[Empreintes de locuteur](https://soniqo.audio/fr/guides/embed-speaker)** -- WeSpeaker ResNet34 (256 dim), CAM++ (192 dim)
+- **[Empreintes de locuteur](https://soniqo.audio/fr/guides/embed-speaker)** -- WeSpeaker ResNet34 (256 dim), ReDimNet2-B6 pour l’identité vocale nommée (192 dim), CAM++ (192 dim)
 
 Articles : [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/fr/guides/upsample) | Super-résolution audio (48 kHz) | MLX | 363 Mo / 720 Mo (int4/int8) | Agnostique |
 | [WeSpeaker](https://soniqo.audio/fr/guides/embed-speaker) | Empreinte de locuteur | MLX, CoreML | 6.6M | Agnostique |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Identité vocale nommée | CoreML | 12.3M | Agnostique |
 
 ## Installation
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -78,7 +78,7 @@ Mac और iOS के लिए ऑन-डिवाइस स्पीच रि
 - **[वेक-वर्ड](https://soniqo.audio/hi/guides/wake-word)** — ऑन-डिवाइस कीवर्ड स्पॉटिंग (KWS Zipformer 3M, CoreML, 26× रियल-टाइम, कॉन्फ़िगरेबल कीवर्ड सूची)
 - **[VAD](https://soniqo.audio/hi/guides/vad)** — वॉयस एक्टिविटी डिटेक्शन (Silero स्ट्रीमिंग, Pyannote ऑफ़लाइन, FireRedVAD 100+ भाषाएँ)
 - **[Speaker Diarization](https://soniqo.audio/hi/guides/diarize)** — कौन कब बोला (Pyannote पाइपलाइन, Neural Engine पर एंड-टू-एंड Sortformer)
-- **[Speaker Embeddings](https://soniqo.audio/hi/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), CAM++ (192-dim)
+- **[Speaker Embeddings](https://soniqo.audio/hi/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), ReDimNet2-B6 नामित आवाज़ पहचान (192-dim), CAM++ (192-dim)
 
 पेपर: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/hi/guides/upsample) | ऑडियो सुपर-रेज़ोल्यूशन (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | भाषा-निरपेक्ष |
 | [WeSpeaker](https://soniqo.audio/hi/guides/embed-speaker) | स्पीकर एम्बेडिंग | MLX, CoreML | 6.6M | भाषा-तटस्थ |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | नामित आवाज़ पहचान | CoreML | 12.3M | भाषा-तटस्थ |
 
 ## इंस्टॉलेशन
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -78,7 +78,7 @@ Mac・iOS向けのオンデバイス音声認識・合成・理解。Apple Silic
 - **[ウェイクワード](https://soniqo.audio/ja/guides/wake-word)** — オンデバイスのキーワード検出（KWS Zipformer 3M、CoreML、リアルタイムの26倍、キーワードリスト設定可能）
 - **[VAD](https://soniqo.audio/ja/guides/vad)** — 音声区間検出（Sileroストリーミング、Pyannoteオフライン、FireRedVAD 100以上の言語）
 - **[話者ダイアライゼーション](https://soniqo.audio/ja/guides/diarize)** — 誰がいつ話したか（Pyannoteパイプライン、Neural Engine上のエンドツーエンドSortformer）
-- **[話者埋め込み](https://soniqo.audio/ja/guides/embed-speaker)** — WeSpeaker ResNet34（256次元）、CAM++（192次元）
+- **[話者埋め込み](https://soniqo.audio/ja/guides/embed-speaker)** — WeSpeaker ResNet34（256次元）、ReDimNet2-B6による名前付き音声識別（192次元）、CAM++（192次元）
 
 論文：[Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ja/guides/upsample) | オーディオ超解像 (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | 言語非依存 |
 | [WeSpeaker](https://soniqo.audio/ja/guides/embed-speaker) | 話者埋め込み | MLX、CoreML | 6.6M | 言語非依存 |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | 名前付き音声識別 | CoreML | 12.3M | 言語非依存 |
 
 ## インストール
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -78,7 +78,7 @@ Mac과 iOS를 위한 온디바이스 음성 인식, 합성 및 이해. Apple Sil
 - **[웨이크워드](https://soniqo.audio/ko/guides/wake-word)** — 온디바이스 키워드 감지 (KWS Zipformer 3M, CoreML, 실시간의 26배, 구성 가능한 키워드 목록)
 - **[VAD](https://soniqo.audio/ko/guides/vad)** — 음성 활동 감지 (Silero 스트리밍, Pyannote 오프라인, FireRedVAD 100+ 개 언어)
 - **[화자 분리](https://soniqo.audio/ko/guides/diarize)** — 누가 언제 말했는지 (Pyannote 파이프라인, Neural Engine 상의 엔드투엔드 Sortformer)
-- **[화자 임베딩](https://soniqo.audio/ko/guides/embed-speaker)** — WeSpeaker ResNet34 (256차원), CAM++ (192차원)
+- **[화자 임베딩](https://soniqo.audio/ko/guides/embed-speaker)** — WeSpeaker ResNet34 (256차원), ReDimNet2-B6 이름 지정 음성 식별 (192차원), CAM++ (192차원)
 
 논문: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ko/guides/upsample) | 오디오 초고해상도 (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | 언어 무관 |
 | [WeSpeaker](https://soniqo.audio/ko/guides/embed-speaker) | 화자 임베딩 | MLX, CoreML | 6.6M | 언어 무관 |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | 이름 지정 음성 식별 | CoreML | 12.3M | 언어 무관 |
 
 ## 설치
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -78,7 +78,7 @@ Reconhecimento, sintese e compreensao de fala no dispositivo para Mac e iOS. Exe
 - **[Palavra de ativacao](https://soniqo.audio/pt/guides/wake-word)** — Deteccao de palavras-chave no dispositivo (KWS Zipformer 3M, CoreML, 26x tempo real, lista de palavras-chave configuravel)
 - **[VAD](https://soniqo.audio/pt/guides/vad)** — Deteccao de atividade de voz (Silero streaming, Pyannote offline, FireRedVAD 100+ idiomas)
 - **[Diarizacao de falantes](https://soniqo.audio/pt/guides/diarize)** — Quem falou quando (pipeline Pyannote, Sortformer ponta-a-ponta no Neural Engine)
-- **[Embeddings de falante](https://soniqo.audio/pt/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), CAM++ (192 dim)
+- **[Embeddings de falante](https://soniqo.audio/pt/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), ReDimNet2-B6 para identidade de voz nomeada (192 dim), CAM++ (192 dim)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/pt/guides/upsample) | Super-resolução de áudio (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnóstico |
 | [WeSpeaker](https://soniqo.audio/pt/guides/embed-speaker) | Embedding de falante | MLX, CoreML | 6.6M | Agnostico |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Identidade de voz nomeada | CoreML | 12.3M | Agnostico |
 
 ## Instalacao
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -78,7 +78,7 @@
 - **[Активационное слово](https://soniqo.audio/ru/guides/wake-word)** — Локальное распознавание ключевых слов (KWS Zipformer 3M, CoreML, 26× реального времени, настраиваемый список ключевых слов)
 - **[VAD](https://soniqo.audio/ru/guides/vad)** — Обнаружение голосовой активности (Silero потоковый, Pyannote офлайн, FireRedVAD 100+ языков)
 - **[Speaker Diarization](https://soniqo.audio/ru/guides/diarize)** — Кто говорил и когда (Pyannote-пайплайн, сквозной Sortformer на Neural Engine)
-- **[Speaker Embeddings](https://soniqo.audio/ru/guides/embed-speaker)** — WeSpeaker ResNet34 (256-мерные векторы), CAM++ (192-мерные)
+- **[Speaker Embeddings](https://soniqo.audio/ru/guides/embed-speaker)** — WeSpeaker ResNet34 (256-мерные векторы), ReDimNet2-B6 для именованной идентификации голоса (192-мерные), CAM++ (192-мерные)
 
 Статьи: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ru/guides/upsample) | Аудио супер-разрешение (48 кГц) | MLX | 363 МБ / 720 МБ (int4/int8) | Языконезависимое |
 | [WeSpeaker](https://soniqo.audio/ru/guides/embed-speaker) | Эмбеддинги спикеров | MLX, CoreML | 6.6M | Универсальный |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Именованная идентификация голоса | CoreML | 12.3M | Универсальный |
 
 ## Установка
 

--- a/README_th.md
+++ b/README_th.md
@@ -78,7 +78,7 @@
 - **[Wake-word](https://soniqo.audio/guides/wake-word)** — การตรวจจับคำสั่งปลุกบนอุปกรณ์ (KWS Zipformer 3M, CoreML, เร็วกว่าเรียลไทม์ 26 เท่า, รายการคำสั่งปลุกปรับแต่งได้)
 - **[VAD](https://soniqo.audio/guides/vad)** — การตรวจจับเสียงพูด (Silero streaming, Pyannote offline, FireRedVAD รองรับกว่า 100 ภาษา)
 - **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — ใครพูดเมื่อใด (pipeline Pyannote, Sortformer แบบ end-to-end บน Neural Engine)
-- **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 มิติ), CAM++ (192 มิติ)
+- **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 มิติ), ReDimNet2-B6 สำหรับการระบุตัวตนเสียงแบบตั้งชื่อ (192 มิติ), CAM++ (192 มิติ)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | การเพิ่มความละเอียดเสียง (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | ไม่จำกัดภาษา |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Embedding ของผู้พูด | MLX, CoreML | 6.6M | ไม่จำกัดภาษา |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | การระบุตัวตนเสียงแบบตั้งชื่อ | CoreML | 12.3M | ไม่จำกัดภาษา |
 
 ## การติดตั้ง
 

--- a/README_tr.md
+++ b/README_tr.md
@@ -78,7 +78,7 @@ Mac ve iOS için cihaz üzerinde konuşma tanıma, sentezleme ve anlama. Apple S
 - **[Uyandırma kelimesi](https://soniqo.audio/guides/wake-word)** — Cihaz üzerinde anahtar kelime tespiti (KWS Zipformer 3M, CoreML, 26× gerçek zaman, yapılandırılabilir anahtar kelime listesi)
 - **[VAD](https://soniqo.audio/guides/vad)** — Ses etkinlik algılama (Silero akış, Pyannote çevrimdışı, FireRedVAD 100+ dil)
 - **[Konuşmacı Ayrımı](https://soniqo.audio/guides/diarize)** — Kim ne zaman konuştu (Pyannote pipeline, Neural Engine üzerinde uçtan uca Sortformer)
-- **[Konuşmacı Gömmeleri](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-boyut), CAM++ (192-boyut)
+- **[Konuşmacı Gömmeleri](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-boyut), ReDimNet2-B6 ile adlandırılmış ses kimliği (192-boyut), CAM++ (192-boyut)
 
 Makaleler: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | Ses süper çözünürlük (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Bağımsız |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Konuşmacı Gömme | MLX, CoreML | 6.6M | Bağımsız |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Adlandırılmış Ses Kimliği | CoreML | 12.3M | Bağımsız |
 
 ## Kurulum
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -78,7 +78,7 @@ Nhận dạng, tổng hợp và hiểu giọng nói trên thiết bị cho Mac v
 - **[Từ kích hoạt](https://soniqo.audio/guides/wake-word)** — Phát hiện từ khóa trên thiết bị (KWS Zipformer 3M, CoreML, 26× thời gian thực, danh sách từ khóa có thể cấu hình)
 - **[VAD](https://soniqo.audio/guides/vad)** — Phát hiện hoạt động giọng nói (Silero streaming, Pyannote ngoại tuyến, FireRedVAD hơn 100 ngôn ngữ)
 - **[Phân tách người nói](https://soniqo.audio/guides/diarize)** — Ai nói khi nào (pipeline Pyannote, Sortformer end-to-end trên Neural Engine)
-- **[Embedding người nói](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 chiều), CAM++ (192 chiều)
+- **[Embedding người nói](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 chiều), ReDimNet2-B6 để nhận dạng giọng nói có tên (192 chiều), CAM++ (192 chiều)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | Siêu phân giải âm thanh (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Không phụ thuộc ngôn ngữ |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Embedding người nói | MLX, CoreML | 6.6M | Không phụ thuộc ngôn ngữ |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Nhận dạng giọng nói có tên | CoreML | 12.3M | Không phụ thuộc ngôn ngữ |
 
 ## Cài đặt
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -78,7 +78,7 @@
 - **[唤醒词](https://soniqo.audio/zh/guides/wake-word)** — 设备端关键词识别（KWS Zipformer 3M，CoreML，26× 实时，可配置关键词列表）
 - **[VAD](https://soniqo.audio/zh/guides/vad)** — 语音活动检测（Silero 流式、Pyannote 离线、FireRedVAD 100+ 种语言）
 - **[说话人分离](https://soniqo.audio/zh/guides/diarize)** — 谁在什么时间说话（Pyannote 流水线，神经引擎上的端到端 Sortformer）
-- **[说话人嵌入向量](https://soniqo.audio/zh/guides/embed-speaker)** — WeSpeaker ResNet34（256 维）、CAM++（192 维）
+- **[说话人嵌入向量](https://soniqo.audio/zh/guides/embed-speaker)** — WeSpeaker ResNet34（256 维）、ReDimNet2-B6 命名语音身份（192 维）、CAM++（192 维）
 
 论文：[Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
 
@@ -200,6 +200,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/zh/guides/upsample) | 音频超分辨率 (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | 通用 |
 | [WeSpeaker](https://soniqo.audio/zh/guides/embed-speaker) | 说话人嵌入向量 | MLX、CoreML | 6.6M | 语言无关 |
+| [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | 命名语音身份 | CoreML | 12.3M | 语言无关 |
 
 ## 安装
 

--- a/Sources/AudioCLILib/EmbedSpeakerCommand.swift
+++ b/Sources/AudioCLILib/EmbedSpeakerCommand.swift
@@ -13,7 +13,7 @@ public struct EmbedSpeakerCommand: ParsableCommand {
     @Argument(help: "Audio file containing speaker voice (WAV, any sample rate)")
     public var audioFile: String
 
-    @Option(name: .long, help: "Inference engine: mlx, coreml (WeSpeaker), or camplusplus (CAM++ CoreML)")
+    @Option(name: .long, help: "Inference engine: mlx, coreml (WeSpeaker), redimnet2 (identity CoreML), or camplusplus (CAM++ CoreML)")
     public var engine: String = "mlx"
 
     @Flag(name: .long, help: "Output as JSON")
@@ -32,7 +32,17 @@ public struct EmbedSpeakerCommand: ParsableCommand {
             let embedding: [Float]
             let elapsed: TimeInterval
 
-            if engine == "camplusplus" {
+            if engine == "redimnet2" {
+                print("Loading ReDimNet2 speaker identity model (CoreML)...")
+                let model = try await ReDimNet2SpeakerModel.fromPretrained(
+                    progressHandler: reportProgress
+                )
+
+                print("Extracting speaker identity embedding...")
+                let start = Date()
+                embedding = try model.embed(audio: audio, sampleRate: 16000)
+                elapsed = Date().timeIntervalSince(start)
+            } else if engine == "camplusplus" {
                 print("Loading CAM++ speaker model (CoreML)...")
                 let model = try await CamPlusPlusSpeaker.fromPretrained(
                     progressHandler: reportProgress
@@ -44,7 +54,7 @@ public struct EmbedSpeakerCommand: ParsableCommand {
                 elapsed = Date().timeIntervalSince(start)
             } else {
                 guard let embEngine = WeSpeakerEngine(rawValue: engine) else {
-                    print("Error: unknown engine '\(engine)'. Use 'mlx', 'coreml', or 'camplusplus'.")
+                    print("Error: unknown engine '\(engine)'. Use 'mlx', 'coreml', 'redimnet2', or 'camplusplus'.")
                     return
                 }
 

--- a/Sources/SpeechVAD/ReDimNet2Speaker.swift
+++ b/Sources/SpeechVAD/ReDimNet2Speaker.swift
@@ -1,0 +1,260 @@
+#if canImport(CoreML)
+import AudioCommon
+import CoreML
+import Foundation
+
+struct ReDimNet2ModelConfiguration: Decodable, Equatable {
+    let modelType: String
+    let sampleRate: Int
+    let inputSamples: Int
+    let embeddingDimension: Int
+    let inputName: String
+    let outputName: String
+    let compiledModel: String
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case sampleRate = "sample_rate"
+        case inputSamples = "input_samples"
+        case embeddingDimension = "embedding_dimension"
+        case inputName = "input_name"
+        case outputName = "output_name"
+        case compiledModel = "compiled_model"
+    }
+}
+
+/// Core ML speaker-identity encoder based on ReDimNet2-B6.
+///
+/// This model is separate from the WeSpeaker embedding stage used inside
+/// diarization. It produces 192-dimensional embeddings for comparing clean
+/// voice samples across recordings and for persistent named voice profiles.
+///
+/// Input audio is resampled to 16 kHz and prepared as one fixed six-second
+/// window. Two-to-six-second clips are repeated to fill the window; longer
+/// clips are center-cropped. Clips shorter than two seconds are rejected
+/// because they did not meet the quality threshold used for identity matching.
+public final class ReDimNet2SpeakerModel {
+    public static let defaultModelId = "aufklarer/ReDimNet2-B6-CoreML"
+    public static let inputSampleRate = 16_000
+    public static let inputSampleCount = 96_000
+    public static let minimumSampleCount = 32_000
+    public static let embeddingDimension = 192
+
+    private let model: MLModel
+
+    init(model: MLModel) {
+        self.model = model
+    }
+
+    /// Download and load the compiled ReDimNet2-B6 Core ML model.
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> ReDimNet2SpeakerModel {
+        let cacheDir = try cacheDir
+            ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+
+        progressHandler?(0.0, "Downloading ReDimNet2 speaker identity model...")
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: modelId,
+            to: cacheDir,
+            additionalFiles: ["ReDimNet2B6.mlmodelc/**", "config.json"],
+            offlineMode: offlineMode,
+            progressHandler: { progress in
+                progressHandler?(
+                    progress * 0.8,
+                    "Downloading ReDimNet2 speaker identity model...")
+            }
+        )
+
+        progressHandler?(0.8, "Loading ReDimNet2 speaker identity model...")
+        let configuration = try loadConfiguration(
+            at: cacheDir.appendingPathComponent("config.json"),
+            modelId: modelId)
+        let modelURL = cacheDir.appendingPathComponent(
+            configuration.compiledModel, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: modelURL.path) else {
+            throw AudioModelError.modelLoadFailed(
+                modelId: modelId,
+                reason: "Core ML model not found at \(modelURL.path)")
+        }
+
+        let loaded: MLModel
+        do {
+            loaded = try CoreMLLoader.load(
+                url: modelURL,
+                computeUnits: .all,
+                name: "redimnet2-b6-speaker")
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: modelId,
+                reason: "Failed to load compiled Core ML model",
+                underlying: error)
+        }
+
+        progressHandler?(1.0, "Ready")
+        return ReDimNet2SpeakerModel(model: loaded)
+    }
+
+    static func decodeConfiguration(_ data: Data) throws -> ReDimNet2ModelConfiguration {
+        let configuration = try JSONDecoder().decode(
+            ReDimNet2ModelConfiguration.self, from: data)
+        guard configuration.modelType == "redimnet2-b6-speaker-coreml",
+            configuration.sampleRate == inputSampleRate,
+            configuration.inputSamples == inputSampleCount,
+            configuration.embeddingDimension == embeddingDimension,
+            configuration.inputName == "audio",
+            configuration.outputName == "embedding",
+            configuration.compiledModel == "ReDimNet2B6.mlmodelc"
+        else {
+            throw AudioModelError.invalidConfiguration(
+                model: "ReDimNet2-B6",
+                reason: "config.json does not match the compiled identity runtime")
+        }
+        return configuration
+    }
+
+    private static func loadConfiguration(
+        at url: URL,
+        modelId: String
+    ) throws -> ReDimNet2ModelConfiguration {
+        do {
+            return try decodeConfiguration(Data(contentsOf: url))
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: modelId,
+                reason: "Missing or incompatible config.json",
+                underlying: error)
+        }
+    }
+
+    /// Extract a normalized 192-dimensional identity embedding.
+    ///
+    /// - Throws: An explicit input or inference error. No zero-vector fallback
+    ///   is returned when identity extraction fails.
+    public func embed(audio: [Float], sampleRate: Int) throws -> [Float] {
+        let resampled: [Float]
+        if sampleRate == Self.inputSampleRate {
+            resampled = audio
+        } else {
+            guard sampleRate > 0 else {
+                throw AudioModelError.invalidConfiguration(
+                    model: "ReDimNet2-B6",
+                    reason: "sample rate must be greater than zero")
+            }
+            resampled = AudioFileLoader.resample(
+                audio, from: sampleRate, to: Self.inputSampleRate)
+        }
+
+        return try predict(Self.preparedAudio(resampled))
+    }
+
+    /// Compile and execute the graph once before latency-sensitive use.
+    public func prewarm() throws {
+        var waveform = [Float](repeating: 0, count: Self.inputSampleCount)
+        for index in waveform.indices {
+            waveform[index] = 0.01 * sin(
+                2 * Float.pi * 173 * Float(index) / Float(Self.inputSampleRate))
+        }
+        _ = try predict(waveform)
+    }
+
+    static func preparedAudio(_ samples: [Float]) throws -> [Float] {
+        guard samples.count >= minimumSampleCount else {
+            let seconds = Double(samples.count) / Double(inputSampleRate)
+            throw AudioModelError.invalidConfiguration(
+                model: "ReDimNet2-B6",
+                reason: String(
+                    format: "speaker identity requires at least 2.0 seconds of clean audio (received %.2f seconds)",
+                    seconds))
+        }
+        guard samples.allSatisfy(\.isFinite) else {
+            throw AudioModelError.invalidConfiguration(
+                model: "ReDimNet2-B6",
+                reason: "audio contains a non-finite sample")
+        }
+
+        if samples.count == inputSampleCount {
+            return samples
+        }
+        if samples.count > inputSampleCount {
+            let start = (samples.count - inputSampleCount) / 2
+            return Array(samples[start..<(start + inputSampleCount)])
+        }
+
+        var prepared = [Float](repeating: 0, count: inputSampleCount)
+        for index in prepared.indices {
+            prepared[index] = samples[index % samples.count]
+        }
+        return prepared
+    }
+
+    private func predict(_ preparedAudio: [Float]) throws -> [Float] {
+        let input = try MLMultiArray(
+            shape: [1, Self.inputSampleCount as NSNumber],
+            dataType: .float32)
+        let inputPointer = input.dataPointer.assumingMemoryBound(to: Float.self)
+        preparedAudio.withUnsafeBufferPointer { source in
+            inputPointer.update(from: source.baseAddress!, count: preparedAudio.count)
+        }
+
+        let provider = try MLDictionaryFeatureProvider(dictionary: [
+            "audio": MLFeatureValue(multiArray: input),
+        ])
+        let output: MLFeatureProvider
+        do {
+            output = try model.prediction(from: provider)
+        } catch {
+            throw AudioModelError.inferenceFailed(
+                operation: "ReDimNet2 speaker identity",
+                reason: error.localizedDescription)
+        }
+
+        guard let values = output.featureValue(
+            for: "embedding")?.multiArrayValue,
+            values.count == Self.embeddingDimension
+        else {
+            throw AudioModelError.inferenceFailed(
+                operation: "ReDimNet2 speaker identity",
+                reason: "missing 192-dimensional 'embedding' output")
+        }
+
+        var embedding = [Float](repeating: 0, count: Self.embeddingDimension)
+        for index in embedding.indices {
+            embedding[index] = values[index].floatValue
+        }
+        guard embedding.allSatisfy(\.isFinite) else {
+            throw AudioModelError.inferenceFailed(
+                operation: "ReDimNet2 speaker identity",
+                reason: "model returned a non-finite embedding")
+        }
+
+        let norm = sqrt(embedding.reduce(Float(0)) { $0 + $1 * $1 })
+        guard norm > 1e-8 else {
+            throw AudioModelError.inferenceFailed(
+                operation: "ReDimNet2 speaker identity",
+                reason: "model returned a zero embedding")
+        }
+        for index in embedding.indices {
+            embedding[index] /= norm
+        }
+        return embedding
+    }
+
+    public static func cosineSimilarity(_ left: [Float], _ right: [Float]) -> Float {
+        guard left.count == right.count, !left.isEmpty else { return 0 }
+        var dot: Float = 0
+        var leftNorm: Float = 0
+        var rightNorm: Float = 0
+        for index in left.indices {
+            dot += left[index] * right[index]
+            leftNorm += left[index] * left[index]
+            rightNorm += right[index] * right[index]
+        }
+        let denominator = sqrt(leftNorm) * sqrt(rightNorm)
+        return denominator > 0 ? dot / denominator : 0
+    }
+}
+#endif

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -411,6 +411,25 @@ final class DiarizeCommandTests: XCTestCase {
     }
 }
 
+// MARK: - EmbedSpeakerCommand
+
+final class EmbedSpeakerCommandTests: XCTestCase {
+
+    func testParsesReDimNet2Engine() throws {
+        let command = try AudioCLI.parseAsRoot([
+            "embed-speaker", "voice.wav", "--engine", "redimnet2",
+        ])
+        let embedSpeaker = try XCTUnwrap(command as? EmbedSpeakerCommand)
+
+        XCTAssertEqual(embedSpeaker.audioFile, "voice.wav")
+        XCTAssertEqual(embedSpeaker.engine, "redimnet2")
+    }
+
+    func testHelpDocumentsReDimNet2Engine() {
+        XCTAssertTrue(EmbedSpeakerCommand.helpMessage().contains("redimnet2"))
+    }
+}
+
 // MARK: - SpeakCommand
 
 final class SpeakCommandTests: XCTestCase {

--- a/Tests/SpeechVADTests/ReDimNet2SpeakerTests.swift
+++ b/Tests/SpeechVADTests/ReDimNet2SpeakerTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import XCTest
+@testable import SpeechVAD
+import AudioCommon
+
+#if canImport(CoreML)
+final class ReDimNet2SpeakerTests: XCTestCase {
+    func testPublishedConfiguration() {
+        XCTAssertEqual(
+            ReDimNet2SpeakerModel.defaultModelId,
+            "aufklarer/ReDimNet2-B6-CoreML")
+        XCTAssertEqual(ReDimNet2SpeakerModel.inputSampleRate, 16_000)
+        XCTAssertEqual(ReDimNet2SpeakerModel.inputSampleCount, 96_000)
+        XCTAssertEqual(ReDimNet2SpeakerModel.minimumSampleCount, 32_000)
+        XCTAssertEqual(ReDimNet2SpeakerModel.embeddingDimension, 192)
+    }
+
+    func testDecodesPublishedModelConfiguration() throws {
+        let data = Data("""
+        {
+          "model_type": "redimnet2-b6-speaker-coreml",
+          "sample_rate": 16000,
+          "input_samples": 96000,
+          "embedding_dimension": 192,
+          "input_name": "audio",
+          "output_name": "embedding",
+          "compiled_model": "ReDimNet2B6.mlmodelc"
+        }
+        """.utf8)
+
+        let configuration = try ReDimNet2SpeakerModel.decodeConfiguration(data)
+        XCTAssertEqual(configuration.inputSamples, 96_000)
+        XCTAssertEqual(configuration.embeddingDimension, 192)
+    }
+
+    func testRejectsIncompatibleModelConfiguration() {
+        let data = Data("""
+        {
+          "model_type": "redimnet2-b6-speaker-coreml",
+          "sample_rate": 16000,
+          "input_samples": 160000,
+          "embedding_dimension": 192,
+          "input_name": "audio",
+          "output_name": "embedding",
+          "compiled_model": "ReDimNet2B6.mlmodelc"
+        }
+        """.utf8)
+
+        XCTAssertThrowsError(try ReDimNet2SpeakerModel.decodeConfiguration(data))
+    }
+
+    func testPreparedAudioRepeatsShortCleanSpeech() throws {
+        let samples = (0..<32_000).map(Float.init)
+        let prepared = try ReDimNet2SpeakerModel.preparedAudio(samples)
+
+        XCTAssertEqual(prepared.count, 96_000)
+        XCTAssertEqual(Array(prepared[0..<32_000]), samples)
+        XCTAssertEqual(Array(prepared[32_000..<64_000]), samples)
+        XCTAssertEqual(Array(prepared[64_000..<96_000]), samples)
+    }
+
+    func testPreparedAudioCenterCropsLongSpeech() throws {
+        let samples = (0..<128_000).map(Float.init)
+        let prepared = try ReDimNet2SpeakerModel.preparedAudio(samples)
+
+        XCTAssertEqual(prepared.count, 96_000)
+        XCTAssertEqual(prepared.first, 16_000)
+        XCTAssertEqual(prepared.last, 111_999)
+    }
+
+    func testPreparedAudioKeepsExactWindow() throws {
+        let samples = [Float](repeating: 0.25, count: 96_000)
+        XCTAssertEqual(try ReDimNet2SpeakerModel.preparedAudio(samples), samples)
+    }
+
+    func testPreparedAudioRejectsLessThanTwoSeconds() {
+        XCTAssertThrowsError(
+            try ReDimNet2SpeakerModel.preparedAudio(
+                [Float](repeating: 0, count: 31_999))) { error in
+            XCTAssertTrue(error.localizedDescription.contains("at least 2.0 seconds"))
+        }
+    }
+
+    func testPreparedAudioRejectsNonFiniteSamples() {
+        var samples = [Float](repeating: 0, count: 32_000)
+        samples[100] = .nan
+        XCTAssertThrowsError(try ReDimNet2SpeakerModel.preparedAudio(samples))
+    }
+
+    func testCosineSimilarity() {
+        XCTAssertEqual(
+            ReDimNet2SpeakerModel.cosineSimilarity([1, 0], [1, 0]),
+            1,
+            accuracy: 1e-6)
+        XCTAssertEqual(
+            ReDimNet2SpeakerModel.cosineSimilarity([1, 0], [0, 1]),
+            0,
+            accuracy: 1e-6)
+        XCTAssertEqual(
+            ReDimNet2SpeakerModel.cosineSimilarity([1], [1, 0]),
+            0)
+    }
+}
+
+final class E2EReDimNet2SpeakerTests: XCTestCase {
+    private func loadModel() async throws -> ReDimNet2SpeakerModel {
+        if let directory = ProcessInfo.processInfo.environment[
+            "REDIMNET2_COREML_MODEL_DIR"]
+        {
+            return try await ReDimNet2SpeakerModel.fromPretrained(
+                cacheDir: URL(fileURLWithPath: directory, isDirectory: true),
+                offlineMode: true)
+        }
+        return try await ReDimNet2SpeakerModel.fromPretrained()
+    }
+
+    func testE2EEmbeddingIsNormalizedAndDeterministic() async throws {
+        let model = try await loadModel()
+        let audioURL = URL(
+            fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+
+        try model.prewarm()
+        let first = try model.embed(audio: samples, sampleRate: sampleRate)
+        let second = try model.embed(audio: samples, sampleRate: sampleRate)
+
+        XCTAssertEqual(first.count, 192)
+        let norm = sqrt(first.reduce(Float(0)) { $0 + $1 * $1 })
+        XCTAssertEqual(norm, 1, accuracy: 0.002)
+        XCTAssertEqual(
+            ReDimNet2SpeakerModel.cosineSimilarity(first, second),
+            1,
+            accuracy: 0.0001)
+    }
+
+    func testE2EDeterministicWaveformProducesValidEmbedding() async throws {
+        let model = try await loadModel()
+        var waveform = [Float](repeating: 0, count: 96_000)
+        for index in waveform.indices {
+            let time = Float(index) / 16_000
+            waveform[index] = 0.12 * sin(2 * .pi * 173 * time)
+                + 0.06 * sin(2 * .pi * 271 * time)
+        }
+
+        let embedding = try model.embed(audio: waveform, sampleRate: 16_000)
+        XCTAssertEqual(embedding.count, 192)
+        XCTAssertTrue(embedding.allSatisfy(\.isFinite))
+        XCTAssertEqual(
+            sqrt(embedding.reduce(Float(0)) { $0 + $1 * $1 }),
+            1,
+            accuracy: 0.002)
+    }
+}
+#endif

--- a/docs/inference/cache-and-offline.md
+++ b/docs/inference/cache-and-offline.md
@@ -100,6 +100,7 @@ All models support both parameters:
 | `PyannoteVADModel` | `cacheDir`, `offlineMode` |
 | `FireRedVADModel` | `cacheDir`, `offlineMode` |
 | `WeSpeakerModel` | `cacheDir`, `offlineMode` |
+| `ReDimNet2SpeakerModel` | `cacheDir`, `offlineMode` |
 | `SpeechEnhancer` | `cacheDir`, `offlineMode` |
 | `SortformerDiarizer` | `cacheDir`, `offlineMode` |
 | `Community1DiarizationPipeline` | `cacheDir`, `offlineMode` |

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -8,6 +8,10 @@ Speaker diarization identifies **who spoke when** in an audio recording. Three e
 2. **Community-1** (CoreML) — Pyannote segmentation + masked WeSpeaker embeddings + native PLDA/VBx clustering
 3. **Sortformer** (CoreML) — NVIDIA's end-to-end neural diarization model, runs on Neural Engine
 
+Named voice identity is a separate operation. `ReDimNet2SpeakerModel` compares
+clean voice samples across recordings; it does not replace the embedding and
+clustering stages inside any diarization engine.
+
 ## Architecture
 
 ### Engine Selection
@@ -125,6 +129,36 @@ The CoreML model uses EnumeratedShapes for variable mel lengths (20–2000 frame
 
 MLX and CoreML embeddings are **not interchangeable** — NHWC vs NCHW layout causes stats pooling to flatten features in different orders. Each backend is self-consistent (cosine sim 1.0 for same input) but cross-backend similarity is low (~0.15). Use the same backend for enrollment and comparison.
 
+### ReDimNet2-B6 Named Voice Identity
+
+ReDimNet2-B6 is the separate Core ML encoder for recording-local and persistent
+named voice matching. It accepts clean speaker-only PCM rather than a mixed
+meeting waveform and returns one 192-dimensional, L2-normalized embedding.
+
+```swift
+let identity = try await ReDimNet2SpeakerModel.fromPretrained()
+try identity.prewarm()
+
+let enrollment = try identity.embed(audio: enrollmentAudio, sampleRate: 16_000)
+let candidate = try identity.embed(audio: candidateAudio, sampleRate: 16_000)
+let similarity = ReDimNet2SpeakerModel.cosineSimilarity(enrollment, candidate)
+```
+
+- Input is fixed at six seconds / 96,000 mono samples for the fast Core ML path.
+- Clean clips from two to six seconds are repeated to fill the window.
+- Longer clips are center-cropped; clips shorter than two seconds fail explicitly.
+- The model uses 192-dimensional embeddings. They cannot be compared with
+  WeSpeaker's 256-dimensional embeddings or Community-1 centroids.
+- Matching thresholds must be calibrated for ReDimNet2; do not reuse WeSpeaker
+  thresholds.
+- Voice embeddings support labeling, not biometric authentication or spoofing
+  resistance.
+
+The fixed-shape compiled model is approximately 25 MiB and measured about
+13.6 ms per warm six-second inference on an Apple M2 Max. This encoder remains
+outside Community-1: Community-1's masked WeSpeaker, PLDA, and VBx stages stay
+in their original shared embedding space.
+
 ### Mel Feature Extraction
 
 80-dim log-mel spectrogram via vDSP (same pipeline as WhisperFeatureExtractor but with different parameters):
@@ -200,6 +234,14 @@ let embedding = model.embed(audio: samples, sampleRate: 16000)
 // embedding: [Float] of length 256, L2-normalized
 ```
 
+For named identity across recordings, use the throwing ReDimNet2 API instead:
+
+```swift
+let model = try await ReDimNet2SpeakerModel.fromPretrained()
+let embedding = try model.embed(audio: cleanSpeakerAudio, sampleRate: 16_000)
+// embedding: [Float] of length 192, L2-normalized
+```
+
 ### Speaker Extraction
 
 Given a reference audio of a target speaker, extract only their segments:
@@ -264,6 +306,7 @@ speech diarize meeting.wav --target-speaker enrollment.wav
 # Embed a speaker's voice
 speech embed-speaker enrollment.wav
 speech embed-speaker enrollment.wav --engine coreml --json
+speech embed-speaker enrollment.wav --engine redimnet2 --json
 ```
 
 Community-1 compute units can be selected with
@@ -290,6 +333,7 @@ whose collar and boundary accounting are intentionally different.
 - **Segmentation**: `aufklarer/Pyannote-Segmentation-MLX` (~5.7 MB)
 - **Speaker Embedding (MLX)**: `aufklarer/WeSpeaker-ResNet34-LM-MLX` (~25 MB)
 - **Speaker Embedding (CoreML)**: `aufklarer/WeSpeaker-ResNet34-LM-CoreML` (~13 MB)
+- **Named Voice Identity (CoreML)**: `aufklarer/ReDimNet2-B6-CoreML` (~25 MiB)
 - **Sortformer (CoreML)**: `aufklarer/Sortformer-Diarization-CoreML` (~240 MB)
 - Cache: `~/Library/Caches/qwen3-speech/`
 
@@ -325,6 +369,7 @@ Sources/SpeechVAD/
 ├── WeSpeakerWeightLoading.swift       Weight loading from safetensors
 ├── WeSpeaker.swift                    Public API: embed(), fromPretrained(), engine selection
 ├── CoreMLWeSpeakerInference.swift     CoreML inference (EnumeratedShapes, float16)
+├── ReDimNet2Speaker.swift             Persistent identity encoder (fixed-waveform CoreML)
 ├── PowersetDecoder.swift              7-class powerset → per-speaker probs
 ├── DiarizationHelpers.swift            Merge segments, compact IDs, constrained clustering
 ├── DiarizationPipeline.swift          Pyannote pipeline (embedding clustering + speaker extraction)

--- a/docs/models/redimnet2-speaker.md
+++ b/docs/models/redimnet2-speaker.md
@@ -1,0 +1,68 @@
+# ReDimNet2-B6 Speaker Identity
+
+## Purpose
+
+`ReDimNet2SpeakerModel` extracts a stable voice representation from a clean
+speaker-only sample. It is intended for recording-local identity continuity and
+persistent named voice profiles across recordings.
+
+It is not a diarization model. Community-1 continues to use its own masked
+WeSpeaker embeddings, PLDA transform, and VBx clustering. Those centroids live
+in a different vector space and must not be compared with ReDimNet2 profiles.
+
+## Model
+
+The source model is the official
+[PalabraAI/ReDimNet2](https://github.com/PalabraAI/redimnet2) B6 large-margin
+checkpoint trained on VoxBlink2 and VoxCeleb2.
+
+| Property | Value |
+|---|---:|
+| Parameters | 12.3 million |
+| Input | 96,000 mono Float32 samples |
+| Sample rate | 16 kHz |
+| Window | 6 seconds |
+| Output | 192 floats, L2-normalized |
+| Runtime | Compiled Core ML |
+| Compiled size | approximately 25 MiB |
+
+The graph includes waveform normalization, pre-emphasis, mel feature
+extraction, ReDimNet2-B6, attentive statistics pooling, the embedding head, and
+final L2 normalization.
+
+## Fixed Window
+
+A fixed six-second waveform avoids the CPU fallback seen with flexible Core ML
+shapes. Runtime preparation follows the benchmarked policy:
+
+- reject less than two seconds of clean speech;
+- repeat two-to-six-second speech until the window is full;
+- keep an exact six-second input unchanged;
+- center-crop longer input.
+
+Inference failures throw an error. The model never substitutes a zero embedding.
+
+## Validation
+
+The conversion compares the checksum-pinned official PyTorch checkpoint with
+the compiled Core ML bundle. The release candidate measured 0.999990 cosine
+agreement, a 0.999916 output norm, and 13.6 ms median warm inference on an Apple
+M2 Max.
+
+On the initial recurring-speaker meeting pilot, the fixed Core ML model reduced
+equal error rate from 3.76% with standalone WeSpeaker to 1.88%. This is a small
+five-speaker pilot, not a universal quality claim. Production thresholds need
+additional accented and multilingual calibration data.
+
+## API
+
+```swift
+let model = try await ReDimNet2SpeakerModel.fromPretrained()
+try model.prewarm()
+
+let profile = try model.embed(audio: cleanAudio, sampleRate: sampleRate)
+let score = ReDimNet2SpeakerModel.cosineSimilarity(profile, candidate)
+```
+
+The model produces features for labeling. It is not an authentication system
+and does not provide anti-spoofing guarantees.

--- a/docs/shared-protocols.md
+++ b/docs/shared-protocols.md
@@ -142,6 +142,10 @@ public protocol SpeakerEmbeddingModel: AnyObject {
 
 **Conforming types:** `WeSpeakerModel`
 
+`ReDimNet2SpeakerModel` is the separate persistent identity encoder. Its
+`embed` method throws so model or input failures remain explicit; it is used
+through its concrete API rather than this legacy non-throwing protocol.
+
 ### SpeakerDiarizationModel
 
 Models that assign speaker identities to speech segments.
@@ -440,6 +444,7 @@ Sources/
 │   ├── DiarizationHelpers.swift   Shared helpers (merge, compact IDs, resample)
 │   ├── SortformerDiarizer.swift   SortformerDiarizer: SpeakerDiarizationModel (CoreML)
 │   ├── WeSpeaker.swift        WeSpeakerModel: SpeakerEmbeddingModel
+│   ├── ReDimNet2Speaker.swift ReDimNet2SpeakerModel: persistent named voice identity (CoreML)
 │   └── PowersetDecoder.swift  7-class powerset → per-speaker probabilities
 │
 ├── SpeechCore/                Voice pipeline (wraps speech-core C++ engine)


### PR DESCRIPTION
## Summary

- add a compiled CoreML ReDimNet2-B6 encoder for persistent named voice identity
- expose the redimnet2 embed-speaker CLI engine without changing Community-1 or other diarization internals
- require at least two seconds of clean speech, repeat clips up to the fixed six-second window, and center-crop longer clips
- return normalized 192-dimensional embeddings with explicit errors instead of zero-vector fallbacks
- document that ReDimNet2 and WeSpeaker embedding spaces are incompatible
- add ReDimNet2-B6 to all 14 repository README translations

Published model: https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML

## Validation

- release build: make build
- complete non-E2E test suite: swift test --skip E2E
- ReDimNet2 unit tests: 9 passed
- CLI parsing and help tests: 2 passed
- isolated ReDimNet2 E2E using the final local artifact: 2 passed
- isolated ReDimNet2 E2E downloading the published model: 2 passed
- PyTorch/CoreML cosine agreement: 0.999990
- warm six-second inference on Apple M2 Max: 13.8 ms
- translated README parity: 14 of 14, with valid five-column model rows

Web documentation and repository READMEs are updated across all 14 locales.