### PR TITLE
Expose emission-aligned word timestamps from Nemotron streaming

### DIFF
--- a/Sources/AudioCommon/Protocols.swift
+++ b/Sources/AudioCommon/Protocols.swift
@@ -128,6 +128,23 @@ public struct WordConfidence: Sendable {
     }
 }
 
+/// A word with the time span it was emitted over, in seconds of session
+/// audio. Streaming transducer decoders emit a token only once the acoustics
+/// are unambiguous, so a word's span trails its true onset by a small,
+/// roughly constant lag; treat the times as emission-aligned rather than
+/// forced-aligned.
+public struct TimedWord: Sendable, Equatable {
+    public let text: String
+    public let startTime: Double
+    public let endTime: Double
+
+    public init(text: String, startTime: Double, endTime: Double) {
+        self.text = text
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+}
+
 /// Result of speech recognition including detected language.
 public struct TranscriptionResult: Sendable {
     public let text: String

--- a/Sources/NemotronStreamingASR/NemotronStreamingASR.swift
+++ b/Sources/NemotronStreamingASR/NemotronStreamingASR.swift
@@ -59,6 +59,10 @@ public class NemotronStreamingASRModel {
         public let confidence: Float
         public let segmentIndex: Int
         public let wordBoostingChangedDecisions: Int
+        /// Cumulative emission-aligned word timings for the whole session so
+        /// far, in seconds of session audio (one encoder frame ≈ 80 ms;
+        /// see `TimedWord` for the emission-lag caveat).
+        public let words: [TimedWord]
     }
 
     /// Create a streaming session. `language` is a BCP-47 tag (e.g. `"en-US"`,

--- a/Sources/NemotronStreamingASR/RNNTGreedyDecoder.swift
+++ b/Sources/NemotronStreamingASR/RNNTGreedyDecoder.swift
@@ -23,6 +23,10 @@ class ReusableFeatureProvider: MLFeatureProvider {
 struct RNNTDecodeResult {
     let tokens: [Int]
     let tokenLogProbs: [Float]
+    /// Chunk-relative encoder frame at which each token was emitted, aligned
+    /// with `tokens`. The caller adds its running frame offset to make these
+    /// session-absolute.
+    let tokenFrames: [Int]
     let wordBoostingChangedDecisions: Int
 }
 
@@ -52,6 +56,7 @@ struct RNNTGreedyDecoder {
     ) throws -> RNNTDecodeResult {
         var tokens = [Int]()
         var tokenLogProbs = [Float]()
+        var tokenFrames = [Int]()
         var wordBoostingChangedDecisions = 0
 
         let tokenPtr = tokenArray.dataPointer.assumingMemoryBound(to: Int32.self)
@@ -82,6 +87,7 @@ struct RNNTGreedyDecoder {
                 tokens.append(tokenId)
                 let logProb = logSoftmax(logits, tokenId: tokenId, count: totalClasses, floatBuf: argmaxBuf)
                 tokenLogProbs.append(logProb)
+                tokenFrames.append(i)
 
                 tokenPtr.pointee = Int32(tokenId)
                 decoderProvider.update("h", h)
@@ -99,6 +105,7 @@ struct RNNTGreedyDecoder {
         return RNNTDecodeResult(
             tokens: tokens,
             tokenLogProbs: tokenLogProbs,
+            tokenFrames: tokenFrames,
             wordBoostingChangedDecisions: wordBoostingChangedDecisions
         )
     }

--- a/Sources/NemotronStreamingASR/StreamingSession.swift
+++ b/Sources/NemotronStreamingASR/StreamingSession.swift
@@ -34,6 +34,10 @@ public class StreamingSession {
 
     private var allTokens: [Int] = []
     private var allLogProbs: [Float] = []
+    /// Session-absolute encoder frame at which each token in `allTokens`
+    /// was emitted.
+    private var allTokenFrames: [Int] = []
+    private var encoderFrameOffset = 0
     private var sampleBuffer: [Float] = []
     private var segmentIndex: Int = 0
     internal private(set) var wordBoostingChangedDecisions: Int = 0
@@ -140,6 +144,23 @@ public class StreamingSession {
         argmaxBuf.deallocate()
     }
 
+    /// Seconds of audio represented by one encoder output frame.
+    public var frameDurationSeconds: Double {
+        Double(config.subsamplingFactor * config.hopLength) / Double(config.sampleRate)
+    }
+
+    /// Cumulative emission-aligned word timings for the whole session so
+    /// far, in seconds of session audio.
+    private func currentTimedWords() -> [TimedWord] {
+        let duration = frameDurationSeconds
+        return vocabulary.decodeTimedWords(allTokens, frames: allTokenFrames).map { piece in
+            TimedWord(
+                text: piece.word,
+                startTime: Double(piece.startFrame) * duration,
+                endTime: Double(piece.endFrame + 1) * duration)
+        }
+    }
+
     public func pushAudio(_ samples: [Float]) throws -> [NemotronStreamingASRModel.PartialTranscript] {
         sampleBuffer.append(contentsOf: samples)
 
@@ -199,7 +220,8 @@ public class StreamingSession {
             isFinal: true,
             confidence: confidence,
             segmentIndex: segmentIndex,
-            wordBoostingChangedDecisions: wordBoostingChangedDecisions
+            wordBoostingChangedDecisions: wordBoostingChangedDecisions,
+            words: currentTimedWords()
         )]
     }
 
@@ -262,6 +284,8 @@ public class StreamingSession {
 
         allTokens.append(contentsOf: result.tokens)
         allLogProbs.append(contentsOf: result.tokenLogProbs)
+        allTokenFrames.append(contentsOf: result.tokenFrames.map { encoderFrameOffset + $0 })
+        encoderFrameOffset += encodedLength
         wordBoostingChangedDecisions += result.wordBoostingChangedDecisions
 
         let text = vocabulary.decode(allTokens)
@@ -280,7 +304,8 @@ public class StreamingSession {
             isFinal: false,
             confidence: confidence,
             segmentIndex: segmentIndex,
-            wordBoostingChangedDecisions: wordBoostingChangedDecisions
+            wordBoostingChangedDecisions: wordBoostingChangedDecisions,
+            words: currentTimedWords()
         )
     }
 

--- a/Sources/NemotronStreamingASR/Vocabulary.swift
+++ b/Sources/NemotronStreamingASR/Vocabulary.swift
@@ -6,6 +6,20 @@ import AudioCommon
 /// regular BPE tokens; per-language tags (`<en-US>`, `<ar-AR>`, …) and
 /// other angle-bracket special tokens (`<unk>`, `<s>`, `</s>`, `<auto>`)
 /// are stripped during decode so they don't pollute the user-facing text.
+/// One decoded word with its encoder-frame emission span, before the
+/// session converts frames to seconds.
+public struct TimedWordPiece: Sendable, Equatable {
+    public let word: String
+    public let startFrame: Int
+    public let endFrame: Int
+
+    public init(word: String, startFrame: Int, endFrame: Int) {
+        self.word = word
+        self.startFrame = startFrame
+        self.endFrame = endFrame
+    }
+}
+
 public struct NemotronVocabulary: Sendable {
     private let idToToken: [Int: String]
     private let tokenToId: [String: Int]
@@ -147,6 +161,50 @@ public struct NemotronVocabulary: Sendable {
             .joined(separator: " ")
         guard !normalized.isEmpty else { return "" }
         return "▁" + normalized.replacingOccurrences(of: " ", with: "▁")
+    }
+
+    /// Decode with per-word emission frames. Mirrors `decodeWords`: special
+    /// tokens are skipped and a `▁`-prefixed piece starts a new word. Frames
+    /// are whatever the caller provides (session-absolute encoder frames);
+    /// `endFrame` is the frame of the word's last token, inclusive. The
+    /// session converts pieces to seconds-based `TimedWord`s.
+    public func decodeTimedWords(
+        _ tokenIds: [Int], frames: [Int]
+    ) -> [TimedWordPiece] {
+        guard tokenIds.count == frames.count else { return [] }
+
+        var words: [TimedWordPiece] = []
+        var currentWord = ""
+        var currentStart = 0
+        var currentEnd = 0
+
+        func flushCurrentWord() {
+            let word = currentWord.replacingOccurrences(of: "▁", with: " ")
+                .trimmingCharacters(in: .whitespaces)
+            if !word.isEmpty {
+                words.append(TimedWordPiece(
+                    word: word, startFrame: currentStart, endFrame: currentEnd))
+            }
+        }
+
+        for (i, id) in tokenIds.enumerated() {
+            guard let token = idToToken[id] else { continue }
+            if Self.isSpecialToken(token) { continue }
+            let isWordStart = token.hasPrefix("▁") && !currentWord.isEmpty
+
+            if isWordStart {
+                flushCurrentWord()
+                currentWord = token
+                currentStart = frames[i]
+                currentEnd = frames[i]
+            } else {
+                if currentWord.isEmpty { currentStart = frames[i] }
+                currentWord += token
+                currentEnd = frames[i]
+            }
+        }
+        flushCurrentWord()
+        return words
     }
 
     /// Decode with per-word confidence scores. Angle-bracket special tokens

--- a/Tests/NemotronStreamingASRTests/E2ENemotronLangTagLeakTests.swift
+++ b/Tests/NemotronStreamingASRTests/E2ENemotronLangTagLeakTests.swift
@@ -98,6 +98,44 @@ final class E2ENemotronLangTagLeakTests: XCTestCase {
         }
     }
 
+    /// Word timings must track the audio: emission-aligned words stay in
+    /// lockstep with the transcript, start monotonically, and remain bounded
+    /// by the (padded) stream duration.
+    func testStreamingWordTimingsAreMonotonicAndBounded() throws {
+        let m = try model
+        let audioURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav")!
+        let audio = try AudioFileLoader.load(url: audioURL, targetSampleRate: 16000)
+        let duration = Double(audio.count) / 16_000
+
+        let session = try m.createSession(language: "en-US")
+        var last: NemotronStreamingASRModel.PartialTranscript?
+        for lower in stride(from: 0, to: audio.count, by: 16_000) {
+            let upper = min(audio.count, lower + 16_000)
+            for partial in try session.pushAudio(Array(audio[lower..<upper])) {
+                last = partial
+            }
+        }
+        for partial in try session.finalize() { last = partial }
+
+        let final = try XCTUnwrap(last)
+        XCTAssertTrue(final.isFinal)
+        XCTAssertFalse(final.words.isEmpty)
+        XCTAssertEqual(
+            final.words.map(\.text).joined(separator: " "),
+            final.text,
+            "timed words must reproduce the transcript exactly")
+        var previousStart = -Double.infinity
+        for word in final.words {
+            XCTAssertLessThanOrEqual(word.startTime, word.endTime)
+            XCTAssertGreaterThanOrEqual(word.startTime, previousStart)
+            previousStart = word.startTime
+        }
+        XCTAssertGreaterThanOrEqual(final.words.first!.startTime, 0)
+        // Greedy RNN-T emission trails the acoustics, but never beyond the
+        // padded final chunk.
+        XCTAssertLessThanOrEqual(final.words.last!.endTime, duration + 1.0)
+    }
+
     /// Same audio through the batch path and the streaming path must produce
     /// transcripts whose content words substantially overlap. A streaming pass
     /// that drops one or more words from the batch reference (e.g. losing a

--- a/Tests/NemotronStreamingASRTests/NemotronStreamingASRTests.swift
+++ b/Tests/NemotronStreamingASRTests/NemotronStreamingASRTests.swift
@@ -120,6 +120,34 @@ final class NemotronVocabularyTests: XCTestCase {
         XCTAssertEqual(vocab.decode([0, 999, 1]), "the cat")
     }
 
+    func testDecodeTimedWordsSpansMultiTokenWordsAndSkipsSpecials() {
+        let vocab = NemotronVocabulary(idToToken: [
+            0: "▁hello",
+            1: "▁wor",
+            2: "ld",
+            3: "<en-US>",
+        ])
+        let words = vocab.decodeTimedWords([3, 0, 1, 2], frames: [0, 2, 5, 6])
+        XCTAssertEqual(words, [
+            TimedWordPiece(word: "hello", startFrame: 2, endFrame: 2),
+            TimedWordPiece(word: "world", startFrame: 5, endFrame: 6),
+        ])
+        // The word list must stay in lockstep with the plain transcript.
+        XCTAssertEqual(
+            words.map(\.word).joined(separator: " "),
+            vocab.decode([3, 0, 1, 2]))
+    }
+
+    func testDecodeTimedWordsHandlesLeadingContinuationAndBadInput() {
+        let vocab = NemotronVocabulary(idToToken: [2: "ld"])
+        // A session can begin mid-word after a language tag; the fragment
+        // still gets its own frames instead of a zero default.
+        XCTAssertEqual(
+            vocab.decodeTimedWords([2], frames: [4]),
+            [TimedWordPiece(word: "ld", startFrame: 4, endFrame: 4)])
+        XCTAssertEqual(vocab.decodeTimedWords([2], frames: []), [])
+    }
+
     func testDecodeWordsEmitsConfidences() {
         let vocab = NemotronVocabulary(idToToken: [
             0: "▁hello",


### PR DESCRIPTION
## Summary

- The greedy RNN-T decoder walks encoder frames one by one but discarded the frame index at token emission. It now records the frame per emitted token, and the streaming session keeps a session-absolute frame offset across chunks — no model change, no re-export, negligible cost (bookkeeping in an existing loop).
- `NemotronVocabulary.decodeTimedWords` groups tokens into words at SentencePiece boundaries exactly like `decodeWords`, carrying each word's emission-frame span.
- Every `PartialTranscript` now includes cumulative `words: [TimedWord]` in seconds of session audio (one encoder frame ≈ 80 ms at the multilingual config). `TimedWord` lives in AudioCommon next to `WordConfidence` so other streaming engines can adopt it.
- Timings are emission-aligned: greedy RNN-T emits a token once the acoustics are unambiguous, so spans trail true onsets by a small, roughly constant lag. Documented on the type.

## Motivation

A live consumer that splits a paragraph at diarized speaker changes currently has to align the change point to cumulative-text checkpoints (320 ms cadence, no timing), which folds fast handoffs into the wrong speaker. Word-level times make that boundary placement exact.

## Validation

- New unit tests: multi-token word spans, special-token skipping, mid-word session starts, malformed input (`NemotronVocabularyTests`, 6/6).
- New E2E on the real multilingual bundle: timed words reproduce the final transcript exactly, start monotonically, and stay bounded by the padded stream duration (5.1 s run).
- Full Nemotron regression suites (config, vocabulary, word boosting, lang-tag leak E2E incl. streaming-vs-batch content check): 13/13, run sequentially.
- Full package build clean — the only `PartialTranscript` constructors are the two session sites, both updated.