### PR TITLE
Add timestamped independent audio capture

### DIFF
--- a/Sources/AudioCommon/AudioIO.swift
+++ b/Sources/AudioCommon/AudioIO.swift
@@ -20,7 +20,8 @@ public final class AudioIO {
         case stopped, running, error(String)
     }
 
-    /// Audio player for TTS output. Attached to the engine when mic starts.
+    /// Audio player for TTS output. Attached when microphone capture starts
+    /// only if `enablePlayback` is true.
     public let player = StreamingAudioPlayer()
 
     /// Current microphone state.
@@ -29,8 +30,13 @@ public final class AudioIO {
     /// RMS audio level (0.0–1.0) for UI meters. Updated on each mic buffer.
     public private(set) var audioLevel: Float = 0
 
-    /// Whether to enable Voice Processing I/O for echo cancellation.
+    /// Whether to enable Apple's Voice Processing I/O for acoustic echo
+    /// cancellation before microphone samples reach the callback.
     public let enableAEC: Bool
+
+    /// Whether to attach the streaming player to the capture engine.
+    /// Listen-only clients can disable this to keep the I/O graph capture-only.
+    public let enablePlayback: Bool
 
     /// Playback sample rate (for TTS output).
     public let playbackSampleRate: Double
@@ -38,15 +44,21 @@ public final class AudioIO {
     private var engine: AVAudioEngine?
     private static let log = Logger(subsystem: "audio.soniqo", category: "AudioIO")
 
-    public init(enableAEC: Bool = false, playbackSampleRate: Double = 24000) {
+    public init(
+        enableAEC: Bool = false,
+        playbackSampleRate: Double = 24000,
+        enablePlayback: Bool = true
+    ) {
         self.enableAEC = enableAEC
         self.playbackSampleRate = playbackSampleRate
+        self.enablePlayback = enablePlayback
     }
 
     /// Start microphone capture, resampled to targetSampleRate.
     ///
-    /// Also attaches the player to the engine for simultaneous playback.
-    /// Call `player.scheduleChunk()` to play audio while recording.
+    /// When `enablePlayback` is true, also attaches the player to the engine
+    /// for simultaneous playback. Call `player.scheduleChunk()` to play audio
+    /// while recording.
     ///
     /// - Parameters:
     ///   - targetSampleRate: Output sample rate for onSamples (default 16kHz for VAD/ASR)
@@ -54,6 +66,20 @@ public final class AudioIO {
     public func startMicrophone(
         targetSampleRate: Int = 16000,
         onSamples: @escaping ([Float]) -> Void
+    ) throws {
+        try startMicrophoneTimestamped(targetSampleRate: targetSampleRate) { chunk in
+            onSamples(chunk.samples)
+        }
+    }
+
+    /// Start microphone capture with the host timestamp of each input buffer.
+    ///
+    /// The timestamp belongs to the first hardware input frame represented by
+    /// the delivered chunk. It remains tied to that frame when capture-side
+    /// resampling changes the number of samples.
+    public func startMicrophoneTimestamped(
+        targetSampleRate: Int = 16000,
+        onChunk: @escaping (CapturedAudioChunk) -> Void
     ) throws {
         stopMicrophone()
 
@@ -69,6 +95,34 @@ public final class AudioIO {
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
+
+        // Voice Processing changes both I/O nodes and the input format, so it
+        // must be enabled while the engine is stopped and before reading that
+        // format or installing a tap. Channel 0 is the processed microphone
+        // signal; any additional channels are Voice Processing metadata.
+        do {
+            try Self.enableVoiceProcessingIfRequested(enableAEC) { enabled in
+                try inputNode.setVoiceProcessingEnabled(enabled)
+            }
+        } catch {
+            microphoneState = .error("Cannot enable acoustic echo cancellation: \(error.localizedDescription)")
+            throw error
+        }
+
+        if enableAEC {
+            // Stenography and ASR clients must not noticeably turn down the
+            // audio they are observing. Voice Processing still gets the
+            // device playback reference used for echo cancellation, while
+            // applying the minimum available ducking to other audio.
+            #if os(macOS) || os(iOS)
+            if #available(macOS 14.0, iOS 17.0, *) {
+                inputNode.voiceProcessingOtherAudioDuckingConfiguration =
+                    AVAudioVoiceProcessingOtherAudioDuckingConfiguration(
+                        enableAdvancedDucking: false,
+                        duckingLevel: .min)
+            }
+            #endif
+        }
         let hwFormat = inputNode.outputFormat(forBus: 0)
 
         // Mono intermediate at hardware rate
@@ -98,7 +152,7 @@ public final class AudioIO {
             return
         }
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: hwFormat) { [weak self] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: hwFormat) { [weak self] buffer, when in
             guard let self else { return }
             guard let srcData = buffer.floatChannelData else { return }
             let frameLen = Int(buffer.frameLength)
@@ -131,35 +185,50 @@ public final class AudioIO {
             for s in samples { sum += s * s }
             self.audioLevel = sqrt(sum / max(Float(count), 1))
 
-            onSamples(samples)
+            onChunk(CapturedAudioChunk(
+                samples: samples,
+                sampleRate: targetSampleRate,
+                hostTime: Self.hostTime(from: when)))
         }
 
-        // Attach player for TTS output
-        guard let playerFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: playbackSampleRate,
-            channels: 1,
-            interleaved: false
-        ) else { return }
-        player.attach(to: engine, format: playerFormat)
+        if enablePlayback {
+            // Attach player for TTS output only when this client needs it.
+            // Capture-only users should not add an unused source node to the
+            // Voice Processing graph.
+            guard let playerFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: playbackSampleRate,
+                channels: 1,
+                interleaved: false
+            ) else { return }
+            player.attach(to: engine, format: playerFormat)
+        }
 
         do {
             try engine.start()
-            player.startPlayback()
+            if enablePlayback {
+                player.startPlayback()
+            }
             self.engine = engine
             microphoneState = .running
-            Self.log.info("Microphone started at \(targetSampleRate)Hz, player at \(self.playbackSampleRate)Hz")
+            Self.log.info(
+                "Microphone started at \(targetSampleRate)Hz, playback \(self.enablePlayback ? "on at \(self.playbackSampleRate)Hz" : "off"), AEC \(self.enableAEC ? "on" : "off")")
         } catch {
-            microphoneState = .error(error.localizedDescription)
+            let message = enableAEC
+                ? "Cannot start acoustic echo cancellation: \(error.localizedDescription)"
+                : error.localizedDescription
+            microphoneState = .error(message)
             throw error
         }
     }
 
-    /// Stop microphone capture and detach player.
+    /// Stop microphone capture and detach the player when it was enabled.
     public func stopMicrophone() {
         if let engine {
             engine.inputNode.removeTap(onBus: 0)
-            player.detach(from: engine)
+            if enablePlayback {
+                player.detach(from: engine)
+            }
             engine.stop()
         }
         engine = nil
@@ -169,6 +238,18 @@ public final class AudioIO {
 
     deinit {
         stopMicrophone()
+    }
+
+    static func enableVoiceProcessingIfRequested(
+        _ enabled: Bool,
+        setEnabled: (Bool) throws -> Void
+    ) throws {
+        guard enabled else { return }
+        try setEnabled(true)
+    }
+
+    static func hostTime(from time: AVAudioTime) -> UInt64? {
+        time.isHostTimeValid ? time.hostTime : nil
     }
 }
 #endif

--- a/Sources/AudioCommon/Protocols.swift
+++ b/Sources/AudioCommon/Protocols.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+// MARK: - Captured Audio Chunk
+
+/// A timestamped chunk produced by a live audio capture source.
+///
+/// `hostTime` is the host-clock time of the first input frame before
+/// resampling. Capture APIs leave it nil only when the underlying audio API
+/// did not provide a valid host timestamp. Consumers can use the shared host
+/// clock to order independently captured streams without mixing their PCM.
+public struct CapturedAudioChunk: Sendable, Equatable {
+    /// Mono Float32 PCM at `sampleRate`.
+    public let samples: [Float]
+    /// Delivered sample rate after capture-side resampling.
+    public let sampleRate: Int
+    /// Mach host-clock time for the first captured input frame, when valid.
+    public let hostTime: UInt64?
+
+    public init(samples: [Float], sampleRate: Int, hostTime: UInt64?) {
+        self.samples = samples
+        self.sampleRate = sampleRate
+        self.hostTime = hostTime
+    }
+}
+
 // MARK: - Model Memory Management
 
 /// Memory statistics for a loaded model.

--- a/Sources/AudioCommon/SystemAudioTap.swift
+++ b/Sources/AudioCommon/SystemAudioTap.swift
@@ -61,8 +61,8 @@ public enum SystemAudioTapError: Error, LocalizedError {
 /// - A global tap follows processes, not a specific device, so it keeps
 ///   capturing across default-output-device switches. The delivered sample rate
 ///   can change on such a switch; a property listener re-reads the tap format
-///   and the internal resampler is rebuilt on the fly. `onSamples` always
-///   receives mono Float32 at `targetSampleRate`.
+///   and the internal resampler is rebuilt on the fly. Both capture callbacks
+///   always receive mono Float32 at `targetSampleRate`.
 ///
 /// Permission: the host app must declare `NSAudioCaptureUsageDescription`;
 /// macOS prompts on first tap creation. **If the permission is denied, Core
@@ -103,7 +103,7 @@ public final class SystemAudioTap {
     private var resampler: AVAudioConverter?
     private var resamplerInputRate: Double = 0
     private var targetSampleRate: Double = 16000
-    private var onSamples: (([Float]) -> Void)?
+    private var onChunk: ((CapturedAudioChunk) -> Void)?
 
     // Shared counters (IO queue writes, any thread reads).
     private var statsLock = os_unfair_lock()
@@ -177,12 +177,23 @@ public final class SystemAudioTap {
         targetSampleRate: Int = 16000,
         onSamples: @escaping ([Float]) -> Void
     ) throws {
+        try startTimestamped(targetSampleRate: targetSampleRate) { chunk in
+            onSamples(chunk.samples)
+        }
+    }
+
+    /// Start capturing the system output mix with each input buffer's host
+    /// timestamp preserved through downmixing and resampling.
+    public func startTimestamped(
+        targetSampleRate: Int = 16000,
+        onChunk: @escaping (CapturedAudioChunk) -> Void
+    ) throws {
         guard case .stopped = captureState else {
             throw SystemAudioTapError.alreadyRunning
         }
 
         do {
-            try activate(targetSampleRate: Double(targetSampleRate), onSamples: onSamples)
+            try activate(targetSampleRate: Double(targetSampleRate), onChunk: onChunk)
             captureState = .running
             Self.log.info("System audio tap started, tap rate \(self.tapSampleRate) Hz → \(targetSampleRate) Hz")
         } catch {
@@ -193,8 +204,8 @@ public final class SystemAudioTap {
     }
 
     /// Stop capturing and destroy the tap, aggregate device, and listeners.
-    /// Idempotent. Must not be called from inside `onSamples` — teardown joins
-    /// the capture queue that the callback runs on.
+    /// Idempotent. Must not be called from inside either capture callback —
+    /// teardown joins the capture queue that the callback runs on.
     public func stop() {
         if let listener = formatListener, tapID != kAudioObjectUnknown {
             var address = Self.tapFormatAddress
@@ -224,7 +235,7 @@ public final class SystemAudioTap {
         ioQueue.sync {
             resampler = nil
             resamplerInputRate = 0
-            onSamples = nil
+            onChunk = nil
         }
         os_unfair_lock_lock(&statsLock)
         _tapSampleRate = 0
@@ -235,7 +246,10 @@ public final class SystemAudioTap {
 
     // MARK: - Capture pipeline
 
-    private func activate(targetSampleRate: Double, onSamples: @escaping ([Float]) -> Void) throws {
+    private func activate(
+        targetSampleRate: Double,
+        onChunk: @escaping (CapturedAudioChunk) -> Void
+    ) throws {
         os_unfair_lock_lock(&statsLock)
         _framesCaptured = 0
         _nonSilentFrames = 0
@@ -244,7 +258,7 @@ public final class SystemAudioTap {
 
         ioQueue.sync {
             self.targetSampleRate = targetSampleRate
-            self.onSamples = onSamples
+            self.onChunk = onChunk
         }
 
         // 1. Translate the exclusion pids to HAL process objects. Excluding a
@@ -313,8 +327,8 @@ public final class SystemAudioTap {
         // 5. IO proc on the aggregate: the tap arrives as the input buffer list.
         var newIOProcID: AudioDeviceIOProcID?
         let ioStatus = AudioDeviceCreateIOProcIDWithBlock(&newIOProcID, aggregateID, ioQueue) {
-            [weak self] _, inInputData, _, _, _ in
-            self?.handleInput(inInputData)
+            [weak self] _, inInputData, inInputTime, _, _ in
+            self?.handleInput(inInputData, timestamp: inInputTime.pointee)
         }
         guard ioStatus == noErr, let procID = newIOProcID else {
             throw SystemAudioTapError.ioProcCreationFailed(status: ioStatus)
@@ -329,7 +343,10 @@ public final class SystemAudioTap {
 
     /// Runs on `ioQueue`. Downmixes the tap buffers to mono, updates counters,
     /// resamples to the target rate, and delivers the batch.
-    private func handleInput(_ list: UnsafePointer<AudioBufferList>) {
+    private func handleInput(
+        _ list: UnsafePointer<AudioBufferList>,
+        timestamp: AudioTimeStamp
+    ) {
         let buffers = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: list))
         guard buffers.count > 0 else { return }
 
@@ -371,15 +388,22 @@ public final class SystemAudioTap {
         os_unfair_lock_unlock(&statsLock)
 
         guard inputRate > 0 else { return }
-        guard let delivery = onSamples else { return }
+        guard let delivery = onChunk else { return }
+        let hostTime = Self.hostTime(from: timestamp)
 
         if inputRate == targetSampleRate {
-            delivery(mono)
+            delivery(CapturedAudioChunk(
+                samples: mono,
+                sampleRate: Int(targetSampleRate),
+                hostTime: hostTime))
             return
         }
         guard let resampled = resampleOnIOQueue(mono, from: inputRate) else { return }
         if !resampled.isEmpty {
-            delivery(resampled)
+            delivery(CapturedAudioChunk(
+                samples: resampled,
+                sampleRate: Int(targetSampleRate),
+                hostTime: hostTime))
         }
     }
 
@@ -455,6 +479,11 @@ public final class SystemAudioTap {
     }
 
     // MARK: - Pure helpers (unit-tested)
+
+    static func hostTime(from timestamp: AudioTimeStamp) -> UInt64? {
+        timestamp.mFlags.contains(.hostTimeValid)
+            ? timestamp.mHostTime : nil
+    }
 
     /// Exclusion list actually applied to the tap: the explicit pids plus the
     /// current process (unless opted out), deduplicated, in stable order.

--- a/Sources/NemotronStreamingASR/NemotronStreamingASR.swift
+++ b/Sources/NemotronStreamingASR/NemotronStreamingASR.swift
@@ -68,6 +68,11 @@ public class NemotronStreamingASRModel {
     /// Create a streaming session. `language` is a BCP-47 tag (e.g. `"en-US"`,
     /// `"ja-JP"`); `nil` or unknown falls back to the model's `"auto"` slot.
     /// `wordBoosting` biases RNN-T decoding toward the provided phrases.
+    ///
+    /// Sessions own independent encoder, decoder, and token state. A caller may
+    /// interleave multiple sessions on one loaded model to avoid duplicating
+    /// weights, provided every call remains serialized; the model and sessions
+    /// are not safe for concurrent inference.
     public func createSession(
         language: String? = nil,
         wordBoosting: WordBoostingConfig? = nil

--- a/Tests/AudioCommonTests/CapturedAudioChunkTests.swift
+++ b/Tests/AudioCommonTests/CapturedAudioChunkTests.swift
@@ -1,0 +1,61 @@
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+import XCTest
+@testable import AudioCommon
+
+final class CapturedAudioChunkTests: XCTestCase {
+    func testChunkPreservesSamplesRateAndOptionalHostTime() {
+        let chunk = CapturedAudioChunk(
+            samples: [0.25, -0.5], sampleRate: 16_000, hostTime: 123)
+
+        XCTAssertEqual(chunk.samples, [0.25, -0.5])
+        XCTAssertEqual(chunk.sampleRate, 16_000)
+        XCTAssertEqual(chunk.hostTime, 123)
+    }
+
+    #if canImport(AVFoundation)
+    func testAudioIOKeepsEchoCancellationAndPlaybackChoicesIndependent() {
+        let captureOnly = AudioIO(enableAEC: true, enablePlayback: false)
+        XCTAssertTrue(captureOnly.enableAEC)
+        XCTAssertFalse(captureOnly.enablePlayback)
+
+        let defaultIO = AudioIO()
+        XCTAssertFalse(defaultIO.enableAEC)
+        XCTAssertTrue(defaultIO.enablePlayback)
+    }
+
+    func testAudioIORequestsVoiceProcessingOnlyWhenAECIsEnabled() throws {
+        var requests: [Bool] = []
+
+        try AudioIO.enableVoiceProcessingIfRequested(false) {
+            requests.append($0)
+        }
+        XCTAssertTrue(requests.isEmpty)
+
+        try AudioIO.enableVoiceProcessingIfRequested(true) {
+            requests.append($0)
+        }
+        XCTAssertEqual(requests, [true])
+    }
+
+    func testAudioIOPropagatesVoiceProcessingFailure() {
+        XCTAssertThrowsError(
+            try AudioIO.enableVoiceProcessingIfRequested(true) { _ in
+                throw VoiceProcessingTestError.unavailable
+            }
+        ) { error in
+            XCTAssertEqual(error as? VoiceProcessingTestError, .unavailable)
+        }
+    }
+
+    func testAudioIOPreservesOnlyValidHostTime() {
+        XCTAssertEqual(AudioIO.hostTime(from: AVAudioTime(hostTime: 42)), 42)
+        XCTAssertNil(AudioIO.hostTime(from: AVAudioTime(sampleTime: 0, atRate: 16_000)))
+    }
+    #endif
+}
+
+private enum VoiceProcessingTestError: Error {
+    case unavailable
+}

--- a/Tests/AudioCommonTests/SystemAudioTapTests.swift
+++ b/Tests/AudioCommonTests/SystemAudioTapTests.swift
@@ -89,6 +89,22 @@ final class SystemAudioTapTests: XCTestCase {
         XCTAssertEqual(SystemAudioTap.nonSilentCount([], threshold: 1e-6), 0)
     }
 
+    // MARK: Capture timestamps
+
+    func testValidHostTimeIsPreserved() {
+        var timestamp = AudioTimeStamp()
+        timestamp.mHostTime = 42
+        timestamp.mFlags = .hostTimeValid
+        XCTAssertEqual(SystemAudioTap.hostTime(from: timestamp), 42)
+    }
+
+    func testInvalidHostTimeIsNil() {
+        var timestamp = AudioTimeStamp()
+        timestamp.mHostTime = 42
+        timestamp.mFlags = []
+        XCTAssertNil(SystemAudioTap.hostTime(from: timestamp))
+    }
+
     // MARK: OSStatus rendering
 
     func testDescribeOSStatusRendersFourCharCode() {

--- a/docs/audio/system-audio-tap.md
+++ b/docs/audio/system-audio-tap.md
@@ -16,6 +16,38 @@ try tap.start(targetSampleRate: 16000) { samples in
 tap.stop()
 ```
 
+For independently processed sources, use the timestamped capture overload so
+system output can be ordered against microphone chunks without mixing PCM:
+
+```swift
+try tap.startTimestamped(targetSampleRate: 16000) { chunk in
+    systemPipeline.pushAudio(
+        chunk.samples,
+        hostTime: chunk.hostTime)
+}
+
+let microphone = AudioIO(enableAEC: true, enablePlayback: false)
+try microphone.startMicrophoneTimestamped(targetSampleRate: 16000) { chunk in
+    microphonePipeline.pushAudio(
+        chunk.samples,
+        hostTime: chunk.hostTime)
+}
+```
+
+`enableAEC: true` enables Apple's Voice Processing I/O before the microphone
+format is read. On macOS this removes audio played by the output device from
+the microphone signal while leaving the system tap as its own untouched
+source. The capture fails instead of silently falling back to raw microphone
+audio if Voice Processing cannot start. Other-audio ducking is set to Apple's
+minimum level on macOS 14 and newer. `enablePlayback: false` keeps a listen-only
+capture graph from attaching the otherwise available TTS player.
+
+`CapturedAudioChunk.hostTime` refers to the first input frame before
+resampling. Both Core Audio and AVAudioEngine express it on the Mach host
+clock, allowing consumers to retain source provenance while merging derived
+events onto one timeline. It is nil only when the underlying callback did not
+provide a valid host timestamp.
+
 ## How it works
 
 The capture path is the Core Audio process-tap API (macOS 14.4+):

--- a/docs/shared-protocols.md
+++ b/docs/shared-protocols.md
@@ -8,7 +8,8 @@ The `AudioCommon` module defines shared protocols that provide model-agnostic in
 ┌─────────────────────────────────────────────────────────┐
 │                    AudioCommon                          │
 │                                                         │
-│  AudioChunk          SpeechGenerationModel (TTS)        │
+│  AudioChunk / CapturedAudioChunk                        │
+│                      SpeechGenerationModel (TTS)        │
 │  AlignedWord         SpeechRecognitionModel (STT)       │
 │  SpeechSegment       ForcedAlignmentModel                │
 │  TranscriptionResult SpeechToSpeechModel                 │
@@ -254,6 +255,28 @@ config.warmupSTT = true             // warm up Neural Engine at pipeline start
 | `error` | STT/LLM/TTS failure |
 
 ## Shared Types
+
+### CapturedAudioChunk
+
+Timestamped mono PCM from live capture. `SystemAudioTap.startTimestamped` and
+`AudioIO.startMicrophoneTimestamped` both return this type, using the same Mach
+host clock so callers can keep independent source pipelines and merge only
+their derived events.
+
+```swift
+public struct CapturedAudioChunk: Sendable, Equatable {
+    public let samples: [Float]
+    public let sampleRate: Int
+    public let hostTime: UInt64?
+}
+```
+
+`hostTime` identifies the first input frame before capture-side resampling. It
+is nil only when the underlying audio callback supplies no valid host time.
+For full-duplex capture, construct `AudioIO(enableAEC: true)` to apply Apple's
+echo-cancelled microphone input before timestamped chunks reach the caller.
+Listen-only clients can additionally pass `enablePlayback: false` to omit the
+streaming player from the engine graph.
 
 ### AudioChunk
 


### PR DESCRIPTION
## Summary

- Add CapturedAudioChunk and timestamped SystemAudioTap and AudioIO overloads while preserving the sample-only APIs.
- Add an independent playback switch for capture-only AudioIO graphs and enable Apple Voice Processing before microphone format and tap setup, with explicit failure instead of raw-input fallback.
- Document independent Nemotron sessions, serialized inference, shared host-clock timestamps, and listen-only AEC usage.

## Regression coverage

- Captured chunk samples, sample rate, and optional host time.
- Voice Processing is requested only when AEC is enabled, and setup failures propagate.
- SystemAudioTap host-time validity alongside its existing mixdown, exclusion, and lifecycle checks.

## Verification

- CI-equivalent debug build, metallib, and no-download unit matrix: 1,022 passed, 30 expected skips, 0 failures.
- Release build and release mlx.metallib via make build.
- Real macOS acceptance: local speech remained available from the echo-cancelled microphone callback while simultaneous device playback did not reappear in that source.