### PR TITLE
feat: support local Parakeet model loading

### DIFF
--- a/Sources/ParakeetStreamingASR/ParakeetStreamingASR.swift
+++ b/Sources/ParakeetStreamingASR/ParakeetStreamingASR.swift
@@ -152,14 +152,16 @@ public class ParakeetStreamingASRModel {
 
     public static func fromPretrained(
         modelId: String? = nil,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> ParakeetStreamingASRModel {
         let effectiveModelId = modelId ?? defaultModelId
         AudioLog.modelLoading.info("Loading Parakeet EOU model: \(effectiveModelId)")
 
-        let cacheDir: URL
+        let resolvedCacheDir: URL
         do {
-            cacheDir = try HuggingFaceDownloader.getCacheDirectory(for: effectiveModelId)
+            resolvedCacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: effectiveModelId)
         } catch {
             throw AudioModelError.modelLoadFailed(
                 modelId: effectiveModelId, reason: "Failed to resolve cache directory", underlying: error)
@@ -169,14 +171,15 @@ public class ParakeetStreamingASRModel {
         do {
             try await HuggingFaceDownloader.downloadWeights(
                 modelId: effectiveModelId,
-                to: cacheDir,
+                to: resolvedCacheDir,
                 additionalFiles: [
                     "encoder.mlmodelc/**",
                     "decoder.mlmodelc/**",
                     "joint.mlmodelc/**",
                     "vocab.json",
                     "config.json",
-                ]
+                ],
+                offlineMode: offlineMode
             ) { fraction in
                 progressHandler?(fraction * 0.7, "Downloading model...")
             }
@@ -185,6 +188,34 @@ public class ParakeetStreamingASRModel {
                 modelId: effectiveModelId, reason: "Download failed", underlying: error)
         }
 
+        return try await load(
+            from: resolvedCacheDir,
+            source: effectiveModelId,
+            progressHandler: progressHandler
+        )
+    }
+
+    /// Load a model from an existing local directory without downloading files.
+    ///
+    /// The directory must contain `encoder.mlmodelc/`, `decoder.mlmodelc/`,
+    /// `joint.mlmodelc/`, `vocab.json`, and optionally `config.json`.
+    public static func fromLocal(
+        bundleDir: URL,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> ParakeetStreamingASRModel {
+        AudioLog.modelLoading.info("Loading Parakeet EOU model from local: \(bundleDir.path)")
+        return try await load(
+            from: bundleDir,
+            source: bundleDir.path,
+            progressHandler: progressHandler
+        )
+    }
+
+    private static func load(
+        from cacheDir: URL,
+        source: String,
+        progressHandler: ((Double, String) -> Void)?
+    ) async throws -> ParakeetStreamingASRModel {
         progressHandler?(0.70, "Loading configuration...")
         let config: ParakeetEOUConfig
         let configURL = cacheDir.appendingPathComponent("config.json")
@@ -197,7 +228,16 @@ public class ParakeetStreamingASRModel {
 
         progressHandler?(0.75, "Loading vocabulary...")
         let vocabURL = cacheDir.appendingPathComponent("vocab.json")
-        let vocabulary = try ParakeetEOUVocabulary.load(from: vocabURL)
+        let vocabulary: ParakeetEOUVocabulary
+        do {
+            vocabulary = try ParakeetEOUVocabulary.load(from: vocabURL)
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: source,
+                reason: "Failed to load vocabulary",
+                underlying: error
+            )
+        }
 
         progressHandler?(0.80, "Loading CoreML models...")
         let encoder = try loadCoreMLModel(name: "encoder", from: cacheDir, computeUnits: .cpuAndGPU)

--- a/Tests/ParakeetStreamingASRTests/ParakeetStreamingASRTests.swift
+++ b/Tests/ParakeetStreamingASRTests/ParakeetStreamingASRTests.swift
@@ -65,6 +65,23 @@ final class ParakeetStreamingASRTests: XCTestCase {
         )
     }
 
+    func testFromLocalRejectsMissingVocabularyWithoutDownloading() async throws {
+        let bundleDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("parakeet-streaming-local-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: bundleDir) }
+
+        do {
+            _ = try await ParakeetStreamingASRModel.fromLocal(bundleDir: bundleDir)
+            XCTFail("Expected a missing local vocabulary to fail")
+        } catch let AudioModelError.modelLoadFailed(modelId, reason, _) {
+            XCTAssertEqual(modelId, bundleDir.path)
+            XCTAssertEqual(reason, "Failed to load vocabulary")
+        } catch {
+            XCTFail("Expected AudioModelError.modelLoadFailed, got \(error)")
+        }
+    }
+
     // MARK: - Vocabulary Tests
 
     func testVocabularyDecode() {
@@ -247,6 +264,33 @@ final class E2EParakeetStreamingASRTests: XCTestCase {
         XCTAssertTrue(m.isLoaded)
         XCTAssertEqual(m.config.encoderHidden, 512)
         XCTAssertEqual(m.config.encoderLayers, 17)
+    }
+
+    func testLocalModelLoading() async throws {
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(
+            for: ParakeetStreamingASRModel.defaultModelId
+        )
+        let local = try await ParakeetStreamingASRModel.fromLocal(bundleDir: cacheDir)
+        defer { local.unload() }
+
+        XCTAssertTrue(local.isLoaded)
+        XCTAssertEqual(local.config.encoderHidden, 512)
+        XCTAssertEqual(local.config.encoderLayers, 17)
+    }
+
+    func testCachedOfflineModelLoading() async throws {
+        let cacheDir = try HuggingFaceDownloader.getCacheDirectory(
+            for: ParakeetStreamingASRModel.defaultModelId
+        )
+        let cached = try await ParakeetStreamingASRModel.fromPretrained(
+            cacheDir: cacheDir,
+            offlineMode: true
+        )
+        defer { cached.unload() }
+
+        XCTAssertTrue(cached.isLoaded)
+        XCTAssertEqual(cached.config.encoderHidden, 512)
+        XCTAssertEqual(cached.config.encoderLayers, 17)
     }
 
     func testWarmup() throws {

--- a/docs/inference/cache-and-offline.md
+++ b/docs/inference/cache-and-offline.md
@@ -90,6 +90,7 @@ All models support both parameters:
 |-------|-----------|
 | `Qwen3ASRModel` | `cacheDir`, `offlineMode` |
 | `ParakeetASRModel` | `cacheDir`, `offlineMode` |
+| `ParakeetStreamingASRModel` | `cacheDir`, `offlineMode`, `fromLocal` |
 | `CoreMLASRModel` | `cacheDir`, `offlineMode` |
 | `KokoroTTSModel` | `cacheDir`, `offlineMode` |
 | `Qwen3TTSModel` | `cacheDir`, `offlineMode` |

--- a/docs/inference/parakeet-streaming-asr-inference.md
+++ b/docs/inference/parakeet-streaming-asr-inference.md
@@ -18,6 +18,28 @@ let text = try model.transcribeAudio(audioSamples, sampleRate: 16000)
 Conforms to `SpeechRecognitionModel`, so it drops into any code path that
 accepts a generic STT model (voice pipelines, diarization + ASR, etc.).
 
+## Preinstalled and offline models
+
+Use `cacheDir` to control where `fromPretrained()` stores the model and
+`offlineMode` to reuse an existing cache without a network request:
+
+```swift
+let model = try await ParakeetStreamingASRModel.fromPretrained(
+    cacheDir: appModelsDirectory,
+    offlineMode: true
+)
+```
+
+Apps that install and verify the model themselves can bypass the downloader
+entirely. The directory must contain `encoder.mlmodelc/`, `decoder.mlmodelc/`,
+`joint.mlmodelc/`, `vocab.json`, and optionally `config.json`:
+
+```swift
+let model = try await ParakeetStreamingASRModel.fromLocal(
+    bundleDir: installedModelDirectory
+)
+```
+
 ## Quick start — AsyncSequence streaming
 
 ```swift


### PR DESCRIPTION
## Summary

- add ParakeetStreamingASR.fromLocal for preinstalled model bundles without network access
- add cacheDir and offlineMode controls to fromPretrained
- share local bundle validation and loading between both entry points
- document custom caches and offline deployment

## Architecture

The existing downloader remains the default path. Both public entry points converge on one bundle loader, so model construction and vocabulary validation stay consistent.

## Tests

- all 18 non-E2E ParakeetStreamingASR tests passed
- E2EParakeetStreamingASRTests.testLocalModelLoading passed with real model weights
- E2EParakeetStreamingASRTests.testCachedOfflineModelLoading passed with real model weights
- git diff --check