### PR TITLE
Add incremental Sortformer streaming session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,27 @@ AI speech models for Apple Silicon (MLX Swift). ASR, TTS, speech-to-speech, VAD,
 - **Every README.md change must update all 13 translations** (`README_zh.md`, `README_ja.md`, `README_ko.md`, `README_es.md`, `README_de.md`, `README_fr.md`, `README_hi.md`, `README_pt.md`, `README_ru.md`, `README_ar.md`, `README_th.md`, `README_tr.md`, `README_vi.md`). No exceptions.
 - **Keep docs and comments scoped to this package.** Model docs, code comments, and PR descriptions describe this package's models, APIs, and formats only — never downstream consumer apps or their integration rules.
 
+## Running Tests and Benchmarks — Sequential and Memory-Aware
+
+Heavy operations in this repo load multi-gigabyte CoreML/MLX models. Run
+them strictly one at a time — overlapping them has exhausted memory and
+rebooted development machines.
+
+- Never run the full `swift test` concurrently with anything else: not with
+  another build, not with a benchmark, not with a model-loading app, not
+  with another agent's test run in a different worktree. Each worktree has
+  its own `.build`, so the SwiftPM lock does **not** protect you across
+  worktrees — check for other `swift`/bench processes before starting.
+- For the full suite, bound memory by disabling test parallelization:
+  `swift test --no-parallel`. Model-gated suites otherwise load their
+  models simultaneously.
+- While iterating, prefer targeted runs: `swift test --filter <Suite>`.
+- Benchmarks (`diarization-bench`, ASR benches) also load models — run them
+  after tests finish, never alongside, and one benchmark process at a time.
+- If a second SwiftPM command queues on the same `.build` lock, don't leave
+  it queued — it will pile its model loads on top of the first the moment
+  the lock frees. Cancel it and rerun after the first completes.
+
 ## Git Conventions
 
 - Never mention Claude, Codex, AI, or any AI tool in commit messages, PR titles, PR descriptions, comments, docs, or co-author tags. Do not add tool-name prefixes such as `[codex]`; use neutral project wording.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarization | MLX | 1.5M | Agnostic |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarization + speaker embeddings | CoreML (ANE) + Swift VBx | 8.35M | Agnostic |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarization (E2E), incremental streaming | CoreML (ANE) | 117M | Agnostic |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Diarization (E2E), incremental streaming](https://soniqo.audio/guides/diarize) | CoreML (ANE) | 117M | Agnostic |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Speech Enhancement | CoreML | 2.1M | Agnostic |
 | [Sidon](https://soniqo.audio/guides/restore) | Speech Restoration (denoise + dereverb, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostic |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | Source Separation | MLX | 168M | Agnostic |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs
 
 - **[Wake-word](https://soniqo.audio/guides/wake-word)** — On-device keyword spotting (KWS Zipformer 3M, CoreML, 26× real-time, configurable keyword list)
 - **[VAD](https://soniqo.audio/guides/vad)** — Voice activity detection (Silero streaming, Pyannote offline, FireRedVAD 100+ languages)
-- **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — Who spoke when (Pyannote pipeline, Sortformer end-to-end on Neural Engine)
+- **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — Who spoke when (Pyannote pipeline, Sortformer end-to-end on Neural Engine) — now with an incremental streaming session (stable speaker IDs, updates every 480 ms)
 - **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), ReDimNet2-B6 named identity (192-dim), CAM++ (192-dim)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -194,7 +194,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Diarization | MLX | 1.5M | Agnostic |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarization + speaker embeddings | CoreML (ANE) + Swift VBx | 8.35M | Agnostic |
-| [Sortformer](https://soniqo.audio/guides/diarize) | Diarization (E2E) | CoreML (ANE) | — | Agnostic |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarization (E2E), incremental streaming | CoreML (ANE) | 117M | Agnostic |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Speech Enhancement | CoreML | 2.1M | Agnostic |
 | [Sidon](https://soniqo.audio/guides/restore) | Speech Restoration (denoise + dereverb, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostic |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | Source Separation | MLX | 168M | Agnostic |

--- a/README_ar.md
+++ b/README_ar.md
@@ -235,7 +235,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ar/guides/diarize) | VAD + تمييز | MLX | 1.5M | محايد للغة |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | فرز المتحدثين + تضمينات المتحدث | CoreML (ANE) + Swift VBx | 8.35M | محايد للغة |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | تمييز (E2E), بث تزايدي | CoreML (ANE) | 117M | محايد للغة |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [تمييز (E2E), بث تزايدي](https://soniqo.audio/ar/guides/diarize) | CoreML (ANE) | 117M | محايد للغة |
 | [DeepFilterNet3](https://soniqo.audio/ar/guides/denoise) | تحسين الكلام | CoreML | 2.1M | محايد للغة |
 | [Sidon](https://soniqo.audio/ar/guides/restore) | استعادة الكلام (إزالة الضوضاء + إزالة الصدى، 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | محايد للغة |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ar/guides/separate) | فصل المصادر | MLX | 168M | محايد للغة |

--- a/README_ar.md
+++ b/README_ar.md
@@ -87,7 +87,7 @@
 
 - **[كلمة التنبيه](https://soniqo.audio/ar/guides/wake-word)** — اكتشاف الكلمات المفتاحية على الجهاز (KWS Zipformer 3M، CoreML، 26× الزمن الحقيقي، قائمة كلمات مفتاحية قابلة للتهيئة)
 - **[VAD](https://soniqo.audio/ar/guides/vad)** — اكتشاف النشاط الصوتي (Silero تدفقي، Pyannote دون اتصال، FireRedVAD أكثر من 100 لغة)
-- **[تمييز المتحدثين](https://soniqo.audio/ar/guides/diarize)** — من تحدث متى (خط أنابيب Pyannote، Sortformer من طرف إلى طرف على Neural Engine)
+- **[تمييز المتحدثين](https://soniqo.audio/ar/guides/diarize)** — من تحدث متى (خط أنابيب Pyannote، Sortformer من طرف إلى طرف على Neural Engine) — الآن مع جلسة بث تزايدي (معرّفات متحدثين ثابتة وتحديث كل 480 مللي ثانية)
 - **[تضمينات المتحدث](https://soniqo.audio/ar/guides/embed-speaker)** — WeSpeaker ResNet34 (256 بُعداً)، ReDimNet2-B6 للهوية الصوتية المسماة (192 بُعداً)، CAM++ (192 بُعداً)
 
 </div>
@@ -235,7 +235,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ar/guides/diarize) | VAD + تمييز | MLX | 1.5M | محايد للغة |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | فرز المتحدثين + تضمينات المتحدث | CoreML (ANE) + Swift VBx | 8.35M | محايد للغة |
-| [Sortformer](https://soniqo.audio/ar/guides/diarize) | تمييز (E2E) | CoreML (ANE) | — | محايد للغة |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | تمييز (E2E), بث تزايدي | CoreML (ANE) | 117M | محايد للغة |
 | [DeepFilterNet3](https://soniqo.audio/ar/guides/denoise) | تحسين الكلام | CoreML | 2.1M | محايد للغة |
 | [Sidon](https://soniqo.audio/ar/guides/restore) | استعادة الكلام (إزالة الضوضاء + إزالة الصدى، 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | محايد للغة |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ar/guides/separate) | فصل المصادر | MLX | 168M | محايد للغة |

--- a/README_de.md
+++ b/README_de.md
@@ -191,7 +191,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/de/guides/diarize) | VAD + Diarisierung | MLX | 1.5M | Sprachunabhängig |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarisierung + Sprechereinbettungen | CoreML (ANE) + Swift VBx | 8.35M | Sprachunabhängig |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarisierung (E2E), inkrementelles Streaming | CoreML (ANE) | 117M | Sprachunabhängig |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Diarisierung (E2E), inkrementelles Streaming](https://soniqo.audio/de/guides/diarize) | CoreML (ANE) | 117M | Sprachunabhängig |
 | [DeepFilterNet3](https://soniqo.audio/de/guides/denoise) | Sprachverbesserung | CoreML | 2.1M | Sprachunabhängig |
 | [Sidon](https://soniqo.audio/de/guides/restore) | Sprachwiederherstellung (Rauschunterdrückung + Enthallung, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Sprachunabhängig |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/de/guides/separate) | Quelltrennung | MLX | 168M | Agnostic |

--- a/README_de.md
+++ b/README_de.md
@@ -77,7 +77,7 @@ Spracherkennung, -synthese und -verständnis auf dem Gerät für Mac und iOS. L�
 
 - **[Wake-Word](https://soniqo.audio/de/guides/wake-word)** — Schlüsselworterkennung auf dem Gerät (KWS Zipformer 3M, CoreML, 26× Echtzeit, konfigurierbare Stichwortliste)
 - **[VAD](https://soniqo.audio/de/guides/vad)** — Sprachaktivitätserkennung (Silero Streaming, Pyannote Offline, FireRedVAD 100+ Sprachen)
-- **[Sprecherdiarisierung](https://soniqo.audio/de/guides/diarize)** — Wer hat wann gesprochen (Pyannote-Pipeline, durchgängiger Sortformer auf der Neural Engine)
+- **[Sprecherdiarisierung](https://soniqo.audio/de/guides/diarize)** — Wer hat wann gesprochen (Pyannote-Pipeline, durchgängiger Sortformer auf der Neural Engine) — jetzt mit inkrementeller Streaming-Session (stabile Sprecher-IDs, Updates alle 480 ms)
 - **[Sprechereinbettungen](https://soniqo.audio/de/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), ReDimNet2-B6 für benannte Stimmidentität (192-dim), CAM++ (192-dim)
 
 Paper: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/de/guides/diarize) | VAD + Diarisierung | MLX | 1.5M | Sprachunabhängig |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarisierung + Sprechereinbettungen | CoreML (ANE) + Swift VBx | 8.35M | Sprachunabhängig |
-| [Sortformer](https://soniqo.audio/de/guides/diarize) | Diarisierung (E2E) | CoreML (ANE) | — | Sprachunabhängig |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarisierung (E2E), inkrementelles Streaming | CoreML (ANE) | 117M | Sprachunabhängig |
 | [DeepFilterNet3](https://soniqo.audio/de/guides/denoise) | Sprachverbesserung | CoreML | 2.1M | Sprachunabhängig |
 | [Sidon](https://soniqo.audio/de/guides/restore) | Sprachwiederherstellung (Rauschunterdrückung + Enthallung, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Sprachunabhängig |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/de/guides/separate) | Quelltrennung | MLX | 168M | Agnostic |

--- a/README_es.md
+++ b/README_es.md
@@ -191,7 +191,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/es/guides/diarize) | VAD + Diarización | MLX | 1.5M | Agnóstico |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarización + embeddings de hablante | CoreML (ANE) + Swift VBx | 8.35M | Agnóstico |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarización (E2E), streaming incremental | CoreML (ANE) | 117M | Agnóstico |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Diarización (E2E), streaming incremental](https://soniqo.audio/es/guides/diarize) | CoreML (ANE) | 117M | Agnóstico |
 | [DeepFilterNet3](https://soniqo.audio/es/guides/denoise) | Mejora de voz | CoreML | 2.1M | Agnóstico |
 | [Sidon](https://soniqo.audio/es/guides/restore) | Restauración de voz (supresión de ruido + dereverberación, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnóstico |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/es/guides/separate) | Separación de fuentes | MLX | 168M | Agnostic |

--- a/README_es.md
+++ b/README_es.md
@@ -77,7 +77,7 @@ Reconocimiento, síntesis y comprensión de voz en el dispositivo para Mac e iOS
 
 - **[Palabra de activación](https://soniqo.audio/es/guides/wake-word)** — Detección de palabras clave en el dispositivo (KWS Zipformer 3M, CoreML, 26× tiempo real, lista de palabras clave configurable)
 - **[VAD](https://soniqo.audio/es/guides/vad)** — Detección de actividad vocal (Silero streaming, Pyannote offline, FireRedVAD 100+ idiomas)
-- **[Diarización de hablantes](https://soniqo.audio/es/guides/diarize)** — Quién habló cuándo (pipeline Pyannote, Sortformer de extremo a extremo en Neural Engine)
+- **[Diarización de hablantes](https://soniqo.audio/es/guides/diarize)** — Quién habló cuándo (pipeline Pyannote, Sortformer de extremo a extremo en Neural Engine) — ahora con una sesión de streaming incremental (IDs de hablante estables, actualizaciones cada 480 ms)
 - **[Embeddings de hablante](https://soniqo.audio/es/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), ReDimNet2-B6 para identidad de voz con nombre (192 dim), CAM++ (192 dim)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/es/guides/diarize) | VAD + Diarización | MLX | 1.5M | Agnóstico |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarización + embeddings de hablante | CoreML (ANE) + Swift VBx | 8.35M | Agnóstico |
-| [Sortformer](https://soniqo.audio/es/guides/diarize) | Diarización (E2E) | CoreML (ANE) | — | Agnóstico |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarización (E2E), streaming incremental | CoreML (ANE) | 117M | Agnóstico |
 | [DeepFilterNet3](https://soniqo.audio/es/guides/denoise) | Mejora de voz | CoreML | 2.1M | Agnóstico |
 | [Sidon](https://soniqo.audio/es/guides/restore) | Restauración de voz (supresión de ruido + dereverberación, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnóstico |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/es/guides/separate) | Separación de fuentes | MLX | 168M | Agnostic |

--- a/README_fr.md
+++ b/README_fr.md
@@ -191,7 +191,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/fr/guides/diarize) | VAD + Diarisation | MLX | 1.5M | Agnostique |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarisation + empreintes de locuteur | CoreML (ANE) + Swift VBx | 8.35M | Agnostique |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarisation (E2E), streaming incrémental | CoreML (ANE) | 117M | Agnostique |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Diarisation (E2E), streaming incrémental](https://soniqo.audio/fr/guides/diarize) | CoreML (ANE) | 117M | Agnostique |
 | [DeepFilterNet3](https://soniqo.audio/fr/guides/denoise) | Amelioration de la parole | CoreML | 2.1M | Agnostique |
 | [Sidon](https://soniqo.audio/fr/guides/restore) | Restauration de la parole (debruitage + dereverberation, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostique |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/fr/guides/separate) | Séparation de sources | MLX | 168M | Agnostic |

--- a/README_fr.md
+++ b/README_fr.md
@@ -77,7 +77,7 @@ Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'e
 
 - **[Mot de reveil](https://soniqo.audio/fr/guides/wake-word)** -- Detection de mots-cles sur appareil (KWS Zipformer 3M, CoreML, 26x temps reel, liste de mots-cles configurable)
 - **[VAD](https://soniqo.audio/fr/guides/vad)** -- Detection d'activite vocale (Silero streaming, Pyannote hors ligne, FireRedVAD 100+ langues)
-- **[Diarisation de locuteurs](https://soniqo.audio/fr/guides/diarize)** -- Qui a parle quand (pipeline Pyannote, Sortformer de bout en bout sur Neural Engine)
+- **[Diarisation de locuteurs](https://soniqo.audio/fr/guides/diarize)** -- Qui a parle quand (pipeline Pyannote, Sortformer de bout en bout sur Neural Engine) — désormais avec une session de streaming incrémental (IDs de locuteurs stables, mises à jour toutes les 480 ms)
 - **[Empreintes de locuteur](https://soniqo.audio/fr/guides/embed-speaker)** -- WeSpeaker ResNet34 (256 dim), ReDimNet2-B6 pour l’identité vocale nommée (192 dim), CAM++ (192 dim)
 
 Articles : [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/fr/guides/diarize) | VAD + Diarisation | MLX | 1.5M | Agnostique |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarisation + empreintes de locuteur | CoreML (ANE) + Swift VBx | 8.35M | Agnostique |
-| [Sortformer](https://soniqo.audio/fr/guides/diarize) | Diarisation (E2E) | CoreML (ANE) | — | Agnostique |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarisation (E2E), streaming incrémental | CoreML (ANE) | 117M | Agnostique |
 | [DeepFilterNet3](https://soniqo.audio/fr/guides/denoise) | Amelioration de la parole | CoreML | 2.1M | Agnostique |
 | [Sidon](https://soniqo.audio/fr/guides/restore) | Restauration de la parole (debruitage + dereverberation, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostique |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/fr/guides/separate) | Séparation de sources | MLX | 168M | Agnostic |

--- a/README_hi.md
+++ b/README_hi.md
@@ -77,7 +77,7 @@ Mac और iOS के लिए ऑन-डिवाइस स्पीच रि
 
 - **[वेक-वर्ड](https://soniqo.audio/hi/guides/wake-word)** — ऑन-डिवाइस कीवर्ड स्पॉटिंग (KWS Zipformer 3M, CoreML, 26× रियल-टाइम, कॉन्फ़िगरेबल कीवर्ड सूची)
 - **[VAD](https://soniqo.audio/hi/guides/vad)** — वॉयस एक्टिविटी डिटेक्शन (Silero स्ट्रीमिंग, Pyannote ऑफ़लाइन, FireRedVAD 100+ भाषाएँ)
-- **[Speaker Diarization](https://soniqo.audio/hi/guides/diarize)** — कौन कब बोला (Pyannote पाइपलाइन, Neural Engine पर एंड-टू-एंड Sortformer)
+- **[Speaker Diarization](https://soniqo.audio/hi/guides/diarize)** — कौन कब बोला (Pyannote पाइपलाइन, Neural Engine पर एंड-टू-एंड Sortformer) — अब इंक्रीमेंटल स्ट्रीमिंग सत्र के साथ (स्थिर स्पीकर ID, हर 480 ms पर अपडेट)
 - **[Speaker Embeddings](https://soniqo.audio/hi/guides/embed-speaker)** — WeSpeaker ResNet34 (256-dim), ReDimNet2-B6 नामित आवाज़ पहचान (192-dim), CAM++ (192-dim)
 
 पेपर: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/hi/guides/diarize) | VAD + Diarization | MLX | 1.5M | भाषा-तटस्थ |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarization + स्पीकर embeddings | CoreML (ANE) + Swift VBx | 8.35M | भाषा-तटस्थ |
-| [Sortformer](https://soniqo.audio/hi/guides/diarize) | Diarization (E2E) | CoreML (ANE) | — | भाषा-तटस्थ |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarization (E2E), इंक्रीमेंटल स्ट्रीमिंग | CoreML (ANE) | 117M | भाषा-तटस्थ |
 | [DeepFilterNet3](https://soniqo.audio/hi/guides/denoise) | स्पीच एन्हांसमेंट | CoreML | 2.1M | भाषा-तटस्थ |
 | [Sidon](https://soniqo.audio/hi/guides/restore) | स्पीच रिस्टोरेशन (नॉइज़ हटाना + डीरीवर्ब, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | भाषा-तटस्थ |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/hi/guides/separate) | सोर्स सेपरेशन | MLX | 168M | Agnostic |

--- a/README_hi.md
+++ b/README_hi.md
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/hi/guides/diarize) | VAD + Diarization | MLX | 1.5M | भाषा-तटस्थ |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarization + स्पीकर embeddings | CoreML (ANE) + Swift VBx | 8.35M | भाषा-तटस्थ |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarization (E2E), इंक्रीमेंटल स्ट्रीमिंग | CoreML (ANE) | 117M | भाषा-तटस्थ |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Diarization (E2E), इंक्रीमेंटल स्ट्रीमिंग](https://soniqo.audio/hi/guides/diarize) | CoreML (ANE) | 117M | भाषा-तटस्थ |
 | [DeepFilterNet3](https://soniqo.audio/hi/guides/denoise) | स्पीच एन्हांसमेंट | CoreML | 2.1M | भाषा-तटस्थ |
 | [Sidon](https://soniqo.audio/hi/guides/restore) | स्पीच रिस्टोरेशन (नॉइज़ हटाना + डीरीवर्ब, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | भाषा-तटस्थ |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/hi/guides/separate) | सोर्स सेपरेशन | MLX | 168M | Agnostic |

--- a/README_ja.md
+++ b/README_ja.md
@@ -77,7 +77,7 @@ Mac・iOS向けのオンデバイス音声認識・合成・理解。Apple Silic
 
 - **[ウェイクワード](https://soniqo.audio/ja/guides/wake-word)** — オンデバイスのキーワード検出（KWS Zipformer 3M、CoreML、リアルタイムの26倍、キーワードリスト設定可能）
 - **[VAD](https://soniqo.audio/ja/guides/vad)** — 音声区間検出（Sileroストリーミング、Pyannoteオフライン、FireRedVAD 100以上の言語）
-- **[話者ダイアライゼーション](https://soniqo.audio/ja/guides/diarize)** — 誰がいつ話したか（Pyannoteパイプライン、Neural Engine上のエンドツーエンドSortformer）
+- **[話者ダイアライゼーション](https://soniqo.audio/ja/guides/diarize)** — 誰がいつ話したか（Pyannoteパイプライン、Neural Engine上のエンドツーエンドSortformer） — インクリメンタルなストリーミングセッションに対応（話者 ID は安定、480 ミリ秒ごとに更新）
 - **[話者埋め込み](https://soniqo.audio/ja/guides/embed-speaker)** — WeSpeaker ResNet34（256次元）、ReDimNet2-B6による名前付き音声識別（192次元）、CAM++（192次元）
 
 論文：[Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ja/guides/diarize) | VAD + ダイアライゼーション | MLX | 1.5M | 言語非依存 |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | ダイアライゼーション + 話者embedding | CoreML (ANE) + Swift VBx | 8.35M | 言語非依存 |
-| [Sortformer](https://soniqo.audio/ja/guides/diarize) | ダイアライゼーション（E2E） | CoreML (ANE) | — | 言語非依存 |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | ダイアライゼーション（E2E）, インクリメンタルストリーミング | CoreML (ANE) | 117M | 言語非依存 |
 | [DeepFilterNet3](https://soniqo.audio/ja/guides/denoise) | 音声強調 | CoreML | 2.1M | 言語非依存 |
 | [Sidon](https://soniqo.audio/ja/guides/restore) | 音声修復（ノイズ抑制 + 残響除去、48 kHz） | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 言語非依存 |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ja/guides/separate) | 音源分離 | MLX | 168M | Agnostic |

--- a/README_ja.md
+++ b/README_ja.md
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ja/guides/diarize) | VAD + ダイアライゼーション | MLX | 1.5M | 言語非依存 |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | ダイアライゼーション + 話者embedding | CoreML (ANE) + Swift VBx | 8.35M | 言語非依存 |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | ダイアライゼーション（E2E）, インクリメンタルストリーミング | CoreML (ANE) | 117M | 言語非依存 |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [ダイアライゼーション（E2E）, インクリメンタルストリーミング](https://soniqo.audio/ja/guides/diarize) | CoreML (ANE) | 117M | 言語非依存 |
 | [DeepFilterNet3](https://soniqo.audio/ja/guides/denoise) | 音声強調 | CoreML | 2.1M | 言語非依存 |
 | [Sidon](https://soniqo.audio/ja/guides/restore) | 音声修復（ノイズ抑制 + 残響除去、48 kHz） | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 言語非依存 |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ja/guides/separate) | 音源分離 | MLX | 168M | Agnostic |

--- a/README_ko.md
+++ b/README_ko.md
@@ -77,7 +77,7 @@ Mac과 iOS를 위한 온디바이스 음성 인식, 합성 및 이해. Apple Sil
 
 - **[웨이크워드](https://soniqo.audio/ko/guides/wake-word)** — 온디바이스 키워드 감지 (KWS Zipformer 3M, CoreML, 실시간의 26배, 구성 가능한 키워드 목록)
 - **[VAD](https://soniqo.audio/ko/guides/vad)** — 음성 활동 감지 (Silero 스트리밍, Pyannote 오프라인, FireRedVAD 100+ 개 언어)
-- **[화자 분리](https://soniqo.audio/ko/guides/diarize)** — 누가 언제 말했는지 (Pyannote 파이프라인, Neural Engine 상의 엔드투엔드 Sortformer)
+- **[화자 분리](https://soniqo.audio/ko/guides/diarize)** — 누가 언제 말했는지 (Pyannote 파이프라인, Neural Engine 상의 엔드투엔드 Sortformer) — 이제 증분 스트리밍 세션 지원(안정적인 화자 ID, 480ms마다 업데이트)
 - **[화자 임베딩](https://soniqo.audio/ko/guides/embed-speaker)** — WeSpeaker ResNet34 (256차원), ReDimNet2-B6 이름 지정 음성 식별 (192차원), CAM++ (192차원)
 
 논문: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ko/guides/diarize) | VAD + 화자 분리 | MLX | 1.5M | 언어 무관 |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | 화자 분리 + 화자 임베딩 | CoreML (ANE) + Swift VBx | 8.35M | 언어 무관 |
-| [Sortformer](https://soniqo.audio/ko/guides/diarize) | 화자 분리 (E2E) | CoreML (ANE) | — | 언어 무관 |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | 화자 분리 (E2E), 증분 스트리밍 | CoreML (ANE) | 117M | 언어 무관 |
 | [DeepFilterNet3](https://soniqo.audio/ko/guides/denoise) | 음성 향상 | CoreML | 2.1M | 언어 무관 |
 | [Sidon](https://soniqo.audio/ko/guides/restore) | 음성 복원 (노이즈 제거 + 잔향 제거, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 언어 무관 |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ko/guides/separate) | 소스 분리 | MLX | 168M | Agnostic |

--- a/README_ko.md
+++ b/README_ko.md
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ko/guides/diarize) | VAD + 화자 분리 | MLX | 1.5M | 언어 무관 |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | 화자 분리 + 화자 임베딩 | CoreML (ANE) + Swift VBx | 8.35M | 언어 무관 |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | 화자 분리 (E2E), 증분 스트리밍 | CoreML (ANE) | 117M | 언어 무관 |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [화자 분리 (E2E), 증분 스트리밍](https://soniqo.audio/ko/guides/diarize) | CoreML (ANE) | 117M | 언어 무관 |
 | [DeepFilterNet3](https://soniqo.audio/ko/guides/denoise) | 음성 향상 | CoreML | 2.1M | 언어 무관 |
 | [Sidon](https://soniqo.audio/ko/guides/restore) | 음성 복원 (노이즈 제거 + 잔향 제거, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 언어 무관 |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ko/guides/separate) | 소스 분리 | MLX | 168M | Agnostic |

--- a/README_pt.md
+++ b/README_pt.md
@@ -77,7 +77,7 @@ Reconhecimento, sintese e compreensao de fala no dispositivo para Mac e iOS. Exe
 
 - **[Palavra de ativacao](https://soniqo.audio/pt/guides/wake-word)** — Deteccao de palavras-chave no dispositivo (KWS Zipformer 3M, CoreML, 26x tempo real, lista de palavras-chave configuravel)
 - **[VAD](https://soniqo.audio/pt/guides/vad)** — Deteccao de atividade de voz (Silero streaming, Pyannote offline, FireRedVAD 100+ idiomas)
-- **[Diarizacao de falantes](https://soniqo.audio/pt/guides/diarize)** — Quem falou quando (pipeline Pyannote, Sortformer ponta-a-ponta no Neural Engine)
+- **[Diarizacao de falantes](https://soniqo.audio/pt/guides/diarize)** — Quem falou quando (pipeline Pyannote, Sortformer ponta-a-ponta no Neural Engine) — agora com uma sessão de streaming incremental (IDs de falante estáveis, atualizações a cada 480 ms)
 - **[Embeddings de falante](https://soniqo.audio/pt/guides/embed-speaker)** — WeSpeaker ResNet34 (256 dim), ReDimNet2-B6 para identidade de voz nomeada (192 dim), CAM++ (192 dim)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/pt/guides/diarize) | VAD + Diarizacao | MLX | 1.5M | Agnostico |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarizacao + embeddings de falante | CoreML (ANE) + Swift VBx | 8.35M | Agnostico |
-| [Sortformer](https://soniqo.audio/pt/guides/diarize) | Diarizacao (E2E) | CoreML (ANE) | — | Agnostico |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarizacao (E2E), streaming incremental | CoreML (ANE) | 117M | Agnostico |
 | [DeepFilterNet3](https://soniqo.audio/pt/guides/denoise) | Aprimoramento de fala | CoreML | 2.1M | Agnostico |
 | [Sidon](https://soniqo.audio/pt/guides/restore) | Restauracao de fala (denoise + dereverb, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostico |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/pt/guides/separate) | Separação de fontes | MLX | 168M | Agnostic |

--- a/README_pt.md
+++ b/README_pt.md
@@ -191,7 +191,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/pt/guides/diarize) | VAD + Diarizacao | MLX | 1.5M | Agnostico |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarizacao + embeddings de falante | CoreML (ANE) + Swift VBx | 8.35M | Agnostico |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Diarizacao (E2E), streaming incremental | CoreML (ANE) | 117M | Agnostico |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Diarizacao (E2E), streaming incremental](https://soniqo.audio/pt/guides/diarize) | CoreML (ANE) | 117M | Agnostico |
 | [DeepFilterNet3](https://soniqo.audio/pt/guides/denoise) | Aprimoramento de fala | CoreML | 2.1M | Agnostico |
 | [Sidon](https://soniqo.audio/pt/guides/restore) | Restauracao de fala (denoise + dereverb, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostico |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/pt/guides/separate) | Separação de fontes | MLX | 168M | Agnostic |

--- a/README_ru.md
+++ b/README_ru.md
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ru/guides/diarize) | VAD + Диаризация | MLX | 1.5M | Универсальный |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Диаризация + эмбеддинги спикеров | CoreML (ANE) + Swift VBx | 8.35M | Универсальный |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Диаризация (E2E), инкрементальный стриминг | CoreML (ANE) | 117M | Универсальный |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Диаризация (E2E), инкрементальный стриминг](https://soniqo.audio/ru/guides/diarize) | CoreML (ANE) | 117M | Универсальный |
 | [DeepFilterNet3](https://soniqo.audio/ru/guides/denoise) | Улучшение речи | CoreML | 2.1M | Универсальный |
 | [Sidon](https://soniqo.audio/ru/guides/restore) | Восстановление речи (подавление шума + дереверберация, 48 кГц) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Универсальный |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ru/guides/separate) | Разделение источников | MLX | 168M | Agnostic |

--- a/README_ru.md
+++ b/README_ru.md
@@ -77,7 +77,7 @@
 
 - **[Активационное слово](https://soniqo.audio/ru/guides/wake-word)** — Локальное распознавание ключевых слов (KWS Zipformer 3M, CoreML, 26× реального времени, настраиваемый список ключевых слов)
 - **[VAD](https://soniqo.audio/ru/guides/vad)** — Обнаружение голосовой активности (Silero потоковый, Pyannote офлайн, FireRedVAD 100+ языков)
-- **[Speaker Diarization](https://soniqo.audio/ru/guides/diarize)** — Кто говорил и когда (Pyannote-пайплайн, сквозной Sortformer на Neural Engine)
+- **[Speaker Diarization](https://soniqo.audio/ru/guides/diarize)** — Кто говорил и когда (Pyannote-пайплайн, сквозной Sortformer на Neural Engine) — теперь с инкрементальной стриминговой сессией (стабильные ID говорящих, обновления каждые 480 мс)
 - **[Speaker Embeddings](https://soniqo.audio/ru/guides/embed-speaker)** — WeSpeaker ResNet34 (256-мерные векторы), ReDimNet2-B6 для именованной идентификации голоса (192-мерные), CAM++ (192-мерные)
 
 Статьи: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/ru/guides/diarize) | VAD + Диаризация | MLX | 1.5M | Универсальный |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Диаризация + эмбеддинги спикеров | CoreML (ANE) + Swift VBx | 8.35M | Универсальный |
-| [Sortformer](https://soniqo.audio/ru/guides/diarize) | Диаризация (E2E) | CoreML (ANE) | — | Универсальный |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Диаризация (E2E), инкрементальный стриминг | CoreML (ANE) | 117M | Универсальный |
 | [DeepFilterNet3](https://soniqo.audio/ru/guides/denoise) | Улучшение речи | CoreML | 2.1M | Универсальный |
 | [Sidon](https://soniqo.audio/ru/guides/restore) | Восстановление речи (подавление шума + дереверберация, 48 кГц) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Универсальный |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/ru/guides/separate) | Разделение источников | MLX | 168M | Agnostic |

--- a/README_th.md
+++ b/README_th.md
@@ -77,7 +77,7 @@
 
 - **[Wake-word](https://soniqo.audio/guides/wake-word)** — การตรวจจับคำสั่งปลุกบนอุปกรณ์ (KWS Zipformer 3M, CoreML, เร็วกว่าเรียลไทม์ 26 เท่า, รายการคำสั่งปลุกปรับแต่งได้)
 - **[VAD](https://soniqo.audio/guides/vad)** — การตรวจจับเสียงพูด (Silero streaming, Pyannote offline, FireRedVAD รองรับกว่า 100 ภาษา)
-- **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — ใครพูดเมื่อใด (pipeline Pyannote, Sortformer แบบ end-to-end บน Neural Engine)
+- **[Speaker Diarization](https://soniqo.audio/guides/diarize)** — ใครพูดเมื่อใด (pipeline Pyannote, Sortformer แบบ end-to-end บน Neural Engine) — ตอนนี้มีเซสชันสตรีมมิงแบบเพิ่มทีละส่วน (ID ผู้พูดคงที่ อัปเดตทุก 480 ms)
 - **[Speaker Embeddings](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 มิติ), ReDimNet2-B6 สำหรับการระบุตัวตนเสียงแบบตั้งชื่อ (192 มิติ), CAM++ (192 มิติ)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + การแยกผู้พูด | MLX | 1.5M | ไม่จำกัดภาษา |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | การแยกผู้พูด + เอ็มเบดดิงผู้พูด | CoreML (ANE) + Swift VBx | 8.35M | ไม่จำกัดภาษา |
-| [Sortformer](https://soniqo.audio/guides/diarize) | การแยกผู้พูด (E2E) | CoreML (ANE) | — | ไม่จำกัดภาษา |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | การแยกผู้พูด (E2E), สตรีมมิงแบบเพิ่มทีละส่วน | CoreML (ANE) | 117M | ไม่จำกัดภาษา |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | การปรับปรุงเสียงพูด | CoreML | 2.1M | ไม่จำกัดภาษา |
 | [Sidon](https://soniqo.audio/guides/restore) | การฟื้นฟูเสียงพูด (ลดเสียงรบกวน + ลดเสียงก้อง, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | ไม่จำกัดภาษา |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | การแยกแหล่งกำเนิด | MLX | 168M | ไม่จำกัดภาษา |

--- a/README_th.md
+++ b/README_th.md
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + การแยกผู้พูด | MLX | 1.5M | ไม่จำกัดภาษา |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | การแยกผู้พูด + เอ็มเบดดิงผู้พูด | CoreML (ANE) + Swift VBx | 8.35M | ไม่จำกัดภาษา |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | การแยกผู้พูด (E2E), สตรีมมิงแบบเพิ่มทีละส่วน | CoreML (ANE) | 117M | ไม่จำกัดภาษา |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [การแยกผู้พูด (E2E), สตรีมมิงแบบเพิ่มทีละส่วน](https://soniqo.audio/th/guides/diarize) | CoreML (ANE) | 117M | ไม่จำกัดภาษา |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | การปรับปรุงเสียงพูด | CoreML | 2.1M | ไม่จำกัดภาษา |
 | [Sidon](https://soniqo.audio/guides/restore) | การฟื้นฟูเสียงพูด (ลดเสียงรบกวน + ลดเสียงก้อง, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | ไม่จำกัดภาษา |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | การแยกแหล่งกำเนิด | MLX | 168M | ไม่จำกัดภาษา |

--- a/README_tr.md
+++ b/README_tr.md
@@ -77,7 +77,7 @@ Mac ve iOS için cihaz üzerinde konuşma tanıma, sentezleme ve anlama. Apple S
 
 - **[Uyandırma kelimesi](https://soniqo.audio/guides/wake-word)** — Cihaz üzerinde anahtar kelime tespiti (KWS Zipformer 3M, CoreML, 26× gerçek zaman, yapılandırılabilir anahtar kelime listesi)
 - **[VAD](https://soniqo.audio/guides/vad)** — Ses etkinlik algılama (Silero akış, Pyannote çevrimdışı, FireRedVAD 100+ dil)
-- **[Konuşmacı Ayrımı](https://soniqo.audio/guides/diarize)** — Kim ne zaman konuştu (Pyannote pipeline, Neural Engine üzerinde uçtan uca Sortformer)
+- **[Konuşmacı Ayrımı](https://soniqo.audio/guides/diarize)** — Kim ne zaman konuştu (Pyannote pipeline, Neural Engine üzerinde uçtan uca Sortformer) — artık artımlı akış oturumuyla (sabit konuşmacı kimlikleri, 480 ms'de bir güncelleme)
 - **[Konuşmacı Gömmeleri](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256-boyut), ReDimNet2-B6 ile adlandırılmış ses kimliği (192-boyut), CAM++ (192-boyut)
 
 Makaleler: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Konuşmacı Ayrımı | MLX | 1.5M | Bağımsız |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Konuşmacı ayrıştırma + konuşmacı gömmeleri | CoreML (ANE) + Swift VBx | 8.35M | Bağımsız |
-| [Sortformer](https://soniqo.audio/guides/diarize) | Konuşmacı Ayrımı (E2E) | CoreML (ANE) | — | Bağımsız |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Konuşmacı Ayrımı (E2E), artımlı akış | CoreML (ANE) | 117M | Bağımsız |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Konuşma İyileştirme | CoreML | 2.1M | Bağımsız |
 | [Sidon](https://soniqo.audio/guides/restore) | Konuşma Onarımı (gürültü bastırma + yankı giderme, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Bağımsız |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | Kaynak Ayrıştırma | MLX | 168M | Bağımsız |

--- a/README_tr.md
+++ b/README_tr.md
@@ -191,7 +191,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Konuşmacı Ayrımı | MLX | 1.5M | Bağımsız |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Konuşmacı ayrıştırma + konuşmacı gömmeleri | CoreML (ANE) + Swift VBx | 8.35M | Bağımsız |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Konuşmacı Ayrımı (E2E), artımlı akış | CoreML (ANE) | 117M | Bağımsız |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Konuşmacı Ayrımı (E2E), artımlı akış](https://soniqo.audio/tr/guides/diarize) | CoreML (ANE) | 117M | Bağımsız |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Konuşma İyileştirme | CoreML | 2.1M | Bağımsız |
 | [Sidon](https://soniqo.audio/guides/restore) | Konuşma Onarımı (gürültü bastırma + yankı giderme, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Bağımsız |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | Kaynak Ayrıştırma | MLX | 168M | Bağımsız |

--- a/README_vi.md
+++ b/README_vi.md
@@ -191,7 +191,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Phân tách người nói | MLX | 1.5M | Không phụ thuộc ngôn ngữ |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Phân tách người nói + embedding người nói | CoreML (ANE) + Swift VBx | 8.35M | Không phụ thuộc ngôn ngữ |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Phân tách người nói (E2E), streaming tăng dần | CoreML (ANE) | 117M | Không phụ thuộc ngôn ngữ |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Phân tách người nói (E2E), streaming tăng dần](https://soniqo.audio/vi/guides/diarize) | CoreML (ANE) | 117M | Không phụ thuộc ngôn ngữ |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Cải thiện chất lượng giọng nói | CoreML | 2.1M | Không phụ thuộc ngôn ngữ |
 | [Sidon](https://soniqo.audio/guides/restore) | Phục hồi giọng nói (khử nhiễu + khử vang, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Không phụ thuộc ngôn ngữ |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | Tách nguồn | MLX | 168M | Không phụ thuộc ngôn ngữ |

--- a/README_vi.md
+++ b/README_vi.md
@@ -77,7 +77,7 @@ Nhận dạng, tổng hợp và hiểu giọng nói trên thiết bị cho Mac v
 
 - **[Từ kích hoạt](https://soniqo.audio/guides/wake-word)** — Phát hiện từ khóa trên thiết bị (KWS Zipformer 3M, CoreML, 26× thời gian thực, danh sách từ khóa có thể cấu hình)
 - **[VAD](https://soniqo.audio/guides/vad)** — Phát hiện hoạt động giọng nói (Silero streaming, Pyannote ngoại tuyến, FireRedVAD hơn 100 ngôn ngữ)
-- **[Phân tách người nói](https://soniqo.audio/guides/diarize)** — Ai nói khi nào (pipeline Pyannote, Sortformer end-to-end trên Neural Engine)
+- **[Phân tách người nói](https://soniqo.audio/guides/diarize)** — Ai nói khi nào (pipeline Pyannote, Sortformer end-to-end trên Neural Engine) — nay có phiên streaming tăng dần (ID người nói ổn định, cập nhật mỗi 480 ms)
 - **[Embedding người nói](https://soniqo.audio/guides/embed-speaker)** — WeSpeaker ResNet34 (256 chiều), ReDimNet2-B6 để nhận dạng giọng nói có tên (192 chiều), CAM++ (192 chiều)
 
 Papers: [Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/guides/diarize) | VAD + Phân tách người nói | MLX | 1.5M | Không phụ thuộc ngôn ngữ |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Phân tách người nói + embedding người nói | CoreML (ANE) + Swift VBx | 8.35M | Không phụ thuộc ngôn ngữ |
-| [Sortformer](https://soniqo.audio/guides/diarize) | Phân tách người nói (E2E) | CoreML (ANE) | — | Không phụ thuộc ngôn ngữ |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | Phân tách người nói (E2E), streaming tăng dần | CoreML (ANE) | 117M | Không phụ thuộc ngôn ngữ |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Cải thiện chất lượng giọng nói | CoreML | 2.1M | Không phụ thuộc ngôn ngữ |
 | [Sidon](https://soniqo.audio/guides/restore) | Phục hồi giọng nói (khử nhiễu + khử vang, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Không phụ thuộc ngôn ngữ |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | Tách nguồn | MLX | 168M | Không phụ thuộc ngôn ngữ |

--- a/README_zh.md
+++ b/README_zh.md
@@ -77,7 +77,7 @@
 
 - **[唤醒词](https://soniqo.audio/zh/guides/wake-word)** — 设备端关键词识别（KWS Zipformer 3M，CoreML，26× 实时，可配置关键词列表）
 - **[VAD](https://soniqo.audio/zh/guides/vad)** — 语音活动检测（Silero 流式、Pyannote 离线、FireRedVAD 100+ 种语言）
-- **[说话人分离](https://soniqo.audio/zh/guides/diarize)** — 谁在什么时间说话（Pyannote 流水线，神经引擎上的端到端 Sortformer）
+- **[说话人分离](https://soniqo.audio/zh/guides/diarize)** — 谁在什么时间说话（Pyannote 流水线，神经引擎上的端到端 Sortformer） — 现支持增量流式会话（说话人 ID 稳定，每 480 毫秒更新）
 - **[说话人嵌入向量](https://soniqo.audio/zh/guides/embed-speaker)** — WeSpeaker ResNet34（256 维）、ReDimNet2-B6 命名语音身份（192 维）、CAM++（192 维）
 
 论文：[Qwen3-ASR](https://arxiv.org/abs/2601.21337) (Alibaba) · [Qwen3-TTS](https://arxiv.org/abs/2601.15621) (Alibaba) · [Omnilingual ASR](https://arxiv.org/abs/2511.09690) (Meta) · [Parakeet TDT](https://arxiv.org/abs/2304.06795) (NVIDIA) · [CosyVoice 3](https://arxiv.org/abs/2505.17589) (Alibaba) · [Kokoro](https://arxiv.org/abs/2301.01695) (StyleTTS 2) · [PersonaPlex](https://arxiv.org/abs/2602.06053) (NVIDIA) · [Mimi](https://arxiv.org/abs/2410.00037) (Kyutai) · [Hibiki](https://arxiv.org/abs/2502.03382) (Kyutai) · [Sortformer](https://arxiv.org/abs/2409.06656) (NVIDIA)
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/zh/guides/diarize) | VAD + 说话人分离 | MLX | 1.5M | 语言无关 |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | 说话人分离 + 说话人嵌入 | CoreML (ANE) + Swift VBx | 8.35M | 语言无关 |
-| [Sortformer](https://soniqo.audio/zh/guides/diarize) | 说话人分离（端到端） | CoreML (ANE) | — | 语言无关 |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | 说话人分离（端到端）, 增量流式 | CoreML (ANE) | 117M | 语言无关 |
 | [DeepFilterNet3](https://soniqo.audio/zh/guides/denoise) | 语音增强 | CoreML | 2.1M | 语言无关 |
 | [Sidon](https://soniqo.audio/zh/guides/restore) | 语音修复（降噪 + 去混响，48 kHz） | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 语言无关 |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/zh/guides/separate) | 音源分离 | MLX | 168M | Agnostic |

--- a/README_zh.md
+++ b/README_zh.md
@@ -191,7 +191,7 @@ struct DictateView: View {
 | [KWS Zipformer](docs/models/kws-zipformer.md) | Audio → Wake word | CoreML (ANE) | 3M | EN/custom keywords |
 | [Pyannote](https://soniqo.audio/zh/guides/diarize) | VAD + 说话人分离 | MLX | 1.5M | 语言无关 |
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | 说话人分离 + 说话人嵌入 | CoreML (ANE) + Swift VBx | 8.35M | 语言无关 |
-| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | 说话人分离（端到端）, 增量流式 | CoreML (ANE) | 117M | 语言无关 |
+| [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [说话人分离（端到端）, 增量流式](https://soniqo.audio/zh/guides/diarize) | CoreML (ANE) | 117M | 语言无关 |
 | [DeepFilterNet3](https://soniqo.audio/zh/guides/denoise) | 语音增强 | CoreML | 2.1M | 语言无关 |
 | [Sidon](https://soniqo.audio/zh/guides/restore) | 语音修复（降噪 + 去混响，48 kHz） | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | 语言无关 |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/zh/guides/separate) | 音源分离 | MLX | 168M | Agnostic |

--- a/Sources/DiarizationBenchmark/DiarizationBench.swift
+++ b/Sources/DiarizationBenchmark/DiarizationBench.swift
@@ -34,6 +34,11 @@ struct DiarizationBench: AsyncParsableCommand {
     @Option(name: .long, help: "Frame scoring resolution in seconds.")
     var resolution: Float = 0.01
 
+    @Option(name: .long, help: """
+        Comma-separated key=value Sortformer tuning overrides applied to the         sortformer engines: onset, offset, minSpeechDuration,         minSilenceDuration, silenceThreshold, predScoreThreshold,         scoresBoostLatest, strongBoostRate, weakBoostRate, minPosScoresRate,         spkcacheSilFramesPerSpk.
+        """)
+    var sortformerTuning: String?
+
     mutating func run() async throws {
         setlinebuf(stdout)
 
@@ -48,9 +53,10 @@ struct DiarizationBench: AsyncParsableCommand {
         let totalAudio = decoded.reduce(0.0) { $0 + $1.duration }
         print(String(format: "Total audio: %.1f s\n", totalAudio))
 
+        let tuning = try SortformerTuning(argument: sortformerTuning)
         var results: [DiarizationEngineResult] = []
         for engineID in engines {
-            guard let engine = makeDiarizationEngine(engineID) else {
+            guard let engine = makeDiarizationEngine(engineID, tuning: tuning) else {
                 fputs("Unknown diarization engine: \(engineID)\n", stderr)
                 throw ExitCode(2)
             }
@@ -202,18 +208,77 @@ private protocol DiarizationBenchEngine: AnyObject {
     func diarize(audio: [Float], sampleRate: Int) throws -> DiarizationResult
 }
 
-private func makeDiarizationEngine(_ id: String) -> DiarizationBenchEngine? {
+/// Parsed --sortformer-tuning overrides. Cache-update keys mutate the
+/// SortformerConfig the model loads with; binarization keys mutate the
+/// DiarizationConfig used when probabilities become segments.
+struct SortformerTuning {
+    var apply: (inout SortformerConfig) -> Void = { _ in }
+    var thresholds = DiarizationConfig.default
+
+    init(argument: String?) throws {
+        guard let argument, !argument.isEmpty else { return }
+        var configEdits: [(inout SortformerConfig) -> Void] = []
+        for pair in argument.split(separator: ",") {
+            let parts = pair.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2, let value = Float(parts[1]) else {
+                throw ValidationError("Bad --sortformer-tuning entry: \(pair)")
+            }
+            switch parts[0] {
+            case "onset": thresholds.onset = value
+            case "offset": thresholds.offset = value
+            case "minSpeechDuration": thresholds.minSpeechDuration = value
+            case "minSilenceDuration": thresholds.minSilenceDuration = value
+            case "silenceThreshold":
+                configEdits.append { $0.silenceThreshold = value }
+            case "predScoreThreshold":
+                configEdits.append { $0.predScoreThreshold = value }
+            case "scoresBoostLatest":
+                configEdits.append { $0.scoresBoostLatest = value }
+            case "strongBoostRate":
+                configEdits.append { $0.strongBoostRate = value }
+            case "weakBoostRate":
+                configEdits.append { $0.weakBoostRate = value }
+            case "minPosScoresRate":
+                configEdits.append { $0.minPosScoresRate = value }
+            case "spkcacheSilFramesPerSpk":
+                configEdits.append { $0.spkcacheSilFramesPerSpk = Int(value) }
+            default:
+                throw ValidationError("Unknown --sortformer-tuning key: \(parts[0])")
+            }
+        }
+        apply = { config in
+            for edit in configEdits { edit(&config) }
+        }
+    }
+
+    func tuned(_ base: SortformerConfig) -> SortformerConfig {
+        var config = base
+        apply(&config)
+        return config
+    }
+}
+
+private func makeDiarizationEngine(
+    _ id: String, tuning: SortformerTuning
+) -> DiarizationBenchEngine? {
     switch id.lowercased() {
     case "community1-coreml":
         return Community1DiarizationBenchEngine()
     case "sortformer-default":
-        return SortformerBenchEngine(name: "sortformer-default", variant: .default)
+        return SortformerBenchEngine(
+            name: "sortformer-default", variant: tuning.tuned(.default),
+            thresholds: tuning.thresholds)
     case "sortformer-balanced":
-        return SortformerBenchEngine(name: "sortformer-balanced", variant: .balanced)
+        return SortformerBenchEngine(
+            name: "sortformer-balanced", variant: tuning.tuned(.balanced),
+            thresholds: tuning.thresholds)
     case "sortformer-streaming":
-        return SortformerBenchEngine(name: "sortformer-streaming", variant: .streaming)
+        return SortformerBenchEngine(
+            name: "sortformer-streaming", variant: tuning.tuned(.streaming),
+            thresholds: tuning.thresholds)
     case "sortformer-session":
-        return SortformerSessionBenchEngine()
+        return SortformerSessionBenchEngine(
+            config: tuning.tuned(.streaming), thresholds: tuning.thresholds)
     case "pyannote-mlx":
         return PyannoteDiarizationBenchEngine(name: "pyannote-mlx", embeddingEngine: .mlx)
     case "pyannote-coreml":
@@ -279,11 +344,16 @@ private final class PyannoteDiarizationBenchEngine: DiarizationBenchEngine {
 private final class SortformerBenchEngine: DiarizationBenchEngine {
     let name: String
     let variant: SortformerConfig
+    let thresholds: DiarizationConfig
     var diarizer: SortformerDiarizer?
 
-    init(name: String, variant: SortformerConfig) {
+    init(
+        name: String, variant: SortformerConfig,
+        thresholds: DiarizationConfig = .default
+    ) {
         self.name = name
         self.variant = variant
+        self.thresholds = thresholds
     }
 
     func load() async throws {
@@ -298,7 +368,7 @@ private final class SortformerBenchEngine: DiarizationBenchEngine {
         guard let diarizer else {
             return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
         }
-        return diarizer.diarize(audio: audio, sampleRate: sampleRate)
+        return diarizer.diarize(audio: audio, sampleRate: sampleRate, config: thresholds)
     }
 }
 
@@ -308,13 +378,25 @@ private final class SortformerBenchEngine: DiarizationBenchEngine {
 /// printing per-push latency, the number a realtime caller actually feels.
 private final class SortformerSessionBenchEngine: DiarizationBenchEngine {
     let name = "sortformer-session"
+    let config: SortformerConfig
+    let thresholds: DiarizationConfig
     var session: SortformerStreamingSession?
     private var pushMilliseconds: [Double] = []
+
+    init(
+        config: SortformerConfig = .streaming,
+        thresholds: DiarizationConfig = .default
+    ) {
+        self.config = config
+        self.thresholds = thresholds
+    }
 
     func load() async throws {
         #if canImport(CoreML)
         session = try await SortformerStreamingSession.fromPretrained(
+            config: config,
             computeUnits: .cpuAndNeuralEngine)
+        session?.binarization = thresholds
         #else
         throw BenchmarkSupportError.unsupportedReference("Sortformer requires CoreML")
         #endif

--- a/Sources/DiarizationBenchmark/DiarizationBench.swift
+++ b/Sources/DiarizationBenchmark/DiarizationBench.swift
@@ -212,6 +212,8 @@ private func makeDiarizationEngine(_ id: String) -> DiarizationBenchEngine? {
         return SortformerBenchEngine(name: "sortformer-balanced", variant: .balanced)
     case "sortformer-streaming":
         return SortformerBenchEngine(name: "sortformer-streaming", variant: .streaming)
+    case "sortformer-session":
+        return SortformerSessionBenchEngine()
     case "pyannote-mlx":
         return PyannoteDiarizationBenchEngine(name: "pyannote-mlx", embeddingEngine: .mlx)
     case "pyannote-coreml":
@@ -297,6 +299,59 @@ private final class SortformerBenchEngine: DiarizationBenchEngine {
             return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
         }
         return diarizer.diarize(audio: audio, sampleRate: sampleRate)
+    }
+}
+
+/// Drives ``SortformerStreamingSession`` the way a live consumer would:
+/// 480 ms pushes through the incremental API, one snapshot per push, final
+/// flush at end of file. Scores the same as batch engines while also
+/// printing per-push latency, the number a realtime caller actually feels.
+private final class SortformerSessionBenchEngine: DiarizationBenchEngine {
+    let name = "sortformer-session"
+    var session: SortformerStreamingSession?
+    private var pushMilliseconds: [Double] = []
+
+    func load() async throws {
+        #if canImport(CoreML)
+        session = try await SortformerStreamingSession.fromPretrained(
+            computeUnits: .cpuAndNeuralEngine)
+        #else
+        throw BenchmarkSupportError.unsupportedReference("Sortformer requires CoreML")
+        #endif
+    }
+
+    func diarize(audio: [Float], sampleRate: Int) throws -> DiarizationResult {
+        #if canImport(CoreML)
+        guard let session else {
+            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        }
+        session.reset()
+        let samples = sampleRate == 16_000
+            ? audio
+            : AudioFileLoader.resample(audio, from: sampleRate, to: 16_000)
+        let pushSize = 16_000 / 2
+        var cursor = 0
+        while cursor < samples.count {
+            let end = min(samples.count, cursor + pushSize)
+            let started = Date()
+            _ = try session.push(audio: Array(samples[cursor..<end]))
+            pushMilliseconds.append(Date().timeIntervalSince(started) * 1000)
+            cursor = end
+        }
+        let result = try session.finish()
+        let sorted = pushMilliseconds.sorted()
+        if !sorted.isEmpty {
+            let p50 = sorted[sorted.count / 2]
+            let p95 = sorted[min(sorted.count - 1, Int(Double(sorted.count) * 0.95))]
+            print(String(
+                format: "    session push latency: p50 %.1f ms · p95 %.1f ms (%d pushes)",
+                p50, p95, sorted.count))
+            pushMilliseconds.removeAll(keepingCapacity: true)
+        }
+        return result
+        #else
+        return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        #endif
     }
 }
 

--- a/Sources/SpeechVAD/SortformerDiarizer.swift
+++ b/Sources/SpeechVAD/SortformerDiarizer.swift
@@ -342,14 +342,35 @@ public final class SortformerDiarizer {
         minSpeechDuration: Float,
         minSilenceDuration: Float
     ) -> [DiarizedSegment] {
-        // Concatenate all chunk predictions into one flat array
         var allProbs = [Float]()
         for chunkProbs in allChunkProbs {
             allProbs.append(contentsOf: chunkProbs)
         }
+        return Self.binarize(
+            probs: allProbs,
+            frameCount: allProbs.count / numSpeakers,
+            audioDuration: audioDuration,
+            config: config,
+            thresholds: DiarizationConfig(
+                onset: onset,
+                offset: offset,
+                minSpeechDuration: minSpeechDuration,
+                minSilenceDuration: minSilenceDuration))
+    }
 
-        let totalFrames = allProbs.count / numSpeakers
-        guard totalFrames > 0 else { return [] }
+    /// Turn flat per-frame speaker probabilities into labeled segments.
+    /// Shared by whole-buffer diarization and the incremental streaming
+    /// session, which re-binarizes its growing confirmed-frame history.
+    static func binarize(
+        probs: [Float],
+        frameCount: Int,
+        audioDuration: Float,
+        config: SortformerConfig,
+        thresholds: DiarizationConfig
+    ) -> [DiarizedSegment] {
+        guard frameCount > 0 else { return [] }
+        let numSpeakers = config.maxSpeakers
+        var allProbs = probs
 
         // Apply sigmoid if predictions are logits
         for i in 0..<allProbs.count {
@@ -358,25 +379,25 @@ public final class SortformerDiarizer {
             }
         }
 
-        // Binarize each speaker track
+        let frameDuration = Float(config.subsamplingFactor * config.hopLength)
+            / Float(config.sampleRate)
         var allSegments = [DiarizedSegment]()
-
         for spk in 0..<numSpeakers {
-            var probs = [Float](repeating: 0, count: totalFrames)
-            for f in 0..<totalFrames {
-                probs[f] = allProbs[f * numSpeakers + spk]
+            var track = [Float](repeating: 0, count: frameCount)
+            for f in 0..<frameCount {
+                track[f] = allProbs[f * numSpeakers + spk]
             }
 
             let rawSegments = PowersetDecoder.binarize(
-                probs: probs,
-                onset: onset,
-                offset: offset,
+                probs: track,
+                onset: thresholds.onset,
+                offset: thresholds.offset,
                 frameDuration: frameDuration
             )
 
             for seg in rawSegments {
                 let duration = seg.endTime - seg.startTime
-                guard duration >= minSpeechDuration else { continue }
+                guard duration >= thresholds.minSpeechDuration else { continue }
                 allSegments.append(DiarizedSegment(
                     startTime: seg.startTime,
                     endTime: min(seg.endTime, audioDuration),
@@ -386,9 +407,15 @@ public final class SortformerDiarizer {
         }
 
         allSegments.sort { $0.startTime < $1.startTime }
-        let merged = DiarizationHelpers.mergeSegments(allSegments, minSilence: minSilenceDuration)
+        let merged = DiarizationHelpers.mergeSegments(
+            allSegments, minSilence: thresholds.minSilenceDuration)
         return DiarizationHelpers.compactSpeakerIds(merged)
     }
+
+    // MARK: - Streaming session support
+
+    var coreMLModel: SortformerCoreMLModel { model }
+    var configuration: SortformerConfig { config }
 }
 
 // MARK: - SpeakerDiarizationModel

--- a/Sources/SpeechVAD/SortformerDiarizer.swift
+++ b/Sources/SpeechVAD/SortformerDiarizer.swift
@@ -280,14 +280,20 @@ public final class SortformerDiarizer {
                         count: fifoCapacity * dim - paddedFifo.count))
 
             do {
-                let output = try model.predict(
-                    chunk: chunkMel,
-                    chunkLength: actualLen,
-                    spkcache: paddedSpkcache,
-                    spkcacheLength: state.spkcacheLength,
-                    fifo: paddedFifo,
-                    fifoLength: state.fifoLength
-                )
+                // Pool per prediction: this loop has no draining run loop, so
+                // autoreleased IOSurface-backed CoreML buffers otherwise
+                // accumulate across chunks until allocation fails on long
+                // inputs.
+                let output = try autoreleasepool {
+                    try model.predict(
+                        chunk: chunkMel,
+                        chunkLength: actualLen,
+                        spkcache: paddedSpkcache,
+                        spkcacheLength: state.spkcacheLength,
+                        fifo: paddedFifo,
+                        fifoLength: state.fifoLength
+                    )
+                }
 
                 let lcFrames = Int(Float(leftOffset) / Float(subFactor) + 0.5)
                 let rcFrames = Int(ceil(Float(rightOffset) / Float(subFactor)))

--- a/Sources/SpeechVAD/SortformerStreamingSession.swift
+++ b/Sources/SpeechVAD/SortformerStreamingSession.swift
@@ -33,6 +33,11 @@ public final class SortformerStreamingSession {
     private let melExtractor: SortformerMelExtractor
     private var state: SortformerStreamingState
 
+    /// Thresholds used when snapshots binarize the confirmed-frame history.
+    /// Adjustable per session so consumers can trade misses against false
+    /// alarms without reloading the model.
+    public var binarization: DiarizationConfig = .default
+
     /// PCM retained for mel extraction, with `pcmBaseSample` giving the
     /// absolute index of `pcm[0]`. Only the span still needed for the next
     /// chunk (plus reflect-padding margin) is kept.
@@ -66,6 +71,7 @@ public final class SortformerStreamingSession {
         modelId: String = SortformerDiarizer.defaultModelId,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
+        config: SortformerConfig = .streaming,
         computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> SortformerStreamingSession {
@@ -73,7 +79,7 @@ public final class SortformerStreamingSession {
             modelId: modelId,
             cacheDir: cacheDir,
             offlineMode: offlineMode,
-            config: .streaming,
+            config: config,
             computeUnits: computeUnits,
             progressHandler: progressHandler)
         return diarizer.makeStreamingSession()
@@ -127,7 +133,7 @@ public final class SortformerStreamingSession {
             frameCount: frames,
             audioDuration: duration,
             config: config,
-            thresholds: .default)
+            thresholds: binarization)
         let usedSpeakers = Set(segments.map(\.speakerId))
         return DiarizationResult(
             segments: segments,
@@ -237,13 +243,18 @@ public final class SortformerStreamingSession {
         paddedFifo.append(contentsOf: [Float](
             repeating: 0, count: config.fifoLen * dim - paddedFifo.count))
 
-        let output = try model.predict(
-            chunk: chunkMel,
-            chunkLength: framesToCopy,
-            spkcache: paddedSpkcache,
-            spkcacheLength: state.spkcacheLength,
-            fifo: paddedFifo,
-            fifoLength: state.fifoLength)
+        // Pool per prediction: the push loop has no draining run loop, and
+        // without this the autoreleased IOSurface-backed CoreML buffers
+        // accumulate across chunks until allocation fails on long streams.
+        let output = try autoreleasepool {
+            try model.predict(
+                chunk: chunkMel,
+                chunkLength: framesToCopy,
+                spkcache: paddedSpkcache,
+                spkcacheLength: state.spkcacheLength,
+                fifo: paddedFifo,
+                fifoLength: state.fifoLength)
+        }
 
         let lcFrames = Int(Float(leftOffset) / Float(subFactor) + 0.5)
         let rcFrames = Int(ceil(Float(rightOffset) / Float(subFactor)))

--- a/Sources/SpeechVAD/SortformerStreamingSession.swift
+++ b/Sources/SpeechVAD/SortformerStreamingSession.swift
@@ -1,0 +1,268 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// Incremental Sortformer diarization over a live audio stream.
+///
+/// Feed PCM in arbitrary sizes with ``push(audio:)``; whenever enough audio
+/// for one streaming chunk (480 ms core + 560 ms lookahead) has accumulated,
+/// the session runs one CoreML step, advances the Arrival-Order Speaker Cache
+/// via ``SortformerStateUpdater``, and appends the newly confirmed frames to
+/// the running result. Speaker IDs are cache slots ordered by first arrival,
+/// so they remain stable for the lifetime of the session — no window
+/// re-clustering and no renumbering.
+///
+/// ```swift
+/// let session = try await SortformerStreamingSession.fromPretrained()
+/// while let samples = captureNextBuffer() {
+///     let snapshot = try session.push(audio: samples)
+///     render(snapshot.segments)
+/// }
+/// let final = try session.finish()
+/// ```
+///
+/// The session expects 16 kHz mono input (`SortformerConfig.sampleRate`).
+/// Results are complete snapshots: every call returns all segments from the
+/// start of the stream, mirroring how downstream consumers replace rather
+/// than append transcript state.
+public final class SortformerStreamingSession {
+
+    private let model: SortformerCoreMLModel
+    private let config: SortformerConfig
+    private let updater: SortformerStateUpdater
+    private let melExtractor: SortformerMelExtractor
+    private var state: SortformerStreamingState
+
+    /// PCM retained for mel extraction, with `pcmBaseSample` giving the
+    /// absolute index of `pcm[0]`. Only the span still needed for the next
+    /// chunk (plus reflect-padding margin) is kept.
+    private var pcm: [Float] = []
+    private var pcmBaseSample = 0
+    private var totalSamples = 0
+
+    /// Next un-emitted core chunk start, in mel frames.
+    private var sttFeat = 0
+    /// Confirmed per-frame speaker probabilities from the stream start, flat
+    /// `[confirmedFrames * maxSpeakers]`. 80 ms per frame — small enough to
+    /// retain for hours and re-binarize per snapshot.
+    private var confirmedProbs: [Float] = []
+    private var finished = false
+
+    /// Mel frames of extra margin on each side of an extracted span so the
+    /// extractor's reflect padding cannot perturb the frames actually used.
+    /// 2 frames × 160 samples ≥ the 200-sample pad of a 400-sample window.
+    private static let melMarginFrames = 2
+
+    init(model: SortformerCoreMLModel, config: SortformerConfig) {
+        self.model = model
+        self.config = config
+        self.updater = SortformerStateUpdater(config: config)
+        self.melExtractor = SortformerMelExtractor(config: config)
+        self.state = SortformerStreamingState(config: config)
+    }
+
+    /// Download (or reuse) the streaming Sortformer variant and open a session.
+    public static func fromPretrained(
+        modelId: String = SortformerDiarizer.defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> SortformerStreamingSession {
+        let diarizer = try await SortformerDiarizer.fromPretrained(
+            modelId: modelId,
+            cacheDir: cacheDir,
+            offlineMode: offlineMode,
+            config: .streaming,
+            computeUnits: computeUnits,
+            progressHandler: progressHandler)
+        return diarizer.makeStreamingSession()
+    }
+
+    /// Discard all stream state and start a fresh session.
+    public func reset() {
+        state = SortformerStreamingState(config: config)
+        pcm.removeAll(keepingCapacity: true)
+        pcmBaseSample = 0
+        totalSamples = 0
+        sttFeat = 0
+        confirmedProbs.removeAll(keepingCapacity: true)
+        finished = false
+    }
+
+    /// Ingest more audio and return the updated whole-stream snapshot.
+    ///
+    /// - Parameter audio: 16 kHz mono PCM. Any length, including empty.
+    /// - Returns: all segments confirmed so far (lookahead means the last
+    ///   ~1 s of pushed audio is still pending the next chunk).
+    @discardableResult
+    public func push(audio: [Float]) throws -> DiarizationResult {
+        precondition(!finished, "push(audio:) after finish(); call reset() first")
+        pcm.append(contentsOf: audio)
+        totalSamples += audio.count
+        try drainReadyChunks(flushing: false)
+        return currentResult()
+    }
+
+    /// Flush the remaining buffered audio (with a shrinking right context,
+    /// exactly like offline chunking at end of file) and return the final
+    /// snapshot. The session must be ``reset()`` before further pushes.
+    public func finish() throws -> DiarizationResult {
+        guard !finished else { return currentResult() }
+        finished = true
+        try drainReadyChunks(flushing: true)
+        return currentResult()
+    }
+
+    /// The whole-stream result at this instant.
+    public func currentResult() -> DiarizationResult {
+        let frames = confirmedProbs.count / config.maxSpeakers
+        guard frames > 0 else {
+            return DiarizationResult(segments: [], numSpeakers: 0, speakerEmbeddings: [])
+        }
+        let duration = Float(frames * config.subsamplingFactor)
+            * Float(config.hopLength) / Float(config.sampleRate)
+        let segments = SortformerDiarizer.binarize(
+            probs: confirmedProbs,
+            frameCount: frames,
+            audioDuration: duration,
+            config: config,
+            thresholds: .default)
+        let usedSpeakers = Set(segments.map(\.speakerId))
+        return DiarizationResult(
+            segments: segments,
+            numSpeakers: usedSpeakers.count,
+            speakerEmbeddings: [])
+    }
+
+    // MARK: - Chunk loop
+
+    private func drainReadyChunks(flushing: Bool) throws {
+        let hop = config.hopLength
+        let nMels = config.nMels
+        let subFactor = config.subsamplingFactor
+        let coreMelFrames = Int(config.chunkLenSeconds) * subFactor
+        let leftCtxMel = Int(config.leftContextSeconds) * subFactor
+        let rightCtxMel = Int(config.rightContextSeconds) * subFactor
+        let margin = Self.melMarginFrames
+
+        // Mel frame k centers on sample k*hop; a frame is only bit-identical
+        // to whole-file extraction when the extracted span extends `margin`
+        // frames past it on both sides (or hits the true stream start/end).
+        // Whole-file extraction yields N/hop + 1 center-padded frames; the
+        // final frame reflects off the true stream end, so it only exists
+        // once the stream is finished — before that it would change when
+        // more audio arrives.
+        let totalMelFrames = finished
+            ? totalSamples / hop + 1
+            : totalSamples / hop
+        while !finished || sttFeat < totalMelFrames {
+            let endFeat = min(sttFeat + coreMelFrames, totalMelFrames)
+            let rightAvailable = totalMelFrames - endFeat
+            let rightOffset = min(rightCtxMel, rightAvailable)
+            if flushing {
+                guard sttFeat < totalMelFrames else { break }
+            } else {
+                // Wait until a full core chunk, its whole lookahead, and the
+                // extraction margin are available.
+                guard endFeat - sttFeat == coreMelFrames,
+                      rightAvailable >= rightCtxMel + margin else { break }
+            }
+            let leftOffset = min(leftCtxMel, sttFeat)
+            try runChunk(
+                sttFeat: sttFeat,
+                endFeat: endFeat,
+                leftOffset: leftOffset,
+                rightOffset: rightOffset)
+            sttFeat = endFeat
+            if flushing, endFeat >= totalMelFrames { break }
+        }
+
+        // Drop PCM that no future chunk (or its margin) can reference.
+        let neededFromMelFrame = max(0, sttFeat - leftCtxMel - margin)
+        let neededFromSample = neededFromMelFrame * hop
+        if neededFromSample > pcmBaseSample {
+            let drop = min(pcm.count, neededFromSample - pcmBaseSample)
+            pcm.removeFirst(drop)
+            pcmBaseSample += drop
+        }
+        _ = nMels
+    }
+
+    private func runChunk(
+        sttFeat: Int, endFeat: Int, leftOffset: Int, rightOffset: Int
+    ) throws {
+        let hop = config.hopLength
+        let nMels = config.nMels
+        let subFactor = config.subsamplingFactor
+        let margin = Self.melMarginFrames
+
+        let chunkStartMel = sttFeat - leftOffset
+        let chunkEndMel = endFeat + rightOffset
+
+        // Extract with margin so reflect padding stays outside the used span.
+        let extractStartMel = max(0, chunkStartMel - margin)
+        let extractStartSample = extractStartMel * hop
+        let extractEndSample = min(
+            totalSamples, chunkEndMel * hop + margin * hop + config.nFFT)
+        let sliceStart = extractStartSample - pcmBaseSample
+        let sliceEnd = extractEndSample - pcmBaseSample
+        guard sliceStart >= 0, sliceEnd <= pcm.count, sliceEnd > sliceStart else {
+            return
+        }
+        let (melSpec, extractedFrames) = melExtractor.extract(
+            Array(pcm[sliceStart..<sliceEnd]))
+        let localStart = chunkStartMel - extractStartMel
+        let localEnd = min(extractedFrames, chunkEndMel - extractStartMel)
+        guard localEnd > localStart else { return }
+
+        let actualLen = localEnd - localStart
+        let coreMLInputFrames = config.coreMLInputFrames
+        var chunkMel = [Float](repeating: 0, count: coreMLInputFrames * nMels)
+        let framesToCopy = min(actualLen, coreMLInputFrames)
+        chunkMel.withUnsafeMutableBufferPointer { dst in
+            melSpec.withUnsafeBufferPointer { src in
+                memcpy(
+                    dst.baseAddress!,
+                    src.baseAddress! + localStart * nMels,
+                    framesToCopy * nMels * MemoryLayout<Float>.stride)
+            }
+        }
+
+        let dim = config.fcDModel
+        var paddedSpkcache = state.spkcache
+        paddedSpkcache.append(contentsOf: [Float](
+            repeating: 0, count: config.spkcacheLen * dim - paddedSpkcache.count))
+        var paddedFifo = state.fifo
+        paddedFifo.append(contentsOf: [Float](
+            repeating: 0, count: config.fifoLen * dim - paddedFifo.count))
+
+        let output = try model.predict(
+            chunk: chunkMel,
+            chunkLength: framesToCopy,
+            spkcache: paddedSpkcache,
+            spkcacheLength: state.spkcacheLength,
+            fifo: paddedFifo,
+            fifoLength: state.fifoLength)
+
+        let lcFrames = Int(Float(leftOffset) / Float(subFactor) + 0.5)
+        let rcFrames = Int(ceil(Float(rightOffset) / Float(subFactor)))
+        let update = updater.update(
+            state: &state,
+            chunkEmbs: output.encoderEmbs,
+            preds: output.speakerPreds,
+            leftContext: lcFrames,
+            rightContext: rcFrames)
+        confirmedProbs.append(contentsOf: update.confirmed)
+    }
+}
+
+extension SortformerDiarizer {
+    /// Open an incremental session sharing this diarizer's loaded model.
+    /// Use the `.streaming` config preset for realtime-shaped chunks; other
+    /// presets work but confirm output only every `chunkLenSeconds` seconds.
+    public func makeStreamingSession() -> SortformerStreamingSession {
+        SortformerStreamingSession(model: coreMLModel, config: configuration)
+    }
+}
+#endif

--- a/Tests/SpeechVADTests/SortformerTests.swift
+++ b/Tests/SpeechVADTests/SortformerTests.swift
@@ -173,6 +173,66 @@ final class SortformerTests: XCTestCase {
     }
 
     #if canImport(CoreML)
+    // MARK: - Streaming session equivalence (requires model download)
+
+    /// The incremental session must reproduce whole-buffer diarization with
+    /// the same `.streaming` preset: identical chunk math fed identical mel.
+    /// Arbitrary push sizes exercise the PCM carry and mel-margin logic.
+    func testStreamingSessionMatchesWholeBufferDiarization() async throws {
+        let diarizer: SortformerDiarizer
+        do {
+            diarizer = try await SortformerDiarizer.fromPretrained(
+                offlineMode: true, config: .streaming)
+        } catch {
+            throw XCTSkip("Sortformer streaming model not cached: \(error)")
+        }
+
+        // Deterministic two-voice-shaped audio: alternating band-limited
+        // bursts with silence gaps, 19 s so the FIFO spills into the cache.
+        var seed: UInt64 = 0x5EED_2026
+        func nextFloat() -> Float {
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            return Float(Int64(bitPattern: seed >> 11)) / Float(Int64.max)
+        }
+        var audio = [Float](repeating: 0, count: 19 * 16_000)
+        var cursor = 0
+        var voice = 0
+        while cursor < audio.count {
+            let burst = 16_000 + Int(abs(nextFloat()) * 16_000)
+            let gap = 4_000 + Int(abs(nextFloat()) * 4_000)
+            let end = min(audio.count, cursor + burst)
+            let carrier: Float = voice == 0 ? 180 : 320
+            for i in cursor..<end {
+                let envelope = 0.5 + 0.5 * sin(
+                    2 * .pi * carrier * Float(i) / 16_000)
+                audio[i] = 0.2 * nextFloat() * envelope
+            }
+            cursor = end + gap
+            voice = 1 - voice
+        }
+
+        let offline = diarizer.diarize(
+            audio: audio, sampleRate: 16_000, config: .default)
+
+        let session = diarizer.makeStreamingSession()
+        var pushed = 0
+        var pushSize = 1_000
+        while pushed < audio.count {
+            let end = min(audio.count, pushed + pushSize)
+            _ = try session.push(audio: Array(audio[pushed..<end]))
+            pushed = end
+            pushSize = pushSize == 1_000 ? 7_333 : 1_000
+        }
+        let streamed = try session.finish()
+
+        XCTAssertEqual(streamed.segments.count, offline.segments.count)
+        for (lhs, rhs) in zip(streamed.segments, offline.segments) {
+            XCTAssertEqual(lhs.speakerId, rhs.speakerId)
+            XCTAssertEqual(lhs.startTime, rhs.startTime, accuracy: 0.09)
+            XCTAssertEqual(lhs.endTime, rhs.endTime, accuracy: 0.09)
+        }
+    }
+
     // MARK: - E2E Integration Test (requires model download)
 
     func testE2EWithRealModel() async throws {

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -280,6 +280,35 @@ let result = diarizer.diarize(audio: samples, sampleRate: 16000) { progress, sta
 }
 ```
 
+### Incremental streaming session
+
+`SortformerStreamingSession` runs the same model incrementally for live
+audio. Feed 16 kHz PCM in arbitrary sizes; every 480 ms of accumulated audio
+triggers one Neural Engine step (~8 ms), and speaker IDs are Arrival-Order
+Speaker Cache slots — stable for the whole session, with no window
+re-clustering and no renumbering. Each push returns a whole-stream snapshot;
+the model's 560 ms right context means the newest ~1 s stays pending until
+the next chunk (or `finish()`).
+
+```swift
+let session = try await SortformerStreamingSession.fromPretrained()
+while let samples = captureNextBuffer() {           // any push size
+    let snapshot = try session.push(audio: samples)
+    render(snapshot.segments)                       // stable speaker IDs
+}
+let final = try session.finish()                    // flushes the tail
+```
+
+An existing `SortformerDiarizer` loaded with the `.streaming` preset can open
+sessions without reloading the model via `makeStreamingSession()`. The
+session reproduces whole-buffer `diarize` output for the same preset —
+chunk mel is extracted with reflect-padding margins that keep every consumed
+frame bit-identical to whole-file extraction.
+
+Measured on VoxConverse-dev samples (M-series ANE): DER on par with the
+offline Community-1 pipeline, 12 ms median latency per 500 ms push, ~39×
+realtime end to end.
+
 ### CLI Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Adds `SortformerStreamingSession`: incremental speaker diarization over a
live stream using the existing Sortformer `.streaming` CoreML variant
(480 ms of new audio per Neural Engine step, ~8 ms/step measured).

- PCM is pushed in arbitrary sizes; chunk mel is extracted from a bounded
  carry with reflect-padding margins, keeping every consumed frame
  bit-identical to whole-file extraction. `finish()` flushes the tail with
  the same shrinking right context as offline chunking.
- Speaker IDs are Arrival-Order Speaker Cache slots — stable for the whole
  session, no window re-clustering, no renumbering. State flows through the
  existing `SortformerStateUpdater`.
- Each push returns a whole-stream snapshot; binarization is now a shared
  static on `SortformerDiarizer`, used by both paths.
- `diarization-bench` gains a `sortformer-session` engine that drives the
  real push API and reports per-push latency.
- Docs: streaming-session section in `docs/inference/speaker-diarization.md`.

## Validation

- Model-gated test: the session reproduces whole-buffer `.streaming`
  diarization across irregular push sizes (segment-for-segment, ±0.09 s).
- Conversion parity (speech-models): the exported CoreML step driven by
  NeMo's own `streaming_feat_loader`/`streaming_update_async` matches
  NeMo's native `forward_streaming` at 100% frame-decision agreement
  (MAE 0.0005).
- Full `swift test` suite green (see CI).

## Benchmarks — VoxConverse-dev pilot (5 files, 17.6 min)

| engine | DER (collar 0.25) | DER (collar 0) | speaker count | xRT | push latency |
|---|---|---|---|---|---|
| sortformer-session (this PR, 480 ms steps) | 8.12% | 11.52% | 5/5 correct | 38.7× | p50 12.4 ms / 500 ms push |
| community1-coreml (offline, whole file) | 9.31% | — | 3/5 correct | 24.7× | n/a |

The incremental session beats the offline Community-1 pipeline on these
files with correct speaker counts on all five and realtime headroom to
spare. The cache-update hyperparameters currently ship at NeMo defaults;
tuning them is a follow-up independent of this PR's API.
