### PR TITLE
Add match-only ReDimNet embeddings for short utterances

### DIFF
--- a/Sources/SpeechVAD/ReDimNet2Speaker.swift
+++ b/Sources/SpeechVAD/ReDimNet2Speaker.swift
@@ -31,13 +31,17 @@ struct ReDimNet2ModelConfiguration: Decodable, Equatable {
 ///
 /// Input audio is resampled to 16 kHz and prepared as one fixed six-second
 /// window. Two-to-six-second clips are repeated to fill the window; longer
-/// clips are center-cropped. Clips shorter than two seconds are rejected
-/// because they did not meet the quality threshold used for identity matching.
+/// clips are center-cropped. The default API rejects clips shorter than two
+/// seconds because they did not meet the quality threshold used for identity
+/// matching. `embedShortUtterance` is an explicit, lower-confidence path for
+/// matching 0.6-to-2-second speech against an identity established from longer
+/// audio; it must not be used to enroll or create an identity.
 public final class ReDimNet2SpeakerModel {
     public static let defaultModelId = "aufklarer/ReDimNet2-B6-CoreML"
     public static let inputSampleRate = 16_000
     public static let inputSampleCount = 96_000
     public static let minimumSampleCount = 32_000
+    public static let minimumShortUtteranceSampleCount = 9_600
     public static let embeddingDimension = 192
 
     private let model: MLModel
@@ -135,20 +139,22 @@ public final class ReDimNet2SpeakerModel {
     /// - Throws: An explicit input or inference error. No zero-vector fallback
     ///   is returned when identity extraction fails.
     public func embed(audio: [Float], sampleRate: Int) throws -> [Float] {
-        let resampled: [Float]
-        if sampleRate == Self.inputSampleRate {
-            resampled = audio
-        } else {
-            guard sampleRate > 0 else {
-                throw AudioModelError.invalidConfiguration(
-                    model: "ReDimNet2-B6",
-                    reason: "sample rate must be greater than zero")
-            }
-            resampled = AudioFileLoader.resample(
-                audio, from: sampleRate, to: Self.inputSampleRate)
-        }
-
+        let resampled = try Self.resampled(audio, sampleRate: sampleRate)
         return try predict(Self.preparedAudio(resampled))
+    }
+
+    /// Extract a normalized embedding from 0.6-to-2 seconds of clean speech.
+    ///
+    /// Short inputs contain less identity evidence than the default two-second
+    /// minimum. Use this only for conservative retrieval against identities
+    /// established from `embed`; never use it for enrollment, cluster creation,
+    /// or centroid updates. Match thresholds require duration-specific
+    /// calibration on the target domain.
+    public func embedShortUtterance(
+        audio: [Float], sampleRate: Int
+    ) throws -> [Float] {
+        let resampled = try Self.resampled(audio, sampleRate: sampleRate)
+        return try predict(Self.preparedShortUtteranceAudio(resampled))
     }
 
     /// Compile and execute the graph once before latency-sensitive use.
@@ -162,13 +168,39 @@ public final class ReDimNet2SpeakerModel {
     }
 
     static func preparedAudio(_ samples: [Float]) throws -> [Float] {
+        try preparedAudio(samples, minimumSampleCount: minimumSampleCount)
+    }
+
+    static func preparedShortUtteranceAudio(_ samples: [Float]) throws -> [Float] {
+        try preparedAudio(
+            samples,
+            minimumSampleCount: minimumShortUtteranceSampleCount)
+    }
+
+    private static func resampled(
+        _ audio: [Float], sampleRate: Int
+    ) throws -> [Float] {
+        if sampleRate == inputSampleRate { return audio }
+        guard sampleRate > 0 else {
+            throw AudioModelError.invalidConfiguration(
+                model: "ReDimNet2-B6",
+                reason: "sample rate must be greater than zero")
+        }
+        return AudioFileLoader.resample(
+            audio, from: sampleRate, to: inputSampleRate)
+    }
+
+    private static func preparedAudio(
+        _ samples: [Float], minimumSampleCount: Int
+    ) throws -> [Float] {
         guard samples.count >= minimumSampleCount else {
             let seconds = Double(samples.count) / Double(inputSampleRate)
+            let minimumSeconds = Double(minimumSampleCount) / Double(inputSampleRate)
             throw AudioModelError.invalidConfiguration(
                 model: "ReDimNet2-B6",
                 reason: String(
-                    format: "speaker identity requires at least 2.0 seconds of clean audio (received %.2f seconds)",
-                    seconds))
+                    format: "speaker identity requires at least %.1f seconds of clean audio (received %.2f seconds)",
+                    minimumSeconds, seconds))
         }
         guard samples.allSatisfy(\.isFinite) else {
             throw AudioModelError.invalidConfiguration(

--- a/Tests/SpeechVADTests/ReDimNet2SpeakerTests.swift
+++ b/Tests/SpeechVADTests/ReDimNet2SpeakerTests.swift
@@ -12,6 +12,9 @@ final class ReDimNet2SpeakerTests: XCTestCase {
         XCTAssertEqual(ReDimNet2SpeakerModel.inputSampleRate, 16_000)
         XCTAssertEqual(ReDimNet2SpeakerModel.inputSampleCount, 96_000)
         XCTAssertEqual(ReDimNet2SpeakerModel.minimumSampleCount, 32_000)
+        XCTAssertEqual(
+            ReDimNet2SpeakerModel.minimumShortUtteranceSampleCount,
+            9_600)
         XCTAssertEqual(ReDimNet2SpeakerModel.embeddingDimension, 192)
     }
 
@@ -81,6 +84,25 @@ final class ReDimNet2SpeakerTests: XCTestCase {
         }
     }
 
+    func testPreparedShortUtteranceRepeatsSixTenthsOfASecond() throws {
+        let samples = (0..<9_600).map(Float.init)
+        let prepared = try ReDimNet2SpeakerModel.preparedShortUtteranceAudio(samples)
+
+        XCTAssertEqual(prepared.count, 96_000)
+        for repetition in 0..<10 {
+            let start = repetition * samples.count
+            XCTAssertEqual(Array(prepared[start..<(start + samples.count)]), samples)
+        }
+    }
+
+    func testPreparedShortUtteranceRejectsLessThanSixTenthsOfASecond() {
+        XCTAssertThrowsError(
+            try ReDimNet2SpeakerModel.preparedShortUtteranceAudio(
+                [Float](repeating: 0, count: 9_599))) { error in
+            XCTAssertTrue(error.localizedDescription.contains("at least 0.6 seconds"))
+        }
+    }
+
     func testPreparedAudioRejectsNonFiniteSamples() {
         var samples = [Float](repeating: 0, count: 32_000)
         samples[100] = .nan
@@ -127,6 +149,29 @@ final class E2EReDimNet2SpeakerTests: XCTestCase {
         XCTAssertEqual(first.count, 192)
         let norm = sqrt(first.reduce(Float(0)) { $0 + $1 * $1 })
         XCTAssertEqual(norm, 1, accuracy: 0.002)
+        XCTAssertEqual(
+            ReDimNet2SpeakerModel.cosineSimilarity(first, second),
+            1,
+            accuracy: 0.0001)
+    }
+
+    func testE2EShortUtteranceEmbeddingIsNormalizedAndDeterministic() async throws {
+        let model = try await loadModel()
+        let audioURL = URL(
+            fileURLWithPath: "Tests/Qwen3ASRTests/Resources/test_audio.wav")
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: audioURL)
+        let shortSamples = Array(samples.prefix(Int(Double(sampleRate) * 0.75)))
+
+        let first = try model.embedShortUtterance(
+            audio: shortSamples, sampleRate: sampleRate)
+        let second = try model.embedShortUtterance(
+            audio: shortSamples, sampleRate: sampleRate)
+
+        XCTAssertEqual(first.count, 192)
+        XCTAssertEqual(
+            sqrt(first.reduce(Float(0)) { $0 + $1 * $1 }),
+            1,
+            accuracy: 0.002)
         XCTAssertEqual(
             ReDimNet2SpeakerModel.cosineSimilarity(first, second),
             1,

--- a/docs/inference/speaker-diarization.md
+++ b/docs/inference/speaker-diarization.md
@@ -141,12 +141,21 @@ try identity.prewarm()
 
 let enrollment = try identity.embed(audio: enrollmentAudio, sampleRate: 16_000)
 let candidate = try identity.embed(audio: candidateAudio, sampleRate: 16_000)
+let shortProbe = try identity.embedShortUtterance(
+    audio: shortCleanAudio,
+    sampleRate: 16_000)
 let similarity = ReDimNet2SpeakerModel.cosineSimilarity(enrollment, candidate)
 ```
 
 - Input is fixed at six seconds / 96,000 mono samples for the fast Core ML path.
 - Clean clips from two to six seconds are repeated to fill the window.
-- Longer clips are center-cropped; clips shorter than two seconds fail explicitly.
+- Longer clips are center-cropped; clips shorter than two seconds fail explicitly
+  through the default `embed` API.
+- `embedShortUtterance` explicitly accepts clean, non-overlapped 0.6-to-2-second
+  input. Repetition only satisfies the fixed graph shape; it adds no evidence.
+  Use these vectors solely as stricter, duration-calibrated probes against an
+  identity anchored by at least two seconds. Never enroll, create, or update an
+  identity with them.
 - The model uses 192-dimensional embeddings. They cannot be compared with
   WeSpeaker's 256-dimensional embeddings or Community-1 centroids.
 - Matching thresholds must be calibrated for ReDimNet2; do not reuse WeSpeaker
@@ -239,6 +248,9 @@ For named identity across recordings, use the throwing ReDimNet2 API instead:
 ```swift
 let model = try await ReDimNet2SpeakerModel.fromPretrained()
 let embedding = try model.embed(audio: cleanSpeakerAudio, sampleRate: 16_000)
+let shortProbe = try model.embedShortUtterance(
+    audio: shortCleanSpeakerAudio,
+    sampleRate: 16_000)
 // embedding: [Float] of length 192, L2-normalized
 ```
 

--- a/docs/models/redimnet2-speaker.md
+++ b/docs/models/redimnet2-speaker.md
@@ -40,6 +40,13 @@ shapes. Runtime preparation follows the benchmarked policy:
 - keep an exact six-second input unchanged;
 - center-crop longer input.
 
+An explicit `embedShortUtterance` path accepts 0.6-to-2 seconds and repeats it
+to the same fixed window. Repetition satisfies the graph shape but adds no voice
+evidence. These embeddings are lower-confidence retrieval probes only: match
+them against an identity established from at least two seconds, and do not use
+them for enrollment, new-cluster creation, or centroid updates. Calibrate a
+stricter threshold and ambiguity margin for each target domain.
+
 Inference failures throw an error. The model never substitutes a zero embedding.
 
 ## Validation
@@ -61,6 +68,9 @@ let model = try await ReDimNet2SpeakerModel.fromPretrained()
 try model.prewarm()
 
 let profile = try model.embed(audio: cleanAudio, sampleRate: sampleRate)
+let shortProbe = try model.embedShortUtterance(
+    audio: shortCleanAudio,
+    sampleRate: sampleRate)
 let score = ReDimNet2SpeakerModel.cosineSimilarity(profile, candidate)
 ```
 

--- a/docs/shared-protocols.md
+++ b/docs/shared-protocols.md
@@ -145,7 +145,10 @@ public protocol SpeakerEmbeddingModel: AnyObject {
 
 `ReDimNet2SpeakerModel` is the separate persistent identity encoder. Its
 `embed` method throws so model or input failures remain explicit; it is used
-through its concrete API rather than this legacy non-throwing protocol.
+through its concrete API rather than this legacy non-throwing protocol. Its
+explicit `embedShortUtterance` method accepts clean 0.6-to-2-second retrieval
+probes, but those lower-evidence vectors must never enroll or update an
+identity.
 
 ### SpeakerDiarizationModel
 


### PR DESCRIPTION
## Summary

- Add an explicit ReDimNet2SpeakerModel.embedShortUtterance API for clean 0.6–2.0-second speech.
- Repeat short input to the fixed six-second Core ML graph while leaving the existing two-second minimum and default embed behavior unchanged.
- Share resampling and prediction preparation between both paths.
- Document that short embeddings are lower-evidence retrieval probes only.

## Safety contract

Short embeddings must only query identities established from at least two seconds of speech. They must not be used for enrollment, identity creation, or centroid updates. Matching thresholds and ambiguity margins require duration-specific calibration for the target domain.

## Verification

- ReDimNet2SpeakerTests: 11 passed.
- E2EReDimNet2SpeakerTests: 3 passed, including deterministic normalized inference from a 0.75-second clip.
- CI-equivalent speech test suite: 1,022 passed, 30 expected skips, 0 failures.
- Documentation updated for the model, diarization pipeline, and shared protocols.