### PR TITLE
feat: add OpenAI-compatible speech synthesis

### DIFF
--- a/Sources/AudioServer/AudioServer.swift
+++ b/Sources/AudioServer/AudioServer.swift
@@ -131,6 +131,10 @@ public struct AudioServer {
             try await handleOpenAITranscriptions(request: request, state: state)
         }
 
+        router.post("/v1/audio/speech") { request, _ in
+            try await handleOpenAISpeech(request: request, state: state)
+        }
+
         router.post("/transcribe") { request, _ in
             let body = try await request.body.collect(upTo: 50 * 1024 * 1024)
             let params = try RequestParams.parse(body, contentType: request.headers[.contentType])
@@ -1521,16 +1525,22 @@ func dispatchSynthesize(
     variant: ModelVariant,
     language: String,
     state: ModelState,
+    voice: String? = nil,
+    speed: Float = 1.0,
     cloneReferenceAudio: [Float]? = nil,
     cloneReferenceText: String? = nil
 ) async throws -> [Float] {
     switch variant.engine {
     case "kokoro":
         let model = try await state.loadKokoro(modelId: variant.modelId)
-        return try model.synthesize(text: text, language: mapToKokoroLanguageCode(language))
+        return try model.synthesize(
+            text: text,
+            voice: voice ?? KokoroTTSModel.defaultVoice,
+            language: mapToKokoroLanguageCode(language),
+            speed: speed)
     case "qwen3-tts":
         let model = try await state.loadQwen3TTS(modelId: variant.modelId)
-        return model.synthesize(text: text, language: language)
+        return model.synthesize(text: text, language: language, speaker: voice)
     case "qwen3-tts-coreml":
         let model = try await state.loadQwen3TTSCoreML(modelId: variant.modelId)
         return try model.synthesize(text: text, language: language)

--- a/Sources/AudioServer/ModelRegistry.swift
+++ b/Sources/AudioServer/ModelRegistry.swift
@@ -123,7 +123,11 @@ public let MODEL_REGISTRY: [ModelVariant] = [
     .init(name: "kokoro-82m-coreml",
           engine: "kokoro",
           modelId: KokoroTTSModel.defaultModelId,
-          aliases: ["kokoro", "kokoro-82m"],
+          aliases: [
+              "kokoro", "kokoro-82m",
+              "tts-1", "tts-1-hd", "gpt-4o-mini-tts",
+              "gpt-4o-mini-tts-2025-12-15",
+          ],
           kind: .tts),
     .init(name: "cosyvoice-3-0.5b-mlx-bf16",
           engine: "cosyvoice",

--- a/Sources/AudioServer/OpenAISpeech.swift
+++ b/Sources/AudioServer/OpenAISpeech.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Hummingbird
+import HummingbirdCore
+import NIOCore
+import KokoroTTS
+
+// MARK: - OpenAI-compatible /v1/audio/speech
+
+enum OpenAISpeechResponseFormat: String, Equatable, Sendable {
+    case wav
+    case pcm
+}
+
+struct OpenAISpeechRequest: Equatable, Sendable {
+    static let maximumInputCharacters = 4096
+
+    let model: String
+    let input: String
+    let voice: String
+    let responseFormat: OpenAISpeechResponseFormat
+    let speed: Float
+    let language: String
+
+    private struct Payload: Decodable {
+        let model: String?
+        let input: String?
+        let voice: String?
+        let responseFormat: String?
+        let speed: Float?
+        let language: String?
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case input
+            case voice
+            case responseFormat = "response_format"
+            case speed
+            case language
+        }
+    }
+
+    static func parse(_ data: Data) throws -> OpenAISpeechRequest {
+        let payload: Payload
+        do {
+            payload = try JSONDecoder().decode(Payload.self, from: data)
+        } catch {
+            throw OpenAISpeechRequestError.invalidJSON
+        }
+
+        guard let model = payload.model?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !model.isEmpty
+        else {
+            throw OpenAISpeechRequestError.missingField("model")
+        }
+        guard let input = payload.input,
+              !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw OpenAISpeechRequestError.missingField("input")
+        }
+        guard input.count <= maximumInputCharacters else {
+            throw OpenAISpeechRequestError.inputTooLong(maximumInputCharacters)
+        }
+        guard let voice = payload.voice?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !voice.isEmpty
+        else {
+            throw OpenAISpeechRequestError.missingField("voice")
+        }
+
+        let formatName = payload.responseFormat?.lowercased() ?? OpenAISpeechResponseFormat.wav.rawValue
+        guard let responseFormat = OpenAISpeechResponseFormat(rawValue: formatName) else {
+            throw OpenAISpeechRequestError.unsupportedResponseFormat(formatName)
+        }
+
+        let speed = payload.speed ?? 1.0
+        guard speed >= 0.25, speed <= 4.0 else {
+            throw OpenAISpeechRequestError.speedOutOfRange(speed)
+        }
+
+        let language = payload.language?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedLanguage = language.flatMap { $0.isEmpty ? nil : $0 } ?? "english"
+        return OpenAISpeechRequest(
+            model: model,
+            input: input,
+            voice: voice,
+            responseFormat: responseFormat,
+            speed: speed,
+            language: resolvedLanguage)
+    }
+}
+
+enum OpenAISpeechRequestError: LocalizedError, Equatable {
+    case invalidJSON
+    case missingField(String)
+    case inputTooLong(Int)
+    case unsupportedResponseFormat(String)
+    case speedOutOfRange(Float)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidJSON:
+            "Invalid JSON request body"
+        case .missingField(let field):
+            "Missing '\(field)' field"
+        case .inputTooLong(let limit):
+            "The 'input' field must not exceed \(limit) characters"
+        case .unsupportedResponseFormat(let format):
+            "Unsupported response format '\(format)'; use 'wav' or 'pcm'"
+        case .speedOutOfRange(let speed):
+            "Speed \(speed) is outside the supported range 0.25...4.0"
+        }
+    }
+}
+
+/// Handle the OpenAI speech synthesis request shape.
+///
+/// The local server emits WAV by default because its synthesis engines produce
+/// 24 kHz PCM directly. Callers that need headerless PCM can request `pcm`.
+/// Compressed OpenAI formats (`mp3`, `opus`, `aac`, `flac`) are rejected rather
+/// than returning bytes under the wrong content type.
+func handleOpenAISpeech(
+    request: Request,
+    state: ModelState
+) async throws -> Response {
+    let body = try await request.body.collect(upTo: 1024 * 1024)
+
+    let speechRequest: OpenAISpeechRequest
+    do {
+        speechRequest = try OpenAISpeechRequest.parse(Data(buffer: body))
+    } catch {
+        return openAIErrorResponse(
+            error.localizedDescription,
+            status: .badRequest)
+    }
+
+    guard let variant = resolveModelToTTSVariant(speechRequest.model) else {
+        return openAIErrorResponse(
+            "Unknown TTS model: \(speechRequest.model)",
+            status: .badRequest)
+    }
+    guard variant.engine == "kokoro" || speechRequest.speed == 1.0 else {
+        return openAIErrorResponse(
+            "The 'speed' field is supported only by Kokoro models",
+            status: .badRequest)
+    }
+
+    let voice = resolvedLocalVoice(
+        speechRequest.voice,
+        engine: variant.engine)
+
+    let samples: [Float]
+    do {
+        samples = try await dispatchSynthesize(
+            text: speechRequest.input,
+            variant: variant,
+            language: speechRequest.language,
+            state: state,
+            voice: voice,
+            speed: speechRequest.speed)
+    } catch {
+        return openAIErrorResponse(
+            "Speech synthesis failed: \(error.localizedDescription)",
+            status: .internalServerError)
+    }
+
+    do {
+        switch speechRequest.responseFormat {
+        case .wav:
+            let wavData = try encodeWAV(samples: samples, sampleRate: 24_000)
+            return Response(
+                status: .ok,
+                headers: [.contentType: "audio/wav"],
+                body: .init(byteBuffer: .init(data: wavData)))
+        case .pcm:
+            let pcmData = floatToPCM16LE(samples)
+            return Response(
+                status: .ok,
+                headers: [.contentType: "audio/pcm"],
+                body: .init(byteBuffer: .init(data: pcmData)))
+        }
+    } catch {
+        return openAIErrorResponse(
+            "Audio encoding failed: \(error.localizedDescription)",
+            status: .internalServerError)
+    }
+}
+
+private let openAIVoiceNames: Set<String> = [
+    "alloy", "ash", "ballad", "cedar", "coral", "echo", "fable",
+    "juniper", "marin", "nova", "onyx", "sage", "shimmer", "verse",
+]
+
+/// Generic OpenAI voice names have no matching embeddings in local models.
+/// Treat them as a request for the selected engine's default voice. Native
+/// model voice names (for example Kokoro's `af_heart`) pass through unchanged.
+func resolvedLocalVoice(_ voice: String, engine: String) -> String? {
+    let normalized = voice.lowercased()
+    if openAIVoiceNames.contains(normalized) {
+        return engine == "kokoro" ? KokoroTTSModel.defaultVoice : nil
+    }
+    switch engine {
+    case "kokoro", "qwen3-tts":
+        return voice
+    default:
+        return nil
+    }
+}

--- a/Sources/AudioServer/OpenAITranscriptions.swift
+++ b/Sources/AudioServer/OpenAITranscriptions.swift
@@ -156,9 +156,9 @@ func handleOpenAITranscriptions(
 /// `{"error": {"message": "...", "type": "invalid_request_error", "code": null, "param": null}}`.
 /// The official openai-python / openai-node SDKs parse `error.message` as a
 /// nested field; returning a bare `{"error": "string"}` crashes their error
-/// handling. Kept local to this file so the shared `errorResponse` used by
-/// other endpoints (e.g. `/transcribe`) keeps its existing shape.
-private func openAIErrorResponse(
+/// handling. Shared by the OpenAI-shaped audio routes while native endpoints
+/// keep their existing `errorResponse` shape.
+func openAIErrorResponse(
     _ message: String,
     status: HTTPResponse.Status
 ) -> Response {

--- a/Sources/AudioServerCLI/AudioServerCommand.swift
+++ b/Sources/AudioServerCLI/AudioServerCommand.swift
@@ -38,6 +38,7 @@ struct AudioServerCommand: AsyncParsableCommand {
         print("Endpoints:")
         print("  POST /transcribe     - Speech-to-text (WAV body or JSON with audio_base64)")
         print("  POST /v1/audio/transcriptions - OpenAI-compatible STT (multipart/form-data)")
+        print("  POST /v1/audio/speech - OpenAI-compatible TTS (JSON body)")
         print("  POST /speak          - Text-to-speech (JSON: {text, engine?, language?})")
         print("  POST /respond        - Speech-to-speech (WAV body, voice/max_steps via query)")
         print("  POST /enhance        - Speech enhancement (WAV body)")

--- a/Tests/AudioServerTests/E2EOpenAISpeechTests.swift
+++ b/Tests/AudioServerTests/E2EOpenAISpeechTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import AudioServer
+
+/// End-to-end coverage for POST /v1/audio/speech.
+///
+/// Requires Kokoro weights and CoreML inference. The `E2E` class prefix keeps
+/// it out of the CI-safe unit phase; run it with the isolated E2E test runner.
+final class E2EOpenAISpeechTests: XCTestCase {
+    static var serverTask: Task<Void, Error>?
+    static let port = 19386
+
+    override class func setUp() {
+        super.setUp()
+        serverTask = Task {
+            let server = AudioServer(host: "127.0.0.1", port: port)
+            try await server.run()
+        }
+        Thread.sleep(forTimeInterval: 1.5)
+    }
+
+    override class func tearDown() {
+        serverTask?.cancel()
+        Thread.sleep(forTimeInterval: 0.5)
+        super.tearDown()
+    }
+
+    func testSynthesizesOpenAICompatibleWAV() async throws {
+        let url = URL(string: "http://127.0.0.1:\(Self.port)/v1/audio/speech")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "model": "tts-1",
+            "input": "Hello from Speech Swift.",
+            "voice": "alloy",
+            "response_format": "wav",
+        ])
+        request.timeoutInterval = 180
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let http = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(http.statusCode, 200)
+        XCTAssertTrue((http.value(forHTTPHeaderField: "Content-Type") ?? "").contains("audio/wav"))
+        XCTAssertGreaterThan(data.count, 44)
+        XCTAssertEqual(String(data: data.prefix(4), encoding: .ascii), "RIFF")
+        XCTAssertEqual(String(data: data.dropFirst(8).prefix(4), encoding: .ascii), "WAVE")
+    }
+}

--- a/Tests/AudioServerTests/OpenAISpeechTests.swift
+++ b/Tests/AudioServerTests/OpenAISpeechTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import AudioServer
+
+final class OpenAISpeechTests: XCTestCase {
+    private func jsonData(_ value: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: value)
+    }
+
+    func testParsesRequiredFieldsAndDefaults() throws {
+        let request = try OpenAISpeechRequest.parse(jsonData([
+            "model": "tts-1",
+            "input": "Hello world",
+            "voice": "alloy",
+        ]))
+
+        XCTAssertEqual(request.model, "tts-1")
+        XCTAssertEqual(request.input, "Hello world")
+        XCTAssertEqual(request.voice, "alloy")
+        XCTAssertEqual(request.responseFormat, .wav)
+        XCTAssertEqual(request.speed, 1.0)
+        XCTAssertEqual(request.language, "english")
+    }
+
+    func testParsesPCMAndOptionalFields() throws {
+        let request = try OpenAISpeechRequest.parse(jsonData([
+            "model": "kokoro",
+            "input": "Bonjour",
+            "voice": "ff_siwis",
+            "response_format": "pcm",
+            "speed": 1.25,
+            "language": "fr",
+        ]))
+
+        XCTAssertEqual(request.responseFormat, .pcm)
+        XCTAssertEqual(request.speed, 1.25)
+        XCTAssertEqual(request.language, "fr")
+    }
+
+    func testRejectsMissingRequiredFields() throws {
+        XCTAssertThrowsError(try OpenAISpeechRequest.parse(jsonData([
+            "input": "Hello",
+            "voice": "alloy",
+        ]))) { error in
+            XCTAssertEqual(error as? OpenAISpeechRequestError, .missingField("model"))
+        }
+
+        XCTAssertThrowsError(try OpenAISpeechRequest.parse(jsonData([
+            "model": "tts-1",
+            "voice": "alloy",
+        ]))) { error in
+            XCTAssertEqual(error as? OpenAISpeechRequestError, .missingField("input"))
+        }
+
+        XCTAssertThrowsError(try OpenAISpeechRequest.parse(jsonData([
+            "model": "tts-1",
+            "input": "Hello",
+        ]))) { error in
+            XCTAssertEqual(error as? OpenAISpeechRequestError, .missingField("voice"))
+        }
+    }
+
+    func testRejectsUnsupportedFormatAndSpeed() throws {
+        XCTAssertThrowsError(try OpenAISpeechRequest.parse(jsonData([
+            "model": "tts-1",
+            "input": "Hello",
+            "voice": "alloy",
+            "response_format": "mp3",
+        ]))) { error in
+            XCTAssertEqual(
+                error as? OpenAISpeechRequestError,
+                .unsupportedResponseFormat("mp3"))
+        }
+
+        XCTAssertThrowsError(try OpenAISpeechRequest.parse(jsonData([
+            "model": "tts-1",
+            "input": "Hello",
+            "voice": "alloy",
+            "speed": 4.1,
+        ]))) { error in
+            XCTAssertEqual(error as? OpenAISpeechRequestError, .speedOutOfRange(4.1))
+        }
+    }
+
+    func testRejectsOversizedInput() throws {
+        let input = String(repeating: "a", count: OpenAISpeechRequest.maximumInputCharacters + 1)
+        XCTAssertThrowsError(try OpenAISpeechRequest.parse(jsonData([
+            "model": "tts-1",
+            "input": input,
+            "voice": "alloy",
+        ]))) { error in
+            XCTAssertEqual(
+                error as? OpenAISpeechRequestError,
+                .inputTooLong(OpenAISpeechRequest.maximumInputCharacters))
+        }
+    }
+
+    func testOpenAIModelAliasesResolveToKokoro() {
+        XCTAssertEqual(resolveModelToTTSVariant("tts-1")?.engine, "kokoro")
+        XCTAssertEqual(resolveModelToTTSVariant("tts-1-hd")?.engine, "kokoro")
+        XCTAssertEqual(resolveModelToTTSVariant("gpt-4o-mini-tts")?.engine, "kokoro")
+        XCTAssertEqual(
+            resolveModelToTTSVariant("gpt-4o-mini-tts-2025-12-15")?.engine,
+            "kokoro")
+    }
+
+    func testGenericAndNativeVoiceResolution() {
+        XCTAssertEqual(resolvedLocalVoice("alloy", engine: "kokoro"), "af_heart")
+        XCTAssertEqual(resolvedLocalVoice("juniper", engine: "kokoro"), "af_heart")
+        XCTAssertNil(resolvedLocalVoice("alloy", engine: "qwen3-tts"))
+        XCTAssertEqual(resolvedLocalVoice("af_heart", engine: "kokoro"), "af_heart")
+        XCTAssertEqual(resolvedLocalVoice("vivian", engine: "qwen3-tts"), "vivian")
+        XCTAssertNil(resolvedLocalVoice("af_heart", engine: "cosyvoice"))
+    }
+}

--- a/docs/shared-protocols.md
+++ b/docs/shared-protocols.md
@@ -499,6 +499,35 @@ All model classes are **not thread-safe** by design. ML inference is inherently 
 **Sendable config types** — The following value types conform to `Sendable` and can be safely passed across concurrency boundaries:
 `SegmentationConfig`, `VADConfig`, `DiarizationConfig`, `VADPipeline`, `Qwen3AudioEncoderConfig`, `Qwen3ASRTokens`, `SlottedText`, `TextChunker`
 
+## OpenAI-Compatible HTTP Audio
+
+The `speech-server` binary exposes the OpenAI audio request shapes alongside
+its native REST endpoints:
+
+- `POST /v1/audio/transcriptions` accepts multipart audio and returns an
+  OpenAI transcription response.
+- `POST /v1/audio/speech` accepts JSON with `model`, `input`, and `voice` and
+  returns synthesized audio.
+
+```bash
+curl http://localhost:8080/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"tts-1","voice":"alloy","input":"Hello","response_format":"wav"}' \
+  -o output.wav
+```
+
+The OpenAI model aliases `tts-1`, `tts-1-hd`, `gpt-4o-mini-tts`, and
+`gpt-4o-mini-tts-2025-12-15` select Kokoro. Native registry aliases select
+their corresponding TTS engine. Generic OpenAI voice names use the selected
+engine's default voice, while native Kokoro and Qwen3-TTS voice names pass
+through. `speed` is supported by Kokoro; the optional `language` extension
+defaults to English.
+
+The endpoint defaults to WAV and also supports headerless 24 kHz mono PCM16
+little-endian output with `response_format: "pcm"`. Compressed OpenAI formats
+are rejected explicitly rather than returning PCM under an incorrect media
+type.
+
 ## Error Handling
 
 ### Realtime WebSocket errors


### PR DESCRIPTION
## Summary

- add `POST /v1/audio/speech` with the standard `model`, `input`, `voice`, `response_format`, and `speed` request fields
- route common OpenAI TTS model aliases through Kokoro while preserving native Speech Swift model and voice aliases
- return WAV by default or headerless 24 kHz mono PCM16 when requested
- return OpenAI-shaped error envelopes and reject unsupported compressed formats explicitly
- document the HTTP audio contract and expose the route in server startup output

## Architecture fit

The route is a thin protocol adapter over the existing model registry and `dispatchSynthesize` path. It adds no model runtime or codec dependency. Voice and speed parameters are carried through the shared dispatcher only where the selected engine supports them.

## Compatibility notes

This endpoint supports WAV and PCM output. Explicit MP3, Opus, AAC, and FLAC requests return a clear 400 response rather than mislabeled audio. Generic OpenAI voice names select the local engine default; native Kokoro and Qwen3-TTS voice names pass through.

## Tests

- `swift test --skip E2E`
- `swift test --filter OpenAISpeechTests`
- `swift test --filter E2EOpenAISpeechTests`