### PR TITLE
fix: prevent LocalVQE CoreML buffer exhaustion

### DIFF
--- a/Sources/SpeechEnhancement/LocalVQEAECResidualMask.swift
+++ b/Sources/SpeechEnhancement/LocalVQEAECResidualMask.swift
@@ -35,16 +35,18 @@ final class LocalVQEAECResidualMask: LocalVQEAECResidualMasking {
     }
 
     func warmUp() throws {
-        let zeroMicrophone = try MLMultiArray(
-            shape: [1, 2, 1, 256], dataType: .float16)
-        let zeroReference = try MLMultiArray(
-            shape: [1, 2, 1, 256], dataType: .float16)
-        let inputs = try MLDictionaryFeatureProvider(dictionary: [
-            "mic_spectrum": MLFeatureValue(multiArray: zeroMicrophone),
-            "reference_spectrum": MLFeatureValue(multiArray: zeroReference),
-        ])
-        let temporaryState = model.makeState()
-        _ = try model.prediction(from: inputs, using: temporaryState)
+        try autoreleasepool {
+            let zeroMicrophone = try MLMultiArray(
+                shape: [1, 2, 1, 256], dataType: .float16)
+            let zeroReference = try MLMultiArray(
+                shape: [1, 2, 1, 256], dataType: .float16)
+            let inputs = try MLDictionaryFeatureProvider(dictionary: [
+                "mic_spectrum": MLFeatureValue(multiArray: zeroMicrophone),
+                "reference_spectrum": MLFeatureValue(multiArray: zeroReference),
+            ])
+            let temporaryState = model.makeState()
+            _ = try model.prediction(from: inputs, using: temporaryState)
+        }
     }
 
     func process(
@@ -56,28 +58,34 @@ final class LocalVQEAECResidualMask: LocalVQEAECResidualMasking {
         write(microphoneSpectrum, to: microphoneInput)
         write(referenceSpectrum, to: referenceInput)
 
-        let inputs = try MLDictionaryFeatureProvider(dictionary: [
-            "mic_spectrum": MLFeatureValue(multiArray: microphoneInput),
-            "reference_spectrum": MLFeatureValue(multiArray: referenceInput),
-        ])
-        let prediction: MLFeatureProvider
-        do {
-            prediction = try model.prediction(from: inputs, using: state)
-        } catch {
-            throw AudioModelError.inferenceFailed(
-                operation: "LocalVQE AEC residual mask",
-                reason: error.localizedDescription)
+        // Streaming capture workers commonly have no run loop to drain
+        // autoreleased Core ML objects. Keep the provider, prediction, output,
+        // and output copy in one per-frame pool; otherwise IOSurface-backed
+        // temporaries accumulate until macOS aborts a long-running process.
+        return try autoreleasepool {
+            let inputs = try MLDictionaryFeatureProvider(dictionary: [
+                "mic_spectrum": MLFeatureValue(multiArray: microphoneInput),
+                "reference_spectrum": MLFeatureValue(multiArray: referenceInput),
+            ])
+            let prediction: MLFeatureProvider
+            do {
+                prediction = try model.prediction(from: inputs, using: state)
+            } catch {
+                throw AudioModelError.inferenceFailed(
+                    operation: "LocalVQE AEC residual mask",
+                    reason: error.localizedDescription)
+            }
+            guard let output = prediction.featureValue(
+                for: "enhanced_spectrum")?.multiArrayValue else {
+                throw LocalVQEEchoCancellationError.missingModelOutput(
+                    "enhanced_spectrum")
+            }
+            guard output.count == Self.elementCount else {
+                throw LocalVQEEchoCancellationError.invalidModelOutputCount(
+                    expected: Self.elementCount, actual: output.count)
+            }
+            return read(output)
         }
-        guard let output = prediction.featureValue(
-            for: "enhanced_spectrum")?.multiArrayValue else {
-            throw LocalVQEEchoCancellationError.missingModelOutput(
-                "enhanced_spectrum")
-        }
-        guard output.count == Self.elementCount else {
-            throw LocalVQEEchoCancellationError.invalidModelOutputCount(
-                expected: Self.elementCount, actual: output.count)
-        }
-        return read(output)
     }
 
     private func write(_ values: [Float], to array: MLMultiArray) {

--- a/Tests/SpeechEnhancementTests/E2ELocalVQEAECTests.swift
+++ b/Tests/SpeechEnhancementTests/E2ELocalVQEAECTests.swift
@@ -165,6 +165,30 @@ final class E2ELocalVQEAECTests: XCTestCase {
             enhancedError, mixtureError, "Echo error did not improve")
     }
 
+    /// Regression for long-lived capture workers, which do not have a run
+    /// loop that periodically drains Foundation's autorelease pool. Core ML
+    /// predictions used to retain one or more IOSurface-backed temporary
+    /// buffers per 16 ms frame until the process hit macOS's per-client
+    /// IOSurface limit and aborted after roughly five minutes of audio.
+    func testTwentyThousandStreamingFramesDoNotExhaustCoreMLBuffers() async throws {
+        let canceller = try await canceller()
+        let microphone = [Float](
+            repeating: 0, count: LocalVQEEchoCanceller.frameSize)
+        let reference = [Float](
+            repeating: 0, count: LocalVQEEchoCanceller.frameSize)
+        let frameCount = 20_000
+        var lastOutput = [Float]()
+
+        for _ in 0..<frameCount {
+            lastOutput = try canceller.processFrame(
+                microphone: microphone,
+                reference: reference)
+        }
+
+        XCTAssertEqual(lastOutput.count, LocalVQEEchoCanceller.frameSize)
+        XCTAssertTrue(lastOutput.allSatisfy(\.isFinite))
+    }
+
     private func rms(_ values: [Float]) -> Float {
         sqrt(values.reduce(0) { $0 + $1 * $1 } / Float(values.count))
     }

--- a/docs/inference/echo-cancellation.md
+++ b/docs/inference/echo-cancellation.md
@@ -43,6 +43,9 @@ let cleanMicrophone = try aec.processFrame(
 
 Create one instance per recording and serialize calls. Call `reset()` when a
 recording ends, when either input drops samples, or when capture is restarted.
+Each `processFrame` call drains its temporary Core ML objects before returning,
+so a dedicated capture thread does not need to provide its own autorelease
+pool for long-running streams.
 Resetting clears:
 
 - online delay estimation;


### PR DESCRIPTION
## Summary

- drain per-frame LocalVQE Core ML prediction objects on capture threads without run loops
- cover long-running streaming with a 20,000-frame regression
- document the long-session memory contract

## Why

LocalVQE predictions accumulated IOSurface-backed temporaries on dedicated capture threads. After roughly five minutes, macOS hit its per-client IOSurface limit, aborted the process, and downstream apps reloaded their models.

## Verification

- reproduced the pre-fix crash with signal 6 and `Failed to allocate memory IOSurface object`
- 20,000-frame soak passes after the fix
- LocalVQE unit tests: 6 passed
- LocalVQE E2E tests: 5 passed
- CI-safe suite: 1,028 passed, 30 skipped
- `make build`