### PR TITLE
Add long-context MLX runtime for MOSS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -644,6 +644,11 @@ let package = Package(
             name: "MossTranscribe",
             dependencies: [
                 "AudioCommon",
+                "MLXCommon",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
                 .product(name: "Tokenizers", package: "swift-transformers")
             ]
         ),
@@ -737,6 +742,7 @@ let package = Package(
             name: "DiarizationBenchmark",
             dependencies: [
                 "AudioCommon",
+                "MossTranscribe",
                 "SpeechVAD",
                 "BenchmarkSupport",
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
@@ -991,6 +997,7 @@ let package = Package(
                 "SourceSeparation",
                 "AudioCommon",
                 .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs
 
 - **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Speech-to-text (automatic speech recognition, 52 languages, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/guides/moss)** — Native CoreML batch transcription with model-generated speaker labels and timestamps (INT8 default, FP16 reference)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/guides/moss)** — Native CoreML/MLX offline transcription with model-generated speaker labels and timestamps (128K MLX context; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — Speech-to-text via CoreML (Neural Engine, NVIDIA FastConformer + TDT decoder, 25 languages)
 - **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Speech-to-text (Meta wav2vec2 + CTC, **1,672 languages** across 32 scripts, CoreML 300M + MLX 300M/1B/3B/7B) — 0.28 RTF on iPhone 16 Pro
 - **[Cohere Transcribe 2B](https://soniqo.audio/guides/cohere-transcribe)** — Native MLX speech-to-text (14 languages, FP16/INT5/INT8)
@@ -178,7 +178,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Speech → Text | MLX, CoreML (hybrid) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/guides/moss) | Speech → Text + speaker timestamps | CoreML | 0.9B (INT8 / FP16) | Multi |
+| [MOSS Transcribe Diarize](https://soniqo.audio/guides/moss) | Speech → Text + speaker timestamps | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | Multi |
 | [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Speech → Text | CoreML (ANE) | 0.6B | 25 European |
 | [Parakeet EOU](https://soniqo.audio/guides/dictate) | Speech → Text (streaming) | CoreML (ANE) | 120M | 25 European |
 | [Nemotron Streaming (Multilingual)](https://soniqo.audio/guides/nemotron) | Speech → Text (streaming, punctuated) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -246,6 +246,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -268,7 +269,7 @@ Import only what you need — every model is its own SPM target:
 ```swift
 import Qwen3ASR             // Speech recognition (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Speech recognition (CoreML, batch)
 import ParakeetStreamingASR // Streaming dictation with partials + EOU
 import NemotronStreamingASR // Multilingual streaming ASR with native punctuation (0.6B, 40 langs)

--- a/README_ar.md
+++ b/README_ar.md
@@ -50,7 +50,7 @@
 
 - **[Qwen3-ASR](https://soniqo.audio/ar/guides/transcribe)** — تحويل الكلام إلى نص (تعرف تلقائي على الكلام، 52 لغة، MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/ar/guides/moss)** — نسخ دفعي أصلي عبر CoreML مع تسميات المتحدثين والطوابع الزمنية التي يولدها النموذج (INT8 افتراضي، وFP16 مرجعي)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/ar/guides/moss)** — نسخ أصلي دون اتصال عبر CoreML/MLX مع تسميات المتحدثين والطوابع الزمنية التي يولدها النموذج (سياق MLX بحجم 128K؛ INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/ar/guides/parakeet)** — تحويل الكلام إلى نص عبر CoreML (Neural Engine، NVIDIA FastConformer + مفكك ترميز TDT، 25 لغة)
 - **[Omnilingual ASR](https://soniqo.audio/ar/guides/omnilingual)** — تحويل الكلام إلى نص (Meta wav2vec2 + CTC، **1,672 لغة** عبر 32 نظام كتابة، CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/ar/guides/cohere-transcribe)** — تحويل الكلام إلى نص محليًا عبر MLX (14 لغة، FP16/INT5/INT8)
@@ -220,7 +220,7 @@ struct DictateView: View {
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/ar/guides/transcribe) | كلام → نص | MLX, CoreML (هجين) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/ar/guides/moss) | الصوت → النص + طوابع زمنية للمتحدثين | CoreML | 0.9B (INT8 / FP16) | متعدد اللغات |
+| [MOSS Transcribe Diarize](https://soniqo.audio/ar/guides/moss) | الصوت → النص + طوابع زمنية للمتحدثين | CoreML / MLX | 0.9B (MLX INT5/INT8؛ CoreML INT8/FP16) | متعدد اللغات |
 | [Parakeet TDT](https://soniqo.audio/ar/guides/parakeet) | كلام → نص | CoreML (ANE) | 0.6B | 25 أوروبية |
 | [Parakeet EOU](https://soniqo.audio/ar/guides/dictate) | كلام → نص (تدفقي) | CoreML (ANE) | 120M | 25 أوروبية |
 | [Nemotron Streaming (متعدد اللغات)](https://soniqo.audio/ar/guides/nemotron) | كلام → نص (تدفقي، مع علامات ترقيم) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -294,6 +294,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -324,7 +325,7 @@ dependencies: [
 ```swift
 import Qwen3ASR             // التعرف على الكلام (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // التعرف على الكلام (CoreML، دفعة)
 import ParakeetStreamingASR // إملاء تدفقي مع جزئيات + EOU
 import NemotronStreamingASR // ASR تدفقي متعدد اللغات مع علامات ترقيم أصلية (0.6B، 40 لغة)

--- a/README_de.md
+++ b/README_de.md
@@ -40,7 +40,7 @@ Spracherkennung, -synthese und -verständnis auf dem Gerät für Mac und iOS. L�
 
 - **[Qwen3-ASR](https://soniqo.audio/de/guides/transcribe)** — Sprache-zu-Text (automatische Spracherkennung, 52 Sprachen, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/de/guides/moss)** — Native CoreML-Batchtranskription mit modellgenerierten Sprecherlabels und Zeitstempeln (INT8 Standard, FP16 Referenz)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/de/guides/moss)** — Native CoreML/MLX-Offlinetranskription mit modellgenerierten Sprecherlabels und Zeitstempeln (128K MLX-Kontext; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/de/guides/parakeet)** — Sprache-zu-Text über CoreML (Neural Engine, NVIDIA FastConformer + TDT-Decoder, 25 Sprachen)
 - **[Omnilingual ASR](https://soniqo.audio/de/guides/omnilingual)** — Sprache-zu-Text (Meta wav2vec2 + CTC, **1.672 Sprachen** in 32 Schriften, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/de/guides/cohere-transcribe)** — Native MLX-Sprache-zu-Text-Erkennung (14 Sprachen, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/de/guides/transcribe) | Sprache → Text | MLX, CoreML (hybrid) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/de/guides/moss) | Sprache → Text + Sprecher-Zeitstempel | CoreML | 0.9B (INT8 / FP16) | Mehrsprachig |
+| [MOSS Transcribe Diarize](https://soniqo.audio/de/guides/moss) | Sprache → Text + Sprecher-Zeitstempel | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | Mehrsprachig |
 | [Parakeet TDT](https://soniqo.audio/de/guides/parakeet) | Sprache → Text | CoreML (ANE) | 0.6B | 25 europäisch |
 | [Parakeet EOU](https://soniqo.audio/de/guides/dictate) | Sprache → Text (Streaming) | CoreML (ANE) | 120M | 25 europäisch |
 | [Nemotron Streaming (Mehrsprachig)](https://soniqo.audio/de/guides/nemotron) | Sprache → Text (Streaming, mit Interpunktion) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ Importiere nur, was du brauchst — jedes Modell hat sein eigenes SPM-Target:
 ```swift
 import Qwen3ASR             // Spracherkennung (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Spracherkennung (CoreML, Batch)
 import ParakeetStreamingASR // Streaming-Diktat mit Teilergebnissen + EOU
 import NemotronStreamingASR // Mehrsprachiges Streaming-ASR mit nativer Interpunktion (0.6B, 40 Sprachen)

--- a/README_es.md
+++ b/README_es.md
@@ -40,7 +40,7 @@ Reconocimiento, síntesis y comprensión de voz en el dispositivo para Mac e iOS
 
 - **[Qwen3-ASR](https://soniqo.audio/es/guides/transcribe)** — Voz a texto (reconocimiento automático del habla, 52 idiomas, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/es/guides/moss)** — Transcripción por lotes CoreML nativa con etiquetas de hablante y marcas de tiempo generadas por el modelo (INT8 predeterminado, FP16 de referencia)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/es/guides/moss)** — Transcripción sin conexión nativa con CoreML/MLX, etiquetas de hablante y marcas de tiempo generadas por el modelo (contexto MLX de 128K; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/es/guides/parakeet)** — Voz a texto vía CoreML (Neural Engine, NVIDIA FastConformer + decodificador TDT, 25 idiomas)
 - **[Omnilingual ASR](https://soniqo.audio/es/guides/omnilingual)** — Voz a texto (Meta wav2vec2 + CTC, **1.672 idiomas** en 32 escrituras, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/es/guides/cohere-transcribe)** — Voz a texto MLX nativa (14 idiomas, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/es/guides/transcribe) | Voz → Texto | MLX, CoreML (híbrido) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/es/guides/moss) | Voz → Texto + marcas de hablante | CoreML | 0.9B (INT8 / FP16) | Multilingüe |
+| [MOSS Transcribe Diarize](https://soniqo.audio/es/guides/moss) | Voz → Texto + marcas de hablante | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | Multilingüe |
 | [Parakeet TDT](https://soniqo.audio/es/guides/parakeet) | Voz → Texto | CoreML (ANE) | 0.6B | 25 europeos |
 | [Parakeet EOU](https://soniqo.audio/es/guides/dictate) | Voz → Texto (streaming) | CoreML (ANE) | 120M | 25 europeos |
 | [Nemotron Streaming (Multilingüe)](https://soniqo.audio/es/guides/nemotron) | Voz → Texto (streaming, con puntuación) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ Importa solo lo que necesites — cada modelo es su propio target SPM:
 ```swift
 import Qwen3ASR             // Reconocimiento de voz (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Reconocimiento de voz (CoreML, batch)
 import ParakeetStreamingASR // Dictado en streaming con parciales + EOU
 import NemotronStreamingASR // ASR streaming multilingüe con puntuación nativa (0.6B, 40 idiomas)

--- a/README_fr.md
+++ b/README_fr.md
@@ -40,7 +40,7 @@ Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'e
 
 - **[Qwen3-ASR](https://soniqo.audio/fr/guides/transcribe)** -- Reconnaissance vocale (reconnaissance automatique de la parole, 52 langues, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/fr/guides/moss)** — Transcription CoreML native par lots avec étiquettes de locuteur et horodatages générés par le modèle (INT8 par défaut, FP16 de référence)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/fr/guides/moss)** — Transcription hors ligne native CoreML/MLX avec étiquettes de locuteur et horodatages générés par le modèle (contexte MLX 128K ; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/fr/guides/parakeet)** -- Reconnaissance vocale via CoreML (Neural Engine, NVIDIA FastConformer + decodeur TDT, 25 langues)
 - **[Omnilingual ASR](https://soniqo.audio/fr/guides/omnilingual)** -- Reconnaissance vocale (Meta wav2vec2 + CTC, **1 672 langues** reparties dans 32 ecritures, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/fr/guides/cohere-transcribe)** -- Reconnaissance vocale MLX native (14 langues, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/fr/guides/transcribe) | Parole → Texte | MLX, CoreML (hybride) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/fr/guides/moss) | Audio → Texte + horodatages par locuteur | CoreML | 0.9B (INT8 / FP16) | Multilingue |
+| [MOSS Transcribe Diarize](https://soniqo.audio/fr/guides/moss) | Audio → Texte + horodatages par locuteur | CoreML / MLX | 0.9B (MLX INT5/INT8 ; CoreML INT8/FP16) | Multilingue |
 | [Parakeet TDT](https://soniqo.audio/fr/guides/parakeet) | Parole → Texte | CoreML (ANE) | 0.6B | 25 europeennes |
 | [Parakeet EOU](https://soniqo.audio/fr/guides/dictate) | Parole → Texte (streaming) | CoreML (ANE) | 120M | 25 europeennes |
 | [Nemotron Streaming (Multilingue)](https://soniqo.audio/fr/guides/nemotron) | Voix → Texte (streaming, ponctué) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ N'importez que ce dont vous avez besoin -- chaque modele est sa propre cible SPM
 ```swift
 import Qwen3ASR             // Reconnaissance vocale (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Reconnaissance vocale (CoreML, batch)
 import ParakeetStreamingASR // Dictee en streaming avec partiels + EOU
 import NemotronStreamingASR // ASR streaming multilingue avec ponctuation native (0.6B, 40 langues)

--- a/README_hi.md
+++ b/README_hi.md
@@ -40,7 +40,7 @@ Speech Swift पैकेज के सत्यापन योग्य सं
 
 - **[Qwen3-ASR](https://soniqo.audio/hi/guides/transcribe)** — स्पीच-टू-टेक्स्ट (ऑटोमैटिक स्पीच रिकग्निशन, 52 भाषाएँ, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/hi/guides/moss)** — मॉडल द्वारा बनाए गए speaker labels और timestamps के साथ native CoreML batch transcription (INT8 default, FP16 reference)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/hi/guides/moss)** — मॉडल द्वारा बनाए गए speaker labels और timestamps के साथ native CoreML/MLX offline transcription (MLX 128K context; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/hi/guides/parakeet)** — CoreML के माध्यम से स्पीच-टू-टेक्स्ट (Neural Engine, NVIDIA FastConformer + TDT decoder, 25 भाषाएँ)
 - **[Omnilingual ASR](https://soniqo.audio/hi/guides/omnilingual)** — स्पीच-टू-टेक्स्ट (Meta wav2vec2 + CTC, **1,672 भाषाएँ** 32 लिपियों में, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/hi/guides/cohere-transcribe)** — नेटिव MLX स्पीच-टू-टेक्स्ट (14 भाषाएँ, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ struct DictateView: View {
 |------|------|--------|------|--------|
 | [Qwen3-ASR](https://soniqo.audio/hi/guides/transcribe) | स्पीच → टेक्स्ट | MLX, CoreML (हाइब्रिड) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/hi/guides/moss) | ऑडियो → टेक्स्ट + speaker timestamps | CoreML | 0.9B (INT8 / FP16) | बहुभाषी |
+| [MOSS Transcribe Diarize](https://soniqo.audio/hi/guides/moss) | ऑडियो → टेक्स्ट + speaker timestamps | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | बहुभाषी |
 | [Parakeet TDT](https://soniqo.audio/hi/guides/parakeet) | स्पीच → टेक्स्ट | CoreML (ANE) | 0.6B | 25 यूरोपीय |
 | [Parakeet EOU](https://soniqo.audio/hi/guides/dictate) | स्पीच → टेक्स्ट (स्ट्रीमिंग) | CoreML (ANE) | 120M | 25 यूरोपीय |
 | [Nemotron Streaming (बहुभाषी)](https://soniqo.audio/hi/guides/nemotron) | भाषण → टेक्स्ट (स्ट्रीमिंग, विराम चिह्नों के साथ) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ dependencies: [
 ```swift
 import Qwen3ASR             // स्पीच रिकग्निशन (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // स्पीच रिकग्निशन (CoreML, बैच)
 import ParakeetStreamingASR // पार्शियल्स + EOU के साथ स्ट्रीमिंग डिक्टेशन
 import NemotronStreamingASR // बहुभाषी स्ट्रीमिंग ASR नेटिव विराम चिह्न के साथ (0.6B, 40 भाषाएँ)

--- a/README_ja.md
+++ b/README_ja.md
@@ -40,7 +40,7 @@ Speech Swift パッケージへの参照を公開ソースで確認できる 15 
 
 - **[Qwen3-ASR](https://soniqo.audio/ja/guides/transcribe)** — 音声認識（自動音声認識、52言語、MLX + CoreML）
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/ja/guides/moss)** — ネイティブ CoreML のバッチ文字起こし。モデル生成の話者ラベルとタイムスタンプ（INT8 が既定、FP16 は参照用）
+- **[MOSS Transcribe Diarize](https://soniqo.audio/ja/guides/moss)** — ネイティブ CoreML/MLX のオフライン文字起こし。モデル生成の話者ラベルとタイムスタンプ（MLX は 128K コンテキスト、INT5/INT8）
 - **[Parakeet TDT](https://soniqo.audio/ja/guides/parakeet)** — CoreMLによる音声認識（Neural Engine、NVIDIA FastConformer + TDTデコーダー、25言語）
 - **[Omnilingual ASR](https://soniqo.audio/ja/guides/omnilingual)** — 音声認識（Meta wav2vec2 + CTC、**1,672言語**、32文字体系、CoreML 300M + MLX 300M/1B/3B/7B）
 - **[Cohere Transcribe 2B](https://soniqo.audio/ja/guides/cohere-transcribe)** — ネイティブ MLX 音声認識（14言語、FP16/INT5/INT8）
@@ -176,7 +176,7 @@ struct DictateView: View {
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/ja/guides/transcribe) | 音声 → テキスト | MLX、CoreML（ハイブリッド） | 0.6B、1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/ja/guides/moss) | 音声 → テキスト + 話者タイムスタンプ | CoreML | 0.9B (INT8 / FP16) | 多言語 |
+| [MOSS Transcribe Diarize](https://soniqo.audio/ja/guides/moss) | 音声 → テキスト + 話者タイムスタンプ | CoreML / MLX | 0.9B (MLX INT5/INT8、CoreML INT8/FP16) | 多言語 |
 | [Parakeet TDT](https://soniqo.audio/ja/guides/parakeet) | 音声 → テキスト | CoreML (ANE) | 0.6B | 25欧州言語 |
 | [Parakeet EOU](https://soniqo.audio/ja/guides/dictate) | 音声 → テキスト（ストリーミング） | CoreML (ANE) | 120M | 25欧州言語 |
 | [Nemotron Streaming (多言語)](https://soniqo.audio/ja/guides/nemotron) | 音声 → テキスト（ストリーミング、句読点付き） | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ dependencies: [
 ```swift
 import Qwen3ASR             // 音声認識 (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // 音声認識 (CoreML、バッチ)
 import ParakeetStreamingASR // 部分結果 + EOU付きストリーミングディクテーション
 import NemotronStreamingASR // 多言語ストリーミングASR、ネイティブ句読点付き（0.6B、40言語）

--- a/README_ko.md
+++ b/README_ko.md
@@ -40,7 +40,7 @@ Speech Swift 패키지 참조를 공개 소스에서 확인할 수 있는 저장
 
 - **[Qwen3-ASR](https://soniqo.audio/ko/guides/transcribe)** — 음성-텍스트 변환 (자동 음성 인식, 52개 언어, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/ko/guides/moss)** — 네이티브 CoreML 배치 전사와 모델 생성 화자 라벨 및 타임스탬프(INT8 기본, FP16 참조)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/ko/guides/moss)** — 네이티브 CoreML/MLX 오프라인 전사와 모델 생성 화자 라벨 및 타임스탬프(MLX 128K 컨텍스트, INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/ko/guides/parakeet)** — CoreML을 통한 음성-텍스트 변환 (Neural Engine, NVIDIA FastConformer + TDT 디코더, 25개 언어)
 - **[Omnilingual ASR](https://soniqo.audio/ko/guides/omnilingual)** — 음성-텍스트 변환 (Meta wav2vec2 + CTC, **1,672개 언어**, 32개 문자 체계, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/ko/guides/cohere-transcribe)** — 네이티브 MLX 음성-텍스트 변환 (14개 언어, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ struct DictateView: View {
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/ko/guides/transcribe) | 음성 → 텍스트 | MLX, CoreML (하이브리드) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/ko/guides/moss) | 음성 → 텍스트 + 화자 타임스탬프 | CoreML | 0.9B (INT8 / FP16) | 다국어 |
+| [MOSS Transcribe Diarize](https://soniqo.audio/ko/guides/moss) | 음성 → 텍스트 + 화자 타임스탬프 | CoreML / MLX | 0.9B (MLX INT5/INT8, CoreML INT8/FP16) | 다국어 |
 | [Parakeet TDT](https://soniqo.audio/ko/guides/parakeet) | 음성 → 텍스트 | CoreML (ANE) | 0.6B | 25개 유럽어 |
 | [Parakeet EOU](https://soniqo.audio/ko/guides/dictate) | 음성 → 텍스트 (스트리밍) | CoreML (ANE) | 120M | 25개 유럽어 |
 | [Nemotron Streaming (다국어)](https://soniqo.audio/ko/guides/nemotron) | 음성 → 텍스트 (스트리밍, 구두점 포함) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ dependencies: [
 ```swift
 import Qwen3ASR             // 음성 인식 (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // 음성 인식 (CoreML, 배치)
 import ParakeetStreamingASR // 부분 결과 + EOU 포함 스트리밍 받아쓰기
 import NemotronStreamingASR // 다국어 스트리밍 ASR, 네이티브 구두점 (0.6B, 40개 언어)

--- a/README_pt.md
+++ b/README_pt.md
@@ -40,7 +40,7 @@ Reconhecimento, sintese e compreensao de fala no dispositivo para Mac e iOS. Exe
 
 - **[Qwen3-ASR](https://soniqo.audio/pt/guides/transcribe)** — Fala para texto (reconhecimento automatico de fala, 52 idiomas, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/pt/guides/moss)** — Transcrição CoreML nativa em lote com rótulos de locutor e timestamps gerados pelo modelo (INT8 padrão, FP16 de referência)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/pt/guides/moss)** — Transcrição offline nativa com CoreML/MLX, rótulos de locutor e timestamps gerados pelo modelo (contexto MLX de 128K; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/pt/guides/parakeet)** — Fala para texto via CoreML (Neural Engine, NVIDIA FastConformer + decodificador TDT, 25 idiomas)
 - **[Omnilingual ASR](https://soniqo.audio/pt/guides/omnilingual)** — Fala para texto (Meta wav2vec2 + CTC, **1.672 idiomas** em 32 escritas, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/pt/guides/cohere-transcribe)** — Fala para texto MLX nativa (14 idiomas, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/pt/guides/transcribe) | Fala → Texto | MLX, CoreML (hibrido) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/pt/guides/moss) | Fala → Texto + timestamps de locutor | CoreML | 0.9B (INT8 / FP16) | Multilíngue |
+| [MOSS Transcribe Diarize](https://soniqo.audio/pt/guides/moss) | Fala → Texto + timestamps de locutor | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | Multilíngue |
 | [Parakeet TDT](https://soniqo.audio/pt/guides/parakeet) | Fala → Texto | CoreML (ANE) | 0.6B | 25 europeus |
 | [Parakeet EOU](https://soniqo.audio/pt/guides/dictate) | Fala → Texto (streaming) | CoreML (ANE) | 120M | 25 europeus |
 | [Nemotron Streaming (Multilíngue)](https://soniqo.audio/pt/guides/nemotron) | Fala → Texto (streaming, com pontuação) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ Importe apenas o que voce precisa — cada modelo e o seu proprio target SPM:
 ```swift
 import Qwen3ASR             // Reconhecimento de fala (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Reconhecimento de fala (CoreML, batch)
 import ParakeetStreamingASR // Ditado em streaming com parciais + EOU
 import NemotronStreamingASR // ASR streaming multilíngue com pontuação nativa (0.6B, 40 idiomas)

--- a/README_ru.md
+++ b/README_ru.md
@@ -40,7 +40,7 @@
 
 - **[Qwen3-ASR](https://soniqo.audio/ru/guides/transcribe)** — Распознавание речи (автоматическое распознавание речи, 52 языка, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/ru/guides/moss)** — Нативная пакетная транскрипция CoreML с генерируемыми моделью метками спикеров и временными метками (INT8 по умолчанию, FP16 для сравнения)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/ru/guides/moss)** — Нативная офлайн-транскрипция CoreML/MLX с генерируемыми моделью метками спикеров и временными метками (контекст MLX 128K; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/ru/guides/parakeet)** — Распознавание речи через CoreML (Neural Engine, NVIDIA FastConformer + TDT-декодер, 25 языков)
 - **[Omnilingual ASR](https://soniqo.audio/ru/guides/omnilingual)** — Распознавание речи (Meta wav2vec2 + CTC, **1 672 языка** в 32 письменностях, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/ru/guides/cohere-transcribe)** — Нативное распознавание речи на MLX (14 языков, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ struct DictateView: View {
 |--------|--------|---------|---------|-------|
 | [Qwen3-ASR](https://soniqo.audio/ru/guides/transcribe) | Речь → Текст | MLX, CoreML (гибрид) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/ru/guides/moss) | Речь → Текст + временные метки спикеров | CoreML | 0.9B (INT8 / FP16) | Многоязычная |
+| [MOSS Transcribe Diarize](https://soniqo.audio/ru/guides/moss) | Речь → Текст + временные метки спикеров | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | Многоязычная |
 | [Parakeet TDT](https://soniqo.audio/ru/guides/parakeet) | Речь → Текст | CoreML (ANE) | 0.6B | 25 европейских |
 | [Parakeet EOU](https://soniqo.audio/ru/guides/dictate) | Речь → Текст (потоковый) | CoreML (ANE) | 120M | 25 европейских |
 | [Nemotron Streaming (Многоязычный)](https://soniqo.audio/ru/guides/nemotron) | Речь → Текст (потоковый, с пунктуацией) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ dependencies: [
 ```swift
 import Qwen3ASR             // Распознавание речи (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Распознавание речи (CoreML, пакетный режим)
 import ParakeetStreamingASR // Потоковая диктовка с частичными результатами + EOU
 import NemotronStreamingASR // Многоязычное потоковое ASR с нативной пунктуацией (0.6B, 40 языков)

--- a/README_th.md
+++ b/README_th.md
@@ -40,7 +40,7 @@
 
 - **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — แปลงเสียงพูดเป็นข้อความ (การรู้จำเสียงพูดอัตโนมัติ รองรับ 52 ภาษา MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/th/guides/moss)** — การถอดเสียงแบบแบตช์ด้วย CoreML แบบเนทีฟ พร้อมป้ายผู้พูดและเวลาโดยโมเดล (ค่าเริ่มต้น INT8, FP16 สำหรับอ้างอิง)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/th/guides/moss)** — การถอดเสียงออฟไลน์ด้วย CoreML/MLX แบบเนทีฟ พร้อมป้ายผู้พูดและเวลาโดยโมเดล (บริบท MLX 128K; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — แปลงเสียงพูดเป็นข้อความผ่าน CoreML (Neural Engine, NVIDIA FastConformer + ตัวถอดรหัส TDT รองรับ 25 ภาษา)
 - **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — แปลงเสียงพูดเป็นข้อความ (Meta wav2vec2 + CTC รองรับ **1,672 ภาษา** ครอบคลุม 32 ระบบอักษร, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/th/guides/cohere-transcribe)** — แปลงเสียงพูดเป็นข้อความด้วย MLX แบบเนทีฟ (14 ภาษา, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ struct DictateView: View {
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | เสียงพูด → ข้อความ | MLX, CoreML (ไฮบริด) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/th/guides/moss) | เสียง → ข้อความ + เวลาผู้พูด | CoreML | 0.9B (INT8 / FP16) | หลายภาษา |
+| [MOSS Transcribe Diarize](https://soniqo.audio/th/guides/moss) | เสียง → ข้อความ + เวลาผู้พูด | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | หลายภาษา |
 | [Parakeet TDT](https://soniqo.audio/guides/parakeet) | เสียงพูด → ข้อความ | CoreML (ANE) | 0.6B | 25 ยุโรป |
 | [Parakeet EOU](https://soniqo.audio/guides/dictate) | เสียงพูด → ข้อความ (สตรีมมิ่ง) | CoreML (ANE) | 120M | 25 ยุโรป |
 | [Nemotron Streaming (หลายภาษา)](https://soniqo.audio/guides/nemotron) | เสียงพูด → ข้อความ (สตรีมมิ่ง มีเครื่องหมายวรรคตอน) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ dependencies: [
 ```swift
 import Qwen3ASR             // การรู้จำเสียงพูด (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // การรู้จำเสียงพูด (CoreML, batch)
 import ParakeetStreamingASR // การเขียนตามคำบอกแบบสตรีมมิ่งพร้อม partials + EOU
 import NemotronStreamingASR // ASR สตรีมมิ่งหลายภาษาพร้อมเครื่องหมายวรรคตอนในตัว (0.6B, 40 ภาษา)

--- a/README_tr.md
+++ b/README_tr.md
@@ -40,7 +40,7 @@ Speech Swift paketine doğrulanabilir biçimde başvuran 15 açık depo.
 
 - **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Konuşmadan metne (otomatik konuşma tanıma, 52 dil, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/tr/guides/moss)** — Model tarafından üretilen konuşmacı etiketleri ve zaman damgalarıyla yerel CoreML toplu transkripsiyonu (varsayılan INT8, referans FP16)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/tr/guides/moss)** — Model tarafından üretilen konuşmacı etiketleri ve zaman damgalarıyla yerel CoreML/MLX çevrimdışı transkripsiyonu (128K MLX bağlamı; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — CoreML üzerinden konuşmadan metne (Neural Engine, NVIDIA FastConformer + TDT kod çözücü, 25 dil)
 - **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Konuşmadan metne (Meta wav2vec2 + CTC, 32 yazı sistemi üzerinde **1.672 dil**, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/tr/guides/cohere-transcribe)** — Yerel MLX konuşmadan metne (14 dil, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Konuşma → Metin | MLX, CoreML (hibrit) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/tr/guides/moss) | Konuşma → Metin + konuşmacı zaman damgaları | CoreML | 0.9B (INT8 / FP16) | Çok dilli |
+| [MOSS Transcribe Diarize](https://soniqo.audio/tr/guides/moss) | Konuşma → Metin + konuşmacı zaman damgaları | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | Çok dilli |
 | [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Konuşma → Metin | CoreML (ANE) | 0.6B | 25 Avrupa dili |
 | [Parakeet EOU](https://soniqo.audio/guides/dictate) | Konuşma → Metin (akış) | CoreML (ANE) | 120M | 25 Avrupa dili |
 | [Nemotron Streaming (Çok dilli)](https://soniqo.audio/guides/nemotron) | Konuşma → Metin (akış, noktalamalı) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ Yalnızca ihtiyacınız olanı içe aktarın — her model kendi SPM hedefidir:
 ```swift
 import Qwen3ASR             // Konuşma tanıma (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Konuşma tanıma (CoreML, batch)
 import ParakeetStreamingASR // Kısmi sonuçlar + EOU ile akış dikte
 import NemotronStreamingASR // Yerel noktalama ile çok dilli akış ASR (0.6B, 40 dil)

--- a/README_vi.md
+++ b/README_vi.md
@@ -40,7 +40,7 @@ Nhận dạng, tổng hợp và hiểu giọng nói trên thiết bị cho Mac v
 
 - **[Qwen3-ASR](https://soniqo.audio/guides/transcribe)** — Chuyển giọng nói thành văn bản (nhận dạng giọng nói tự động, 52 ngôn ngữ, MLX + CoreML)
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/vi/guides/moss)** — Phiên âm theo lô CoreML gốc với nhãn người nói và mốc thời gian do mô hình tạo (INT8 mặc định, FP16 tham chiếu)
+- **[MOSS Transcribe Diarize](https://soniqo.audio/vi/guides/moss)** — Phiên âm ngoại tuyến CoreML/MLX gốc với nhãn người nói và mốc thời gian do mô hình tạo (ngữ cảnh MLX 128K; INT5/INT8)
 - **[Parakeet TDT](https://soniqo.audio/guides/parakeet)** — Chuyển giọng nói thành văn bản qua CoreML (Neural Engine, NVIDIA FastConformer + bộ giải mã TDT, 25 ngôn ngữ)
 - **[Omnilingual ASR](https://soniqo.audio/guides/omnilingual)** — Chuyển giọng nói thành văn bản (Meta wav2vec2 + CTC, **1.672 ngôn ngữ** trên 32 hệ chữ viết, CoreML 300M + MLX 300M/1B/3B/7B)
 - **[Cohere Transcribe 2B](https://soniqo.audio/vi/guides/cohere-transcribe)** — Chuyển giọng nói thành văn bản bằng MLX gốc (14 ngôn ngữ, FP16/INT5/INT8)
@@ -176,7 +176,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/guides/transcribe) | Giọng nói → Văn bản | MLX, CoreML (hybrid) | 0.6B, 1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/vi/guides/moss) | Giọng nói → Văn bản + mốc thời gian người nói | CoreML | 0.9B (INT8 / FP16) | Đa ngôn ngữ |
+| [MOSS Transcribe Diarize](https://soniqo.audio/vi/guides/moss) | Giọng nói → Văn bản + mốc thời gian người nói | CoreML / MLX | 0.9B (MLX INT5/INT8; CoreML INT8/FP16) | Đa ngôn ngữ |
 | [Parakeet TDT](https://soniqo.audio/guides/parakeet) | Giọng nói → Văn bản | CoreML (ANE) | 0.6B | 25 ngôn ngữ châu Âu |
 | [Parakeet EOU](https://soniqo.audio/guides/dictate) | Giọng nói → Văn bản (streaming) | CoreML (ANE) | 120M | 25 ngôn ngữ châu Âu |
 | [Nemotron Streaming (Đa ngôn ngữ)](https://soniqo.audio/guides/nemotron) | Giọng nói → Văn bản (streaming, có dấu câu) | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ Chỉ import những gì bạn cần — mỗi mô hình là target SPM riêng:
 ```swift
 import Qwen3ASR             // Nhận dạng giọng nói (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // Nhận dạng giọng nói (CoreML, batch)
 import ParakeetStreamingASR // Đọc chính tả streaming với kết quả tạm thời + EOU
 import NemotronStreamingASR // ASR streaming đa ngôn ngữ với dấu câu tự nhiên (0.6B, 40 ngôn ngữ)

--- a/README_zh.md
+++ b/README_zh.md
@@ -40,7 +40,7 @@
 
 - **[Qwen3-ASR](https://soniqo.audio/zh/guides/transcribe)** — 语音转文字（自动语音识别，52 种语言，MLX + CoreML）
 - **[WhisperASR](docs/models/whisper-asr.md)** — Whisper Large-v3 Turbo speech-to-text via native CoreML runtime (ANE, multilingual)
-- **[MOSS Transcribe Diarize](https://soniqo.audio/zh/guides/moss)** — 原生 CoreML 批量转写，模型生成说话人标签与时间戳（默认 INT8，FP16 参考）
+- **[MOSS Transcribe Diarize](https://soniqo.audio/zh/guides/moss)** — 原生 CoreML/MLX 离线转写，模型生成说话人标签与时间戳（MLX 128K 上下文；INT5/INT8）
 - **[Parakeet TDT](https://soniqo.audio/zh/guides/parakeet)** — 通过 CoreML 进行语音转文字（神经引擎，NVIDIA FastConformer + TDT 解码器，25 种语言）
 - **[Omnilingual ASR](https://soniqo.audio/zh/guides/omnilingual)** — 语音转文字（Meta wav2vec2 + CTC，**1,672 种语言**，覆盖 32 种文字系统，CoreML 300M + MLX 300M/1B/3B/7B）
 - **[Cohere Transcribe 2B](https://soniqo.audio/zh/guides/cohere-transcribe)** — 原生 MLX 语音转文字（14 种语言，FP16/INT5/INT8）
@@ -176,7 +176,7 @@ struct DictateView: View {
 |-------|------|----------|-------|-----------|
 | [Qwen3-ASR](https://soniqo.audio/zh/guides/transcribe) | 语音 → 文字 | MLX、CoreML（混合） | 0.6B、1.7B | 52 |
 | [WhisperASR](docs/models/whisper-asr.md) | Speech → Text | CoreML (ANE) | Large-v3 Turbo | Multi |
-| [MOSS Transcribe Diarize](https://soniqo.audio/zh/guides/moss) | 语音 → 文字 + 说话人时间戳 | CoreML | 0.9B (INT8 / FP16) | 多语言 |
+| [MOSS Transcribe Diarize](https://soniqo.audio/zh/guides/moss) | 语音 → 文字 + 说话人时间戳 | CoreML / MLX | 0.9B (MLX INT5/INT8；CoreML INT8/FP16) | 多语言 |
 | [Parakeet TDT](https://soniqo.audio/zh/guides/parakeet) | 语音 → 文字 | CoreML (ANE) | 0.6B | 25 种欧洲语言 |
 | [Parakeet EOU](https://soniqo.audio/zh/guides/dictate) | 语音 → 文字（流式） | CoreML (ANE) | 120M | 25 种欧洲语言 |
 | [Nemotron Streaming (多语言)](https://soniqo.audio/zh/guides/nemotron) | 语音 → 文本（流式、带标点） | CoreML (ANE), MLX | 0.6B | **40** |
@@ -242,6 +242,7 @@ speech transcribe recording.wav
 speech transcribe recording.wav --engine cohere
 speech transcribe recording.wav --engine voxtral
 speech transcribe recording.wav --engine moss
+speech transcribe meeting.wav --engine moss --backend mlx
 speech speak "Hello world"
 speech csm "Nice to meet you" --ref-audio voice.wav --ref-text "reference transcript"
 speech translate "Hello, how are you?" --to es
@@ -264,7 +265,7 @@ dependencies: [
 ```swift
 import Qwen3ASR             // 语音识别 (MLX)
 import WhisperASR           // Whisper Large-v3 Turbo (CoreML)
-import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML)
+import MossTranscribe       // MOSS transcription with timestamps + speaker labels (CoreML + MLX)
 import ParakeetASR          // 语音识别 (CoreML，批量)
 import ParakeetStreamingASR // 带部分结果和 EOU 的流式听写
 import NemotronStreamingASR // 多语言流式 ASR，原生标点（0.6B，40 种语言）

--- a/Sources/AsrBenchmark/Engine.swift
+++ b/Sources/AsrBenchmark/Engine.swift
@@ -53,6 +53,8 @@ public enum EngineID: String, CaseIterable, Sendable {
     case whisperASRTurbo = "whisper-asr-turbo"
     case mossCoreMLInt8 = "moss-coreml-int8"
     case mossCoreMLFP16 = "moss-coreml-fp16"
+    case mossMLXInt5 = "moss-mlx-int5"
+    case mossMLXInt8 = "moss-mlx-int8"
     case whisperKitLargeV3Turbo = "whisperkit-large-v3-turbo"
     case whisperKitLargeV3 = "whisperkit-large-v3"
     case whisperKitDistilLargeV3 = "whisperkit-distil-large-v3"
@@ -82,6 +84,8 @@ public enum EngineID: String, CaseIterable, Sendable {
         case .whisperASRTurbo: return WhisperASREngine()
         case .mossCoreMLInt8: return MossCoreMLEngine(variant: .int8)
         case .mossCoreMLFP16: return MossCoreMLEngine(variant: .fp16)
+        case .mossMLXInt5: return MossMLXEngine(variant: .int5)
+        case .mossMLXInt8: return MossMLXEngine(variant: .int8)
         case .whisperKitLargeV3Turbo: return WhisperKitEngine(model: "openai_whisper-large-v3-v20240930_turbo")
         case .whisperKitLargeV3: return WhisperKitEngine(model: "openai_whisper-large-v3")
         case .whisperKitDistilLargeV3: return WhisperKitEngine(model: "distil-whisper_distil-large-v3")

--- a/Sources/AsrBenchmark/EngineMoss.swift
+++ b/Sources/AsrBenchmark/EngineMoss.swift
@@ -48,3 +48,66 @@ final class MossCoreMLEngine: BenchEngine, @unchecked Sendable {
         )
     }
 }
+
+final class MossMLXEngine: BenchEngine, @unchecked Sendable {
+    let variant: MossMLXVariant
+    let name: String
+    private(set) var loadElapsed: Double = 0
+    private var model: MossMLXModel?
+
+    init(variant: MossMLXVariant) {
+        self.variant = variant
+        name = "moss-mlx-\(variant.rawValue)"
+    }
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let started = Date()
+        let environmentKey =
+            variant == .int5
+            ? "MOSS_MLX_INT5_MODEL_DIR"
+            : "MOSS_MLX_INT8_MODEL_DIR"
+        let model: MossMLXModel
+        if let local = ProcessInfo.processInfo.environment[environmentKey] {
+            model = try await MossMLXModel.fromDirectory(
+                URL(fileURLWithPath: local),
+                modelId: "local/MOSS-MLX-\(variant.rawValue.uppercased())"
+            )
+        } else {
+            model = try await MossMLXModel.fromPretrained(
+                variant: variant
+            )
+        }
+        var options = MossMLXDecodingOptions(maxTokens: 32)
+        options.encoderBatchSize = 1
+        _ = try model.transcribeDetailed(
+            audio: warmupAudio,
+            sampleRate: sampleRate,
+            options: options
+        )
+        self.model = model
+        loadElapsed = Date().timeIntervalSince(started)
+    }
+
+    func transcribe(
+        audio: [Float],
+        sampleRate: Int,
+        language: String?
+    ) async throws -> (text: String, timings: Timings) {
+        guard let model else { throw BenchError.notLoaded(name) }
+        var text = ""
+        var elapsed = 0.0
+        try autoreleasepool {
+            let started = Date()
+            text = try model.transcribeDetailed(
+                audio: audio,
+                sampleRate: sampleRate
+            ).text
+            elapsed = Date().timeIntervalSince(started)
+        }
+        let duration = Double(audio.count) / Double(sampleRate)
+        return (
+            text,
+            Timings(elapsed: elapsed, audioDuration: duration)
+        )
+    }
+}

--- a/Sources/AudioCLILib/TranscribeCommand.swift
+++ b/Sources/AudioCLILib/TranscribeCommand.swift
@@ -26,7 +26,7 @@ public struct TranscribeCommand: ParsableCommand {
     @Option(name: .long, help: "[omnilingual] Window size in seconds: 5 or 10 (default 10) — CoreML backend only")
     public var window: Int = 10
 
-    @Option(name: .long, help: "[omnilingual] Backend: coreml (default) or mlx")
+    @Option(name: .long, help: "[omnilingual/moss] Backend: coreml (default) or mlx")
     public var backend: String = "coreml"
 
     @Option(name: .long, help: "[omnilingual mlx] Variant: 300M (default), 1B, 3B, or 7B")
@@ -35,11 +35,14 @@ public struct TranscribeCommand: ParsableCommand {
     @Option(name: .long, help: "[omnilingual mlx] Quantization bits: 4 (default) or 8")
     public var bits: Int = 4
 
-    @Option(name: .shortAndLong, help: "[qwen3] 0.6B (default), 0.6B-8bit, 1.7B, or 1.7B-4bit; [cohere/voxtral] int5 (default), int8, or fp16; [moss] int8 (default) or fp16; [whisper] default or turbo; alternatively a model ID or local directory")
+    @Option(name: .shortAndLong, help: "[qwen3] 0.6B (default), 0.6B-8bit, 1.7B, or 1.7B-4bit; [cohere/voxtral] int5 (default), int8, or fp16; [moss coreml] int8 (default) or fp16; [moss mlx] int5 (default) or int8; [whisper] default or turbo; alternatively a model ID or local directory")
     public var model: String = "0.6B"
 
-    @Option(name: .long, help: "[moss] Maximum generated transcript tokens (default 512)")
-    public var maxTokens: Int = 512
+    @Option(name: .long, help: "[moss] Maximum generated transcript tokens (default: Core ML 512, MLX 5120)")
+    public var maxTokens: Int?
+
+    @Option(name: .long, help: "[moss mlx] KV-cache precision: fp16 (default) or int8")
+    public var kvCache: String = "fp16"
 
     @Option(name: .long, help: "Language hint (optional)")
     public var language: String?
@@ -75,10 +78,21 @@ public struct TranscribeCommand: ParsableCommand {
             guard !stream else {
                 throw ValidationError("--stream is not supported by the MOSS batch runtime")
             }
-            guard maxTokens > 0 else {
+            if let maxTokens, maxTokens <= 0 {
                 throw ValidationError("--max-tokens must be positive")
             }
-            _ = try resolveMossModelId(model)
+            let backendNorm = backend.lowercased()
+            guard backendNorm == "coreml" || backendNorm == "mlx" else {
+                throw ValidationError("--backend must be 'coreml' or 'mlx' for moss")
+            }
+            _ = try resolveMossModelId(model, backend: backendNorm)
+            if backendNorm == "mlx" {
+                guard MossMLXKVCachePrecision(rawValue: kvCache.lowercased()) != nil else {
+                    throw ValidationError(
+                        "--kv-cache must be 'fp16' or 'int8' for moss mlx"
+                    )
+                }
+            }
         }
         if eng == "omnilingual" {
             if window != 5 && window != 10 {
@@ -182,35 +196,77 @@ public struct TranscribeCommand: ParsableCommand {
 
     private func runMossTranscription() throws {
         try runAsync {
+            let backend = backend.lowercased()
             print("Loading audio: \(audioFile)")
             let audio = try AudioFileLoader.load(
                 url: URL(fileURLWithPath: audioFile),
-                targetSampleRate: MossTranscribeModel.inputSampleRate
+                targetSampleRate: MossMLXModel.inputSampleRate
             )
             let duration =
                 Double(audio.count)
-                / Double(MossTranscribeModel.inputSampleRate)
+                / Double(MossMLXModel.inputSampleRate)
             print(
                 "  Loaded \(audio.count) samples "
                     + "(\(String(format: "%.2f", duration))s)"
             )
 
-            let modelId = try resolveMossModelId(model)
-
-            print("Loading MOSS Core ML model: \(modelId)")
-            let moss = try await MossTranscribeModel.fromPretrained(
-                modelId: modelId,
-                progressHandler: reportProgress
-            )
-            print("Warming up Core ML...")
-            try moss.warmUp()
-
-            print("Transcribing with timestamps and speakers...")
-            let result = try moss.transcribeDetailed(
-                audio: audio,
-                sampleRate: MossTranscribeModel.inputSampleRate,
-                maxNewTokens: maxTokens
-            )
+            let modelId = try resolveMossModelId(model, backend: backend)
+            let result: MossTranscription
+            if backend == "mlx" {
+                print("Loading MOSS MLX model: \(modelId)")
+                let moss: MossMLXModel
+                if FileManager.default.fileExists(atPath: modelId) {
+                    moss = try await MossMLXModel.fromDirectory(
+                        URL(fileURLWithPath: modelId),
+                        progressHandler: reportProgress
+                    )
+                } else {
+                    moss = try await MossMLXModel.fromPretrained(
+                        modelId: modelId,
+                        progressHandler: reportProgress
+                    )
+                }
+                print("Warming up MLX...")
+                try moss.warmUp()
+                let cachePrecision = MossMLXKVCachePrecision(
+                    rawValue: kvCache.lowercased()
+                ) ?? .float16
+                let options = MossMLXDecodingOptions(
+                    maxTokens: maxTokens ?? 5_120,
+                    kvCachePrecision: cachePrecision
+                )
+                print(
+                    "Transcribing offline with global context "
+                        + "(\(cachePrecision.rawValue) KV cache)..."
+                )
+                result = try moss.transcribeDetailed(
+                    audio: audio,
+                    sampleRate: MossMLXModel.inputSampleRate,
+                    options: options
+                )
+            } else {
+                print("Loading MOSS Core ML model: \(modelId)")
+                let moss: MossTranscribeModel
+                if FileManager.default.fileExists(atPath: modelId) {
+                    moss = try await MossTranscribeModel.fromDirectory(
+                        URL(fileURLWithPath: modelId),
+                        progressHandler: reportProgress
+                    )
+                } else {
+                    moss = try await MossTranscribeModel.fromPretrained(
+                        modelId: modelId,
+                        progressHandler: reportProgress
+                    )
+                }
+                print("Warming up Core ML...")
+                try moss.warmUp()
+                print("Transcribing with timestamps and speakers...")
+                result = try moss.transcribeDetailed(
+                    audio: audio,
+                    sampleRate: MossTranscribeModel.inputSampleRate,
+                    maxNewTokens: maxTokens ?? 512
+                )
+            }
             print("Result: \(result.text)")
             if !result.segments.isEmpty {
                 print("Segments:")
@@ -624,19 +680,43 @@ private func resolveNewASRModelId(
     }
 }
 
-/// Resolve MOSS model aliases to the published CoreML bundles.
-public func resolveMossModelId(_ specifier: String) throws -> String {
-    switch specifier.lowercased() {
-    case "0.6b", "default", "int8":
-        return MossModelVariant.int8.modelId
-    case "fp16":
-        return MossModelVariant.fp16.modelId
-    default:
-        if specifier.contains("/") {
-            return specifier
+/// Resolve MOSS model aliases for either the Core ML or MLX runtime.
+public func resolveMossModelId(
+    _ specifier: String,
+    backend: String = "coreml"
+) throws -> String {
+    switch backend.lowercased() {
+    case "coreml":
+        switch specifier.lowercased() {
+        case "0.6b", "0.9b", "default", "int8", "8bit":
+            return MossModelVariant.int8.modelId
+        case "fp16", "16bit":
+            return MossModelVariant.fp16.modelId
+        default:
+            if specifier.contains("/") {
+                return specifier
+            }
+            throw ValidationError(
+                "[moss coreml] --model must be 'int8', 'fp16', "
+                    + "a Hugging Face model ID, or a local directory"
+            )
         }
-        throw ValidationError(
-            "[moss] --model must be 'int8', 'fp16', or a full CoreML HuggingFace repo ID"
-        )
+    case "mlx":
+        switch specifier.lowercased() {
+        case "0.6b", "0.9b", "default", "int5", "5bit":
+            return MossMLXVariant.int5.modelId
+        case "int8", "8bit":
+            return MossMLXVariant.int8.modelId
+        default:
+            if specifier.contains("/") {
+                return specifier
+            }
+            throw ValidationError(
+                "[moss mlx] --model must be 'int5', 'int8', "
+                    + "a Hugging Face model ID, or a local directory"
+            )
+        }
+    default:
+        throw ValidationError("[moss] --backend must be 'coreml' or 'mlx'")
     }
 }

--- a/Sources/DiarizationBenchmark/DiarizationBench.swift
+++ b/Sources/DiarizationBenchmark/DiarizationBench.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import AudioCommon
 import BenchmarkSupport
 import Foundation
+import MossTranscribe
 import SpeechVAD
 
 #if canImport(CoreML)
@@ -19,7 +20,7 @@ struct DiarizationBench: AsyncParsableCommand {
     var manifest: String
 
     @Option(name: .shortAndLong, parsing: .upToNextOption,
-            help: "Engines: community1-coreml, sortformer-default, sortformer-balanced, sortformer-streaming, sortformer-session, sortformer-streaming-ultra8, sortformer-session-ultra8, pyannote-mlx, pyannote-coreml.")
+            help: "Engines: community1-coreml, sortformer-default, sortformer-balanced, sortformer-streaming, sortformer-session, sortformer-streaming-ultra8, sortformer-session-ultra8, pyannote-mlx, pyannote-coreml, moss-coreml-int8, moss-mlx-int5, moss-mlx-int8.")
     var engines: [String] = ["sortformer-default", "pyannote-mlx"]
 
     @Option(name: .shortAndLong, help: "Max files to process.")
@@ -301,9 +302,114 @@ private func makeDiarizationEngine(
         return PyannoteDiarizationBenchEngine(name: "pyannote-mlx", embeddingEngine: .mlx)
     case "pyannote-coreml":
         return PyannoteDiarizationBenchEngine(name: "pyannote-coreml", embeddingEngine: .coreml)
+    case "moss-coreml-int8":
+        return MossCoreMLDiarizationBenchEngine()
+    case "moss-mlx-int5":
+        return MossMLXDiarizationBenchEngine(variant: .int5)
+    case "moss-mlx-int8":
+        return MossMLXDiarizationBenchEngine(variant: .int8)
     default:
         return nil
     }
+}
+
+private final class MossCoreMLDiarizationBenchEngine:
+    DiarizationBenchEngine
+{
+    let name = "moss-coreml-int8"
+    private var model: MossTranscribeModel?
+
+    func load() async throws {
+        model = try await MossTranscribeModel.fromPretrained(
+            variant: .int8
+        )
+    }
+
+    func diarize(
+        audio: [Float],
+        sampleRate: Int
+    ) throws -> DiarizationResult {
+        guard let model else {
+            return DiarizationResult(
+                segments: [],
+                numSpeakers: 0,
+                speakerEmbeddings: []
+            )
+        }
+        let transcription = try model.transcribeDetailed(
+            audio: audio,
+            sampleRate: sampleRate
+        )
+        return makeMossDiarizationResult(
+            transcription,
+            audioDuration: Double(audio.count) / Double(sampleRate)
+        )
+    }
+}
+
+private final class MossMLXDiarizationBenchEngine:
+    DiarizationBenchEngine
+{
+    let name: String
+    private let variant: MossMLXVariant
+    private var model: MossMLXModel?
+
+    init(variant: MossMLXVariant) {
+        self.variant = variant
+        name = "moss-mlx-\(variant.rawValue)"
+    }
+
+    func load() async throws {
+        let environmentKey =
+            variant == .int5
+            ? "MOSS_MLX_INT5_MODEL_DIR"
+            : "MOSS_MLX_INT8_MODEL_DIR"
+        if let local = ProcessInfo.processInfo.environment[environmentKey] {
+            model = try await MossMLXModel.fromDirectory(
+                URL(fileURLWithPath: local),
+                modelId: "local/MOSS-MLX-\(variant.rawValue.uppercased())"
+            )
+        } else {
+            model = try await MossMLXModel.fromPretrained(
+                variant: variant
+            )
+        }
+    }
+
+    func diarize(
+        audio: [Float],
+        sampleRate: Int
+    ) throws -> DiarizationResult {
+        guard let model else {
+            return DiarizationResult(
+                segments: [],
+                numSpeakers: 0,
+                speakerEmbeddings: []
+            )
+        }
+        let transcription = try model.transcribeDetailed(
+            audio: audio,
+            sampleRate: sampleRate
+        )
+        return makeMossDiarizationResult(
+            transcription,
+            audioDuration: Double(audio.count) / Double(sampleRate)
+        )
+    }
+}
+
+private func makeMossDiarizationResult(
+    _ transcription: MossTranscription,
+    audioDuration: Double
+) -> DiarizationResult {
+    let segments = transcription.diarizedSegments(
+        audioDuration: audioDuration
+    )
+    return DiarizationResult(
+        segments: segments,
+        numSpeakers: Set(segments.map(\.speakerId)).count,
+        speakerEmbeddings: []
+    )
 }
 
 #if canImport(CoreML)

--- a/Sources/MossTranscribe/MossMLXAudioModel.swift
+++ b/Sources/MossTranscribe/MossMLXAudioModel.swift
@@ -1,0 +1,259 @@
+import Foundation
+import MLX
+import MLXCommon
+import MLXNN
+
+final class MossMLXEncoderAttention: Module {
+    let heads: Int
+    let headDimension: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var queryProjection: Linear
+    @ModuleInfo(key: "k_proj") var keyProjection: Linear
+    @ModuleInfo(key: "v_proj") var valueProjection: Linear
+    @ModuleInfo(key: "out_proj") var outputProjection: Linear
+
+    init(_ config: MossMLXConfiguration.Audio) {
+        heads = config.attentionHeads
+        headDimension = config.hiddenSize / config.attentionHeads
+        scale = 1 / sqrt(Float(headDimension))
+        _queryProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.hiddenSize,
+            bias: true
+        )
+        _keyProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.hiddenSize,
+            bias: false
+        )
+        _valueProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.hiddenSize,
+            bias: true
+        )
+        _outputProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.hiddenSize,
+            bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let length = input.dim(1)
+        let query = queryProjection(input)
+            .reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let key = keyProjection(input)
+            .reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let value = valueProjection(input)
+            .reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let attended = SDPA.attendAndMerge(
+            qHeads: query,
+            kHeads: key,
+            vHeads: value,
+            scale: scale
+        )
+        return outputProjection(attended)
+    }
+}
+
+final class MossMLXEncoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention:
+        MossMLXEncoderAttention
+    @ModuleInfo(key: "self_attn_layer_norm") var
+        selfAttentionLayerNorm: LayerNorm
+    @ModuleInfo(key: "fc1") var feedForward1: Linear
+    @ModuleInfo(key: "fc2") var feedForward2: Linear
+    @ModuleInfo(key: "final_layer_norm") var finalLayerNorm: LayerNorm
+
+    init(_ config: MossMLXConfiguration.Audio) {
+        _selfAttention.wrappedValue = MossMLXEncoderAttention(config)
+        _selfAttentionLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize,
+            eps: config.layerNormEpsilon
+        )
+        _feedForward1.wrappedValue = Linear(
+            config.hiddenSize,
+            config.intermediateSize,
+            bias: true
+        )
+        _feedForward2.wrappedValue = Linear(
+            config.intermediateSize,
+            config.hiddenSize,
+            bias: true
+        )
+        _finalLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize,
+            eps: config.layerNormEpsilon
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden =
+            input + selfAttention(selfAttentionLayerNorm(input))
+        hidden =
+            hidden
+            + feedForward2(gelu(feedForward1(finalLayerNorm(hidden))))
+        return hidden
+    }
+}
+
+final class MossMLXWhisperEncoder: Module {
+    let config: MossMLXConfiguration.Audio
+
+    @ModuleInfo var conv1: Conv1d
+    @ModuleInfo var conv2: Conv1d
+    @ModuleInfo(key: "embed_positions") var positionEmbedding: Embedding
+    @ModuleInfo var layers: [MossMLXEncoderLayer]
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+
+    init(_ config: MossMLXConfiguration.Audio) {
+        self.config = config
+        _conv1.wrappedValue = Conv1d(
+            inputChannels: config.melBins,
+            outputChannels: config.hiddenSize,
+            kernelSize: 3,
+            padding: 1
+        )
+        _conv2.wrappedValue = Conv1d(
+            inputChannels: config.hiddenSize,
+            outputChannels: config.hiddenSize,
+            kernelSize: 3,
+            stride: 2,
+            padding: 1
+        )
+        _positionEmbedding.wrappedValue = Embedding(
+            embeddingCount: config.maximumSourcePositions,
+            dimensions: config.hiddenSize
+        )
+        _layers.wrappedValue = (0..<config.layers).map { _ in
+            MossMLXEncoderLayer(config)
+        }
+        _layerNorm.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize,
+            eps: config.layerNormEpsilon
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ features: MLXArray) -> MLXArray {
+        var hidden = features.asType(conv1.weight.dtype)
+        hidden = gelu(conv1(hidden))
+        hidden = gelu(conv2(hidden))
+        precondition(
+            hidden.dim(1) == config.maximumSourcePositions,
+            "MOSS audio chunks must contain exactly "
+                + "\(config.maximumSourcePositions) encoder positions"
+        )
+        hidden =
+            hidden
+            + positionEmbedding.weight
+                .expandedDimensions(axis: 0)
+                .asType(hidden.dtype)
+        for layer in layers {
+            hidden = layer(hidden)
+        }
+        return layerNorm(hidden)
+    }
+}
+
+final class MossMLXVQAdaptor: Module {
+    /// Preserve the upstream Sequential indices (Linear, SiLU, Linear,
+    /// LayerNorm). The activation has no parameters, so its unflattened
+    /// weight-tree entry is `none`.
+    @ModuleInfo var layers: [Module]
+
+    init(_ config: MossMLXConfiguration) {
+        _layers.wrappedValue = [
+            Linear(
+                config.audio.hiddenSize * config.audio.mergeSize,
+                config.decoder.hiddenSize,
+                bias: true
+            ),
+            Identity(),
+            Linear(
+                config.decoder.hiddenSize,
+                config.decoder.hiddenSize,
+                bias: true
+            ),
+            LayerNorm(
+                dimensions: config.decoder.hiddenSize,
+                eps: config.decoder.rmsNormEpsilon
+            ),
+        ]
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let inputProjection = layers[0] as! Linear
+        let outputProjection = layers[2] as! Linear
+        let outputNorm = layers[3] as! LayerNorm
+        return outputNorm(
+            outputProjection(silu(inputProjection(input)))
+        )
+    }
+}
+
+final class MossMLXAudioModel: Module {
+    let config: MossMLXConfiguration
+
+    @ModuleInfo(key: "whisper_encoder") var encoder:
+        MossMLXWhisperEncoder
+    @ModuleInfo(key: "vq_adaptor") var adaptor: MossMLXVQAdaptor
+
+    init(_ config: MossMLXConfiguration) {
+        self.config = config
+        _encoder.wrappedValue = MossMLXWhisperEncoder(config.audio)
+        _adaptor.wrappedValue = MossMLXVQAdaptor(config)
+        super.init()
+    }
+
+    /// Encode one batch of padded 30-second feature chunks.
+    ///
+    /// `features` is `[batch, 3000, 80]`. Each token count identifies how
+    /// many of the 375 merged outputs are real for its corresponding chunk.
+    func encode(
+        features: MLXArray,
+        tokenCounts: [Int]
+    ) throws -> MLXArray {
+        guard
+            features.ndim == 3,
+            features.dim(0) == tokenCounts.count,
+            features.dim(1) == MossWhisperFeatureExtractor.timeFrames,
+            features.dim(2) == config.audio.melBins
+        else {
+            throw MossTranscribeError.invalidAudio(
+                "MLX feature batch has an unexpected shape"
+            )
+        }
+        let encoded = encoder(features)
+        var mergedChunks: [MLXArray] = []
+        mergedChunks.reserveCapacity(tokenCounts.count)
+        for (index, tokenCount) in tokenCounts.enumerated() {
+            let encoderPositions = tokenCount * config.audio.mergeSize
+            guard
+                tokenCount > 0,
+                encoderPositions <= encoded.dim(1)
+            else {
+                throw MossTranscribeError.invalidAudio(
+                    "invalid MOSS audio token count \(tokenCount)"
+                )
+            }
+            mergedChunks.append(
+                encoded[index, 0..<encoderPositions, 0...]
+                    .reshaped(
+                        tokenCount,
+                        config.audio.hiddenSize
+                            * config.audio.mergeSize
+                    )
+            )
+        }
+        return adaptor(concatenated(mergedChunks, axis: 0))
+    }
+}

--- a/Sources/MossTranscribe/MossMLXConfiguration.swift
+++ b/Sources/MossTranscribe/MossMLXConfiguration.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+struct MossMLXConfiguration: Decodable, Sendable, Equatable {
+    struct Audio: Decodable, Sendable, Equatable {
+        let hiddenSize: Int
+        let intermediateSize: Int
+        let layerNormEpsilon: Float
+        let maximumSourcePositions: Int
+        let mergeSize: Int
+        let attentionHeads: Int
+        let layers: Int
+        let melBins: Int
+
+        enum CodingKeys: String, CodingKey {
+            case hiddenSize = "hidden_size"
+            case intermediateSize = "intermediate_size"
+            case layerNormEpsilon = "layer_norm_eps"
+            case maximumSourcePositions = "max_source_positions"
+            case mergeSize = "merge_size"
+            case attentionHeads = "num_heads"
+            case layers = "num_layers"
+            case melBins = "num_mel_bins"
+        }
+    }
+
+    struct Decoder: Decodable, Sendable, Equatable {
+        let headDimension: Int
+        let hiddenSize: Int
+        let intermediateSize: Int
+        let attentionHeads: Int
+        let keyValueHeads: Int
+        let layers: Int
+        let rmsNormEpsilon: Float
+        let ropeTheta: Float
+        let vocabularySize: Int
+
+        enum CodingKeys: String, CodingKey {
+            case headDimension = "head_dim"
+            case hiddenSize = "hidden_size"
+            case intermediateSize = "intermediate_size"
+            case attentionHeads = "num_heads"
+            case keyValueHeads = "num_kv_heads"
+            case layers = "num_layers"
+            case rmsNormEpsilon = "rms_norm_eps"
+            case ropeTheta = "rope_theta"
+            case vocabularySize = "vocab_size"
+        }
+    }
+
+    struct Files: Decodable, Sendable, Equatable {
+        let audioEncoder: String
+        let decoder: String
+
+        enum CodingKeys: String, CodingKey {
+            case audioEncoder = "audio_encoder"
+            case decoder
+        }
+    }
+
+    struct Quantization: Decodable, Sendable, Equatable {
+        let bits: Int
+        let groupSize: Int
+        let mode: String
+
+        enum CodingKeys: String, CodingKey {
+            case bits
+            case groupSize = "group_size"
+            case mode
+        }
+    }
+
+    static let maximumContextTokens = 131_072
+    static let supportedQuantizationBits = Set([2, 3, 4, 5, 6, 8])
+
+    let audio: Audio
+    let audioTokenID: Int
+    let backend: String
+    let decoder: Decoder
+    let files: Files
+    let maximumContextTokens: Int?
+    let modelType: String
+    let precision: String
+    let quantization: Quantization
+
+    enum CodingKeys: String, CodingKey {
+        case audio = "audio_config"
+        case audioTokenID = "audio_token_id"
+        case backend
+        case decoder = "decoder_config"
+        case files
+        case maximumContextTokens = "max_context_tokens"
+        case modelType = "model_type"
+        case precision
+        case quantization = "quantization_config"
+    }
+
+    func validate() throws {
+        guard backend == "mlx" else {
+            throw MossTranscribeError.invalidConfiguration(
+                "MLX bundle backend must be mlx"
+            )
+        }
+        guard modelType == "moss-transcribe-diarize-mlx" else {
+            throw MossTranscribeError.invalidConfiguration(
+                "unsupported MLX model_type \(modelType)"
+            )
+        }
+        guard
+            audio.hiddenSize > 0,
+            audio.intermediateSize > 0,
+            audio.maximumSourcePositions
+                == MossWhisperFeatureExtractor.timeFrames / 2,
+            audio.mergeSize == 4,
+            audio.attentionHeads > 0,
+            audio.hiddenSize.isMultiple(of: audio.attentionHeads),
+            audio.layers > 0,
+            audio.melBins == MossWhisperFeatureExtractor.melBins
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "audio geometry does not match the MOSS Whisper frontend"
+            )
+        }
+        guard
+            decoder.headDimension > 0,
+            decoder.hiddenSize > 0,
+            decoder.intermediateSize > 0,
+            decoder.attentionHeads > 0,
+            decoder.keyValueHeads > 0,
+            decoder.attentionHeads.isMultiple(
+                of: decoder.keyValueHeads
+            ),
+            decoder.layers > 0,
+            audioTokenID >= 0,
+            decoder.vocabularySize > audioTokenID,
+            decoder.ropeTheta > 0
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "invalid Qwen3 decoder geometry"
+            )
+        }
+        guard decoder.hiddenSize == audio.hiddenSize else {
+            throw MossTranscribeError.invalidConfiguration(
+                "audio and decoder hidden sizes must match"
+            )
+        }
+        guard
+            maximumContextTokens == nil
+                || maximumContextTokens == Self.maximumContextTokens
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "MLX context must be \(Self.maximumContextTokens) tokens"
+            )
+        }
+        guard
+            Self.supportedQuantizationBits.contains(quantization.bits),
+            quantization.groupSize > 0,
+            quantization.mode == "affine"
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "unsupported decoder quantization: "
+                    + "\(quantization.bits)-bit group-"
+                    + "\(quantization.groupSize) \(quantization.mode)"
+            )
+        }
+        guard
+            precision
+                == "fp16-audio-int\(quantization.bits)-decoder"
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "precision does not match quantization_config"
+            )
+        }
+        guard
+            files.audioEncoder == "audio_encoder.safetensors",
+            files.decoder == "decoder.safetensors"
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "MLX weight files must use the published bundle names"
+            )
+        }
+    }
+}

--- a/Sources/MossTranscribe/MossMLXRuntime.swift
+++ b/Sources/MossTranscribe/MossMLXRuntime.swift
@@ -1,0 +1,638 @@
+import AudioCommon
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Tokenizers
+
+/// Long-context MLX runtime for MOSS-Transcribe-Diarize 0.9B.
+///
+/// The Whisper encoder processes non-overlapping 30-second chunks in bounded
+/// batches. All adapted audio embeddings then enter one Qwen3 prompt, so
+/// transcription and speaker attribution retain global recording context.
+/// This remains an offline autoregressive model; it does not emit streaming
+/// partials while audio is being recorded.
+public final class MossMLXModel:
+    SpeechRecognitionModel,
+    @unchecked Sendable
+{
+    public static let defaultModelId = MossMLXVariant.int5.modelId
+    public static let defaultInstruction =
+        MossPromptProcessor.defaultInstruction
+    public static let inputSampleRate =
+        MossWhisperFeatureExtractor.sampleRate
+    public static let maximumContextTokens =
+        MossMLXConfiguration.maximumContextTokens
+
+    static let requiredBundleFiles = [
+        "config.json",
+        "audio_encoder.safetensors",
+        "decoder.safetensors",
+        "processor_config.json",
+        "preprocessor_config.json",
+        "generation_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ]
+
+    static let downloadAdditionalFiles = [
+        "processor_config.json",
+        "preprocessor_config.json",
+        "generation_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "added_tokens.json",
+        "merges.txt",
+        "vocab.json",
+        "chat_template.jinja",
+        "source_config.json",
+        "export_config.json",
+        "validation.json",
+    ]
+
+    public let modelId: String
+    public let modelFolder: URL
+    public var inputSampleRate: Int { Self.inputSampleRate }
+    public var quantizationBits: Int {
+        configuration.quantization.bits
+    }
+
+    private let configuration: MossMLXConfiguration
+    private let audioModel: MossMLXAudioModel
+    private let textModel: MossMLXTextModel
+    private let tokenizer: any Tokenizers.Tokenizer
+    private let promptProcessor: MossPromptProcessor
+    private let featureExtractor = MossWhisperFeatureExtractor()
+    private let inferenceLock = NSLock()
+
+    private init(
+        modelId: String,
+        modelFolder: URL,
+        configuration: MossMLXConfiguration,
+        audioModel: MossMLXAudioModel,
+        textModel: MossMLXTextModel,
+        tokenizer: any Tokenizers.Tokenizer,
+        promptProcessor: MossPromptProcessor
+    ) {
+        self.modelId = modelId
+        self.modelFolder = modelFolder
+        self.configuration = configuration
+        self.audioModel = audioModel
+        self.textModel = textModel
+        self.tokenizer = tokenizer
+        self.promptProcessor = promptProcessor
+    }
+
+    public static func fromPretrained(
+        variant: MossMLXVariant = .int5,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> MossMLXModel {
+        try await fromPretrained(
+            modelId: variant.modelId,
+            cacheDir: cacheDir,
+            offlineMode: offlineMode,
+            progressHandler: progressHandler
+        )
+    }
+
+    public static func fromPretrained(
+        modelId: String = defaultModelId,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> MossMLXModel {
+        let directory: URL
+        do {
+            directory = try cacheDir
+                ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: modelId,
+                reason: "Failed to resolve the MOSS MLX cache directory",
+                underlying: error
+            )
+        }
+
+        progressHandler?(0, "Preparing MOSS MLX bundle...")
+        do {
+            try await HuggingFaceDownloader.downloadWeights(
+                modelId: modelId,
+                to: directory,
+                additionalFiles: downloadAdditionalFiles,
+                offlineMode: offlineMode
+            ) { fraction in
+                progressHandler?(
+                    fraction * 0.75,
+                    "Downloading MOSS MLX bundle..."
+                )
+            }
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: modelId,
+                reason: "Failed to download the MOSS MLX bundle",
+                underlying: error
+            )
+        }
+        return try await fromDirectory(
+            directory,
+            modelId: modelId
+        ) { fraction, message in
+            progressHandler?(0.75 + fraction * 0.25, message)
+        }
+    }
+
+    /// Load an exported MLX bundle without accessing the network.
+    public static func fromDirectory(
+        _ directory: URL,
+        modelId: String = "local/MOSS-Transcribe-Diarize-MLX",
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> MossMLXModel {
+        guard hasCompleteCachedBundle(in: directory) else {
+            let missing = requiredBundleFiles.first {
+                !FileManager.default.fileExists(
+                    atPath: directory.appendingPathComponent($0).path
+                )
+            } ?? "unknown file"
+            throw MossTranscribeError.missingModelFile(missing)
+        }
+
+        let configuration = try JSONDecoder().decode(
+            MossMLXConfiguration.self,
+            from: Data(
+                contentsOf: directory.appendingPathComponent(
+                    "config.json"
+                )
+            )
+        )
+        try configuration.validate()
+        for file in [
+            configuration.files.audioEncoder,
+            configuration.files.decoder,
+        ] where !FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(file).path
+        ) {
+            throw MossTranscribeError.missingModelFile(file)
+        }
+
+        let preprocessor = try JSONDecoder().decode(
+            MossPreprocessorConfiguration.self,
+            from: Data(
+                contentsOf: directory.appendingPathComponent(
+                    "preprocessor_config.json"
+                )
+            )
+        )
+        try preprocessor.validate()
+        let processor = try JSONDecoder().decode(
+            MossProcessorConfiguration.self,
+            from: Data(
+                contentsOf: directory.appendingPathComponent(
+                    "processor_config.json"
+                )
+            )
+        )
+        try validateProcessorConfiguration(processor)
+
+        progressHandler?(0.05, "Loading MOSS tokenizer...")
+        let tokenizer = try await AutoTokenizer.from(
+            modelFolder: directory
+        )
+        let promptProcessor = try MossPromptProcessor(
+            tokenizer: tokenizer,
+            configuration: processor
+        )
+        guard promptProcessor.audioTokenID == configuration.audioTokenID else {
+            throw MossTranscribeError.invalidConfiguration(
+                "config audio_token_id does not match the tokenizer"
+            )
+        }
+
+        progressHandler?(0.1, "Loading MOSS MLX audio encoder...")
+        let audioModel = MossMLXAudioModel(configuration)
+        do {
+            let audioWeights = try MLX.loadArrays(
+                url: directory.appendingPathComponent(
+                    configuration.files.audioEncoder
+                )
+            )
+            try audioModel.update(
+                parameters: ModuleParameters.unflattened(audioWeights),
+                verify: .all
+            )
+            audioModel.train(false)
+            eval(audioModel)
+        } catch {
+            throw MossTranscribeError.invalidConfiguration(
+                "incompatible MLX audio weights: "
+                    + error.localizedDescription
+            )
+        }
+
+        progressHandler?(0.45, "Loading quantized MOSS decoder...")
+        let textModel = MossMLXTextModel(configuration.decoder)
+        do {
+            let decoderWeights = try MLX.loadArrays(
+                url: directory.appendingPathComponent(
+                    configuration.files.decoder
+                )
+            )
+            MLXNN.quantize(model: textModel) { path, _ in
+                decoderWeights["\(path).scales"] == nil
+                    ? nil
+                    : (
+                        configuration.quantization.groupSize,
+                        configuration.quantization.bits,
+                        .affine
+                    )
+            }
+            try textModel.update(
+                parameters: ModuleParameters.unflattened(decoderWeights),
+                verify: .all
+            )
+            textModel.train(false)
+            eval(textModel)
+        } catch {
+            throw MossTranscribeError.invalidConfiguration(
+                "incompatible quantized MLX decoder weights: "
+                    + error.localizedDescription
+            )
+        }
+        Memory.clearCache()
+        progressHandler?(1, "MOSS MLX ready")
+
+        return MossMLXModel(
+            modelId: modelId,
+            modelFolder: directory,
+            configuration: configuration,
+            audioModel: audioModel,
+            textModel: textModel,
+            tokenizer: tokenizer,
+            promptProcessor: promptProcessor
+        )
+    }
+
+    /// Compile representative encoder, prefill, and decode paths.
+    public func warmUp() throws {
+        var options = MossMLXDecodingOptions(maxTokens: 1)
+        options.encoderBatchSize = 1
+        _ = try transcribeDetailed(
+            audio: [Float](repeating: 0, count: 1_600),
+            sampleRate: Self.inputSampleRate,
+            options: options
+        )
+    }
+
+    public func transcribeDetailed(
+        audio: [Float],
+        sampleRate: Int,
+        options: MossMLXDecodingOptions = MossMLXDecodingOptions(),
+        instruction: String = MossMLXModel.defaultInstruction
+    ) throws -> MossTranscription {
+        inferenceLock.lock()
+        defer { inferenceLock.unlock() }
+        return try autoreleasepool {
+            defer { Memory.clearCache() }
+            return try transcribeLocked(
+                audio: audio,
+                sampleRate: sampleRate,
+                options: options,
+                instruction: instruction
+            )
+        }
+    }
+
+    public func transcribeDetailed(
+        audio: [Float],
+        sampleRate: Int,
+        maxNewTokens: Int,
+        instruction: String = MossMLXModel.defaultInstruction
+    ) throws -> MossTranscription {
+        try transcribeDetailed(
+            audio: audio,
+            sampleRate: sampleRate,
+            options: MossMLXDecodingOptions(maxTokens: maxNewTokens),
+            instruction: instruction
+        )
+    }
+
+    public func transcribe(
+        audio: [Float],
+        sampleRate: Int,
+        language: String?
+    ) -> String {
+        do {
+            return try transcribeDetailed(
+                audio: audio,
+                sampleRate: sampleRate
+            ).text
+        } catch {
+            AudioLog.inference.error(
+                "MOSS MLX transcription failed: \(error.localizedDescription)"
+            )
+            return ""
+        }
+    }
+
+    static func hasCompleteCachedBundle(in directory: URL) -> Bool {
+        requiredBundleFiles.allSatisfy {
+            FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent($0).path
+            )
+        }
+    }
+
+    private static func validateProcessorConfiguration(
+        _ processor: MossProcessorConfiguration
+    ) throws {
+        let expectedTokenRate =
+            Double(MossWhisperFeatureExtractor.sampleRate)
+            / Double(
+                MossWhisperFeatureExtractor.encoderStrideSamples
+            )
+        guard
+            abs(
+                processor.audioTokensPerSecond - expectedTokenRate
+            ) < 1e-9,
+            processor.audioMergeSize == 4,
+            processor.timeMarkerEverySeconds > 0
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "processor settings do not match the native MOSS runtime"
+            )
+        }
+    }
+
+    private func transcribeLocked(
+        audio: [Float],
+        sampleRate: Int,
+        options: MossMLXDecodingOptions,
+        instruction: String
+    ) throws -> MossTranscription {
+        guard !audio.isEmpty else {
+            throw MossTranscribeError.invalidAudio(
+                "the waveform is empty"
+            )
+        }
+        guard sampleRate > 0 else {
+            throw MossTranscribeError.invalidAudio(
+                "sample rate must be positive"
+            )
+        }
+        guard
+            options.maxTokens > 0,
+            options.encoderBatchSize > 0,
+            options.prefillChunkSize > 0
+        else {
+            throw MossTranscribeError.invalidConfiguration(
+                "maxTokens, encoderBatchSize, and prefillChunkSize "
+                    + "must be positive"
+            )
+        }
+
+        let totalStarted = CFAbsoluteTimeGetCurrent()
+        var preprocessingSeconds = 0.0
+        var audioEncoderSeconds = 0.0
+
+        var phaseStarted = CFAbsoluteTimeGetCurrent()
+        let waveform =
+            sampleRate == Self.inputSampleRate
+            ? audio
+            : AudioFileLoader.resample(
+                audio,
+                from: sampleRate,
+                to: Self.inputSampleRate
+            )
+        preprocessingSeconds +=
+            CFAbsoluteTimeGetCurrent() - phaseStarted
+        guard !waveform.isEmpty else {
+            throw MossTranscribeError.invalidAudio(
+                "resampling produced an empty waveform"
+            )
+        }
+
+        var featureChunks: [MossLogMelFeatures] = []
+        var tokenCounts: [Int] = []
+        for start in stride(
+            from: 0,
+            to: waveform.count,
+            by: MossWhisperFeatureExtractor.chunkSamples
+        ) {
+            let end = min(
+                start + MossWhisperFeatureExtractor.chunkSamples,
+                waveform.count
+            )
+            let chunk = Array(waveform[start..<end])
+            phaseStarted = CFAbsoluteTimeGetCurrent()
+            featureChunks.append(
+                try featureExtractor.extractPaddedChunk(chunk)
+            )
+            preprocessingSeconds +=
+                CFAbsoluteTimeGetCurrent() - phaseStarted
+            tokenCounts.append(
+                MossWhisperFeatureExtractor.audioTokenCount(
+                    sampleCount: chunk.count
+                )
+            )
+        }
+
+        var embeddingBatches: [MLXArray] = []
+        embeddingBatches.reserveCapacity(
+            (featureChunks.count + options.encoderBatchSize - 1)
+                / options.encoderBatchSize
+        )
+        for start in stride(
+            from: 0,
+            to: featureChunks.count,
+            by: options.encoderBatchSize
+        ) {
+            let end = min(
+                start + options.encoderBatchSize,
+                featureChunks.count
+            )
+            let features = featureChunks[start..<end]
+            let values = features.flatMap(\.data)
+            let featureArray = MLXArray(
+                values,
+                [
+                    features.count,
+                    MossWhisperFeatureExtractor.melBins,
+                    MossWhisperFeatureExtractor.timeFrames,
+                ]
+            ).transposed(0, 2, 1)
+
+            phaseStarted = CFAbsoluteTimeGetCurrent()
+            let embeddings = try audioModel.encode(
+                features: featureArray,
+                tokenCounts: Array(tokenCounts[start..<end])
+            )
+            eval(embeddings)
+            embeddingBatches.append(embeddings)
+            audioEncoderSeconds +=
+                CFAbsoluteTimeGetCurrent() - phaseStarted
+            Memory.clearCache()
+        }
+        let audioEmbeddings = concatenated(
+            embeddingBatches,
+            axis: 0
+        )
+        eval(audioEmbeddings)
+        let audioTokenCount = tokenCounts.reduce(0, +)
+
+        phaseStarted = CFAbsoluteTimeGetCurrent()
+        let prompt = try promptProcessor.prepare(
+            audioTokenCount: audioTokenCount,
+            instruction: instruction
+        )
+        preprocessingSeconds +=
+            CFAbsoluteTimeGetCurrent() - phaseStarted
+        guard
+            prompt.inputIDs.count
+                < Self.maximumContextTokens
+        else {
+            throw MossTranscribeError.promptTooLong(
+                actual: prompt.inputIDs.count,
+                maximum: Self.maximumContextTokens
+            )
+        }
+        guard
+            prompt.audioPlaceholderCount == audioTokenCount,
+            audioEmbeddings.dim(0) == audioTokenCount
+        else {
+            throw MossTranscribeError.audioEmbeddingMismatch(
+                placeholders: prompt.audioPlaceholderCount,
+                embeddings: audioEmbeddings.dim(0)
+            )
+        }
+
+        let prefillStarted = CFAbsoluteTimeGetCurrent()
+        let cache = textModel.makeCache(
+            precision: options.kvCachePrecision,
+            step: options.prefillChunkSize
+        )
+        var audioIndex = 0
+        var finalHidden: MLXArray?
+        for start in stride(
+            from: 0,
+            to: prompt.inputIDs.count,
+            by: options.prefillChunkSize
+        ) {
+            let end = min(
+                start + options.prefillChunkSize,
+                prompt.inputIDs.count
+            )
+            let ids = Array(prompt.inputIDs[start..<end])
+            let tokenRows = textModel.embed(
+                MLXArray(ids.map(Int32.init)).reshaped(1, ids.count)
+            )[0]
+            var audioIndices = [Int32](
+                repeating: 0,
+                count: ids.count
+            )
+            var audioMask = [Float](
+                repeating: 0,
+                count: ids.count
+            )
+            for index in ids.indices
+            where ids[index] == promptProcessor.audioTokenID {
+                audioIndices[index] = Int32(audioIndex)
+                audioMask[index] = 1
+                audioIndex += 1
+            }
+            let replacementRows = audioEmbeddings[
+                MLXArray(audioIndices)
+            ].asType(tokenRows.dtype)
+            let mask = MLXArray(audioMask)
+                .expandedDimensions(axis: 1)
+                .asType(tokenRows.dtype)
+            let mixedRows =
+                tokenRows * (1 - mask) + replacementRows * mask
+            finalHidden = textModel.forward(
+                embeddings: mixedRows.expandedDimensions(axis: 0),
+                cache: cache
+            )
+            asyncEval(cache)
+        }
+        eval(cache)
+        guard
+            audioIndex == audioTokenCount,
+            let finalHidden
+        else {
+            throw MossTranscribeError.audioEmbeddingMismatch(
+                placeholders: audioIndex,
+                embeddings: audioTokenCount
+            )
+        }
+        var logits = textModel.logits(finalHidden[0, -1])
+        eval(logits)
+        let decoderPrefillSeconds =
+            CFAbsoluteTimeGetCurrent() - prefillStarted
+
+        let decodeStarted = CFAbsoluteTimeGetCurrent()
+        let availableContext =
+            Self.maximumContextTokens - prompt.inputIDs.count
+        let generationLimit = min(
+            options.maxTokens,
+            availableContext
+        )
+        var generated: [Int] = []
+        generated.reserveCapacity(generationLimit)
+        var stopReason: MossGenerationStopReason =
+            options.maxTokens > availableContext
+            ? .contextLimit
+            : .maximumTokens
+
+        while generated.count < generationLimit {
+            let candidate = logits.argMax(axis: -1).item(Int.self)
+            generated.append(candidate)
+            if candidate == prompt.eosTokenID {
+                stopReason = .endOfSequence
+                break
+            }
+            if generated.count == generationLimit {
+                break
+            }
+            let embedding = textModel.embed(
+                MLXArray([Int32(candidate)]).reshaped(1, 1)
+            )
+            let hidden = textModel.forward(
+                embeddings: embedding,
+                cache: cache
+            )
+            logits = textModel.logits(hidden[0, -1])
+            eval(logits)
+        }
+        let tokenDecodeSeconds =
+            CFAbsoluteTimeGetCurrent() - decodeStarted
+
+        let raw = tokenizer.decode(
+            tokens: generated,
+            skipSpecialTokens: true
+        ).trimmingCharacters(
+            in: CharacterSet.whitespacesAndNewlines
+        )
+        let parsed = MossTranscriptParser.plainText(from: raw)
+        let metrics = MossTranscriptionMetrics(
+            preprocessingSeconds: preprocessingSeconds,
+            audioEncoderSeconds: audioEncoderSeconds,
+            decoderPrefillSeconds: decoderPrefillSeconds,
+            tokenDecodeSeconds: tokenDecodeSeconds,
+            totalSeconds:
+                CFAbsoluteTimeGetCurrent() - totalStarted,
+            audioDurationSeconds:
+                Double(waveform.count)
+                / Double(Self.inputSampleRate),
+            promptTokens: prompt.inputIDs.count,
+            generatedTokens: generated.count,
+            stopReason: stopReason
+        )
+        return MossTranscription(
+            rawText: raw,
+            text: parsed.text,
+            segments: parsed.segments,
+            metrics: metrics
+        )
+    }
+}

--- a/Sources/MossTranscribe/MossMLXTextModel.swift
+++ b/Sources/MossTranscribe/MossMLXTextModel.swift
@@ -1,0 +1,245 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXLMCommon
+import MLXNN
+
+final class MossMLXTextAttention: Module {
+    let config: MossMLXConfiguration.Decoder
+    let scale: Float
+    let rope: RoPE
+
+    @ModuleInfo(key: "q_proj") var queryProjection: Linear
+    @ModuleInfo(key: "k_proj") var keyProjection: Linear
+    @ModuleInfo(key: "v_proj") var valueProjection: Linear
+    @ModuleInfo(key: "o_proj") var outputProjection: Linear
+    @ModuleInfo(key: "q_norm") var queryNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var keyNorm: RMSNorm
+
+    init(_ config: MossMLXConfiguration.Decoder) {
+        self.config = config
+        scale = 1 / sqrt(Float(config.headDimension))
+        _queryProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.attentionHeads * config.headDimension,
+            bias: false
+        )
+        _keyProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.keyValueHeads * config.headDimension,
+            bias: false
+        )
+        _valueProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.keyValueHeads * config.headDimension,
+            bias: false
+        )
+        _outputProjection.wrappedValue = Linear(
+            config.attentionHeads * config.headDimension,
+            config.hiddenSize,
+            bias: false
+        )
+        _queryNorm.wrappedValue = RMSNorm(
+            dimensions: config.headDimension,
+            eps: config.rmsNormEpsilon
+        )
+        _keyNorm.wrappedValue = RMSNorm(
+            dimensions: config.headDimension,
+            eps: config.rmsNormEpsilon
+        )
+        rope = RoPE(
+            dimensions: config.headDimension,
+            traditional: false,
+            base: config.ropeTheta
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache
+    ) -> MLXArray {
+        let batch = input.dim(0)
+        let length = input.dim(1)
+        var query = queryNorm(
+            queryProjection(input).reshaped(
+                batch,
+                length,
+                config.attentionHeads,
+                config.headDimension
+            )
+        ).transposed(0, 2, 1, 3)
+        var key = keyNorm(
+            keyProjection(input).reshaped(
+                batch,
+                length,
+                config.keyValueHeads,
+                config.headDimension
+            )
+        ).transposed(0, 2, 1, 3)
+        let value = valueProjection(input).reshaped(
+            batch,
+            length,
+            config.keyValueHeads,
+            config.headDimension
+        ).transposed(0, 2, 1, 3)
+
+        query = rope(query, offset: cache.offset)
+        key = rope(key, offset: cache.offset)
+        let attended = attentionWithCacheUpdate(
+            queries: query,
+            keys: key,
+            values: value,
+            cache: cache,
+            scale: scale,
+            mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(
+            batch,
+            length,
+            config.attentionHeads * config.headDimension
+        )
+        return outputProjection(attended)
+    }
+}
+
+final class MossMLXTextMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProjection: Linear
+    @ModuleInfo(key: "up_proj") var upProjection: Linear
+    @ModuleInfo(key: "down_proj") var downProjection: Linear
+
+    init(_ config: MossMLXConfiguration.Decoder) {
+        _gateProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.intermediateSize,
+            bias: false
+        )
+        _upProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.intermediateSize,
+            bias: false
+        )
+        _downProjection.wrappedValue = Linear(
+            config.intermediateSize,
+            config.hiddenSize,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        downProjection(
+            silu(gateProjection(input)) * upProjection(input)
+        )
+    }
+}
+
+final class MossMLXTextLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: MossMLXTextAttention
+    @ModuleInfo var mlp: MossMLXTextMLP
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var
+        postAttentionLayerNorm: RMSNorm
+
+    init(_ config: MossMLXConfiguration.Decoder) {
+        _attention.wrappedValue = MossMLXTextAttention(config)
+        _mlp.wrappedValue = MossMLXTextMLP(config)
+        _inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEpsilon
+        )
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEpsilon
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache
+    ) -> MLXArray {
+        let hidden =
+            input
+            + attention(
+                inputLayerNorm(input),
+                mask: mask,
+                cache: cache
+            )
+        return hidden + mlp(postAttentionLayerNorm(hidden))
+    }
+}
+
+final class MossMLXTextModel: Module {
+    let config: MossMLXConfiguration.Decoder
+
+    @ModuleInfo(key: "embed_tokens") var tokenEmbedding: Embedding
+    @ModuleInfo var layers: [MossMLXTextLayer]
+    @ModuleInfo var norm: RMSNorm
+
+    init(_ config: MossMLXConfiguration.Decoder) {
+        self.config = config
+        _tokenEmbedding.wrappedValue = Embedding(
+            embeddingCount: config.vocabularySize,
+            dimensions: config.hiddenSize
+        )
+        _layers.wrappedValue = (0..<config.layers).map { _ in
+            MossMLXTextLayer(config)
+        }
+        _norm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEpsilon
+        )
+        super.init()
+    }
+
+    func embed(_ tokenIDs: MLXArray) -> MLXArray {
+        tokenEmbedding(tokenIDs)
+    }
+
+    func forward(
+        embeddings: MLXArray,
+        cache: [KVCache]
+    ) -> MLXArray {
+        precondition(
+            cache.count == layers.count,
+            "MOSS requires one K/V cache per decoder layer"
+        )
+        let mask = createAttentionMask(
+            h: embeddings,
+            cache: cache.first
+        )
+        var hidden = embeddings
+        for index in layers.indices {
+            hidden = layers[index](
+                hidden,
+                mask: mask,
+                cache: cache[index]
+            )
+        }
+        return norm(hidden)
+    }
+
+    func logits(_ hidden: MLXArray) -> MLXArray {
+        tokenEmbedding.asLinear(hidden)
+    }
+
+    func makeCache(
+        precision: MossMLXKVCachePrecision,
+        step: Int
+    ) -> [KVCache] {
+        (0..<config.layers).map { _ in
+            switch precision {
+            case .float16:
+                let cache = KVCacheSimple()
+                cache.step = max(1, step)
+                return cache
+            case .int8:
+                return QuantizedKVCache(groupSize: 64, bits: 8)
+            }
+        }
+    }
+}

--- a/Sources/MossTranscribe/MossTypes.swift
+++ b/Sources/MossTranscribe/MossTypes.swift
@@ -1,3 +1,4 @@
+import AudioCommon
 import Foundation
 
 /// Published Core ML variants supported by the native MOSS runtime.
@@ -11,6 +12,108 @@ public enum MossModelVariant: String, CaseIterable, Sendable {
             return "aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-INT8"
         case .fp16:
             return "aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-FP16"
+        }
+    }
+}
+
+/// Quantized decoder variants for the long-context MLX runtime.
+///
+/// Both bundles keep the Whisper encoder and VQ adaptor in FP16. Only the
+/// Qwen3 decoder weights differ, so quality comparisons isolate decoder
+/// quantization.
+public enum MossMLXVariant: String, CaseIterable, Sendable {
+    case int5
+    case int8
+
+    public var modelId: String {
+        switch self {
+        case .int5:
+            return "aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-5bit"
+        case .int8:
+            return "aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-INT8"
+        }
+    }
+
+    public var quantizationBits: Int {
+        switch self {
+        case .int5: return 5
+        case .int8: return 8
+        }
+    }
+}
+
+/// Precision used for the dynamically growing MLX key/value cache.
+///
+/// Decoder weight precision and cache precision are intentionally separate.
+/// Use `.float16` when comparing INT5 and INT8 model quality. Quantized cache
+/// can affect quality while reducing long-context memory.
+public enum MossMLXKVCachePrecision: String, CaseIterable, Sendable {
+    case float16 = "fp16"
+    case int8
+
+    public var bitsPerElement: Int {
+        switch self {
+        case .float16: return 16
+        case .int8: return 8
+        }
+    }
+}
+
+/// Greedy decoding and memory controls for the MOSS MLX runtime.
+public struct MossMLXDecodingOptions: Sendable, Equatable {
+    public var maxTokens: Int
+    public var encoderBatchSize: Int
+    public var prefillChunkSize: Int
+    public var kvCachePrecision: MossMLXKVCachePrecision
+
+    public init(
+        maxTokens: Int = 5_120,
+        encoderBatchSize: Int = 4,
+        prefillChunkSize: Int = 512,
+        kvCachePrecision: MossMLXKVCachePrecision = .float16
+    ) {
+        self.maxTokens = maxTokens
+        self.encoderBatchSize = encoderBatchSize
+        self.prefillChunkSize = prefillChunkSize
+        self.kvCachePrecision = kvCachePrecision
+    }
+}
+
+/// Analytical MOSS key/value-cache sizing.
+public enum MossMLXCacheMemory {
+    /// Estimated bytes occupied by all decoder-layer K/V tensors.
+    ///
+    /// Affine quantized estimates include FP16 scale and bias tensors for
+    /// each group. Runtime allocator padding is not included.
+    public static func estimatedBytes(
+        tokenCount: Int,
+        precision: MossMLXKVCachePrecision,
+        layers: Int = 28,
+        keyValueHeads: Int = 8,
+        headDimension: Int = 128,
+        groupSize: Int = 64
+    ) -> Int {
+        guard
+            tokenCount > 0,
+            layers > 0,
+            keyValueHeads > 0,
+            headDimension > 0
+        else {
+            return 0
+        }
+        let elementCount =
+            tokenCount * layers * 2 * keyValueHeads * headDimension
+        switch precision {
+        case .float16:
+            return elementCount * MemoryLayout<Float16>.stride
+        case .int8:
+            let packedBits = elementCount * precision.bitsPerElement
+            let packedBytes = (packedBits + 7) / 8
+            let groups = (elementCount + max(groupSize, 1) - 1)
+                / max(groupSize, 1)
+            let affineMetadataBytes =
+                groups * 2 * MemoryLayout<Float16>.stride
+            return packedBytes + affineMetadataBytes
         }
     }
 }
@@ -120,6 +223,41 @@ public struct MossTranscription: Sendable, Equatable {
     }
 }
 
+public extension MossTranscription {
+    /// Convert model speaker labels into contiguous integer identities for
+    /// diarization scoring and shared `AudioCommon` consumers.
+    ///
+    /// Speaker names are assigned in first-appearance order because MOSS
+    /// labels are anonymous within each recording.
+    func diarizedSegments(
+        audioDuration: Double? = nil
+    ) -> [DiarizedSegment] {
+        var speakerIDs: [String: Int] = [:]
+        var nextSpeakerID = 0
+        return segments.compactMap { segment in
+            let start = max(0, segment.startTime)
+            let end = min(
+                max(start, segment.endTime),
+                audioDuration ?? segment.endTime
+            )
+            guard end > start else { return nil }
+            let speakerID: Int
+            if let existing = speakerIDs[segment.speaker] {
+                speakerID = existing
+            } else {
+                speakerID = nextSpeakerID
+                speakerIDs[segment.speaker] = speakerID
+                nextSpeakerID += 1
+            }
+            return DiarizedSegment(
+                startTime: Float(start),
+                endTime: Float(end),
+                speakerId: speakerID
+            )
+        }
+    }
+}
+
 public enum MossTranscribeError: Error, LocalizedError {
     case invalidAudio(String)
     case missingModelFile(String)
@@ -142,7 +280,7 @@ public enum MossTranscribeError: Error, LocalizedError {
         case .missingTokenizerToken(let token):
             return "MOSS tokenizer is missing required token \(token)"
         case .promptTooLong(let actual, let maximum):
-            return "MOSS prompt has \(actual) tokens, exceeding the Core ML cache limit of \(maximum)"
+            return "MOSS prompt has \(actual) tokens, exceeding the model context limit of \(maximum)"
         case .audioEmbeddingMismatch(let placeholders, let embeddings):
             return "MOSS audio placeholder/embedding mismatch: \(placeholders) placeholders, \(embeddings) embeddings"
         case .missingModelOutput(let name):

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -255,7 +255,7 @@ final class TranscribeCommandTests: XCTestCase {
     func testParsesMossOptions() throws {
         let cmd = try AudioCLI.parseAsRoot([
             "transcribe", "audio.wav", "--engine", "moss",
-            "--model", "fp16", "--max-tokens", "128"
+            "--model", "fp16", "--max-tokens", "128",
         ])
         let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)
         XCTAssertEqual(transcribe.engine, "moss")
@@ -264,7 +264,7 @@ final class TranscribeCommandTests: XCTestCase {
     }
 
     func testMossModelAliasesResolvePublishedBundles() throws {
-        for alias in ["0.6B", "default", "int8"] {
+        for alias in ["0.6B", "0.9B", "default", "int8"] {
             XCTAssertEqual(
                 try resolveMossModelId(alias),
                 "aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-INT8",
@@ -282,6 +282,57 @@ final class TranscribeCommandTests: XCTestCase {
             try resolveMossModelId("org/custom-moss-coreml"),
             "org/custom-moss-coreml"
         )
+    }
+
+    func testMossMLXOptionsAndAliases() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "transcribe", "audio.wav", "--engine", "moss",
+            "--backend", "mlx", "--model", "int5",
+            "--kv-cache", "int8",
+        ])
+        let transcribe = try XCTUnwrap(cmd as? TranscribeCommand)
+        XCTAssertEqual(transcribe.backend, "mlx")
+        XCTAssertEqual(transcribe.kvCache, "int8")
+        XCTAssertNoThrow(try transcribe.validate())
+
+        for alias in ["0.6B", "0.9B", "default", "int5", "5bit"] {
+            XCTAssertEqual(
+                try resolveMossModelId(alias, backend: "mlx"),
+                "aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-5bit"
+            )
+        }
+        XCTAssertEqual(
+            try resolveMossModelId("int8", backend: "mlx"),
+            "aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-INT8"
+        )
+        XCTAssertEqual(
+            try resolveMossModelId("./local-moss-mlx", backend: "mlx"),
+            "./local-moss-mlx"
+        )
+    }
+
+    func testMossMLXRejectsUnsupportedModelAndCache() {
+        XCTAssertThrowsError(try {
+            let cmd = try AudioCLI.parseAsRoot([
+                "transcribe", "audio.wav", "--engine", "moss",
+                "--backend", "mlx", "--model", "fp16",
+            ])
+            try (cmd as? TranscribeCommand)?.validate()
+        }())
+        XCTAssertThrowsError(try {
+            let cmd = try AudioCLI.parseAsRoot([
+                "transcribe", "audio.wav", "--engine", "moss",
+                "--backend", "mlx", "--kv-cache", "int6",
+            ])
+            try (cmd as? TranscribeCommand)?.validate()
+        }())
+        XCTAssertThrowsError(try {
+            let cmd = try AudioCLI.parseAsRoot([
+                "transcribe", "audio.wav", "--engine", "moss",
+                "--backend", "mlx", "--kv-cache", "int4",
+            ])
+            try (cmd as? TranscribeCommand)?.validate()
+        }())
     }
 
     func testMossRejectsUnknownShortModelName() {

--- a/Tests/MossTranscribeTests/E2EMossTranscribeTests.swift
+++ b/Tests/MossTranscribeTests/E2EMossTranscribeTests.swift
@@ -64,6 +64,72 @@ final class E2EMossTranscribeTests: XCTestCase {
         )
     }
 
+    func testMLXINT5RoundTripProducesStructuredTranscript() async throws {
+        try await assertMLXRoundTrip(
+            variant: .int5,
+            localEnvironment: "MOSS_E2E_MLX_INT5_MODEL_DIR"
+        )
+    }
+
+    func testMLXINT8RoundTripProducesStructuredTranscript() async throws {
+        try await assertMLXRoundTrip(
+            variant: .int8,
+            localEnvironment: "MOSS_E2E_MLX_INT8_MODEL_DIR"
+        )
+    }
+
+    func testMLXINT5WeightsWithINT8KVCacheProduceStructuredTranscript()
+        async throws
+    {
+        try await assertMLXINT8KVCache(
+            variant: .int5,
+            localEnvironment: "MOSS_E2E_MLX_INT5_MODEL_DIR"
+        )
+    }
+
+    func testMLXINT8WeightsWithINT8KVCacheProduceStructuredTranscript()
+        async throws
+    {
+        try await assertMLXINT8KVCache(
+            variant: .int8,
+            localEnvironment: "MOSS_E2E_MLX_INT8_MODEL_DIR"
+        )
+    }
+
+    private func assertMLXINT8KVCache(
+        variant: MossMLXVariant,
+        localEnvironment: String
+    ) async throws {
+        let (audio, model) = try await loadMLXFixture(
+            variant: variant,
+            localEnvironment: localEnvironment
+        )
+        let reference =
+            "Can you guarantee that the replacement part will be shipped tomorrow?"
+
+        let result = try model.transcribeDetailed(
+            audio: audio,
+            sampleRate: MossMLXModel.inputSampleRate,
+            options: MossMLXDecodingOptions(
+                kvCachePrecision: .int8
+            )
+        )
+
+        XCTAssertEqual(result.text, reference)
+        XCTAssertEqual(
+            result.segments,
+            [
+                MossTranscriptSegment(
+                    startTime: 5,
+                    endTime: 8.4,
+                    speaker: "S01",
+                    text: reference
+                )
+            ]
+        )
+        XCTAssertEqual(result.metrics.stopReason, .endOfSequence)
+    }
+
     private func assertRoundTrip(
         variant: MossModelVariant,
         localEnvironment: String
@@ -151,5 +217,86 @@ final class E2EMossTranscribeTests: XCTestCase {
                 result.metrics.generatedTokens
             )
         )
+    }
+
+    private func assertMLXRoundTrip(
+        variant: MossMLXVariant,
+        localEnvironment: String
+    ) async throws {
+        let (audio, model) = try await loadMLXFixture(
+            variant: variant,
+            localEnvironment: localEnvironment
+        )
+        let result = try model.transcribeDetailed(
+            audio: audio,
+            sampleRate: MossMLXModel.inputSampleRate
+        )
+        let reference =
+            "Can you guarantee that the replacement part will be shipped tomorrow?"
+        XCTAssertEqual(result.text, reference)
+        XCTAssertEqual(
+            result.segments,
+            [
+                MossTranscriptSegment(
+                    startTime: 5,
+                    endTime: 8.4,
+                    speaker: "S01",
+                    text: reference
+                )
+            ]
+        )
+        XCTAssertEqual(result.metrics.stopReason, .endOfSequence)
+        XCTAssertGreaterThan(result.metrics.promptTokens, 0)
+        XCTAssertGreaterThan(result.metrics.generatedTokens, 0)
+
+        print(
+            String(
+                format:
+                    "[MOSS-MLX-\(variant.rawValue.uppercased())] RTF=%.4f throughput=%.2fx preprocessing=%.3fs encoder=%.3fs prefill=%.3fs decode=%.3fs prompt=%d generated=%d",
+                result.metrics.realTimeFactor,
+                result.metrics.realtimeThroughput,
+                result.metrics.preprocessingSeconds,
+                result.metrics.audioEncoderSeconds,
+                result.metrics.decoderPrefillSeconds,
+                result.metrics.tokenDecodeSeconds,
+                result.metrics.promptTokens,
+                result.metrics.generatedTokens
+            )
+        )
+    }
+
+    private func loadMLXFixture(
+        variant: MossMLXVariant,
+        localEnvironment: String
+    ) async throws -> (audio: [Float], model: MossMLXModel) {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let audioURL = repositoryRoot.appendingPathComponent(
+            "Tests/Qwen3ASRTests/Resources/test_audio.wav"
+        )
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw XCTSkip("shared ASR test_audio.wav is unavailable")
+        }
+        let audio = try AudioFileLoader.load(
+            url: audioURL,
+            targetSampleRate: MossMLXModel.inputSampleRate
+        )
+
+        let model: MossMLXModel
+        if let local = ProcessInfo.processInfo.environment[
+            localEnvironment
+        ] {
+            model = try await MossMLXModel.fromDirectory(
+                URL(fileURLWithPath: local),
+                modelId: "local/MOSS-MLX-\(variant.rawValue.uppercased())"
+            )
+        } else {
+            model = try await MossMLXModel.fromPretrained(
+                variant: variant
+            )
+        }
+        return (audio, model)
     }
 }

--- a/Tests/MossTranscribeTests/MossTranscribeTests.swift
+++ b/Tests/MossTranscribeTests/MossTranscribeTests.swift
@@ -297,3 +297,289 @@ final class MossWhisperFeatureExtractorTests: XCTestCase {
         }
     }
 }
+
+final class MossMLXConfigurationTests: XCTestCase {
+    func testPublishedINT5GeometryValidates() throws {
+        let configuration = try JSONDecoder().decode(
+            MossMLXConfiguration.self,
+            from: Data(
+                """
+                {
+                  "audio_config": {
+                    "hidden_size": 1024,
+                    "intermediate_size": 4096,
+                    "layer_norm_eps": 0.00001,
+                    "max_source_positions": 1500,
+                    "merge_size": 4,
+                    "num_heads": 16,
+                    "num_layers": 24,
+                    "num_mel_bins": 80
+                  },
+                  "audio_token_id": 151671,
+                  "backend": "mlx",
+                  "decoder_config": {
+                    "head_dim": 128,
+                    "hidden_size": 1024,
+                    "intermediate_size": 3072,
+                    "num_heads": 16,
+                    "num_kv_heads": 8,
+                    "num_layers": 28,
+                    "rms_norm_eps": 0.000001,
+                    "rope_theta": 1000000,
+                    "vocab_size": 151936
+                  },
+                  "files": {
+                    "audio_encoder": "audio_encoder.safetensors",
+                    "decoder": "decoder.safetensors"
+                  },
+                  "max_context_tokens": 131072,
+                  "model_type": "moss-transcribe-diarize-mlx",
+                  "precision": "fp16-audio-int5-decoder",
+                  "quantization_config": {
+                    "bits": 5,
+                    "group_size": 64,
+                    "mode": "affine"
+                  }
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertNoThrow(try configuration.validate())
+        XCTAssertEqual(configuration.quantization.bits, 5)
+        XCTAssertEqual(configuration.decoder.layers, 28)
+        XCTAssertEqual(configuration.audio.layers, 24)
+    }
+
+    func testPrecisionMustMatchQuantizationBits() throws {
+        let configuration = try JSONDecoder().decode(
+            MossMLXConfiguration.self,
+            from: Data(
+                """
+                {
+                  "audio_config": {
+                    "hidden_size": 1024,
+                    "intermediate_size": 4096,
+                    "layer_norm_eps": 0.00001,
+                    "max_source_positions": 1500,
+                    "merge_size": 4,
+                    "num_heads": 16,
+                    "num_layers": 24,
+                    "num_mel_bins": 80
+                  },
+                  "audio_token_id": 151671,
+                  "backend": "mlx",
+                  "decoder_config": {
+                    "head_dim": 128,
+                    "hidden_size": 1024,
+                    "intermediate_size": 3072,
+                    "num_heads": 16,
+                    "num_kv_heads": 8,
+                    "num_layers": 28,
+                    "rms_norm_eps": 0.000001,
+                    "rope_theta": 1000000,
+                    "vocab_size": 151936
+                  },
+                  "files": {
+                    "audio_encoder": "audio_encoder.safetensors",
+                    "decoder": "decoder.safetensors"
+                  },
+                  "max_context_tokens": 131072,
+                  "model_type": "moss-transcribe-diarize-mlx",
+                  "precision": "fp16-audio-int8-decoder",
+                  "quantization_config": {
+                    "bits": 5,
+                    "group_size": 64,
+                    "mode": "affine"
+                  }
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertThrowsError(try configuration.validate())
+    }
+
+    func testUnsupportedQuantizationIsRejected() throws {
+        let configuration = try JSONDecoder().decode(
+            MossMLXConfiguration.self,
+            from: Data(
+                """
+                {
+                  "audio_config": {
+                    "hidden_size": 1024,
+                    "intermediate_size": 4096,
+                    "layer_norm_eps": 0.00001,
+                    "max_source_positions": 1500,
+                    "merge_size": 4,
+                    "num_heads": 16,
+                    "num_layers": 24,
+                    "num_mel_bins": 80
+                  },
+                  "audio_token_id": 151671,
+                  "backend": "mlx",
+                  "decoder_config": {
+                    "head_dim": 128,
+                    "hidden_size": 1024,
+                    "intermediate_size": 3072,
+                    "num_heads": 16,
+                    "num_kv_heads": 8,
+                    "num_layers": 28,
+                    "rms_norm_eps": 0.000001,
+                    "rope_theta": 1000000,
+                    "vocab_size": 151936
+                  },
+                  "files": {
+                    "audio_encoder": "audio_encoder.safetensors",
+                    "decoder": "decoder.safetensors"
+                  },
+                  "model_type": "moss-transcribe-diarize-mlx",
+                  "precision": "invalid",
+                  "quantization_config": {
+                    "bits": 7,
+                    "group_size": 64,
+                    "mode": "affine"
+                  }
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertThrowsError(try configuration.validate())
+    }
+
+    func testUnexpectedWeightPathIsRejected() throws {
+        let configuration = try JSONDecoder().decode(
+            MossMLXConfiguration.self,
+            from: Data(
+                """
+                {
+                  "audio_config": {
+                    "hidden_size": 1024,
+                    "intermediate_size": 4096,
+                    "layer_norm_eps": 0.00001,
+                    "max_source_positions": 1500,
+                    "merge_size": 4,
+                    "num_heads": 16,
+                    "num_layers": 24,
+                    "num_mel_bins": 80
+                  },
+                  "audio_token_id": 151671,
+                  "backend": "mlx",
+                  "decoder_config": {
+                    "head_dim": 128,
+                    "hidden_size": 1024,
+                    "intermediate_size": 3072,
+                    "num_heads": 16,
+                    "num_kv_heads": 8,
+                    "num_layers": 28,
+                    "rms_norm_eps": 0.000001,
+                    "rope_theta": 1000000,
+                    "vocab_size": 151936
+                  },
+                  "files": {
+                    "audio_encoder": "/tmp/audio_encoder.safetensors",
+                    "decoder": "decoder.safetensors"
+                  },
+                  "max_context_tokens": 131072,
+                  "model_type": "moss-transcribe-diarize-mlx",
+                  "precision": "fp16-audio-int5-decoder",
+                  "quantization_config": {
+                    "bits": 5,
+                    "group_size": 64,
+                    "mode": "affine"
+                  }
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertThrowsError(try configuration.validate())
+    }
+}
+
+final class MossMLXMemoryTests: XCTestCase {
+    func testNinetyMinuteCacheEstimatesSeparateCachePrecision() {
+        let tokens = 67_500
+
+        XCTAssertEqual(
+            MossMLXCacheMemory.estimatedBytes(
+                tokenCount: tokens,
+                precision: .float16
+            ),
+            7_741_440_000
+        )
+        XCTAssertEqual(
+            MossMLXCacheMemory.estimatedBytes(
+                tokenCount: tokens,
+                precision: .int8
+            ),
+            4_112_640_000
+        )
+    }
+
+    func testMLXVariantRepositoriesAndDefaults() {
+        XCTAssertEqual(MossMLXVariant.int5.quantizationBits, 5)
+        XCTAssertEqual(MossMLXVariant.int8.quantizationBits, 8)
+        XCTAssertTrue(
+            MossMLXVariant.int5.modelId.hasSuffix("MLX-5bit")
+        )
+        XCTAssertTrue(
+            MossMLXVariant.int8.modelId.hasSuffix("MLX-INT8")
+        )
+
+        let options = MossMLXDecodingOptions()
+        XCTAssertEqual(options.maxTokens, 5_120)
+        XCTAssertEqual(options.encoderBatchSize, 4)
+        XCTAssertEqual(options.prefillChunkSize, 512)
+        XCTAssertEqual(options.kvCachePrecision, .float16)
+    }
+}
+
+final class MossDiarizationBridgeTests: XCTestCase {
+    func testAnonymousLabelsBecomeContiguousAndClampToAudio() {
+        let transcription = MossTranscription(
+            rawText: "",
+            text: "",
+            segments: [
+                MossTranscriptSegment(
+                    startTime: 0.5,
+                    endTime: 2,
+                    speaker: "S03",
+                    text: "one"
+                ),
+                MossTranscriptSegment(
+                    startTime: 1.5,
+                    endTime: 4,
+                    speaker: "S01",
+                    text: "two"
+                ),
+                MossTranscriptSegment(
+                    startTime: 3,
+                    endTime: 6,
+                    speaker: "S03",
+                    text: "three"
+                ),
+            ],
+            metrics: MossTranscriptionMetrics(
+                preprocessingSeconds: 0,
+                audioEncoderSeconds: 0,
+                decoderPrefillSeconds: 0,
+                tokenDecodeSeconds: 0,
+                totalSeconds: 0,
+                audioDurationSeconds: 5,
+                promptTokens: 0,
+                generatedTokens: 0,
+                stopReason: .endOfSequence
+            )
+        )
+
+        let segments = transcription.diarizedSegments(
+            audioDuration: 5
+        )
+
+        XCTAssertEqual(segments.count, 3)
+        XCTAssertEqual(segments.map(\.speakerId), [0, 1, 0])
+        XCTAssertEqual(segments[2].endTime, 5)
+    }
+}

--- a/docs/benchmarks/asr-wer.md
+++ b/docs/benchmarks/asr-wer.md
@@ -77,6 +77,20 @@ The full methodology, per-run variance, exact round-trip assertion, and
 reproduction commands are recorded in
 [MOSS CoreML Native Runtime Benchmark](moss-coreml.md).
 
+### MOSS long-context MLX runtime
+
+The matched self-exported `moss-mlx-int5` and `moss-mlx-int8` bundles use the
+same FP16 audio/VQ weights and FP16 KV cache; only decoder weight precision
+changes. On the same 80-clip, 759.56-second English FLEURS fixture, INT5
+recorded 8.55% aggregate WER, 6.36% CER, and 0.028 overall RTF. INT8 recorded
+8.27% WER, 5.98% CER, and 0.032 RTF. Peak RSS was 1,196 MiB for INT5 and
+1,407 MiB for INT8.
+
+The separate five-file VoxConverse comparison measured 28.05% DER for INT5
+and 28.02% for INT8. See
+[MOSS MLX INT5 vs INT8 Benchmark](moss-mlx.md) for the long-context
+diarization results, weight sizes, caveats, and reproduction commands.
+
 ## Comparison with published models
 
 | Model | Params | Size | Precision | WER% (test-clean) | Source |
@@ -181,6 +195,8 @@ Available engine IDs (see `Sources/AsrBenchmark/Engine.swift::EngineID`):
 - `whisper-asr-turbo` — speech-swift native WhisperASR CoreML runtime over `aufklarer/Whisper-Large-v3-Turbo-CoreML`
 - `moss-coreml-int8` — native MOSS CoreML runtime with an FP16 audio encoder and block-32 INT8 decoder
 - `moss-coreml-fp16` — native MOSS CoreML FP16 reference
+- `moss-mlx-int5` — long-context MOSS MLX runtime with FP16 audio/VQ weights and an affine group-64 INT5 decoder
+- `moss-mlx-int8` — long-context MOSS MLX quality reference with an affine group-64 INT8 decoder
 - `whisperkit-large-v3-turbo` / `whisperkit-large-v3` / `whisperkit-distil-large-v3` — Argmax WhisperKit
 
 Without `--isolated`, peak RSS reflects the sequential high-water mark across the whole run (MLX/CoreML caches don't release between engines). With `--isolated`, each engine runs in a child process and its peak RSS is its own.

--- a/docs/benchmarks/moss-mlx.md
+++ b/docs/benchmarks/moss-mlx.md
@@ -1,0 +1,127 @@
+# MOSS MLX INT5 vs INT8 Benchmark
+
+## Recommendation
+
+Use `moss-mlx-int5` by default. Against the matched INT8 export it reduced the
+two weight files from 1,200.1 MiB to 987.0 MiB, lowered peak RSS by about
+211–217 MiB, and ran faster. English aggregate WER increased by 0.28
+percentage points. Aggregate diarization error on the five-file slice was
+effectively unchanged: 28.05% DER for INT5 versus 28.02% for INT8.
+
+Use `moss-mlx-int8` when the small measured ASR-quality advantage matters more
+than decoder size and memory.
+
+## Controlled setup
+
+- Date: 2026-07-24
+- Machine: MacBook Pro, Apple M5 Pro (18 cores), 48 GB unified memory
+- Build: release, compiled MLX Metal library
+- Source checkpoint:
+  `OpenMOSS-Team/MOSS-Transcribe-Diarize` at
+  `e6d68cdfcddbdad1a7e8454f0cb859cad76e2502`
+- Audio encoder and VQ adaptor: identical FP16 weights
+- Decoder: affine group-64 INT5 or INT8
+- Decode: greedy
+- KV cache: FP16 for both variants
+- Each engine: separate process, one benchmark at a time
+
+The comparison isolates decoder weight precision. It does not compare
+quantized KV-cache quality. A separate short-fixture integration check found
+that INT8 cache preserved the exact structured transcript. INT4 cache dropped
+timestamp structure and repeated a word, so the runtime does not expose it.
+
+## ASR
+
+The ASR fixture contains the first 80 English-US test clips from
+[`google/fleurs`](https://huggingface.co/datasets/google/fleurs), 759.56
+seconds of audio and 1,813 reference words.
+
+| Variant | Aggregate WER | CER | Overall ×RT | Elapsed | Peak RSS |
+|---|---:|---:|---:|---:|---:|
+| INT5 | 8.55% | 6.36% | 35.2× | 21.60 s | 1,196 MiB |
+| INT8 | **8.27%** | **5.98%** | 31.6× | 24.04 s | 1,407 MiB |
+
+INT5 changed the aggregate error counts from 150 to 155 word errors. On this
+fixture, the 213 MiB smaller decoder is a measurable speed and memory win with
+a small ASR-quality cost.
+
+## Speaker diarization
+
+The diarization fixture contains five recordings from the CC-BY-4.0
+[`ggfox00000/dia-voxconverse-test`](https://huggingface.co/datasets/ggfox00000/dia-voxconverse-test)
+mirror of VoxConverse v0.3 (`aepyx`, `aggyz`, `aiqwk`, `aorju`, `auzru`),
+totaling 2,346.56 seconds. The files contain 4, 13, 7, 12, and 8 reference
+speakers. Scoring uses a 0.25-second collar and 10 ms resolution.
+
+This is not the Community-1 five-file development slice used in
+[`moss-coreml.md`](moss-coreml.md); the two DER figures are not directly
+comparable.
+
+| Variant | DER | JER | Miss | False alarm | Speaker error | Count accuracy | Overall ×RT | Peak RSS |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| INT5 | 28.05% | 26.56% | 22.96% | **0.93%** | 4.16% | **40%** | **15.5×** | **1,281 MiB** |
+| INT8 | **28.02%** | **25.79%** | 23.14% | 1.25% | **3.62%** | 20% | 11.8× | 1,498 MiB |
+
+| Reference speakers | INT5 DER | INT8 DER |
+|---:|---:|---:|
+| 4 | 6.95% | 6.97% |
+| 7 | **24.32%** | 30.52% |
+| 8 | **7.81%** | 8.11% |
+| 12 | 46.55% | **45.40%** |
+| 13 | 3.18% | 3.18% |
+
+The pooled DER difference is 0.03 percentage points, which is not meaningful
+on five files. Quantization changed individual decoding trajectories: INT5 was
+better on the 7-speaker recording and worse on the 12-speaker recording. The
+12-speaker, 20-minute file dominates both aggregates through missed speech.
+
+This slice validates multi-chunk global-context execution but is too small for
+a general diarization-quality claim. A full VoxConverse run and multilingual
+speaker-attributed transcription evaluation remain needed.
+
+## Weight export
+
+| Artifact | INT5 | INT8 |
+|---|---:|---:|
+| `audio_encoder.safetensors` | 596.0 MiB | 596.0 MiB |
+| `decoder.safetensors` | 391.0 MiB | 604.1 MiB |
+| Combined | 987.0 MiB | 1,200.1 MiB |
+| Validation cosine | 0.99897182 | 0.99998456 |
+| Validation max absolute error | 0.02246094 | 0.00268555 |
+
+The self-exported INT8 bundle was compared tensor by tensor with the earlier
+published INT8 bundle: all 373 audio tensors and all 704 exported decoder
+tensors were equal. File hashes differ because safetensors header ordering and
+metadata serialization differ.
+
+## Reproduce
+
+Prepare the FLEURS manifest:
+
+```bash
+python3.11 scripts/prepare_fleurs_asr_manifest.py \
+  --fleurs-dir /path/to/fleurs/en_us \
+  --output /path/to/fleurs-en-us-80.tsv \
+  --limit 80
+```
+
+Run each engine separately:
+
+```bash
+MOSS_MLX_INT5_MODEL_DIR=/path/to/int5 \
+.build/release/asr-bench \
+  --dataset /path/to/fleurs-en-us-80.tsv \
+  --engines moss-mlx-int5 \
+  --output moss-int5-asr.json
+
+MOSS_MLX_INT8_MODEL_DIR=/path/to/int8 \
+.build/release/diarization-bench \
+  --manifest /path/to/voxconverse.tsv \
+  --engines moss-mlx-int8 \
+  --collar 0.25 \
+  --resolution 0.01 \
+  --output moss-int8-diarization.json
+```
+
+Repeat the commands with the other engine. Do not overlap model-loading
+benchmarks; separate processes are required for comparable peak memory.

--- a/docs/inference/moss-transcribe-diarize.md
+++ b/docs/inference/moss-transcribe-diarize.md
@@ -1,153 +1,201 @@
 # MOSS Transcribe Diarize Inference
 
-## Overview
+## Choose a backend
 
 ```text
 Audio
   -> 16 kHz mono
   -> native Whisper log-mel frontend
-  -> Core ML audio encoder
-  -> audio-aware MOSS prompt
-  -> stateful Core ML decoder
+  -> 30-second audio-encoder chunks
+  -> one audio-aware MOSS prompt
+  -> autoregressive Qwen3 decoder
   -> timestamped speaker segments + plain text
 ```
 
-The `MossTranscribe` target is a native Swift/Core ML runtime. It does not
-invoke Python, ONNX Runtime, or MLX during inference.
+Use MLX for the upstream 128K long-context behavior. Use Core ML for short
+recordings where Neural Engine execution and its fixed 1,024-token state are
+more important.
+
+Both paths are offline. `--stream` is rejected because MOSS needs the complete
+recording before it can assemble the global prompt and begin transcript
+generation. A live microphone workflow should use a streaming ASR model and a
+separate online diarization strategy instead.
 
 ## CLI
 
-INT8 is the default MOSS variant:
+Core ML INT8 remains the default for compatibility:
 
 ```bash
 .build/release/speech transcribe recording.wav --engine moss
+.build/release/speech transcribe recording.wav \
+  --engine moss --backend coreml --model fp16
 ```
 
-Select the FP16 reference or a custom compatible repository:
+Select the long-context MLX runtime. INT5 is the MLX default:
 
 ```bash
-.build/release/speech transcribe recording.wav \
-  --engine moss --model fp16
-
-.build/release/speech transcribe recording.wav \
+.build/release/speech transcribe meeting.wav \
   --engine moss \
-  --model organization/custom-moss-coreml \
-  --max-tokens 768
+  --backend mlx
+
+.build/release/speech transcribe meeting.wav \
+  --engine moss \
+  --backend mlx \
+  --model int8
 ```
 
-The command prints the plain transcript, timestamped speaker segments, elapsed
-time, real-time factor, and realtime throughput. `--stream` is rejected because
-this runtime currently performs batch decoding.
+`--model` also accepts a Hugging Face repository ID or a local bundle
+directory:
+
+```bash
+.build/release/speech transcribe meeting.wav \
+  --engine moss \
+  --backend mlx \
+  --model /path/to/MOSS-Transcribe-Diarize-0.9B-MLX-5bit
+```
+
+MLX generates at most 5,120 transcript tokens by default; Core ML defaults to
+512. Increase the MLX limit for a dense long recording while keeping the
+combined 131,072-token context in mind:
+
+```bash
+.build/release/speech transcribe meeting.wav \
+  --engine moss \
+  --backend mlx \
+  --max-tokens 16384
+```
 
 ## Swift API
 
 ```swift
 import MossTranscribe
 
-let model = try await MossTranscribeModel.fromPretrained(
-    variant: .int8)
+let model = try await MossMLXModel.fromPretrained(variant: .int5)
 try model.warmUp()
 
+let options = MossMLXDecodingOptions(
+    maxTokens: 5_120,
+    encoderBatchSize: 4,
+    prefillChunkSize: 512,
+    kvCachePrecision: .float16
+)
 let result = try model.transcribeDetailed(
     audio: samples,
-    sampleRate: 48_000)
+    sampleRate: 48_000,
+    options: options
+)
 
 print(result.text)
 for segment in result.segments {
     print(segment.startTime, segment.endTime, segment.speaker, segment.text)
 }
-print(result.metrics.realTimeFactor)
 ```
 
-Use `.fp16` for the FP16 decoder:
+Use `.int8` for the MLX quality reference:
 
 ```swift
-let reference = try await MossTranscribeModel.fromPretrained(
-    variant: .fp16)
+let reference = try await MossMLXModel.fromPretrained(variant: .int8)
 ```
 
-`fromDirectory` loads a freshly exported or already downloaded bundle without
-contacting Hugging Face:
+Load a self-exported directory without network access:
 
 ```swift
-let local = try await MossTranscribeModel.fromDirectory(
-    URL(fileURLWithPath: "/path/to/moss-coreml"))
+let local = try await MossMLXModel.fromDirectory(
+    URL(fileURLWithPath: "/path/to/moss-mlx")
+)
 ```
+
+The existing `MossTranscribeModel` API remains the Core ML path.
+
+## What “single pass” means
+
+The encoder still operates on Whisper-sized 30-second chunks. The MLX runtime
+does not transcribe those chunks independently:
+
+1. It encodes chunks in bounded batches.
+2. It concatenates every resulting audio embedding in chronological order.
+3. It prefills the decoder with one prompt containing the complete recording.
+4. It generates one timestamped, speaker-attributed transcript
+   autoregressively.
+
+This provides global speaker context across the recording. It does not mean
+all text tokens are produced simultaneously, and it does not provide partial
+results while audio is arriving.
+
+## Context and memory
+
+Audio consumes 12.5 context tokens per second. Ninety minutes is about 67,500
+audio tokens before prompt and output tokens. Approximate KV-cache storage at
+that audio-token count is:
+
+| KV cache | Estimated storage |
+|---|---:|
+| FP16 | 7.74 GB |
+| INT8 affine | 4.11 GB |
+
+These analytical values cover the 28 decoder layers' key/value tensors and
+affine metadata; model weights, audio embeddings, temporary tensors, allocator
+overhead, and generated transcript tokens are additional.
+
+Use FP16 cache for highest fidelity and for INT5/INT8 weight comparisons.
+Select a lower-memory cache independently:
+
+```bash
+.build/release/speech transcribe meeting.wav \
+  --engine moss \
+  --backend mlx \
+  --kv-cache int8
+```
+
+INT8 cache preserved the exact structured short-fixture transcript in E2E
+validation. INT4 cache is intentionally not exposed: it dropped timestamp
+structure and repeated a word on that same quality gate. Long-form INT8-cache
+quality has not yet been included in the published INT5/INT8 comparison.
 
 ## Structured output
 
 `MossTranscription` contains:
 
-- `rawText`: the decoded upstream timestamp/speaker wire format;
+- `rawText`: the generated `[start][Sxx]text[end]` form;
 - `text`: plain text formed from valid segments;
 - `segments`: `[MossTranscriptSegment]`;
-- `metrics`: preprocessing, encoder, prefill, decode, total time, token counts,
-  RTF, throughput, and stop reason.
+- `metrics`: preprocessing, encoder, prefill, decode, token counts, total time,
+  RTF, and stop reason.
 
-The default instruction requests `[start][Sxx] text [end]` segments. A custom
-instruction can be supplied to `transcribeDetailed`, but changing the output
-contract may leave `segments` empty; `rawText` and `text` still preserve the
-model output.
-
-## Warm-up
-
-`warmUp()` specializes the audio encoder, 128-token prefill, and one-token
-decode paths. It also preloads the fixed prompt embeddings. Call it once during
-application initialization when first-request latency matters.
-
-Core ML caches compiled execution plans on disk. The first run after changing a
-model or compute-unit policy may therefore take longer than subsequent process
-launches.
-
-## Audio and context limits
-
-- Input is resampled to 16 kHz mono Float32.
-- The frontend emits one fixed `[80, 3000]` feature tensor per at-most-30-second
-  encoder chunk.
-- Audio produces 12.5 decoder embeddings per second.
-- The stateful decoder has a fixed 1024-token cache shared by the prompt and
-  generated output.
-
-Longer input consumes more of the decoder cache and leaves fewer generation
-tokens. If the audio prompt itself exceeds 1024 tokens, the call fails with
-`promptTooLong` instead of truncating audio silently.
-
-## Cache and offline use
-
-Models use the standard speech-swift cache. Once downloaded:
-
-```swift
-let model = try await MossTranscribeModel.fromPretrained(
-    variant: .int8,
-    offlineMode: true)
-```
-
-The runtime checks the compiled Core ML files, decoder configuration, tokenizer,
-host contract, and exact Whisper frontend configuration before loading.
+`diarizedSegments(audioDuration:)` converts anonymous speaker strings to
+contiguous integer speaker IDs for `AudioCommon` consumers and the
+diarization benchmark.
 
 ## Benchmarking
 
-Both variants are registered in `asr-bench`:
+MLX engines are registered in both benchmark binaries:
 
 ```bash
 .build/release/asr-bench \
   --dataset english.tsv \
-  --engines moss-coreml-int8 moss-coreml-fp16 \
-  --isolated \
-  --output moss.json
+  --engines moss-mlx-int5 moss-mlx-int8 \
+  --output moss-mlx-asr.json
+
+.build/release/diarization-bench \
+  --manifest voxconverse.tsv \
+  --engines moss-mlx-int5 moss-mlx-int8 \
+  --collar 0.25 \
+  --output moss-mlx-diarization.json
 ```
 
-Use an isolated release build for publishable RSS numbers. The current matched
-results and reproduction details are in
-[MOSS CoreML benchmark](../benchmarks/moss-coreml.md).
+Run engines in separate processes for publishable peak-memory numbers. Local
+bundles can be selected with `MOSS_MLX_INT5_MODEL_DIR` and
+`MOSS_MLX_INT8_MODEL_DIR`.
+
+See [MOSS MLX benchmark](../benchmarks/moss-mlx.md) for matched results and
+[MOSS model architecture](../models/moss-transcribe-diarize.md) for export
+details.
 
 ## Current scope
 
 - Greedy decoding only; no beam search or temperature fallback.
-- Timestamped speaker segments are model-generated, not a separate diarization
-  pipeline.
-- Batch inference only.
-- The 1024-token decoder context is the hard combined prompt/output limit.
-
-See [MOSS model architecture](../models/moss-transcribe-diarize.md) for the
-export layout and quantization profile.
+- Model-generated timestamps and speaker labels, not a separate diarizer.
+- Offline batch inference only; no published streaming checkpoint for this
+  MOSS model.
+- 131,072 combined prompt/output tokens for MLX.
+- 1,024 combined prompt/output tokens for Core ML.

--- a/docs/models/moss-transcribe-diarize.md
+++ b/docs/models/moss-transcribe-diarize.md
@@ -1,86 +1,127 @@
-# MOSS Transcribe Diarize CoreML
+# MOSS Transcribe Diarize
 
-`MossTranscribe` is the native speech-swift runtime for
-MOSS-Transcribe-Diarize 0.9B. It produces transcription text together with
-speaker labels and segment timestamps. Audio preprocessing, prompt assembly,
-state management, decoding, and output parsing are implemented in Swift; the
-audio encoder and decoder run directly through Core ML.
+`MossTranscribe` runs MOSS-Transcribe-Diarize 0.9B natively on Apple
+Silicon. It jointly generates transcript text, timestamps, and anonymous
+speaker labels such as `[S01]`; it is not an ASR model followed by a separate
+speaker clustering pipeline.
 
-## Model layout
+speech-swift provides two execution backends:
+
+| Backend | Context | Weights | Intended use |
+|---|---:|---|---|
+| MLX | 131,072 dynamic tokens | FP16 audio/VQ + affine INT5 or INT8 decoder | Long-form, globally contextualized offline transcription |
+| Core ML | 1,024 fixed tokens | FP16 audio + block-32 INT8 or FP16 decoder | Short recordings and Neural Engine execution |
+
+The upstream model and both speech-swift backends are offline and
+autoregressive. No streaming checkpoint is published for this MOSS model: the
+complete recording must be available before transcript generation begins, and
+no partial transcript is emitted while recording.
+
+## Architecture
 
 | Component | Shape / configuration | Purpose |
 |---|---|---|
-| Whisper frontend | 16 kHz, 80 mel bins, 400-point FFT, 160-sample hop | Audio to `[1, 80, 3000]` log-mel features |
-| Audio encoder | FP16 input/output, 30 s fixed input | Mel features to 12.5 audio embeddings per second |
-| Token embedding | Core ML multifunction entry point | Token IDs to 1024-dimensional embeddings |
-| Stateful decoder | 28 layers, 1024 hidden, 16 attention heads, 8 KV heads | Prompt prefill and greedy generation |
-| KV state | 1024-token context | Shared state across prefill and one-token decode calls |
-| Vocabulary | 151,936 tokens | Qwen tokenizer plus MOSS audio special tokens |
+| Whisper frontend | 16 kHz, 80 mel bins, 400-point FFT, 160-sample hop | Audio to fixed 30-second log-mel chunks |
+| Whisper encoder | 24 layers, 1,024 hidden, 16 heads | Each chunk to contextual audio features |
+| VQ adaptor | merge size 4 | 12.5 decoder audio embeddings per second |
+| Qwen3 decoder | 28 layers, 1,024 hidden, 16 query heads, 8 KV heads | Greedy speaker-attributed transcript generation |
+| Vocabulary | 151,936 tokens | Qwen tokenizer plus MOSS audio tokens |
+| MLX context | 131,072 combined prompt/output tokens | Dynamic long-context KV cache |
 
-The decoder bundle exposes `embedding` and `decoder` functions from the same
-compiled Core ML model, so both entry points share the exported weight file.
-The runtime uses `FastPrediction` specialization and `.all` compute units.
+For MLX, the encoder processes non-overlapping 30-second chunks in bounded
+batches. All adapted audio embeddings are then concatenated into one prompt.
+The decoder therefore sees the recording as one global context rather than
+independently transcribing and stitching windows.
 
-## Published variants
+At 12.5 audio tokens per second, 90 minutes uses about 67,500 audio tokens.
+The remaining context must hold instructions, time markers, and generated
+transcript tokens. The upstream 90-minute figure is therefore a model
+capability, not a fixed host guarantee: available unified memory, KV-cache
+precision, transcript length, and content determine the practical limit.
 
-| Variant | Audio encoder | Decoder | Bundle size | Recommended use |
-|---|---|---|---:|---|
-| `int8` (default) | FP16 | Symmetric linear INT8, block size 32 | 1.2 GB | Best speed and memory |
-| `fp16` | FP16 | FP16 | 1.7 GB | FP16 reference |
+## MLX quantization
 
-The INT8 profile quantizes the homogeneous decoder linear layers while keeping
-the audio encoder and decoder I/O in FP16. On the matched native benchmark it
-retains the same aggregate English WER as FP16, runs about 11% faster when the
-two order-reversed runs are pooled, and lowers sampled peak RSS by about 36%.
-See [MOSS CoreML benchmark](../benchmarks/moss-coreml.md).
+The reproducible exporter keeps all 312,463,360 Whisper/VQ parameters in FP16
+and quantizes the 596,049,920 tied Qwen3 decoder parameters with MLX affine
+group-64 quantization. No training or fine-tuning is performed.
 
-## Prompt and timestamps
+| MLX variant | Decoder | Audio weights | Decoder weights | Total weights | Default |
+|---|---|---:|---:|---:|---|
+| `int5` | Affine INT5, group 64 | 596.0 MiB | 391.0 MiB | 987.0 MiB | Yes, for MLX |
+| `int8` | Affine INT8, group 64 | 596.0 MiB | 604.1 MiB | 1,200.1 MiB | Quality reference |
+
+Decoder weight precision and KV-cache precision are independent. Matched
+INT5/INT8 quality comparisons use the same FP16 audio weights and FP16 KV
+cache. Quantizing the cache to INT8 further lowers long-context memory but
+introduces another quality variable.
+
+The matched measurements show a small English ASR advantage for INT8 and
+effectively equal aggregate diarization error on the five-file test slice.
+INT5 is the recommended MLX default because it is smaller, uses less peak
+memory, and was faster in both runs. See
+[MOSS MLX benchmark](../benchmarks/moss-mlx.md).
+
+## Prompt and output
 
 MOSS represents audio with `<|audio_start|>`, repeated `<|audio_pad|>`
-positions, and `<|audio_end|>`. The runtime injects the audio encoder output at
-the placeholder positions. It also inserts numeric time markers every five
-seconds, matching the published processor.
+positions, and `<|audio_end|>`. Numeric time markers are inserted every five
+seconds, matching the upstream processor.
 
-The expected decoded form is:
+The canonical decoded form is:
 
 ```text
-[5.00][S01] Can you guarantee that the replacement part will be shipped tomorrow?[8.40]
+[5.00][S01]Can you guarantee that the replacement part will be shipped tomorrow?[8.40]
 ```
 
-`MossTranscriptParser` returns both the plain text and structured
-`MossTranscriptSegment` values. If the model emits malformed structure, the
-raw decoded text remains visible instead of being silently discarded.
+`MossTranscriptParser` preserves the raw generated form and returns both plain
+text and `MossTranscriptSegment` values. Speaker labels are anonymous within a
+recording and are not persistent identities.
 
-## Native runtime responsibilities
+## Languages
 
-`Sources/MossTranscribe/` implements:
+The upstream model card claims transcription and diarization across 50+
+languages but does not publish an exhaustive language list. Publicly named
+evidence includes Mandarin Chinese plus English, French, German, Italian,
+Portuguese, Spanish, Japanese, Korean, Russian, Thai, Vietnamese, Tagalog,
+Urdu, and Turkish. Treat the 50+ figure as an upstream capability claim and
+validate the target language, accents, speaker count, and acoustic domain.
 
-- exact Hugging Face Whisper log-mel preprocessing with Accelerate;
-- model-bundle and processor-contract validation;
-- time-marker and chat-prompt construction;
-- audio-embedding injection;
-- 128-token decoder prefill plus one-token stateful decode;
-- bounded token-embedding caching;
-- greedy argmax generation and end-token handling;
-- timestamp/speaker parsing and per-stage timing metrics.
+The speech-swift quantization comparison currently measures English ASR and an
+English VoxConverse diarization slice; it does not establish quality parity
+for every upstream language.
 
-The frontend is numerically regression-tested against pinned Hugging Face
-fixtures. The tokenizer prompt IDs are also pinned against the exporter
-reference.
+## Export and model weights
 
-## Model weights
+Run the pinned exporter with Python MLX:
 
-- [aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-INT8](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-INT8)
-- [aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-FP16](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-FP16)
-- Source model:
-  [OpenMOSS-Team/MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize)
+```bash
+python3.11 scripts/export_moss_mlx.py \
+  --bits 5 \
+  --output /path/to/MOSS-Transcribe-Diarize-0.9B-MLX-5bit
 
-## Platform and concurrency
+python3.11 scripts/export_moss_mlx.py \
+  --bits 8 \
+  --output /path/to/MOSS-Transcribe-Diarize-0.9B-MLX-INT8
+```
 
-- Minimum deployment: macOS 15 or iOS 18.
-- A model instance serializes inference because its embedding cache and Core ML
-  stateful decoder are not re-entrant.
-- Create separate model instances when concurrent transcription is required.
-- The fixed 1024-token decoder context limits the combined audio prompt and
-  generated transcript. The runtime processes audio in 30-second encoder
-  chunks and rejects prompts that exceed that context.
+The exporter pins source revision
+`e6d68cdfcddbdad1a7e8454f0cb859cad76e2502`, validates the expected tensor
+counts and architecture, writes artifact checksums, verifies a dequantized
+reference tensor, copies the exact tokenizer/processor assets, and includes
+the Apache 2.0 license.
+
+Published model repositories used by the runtime:
+
+- [MLX INT5](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-5bit)
+- [MLX INT8](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-INT8)
+- [Core ML INT8](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-INT8)
+- [Core ML FP16](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-CoreML-FP16)
+- [Upstream model](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize)
+- [Technical report](https://arxiv.org/abs/2601.01554)
+
+## License and platform
+
+MOSS-Transcribe-Diarize and the converted weight bundles use Apache License
+2.0. The speech-swift runtime supports macOS 15+ and iOS 18+ on Apple Silicon.
+A model instance serializes inference; use separate instances only when the
+additional model and cache memory is acceptable.

--- a/scripts/export_moss_mlx.py
+++ b/scripts/export_moss_mlx.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Export MOSS-Transcribe-Diarize weights to a native MLX bundle.
+
+The audio encoder and VQ adaptor remain FP16. The tied Qwen3 decoder is
+quantized with MLX affine group quantization so INT5 and INT8 differ only in
+decoder weight precision. Runtime assets are copied from the exact pinned
+source revision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+from huggingface_hub import snapshot_download
+
+
+DEFAULT_SOURCE_MODEL = "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+DEFAULT_SOURCE_REVISION = "e6d68cdfcddbdad1a7e8454f0cb859cad76e2502"
+DEFAULT_REPOSITORIES = {
+    5: "aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-5bit",
+    8: "aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-INT8",
+}
+WEIGHT_PATTERN = "model-*.safetensors"
+RUNTIME_ASSETS = [
+    "added_tokens.json",
+    "chat_template.jinja",
+    "generation_config.json",
+    "merges.txt",
+    "preprocessor_config.json",
+    "processing_moss_transcribe_diarize.py",
+    "processor_config.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json",
+]
+GENERATED_FILES = [
+    ".gitattributes",
+    "LICENSE",
+    "README.md",
+    "audio_encoder.safetensors",
+    "config.json",
+    "decoder.safetensors",
+    "export_config.json",
+    "source_config.json",
+    "validation.json",
+    *RUNTIME_ASSETS,
+]
+EXPECTED_AUDIO_TENSORS = 373
+EXPECTED_DECODER_SOURCE_TENSORS = 310
+EXPECTED_DECODER_MATRICES = 197
+VALIDATION_TENSOR = "layers.0.self_attn.q_proj.weight"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export the pinned MOSS 0.9B checkpoint to an MLX bundle with "
+            "an FP16 audio frontend and affine INT5 or INT8 decoder."
+        )
+    )
+    parser.add_argument(
+        "--bits",
+        type=int,
+        choices=(5, 8),
+        required=True,
+        help="Decoder weight precision.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination directory for the complete MLX bundle.",
+    )
+    parser.add_argument(
+        "--source-model",
+        default=DEFAULT_SOURCE_MODEL,
+        help="Hugging Face source repository.",
+    )
+    parser.add_argument(
+        "--source-revision",
+        default=DEFAULT_SOURCE_REVISION,
+        help="Immutable source commit.",
+    )
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        help="Use an already downloaded source snapshot instead of downloading.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        help="Optional huggingface_hub cache directory.",
+    )
+    parser.add_argument(
+        "--repo-id",
+        help="Repository ID recorded in metadata and the generated model card.",
+    )
+    parser.add_argument(
+        "--group-size",
+        type=int,
+        default=64,
+        choices=(32, 64, 128),
+        help="MLX affine quantization group size (default: 64).",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace known generated files in an existing output directory.",
+    )
+    return parser.parse_args()
+
+
+def json_dump(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def prepare_output(directory: Path, overwrite: bool) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    existing = [
+        directory / name
+        for name in GENERATED_FILES
+        if (directory / name).exists()
+    ]
+    if existing and not overwrite:
+        names = ", ".join(path.name for path in existing[:5])
+        raise RuntimeError(
+            f"{directory} already contains generated files ({names}); "
+            "pass --overwrite to replace this bundle"
+        )
+    if overwrite:
+        for path in existing:
+            if path.is_file() or path.is_symlink():
+                path.unlink()
+
+
+def resolve_source(args: argparse.Namespace) -> Path:
+    if args.source_dir:
+        source = args.source_dir.expanduser().resolve()
+    else:
+        allow_patterns = [
+            WEIGHT_PATTERN,
+            "config.json",
+            "model.safetensors.index.json",
+            *RUNTIME_ASSETS,
+        ]
+        source = Path(
+            snapshot_download(
+                repo_id=args.source_model,
+                revision=args.source_revision,
+                cache_dir=(
+                    str(args.cache_dir.expanduser())
+                    if args.cache_dir
+                    else None
+                ),
+                allow_patterns=allow_patterns,
+            )
+        )
+    required = [
+        source / "config.json",
+        source / "model.safetensors.index.json",
+        *[source / name for name in RUNTIME_ASSETS],
+    ]
+    missing = [path.name for path in required if not path.is_file()]
+    shards = sorted(source.glob(WEIGHT_PATTERN))
+    if not shards:
+        missing.append(WEIGHT_PATTERN)
+    if missing:
+        raise RuntimeError(
+            f"source snapshot is incomplete; missing: {', '.join(missing)}"
+        )
+    return source
+
+
+def validate_source_config(config: dict[str, Any]) -> None:
+    audio = config["audio_config"]
+    text = config["text_config"]
+    expected = {
+        "audio d_model": (audio["d_model"], 1024),
+        "audio layers": (audio["encoder_layers"], 24),
+        "audio heads": (audio["encoder_attention_heads"], 16),
+        "audio mel bins": (audio["num_mel_bins"], 80),
+        "audio positions": (audio["max_source_positions"], 1500),
+        "merge size": (config["audio_merge_size"], 4),
+        "audio token": (config["audio_token_id"], 151671),
+        "decoder hidden": (text["hidden_size"], 1024),
+        "decoder layers": (text["num_hidden_layers"], 28),
+        "decoder heads": (text["num_attention_heads"], 16),
+        "decoder KV heads": (text["num_key_value_heads"], 8),
+        "decoder head dim": (text["head_dim"], 128),
+        "decoder vocabulary": (text["vocab_size"], 151936),
+        "decoder context": (text["max_position_embeddings"], 131072),
+    }
+    mismatches = [
+        f"{name}={actual} (expected {wanted})"
+        for name, (actual, wanted) in expected.items()
+        if actual != wanted
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "source architecture does not match the Swift runtime: "
+            + "; ".join(mismatches)
+        )
+
+
+def load_source_weights(source: Path) -> dict[str, mx.array]:
+    weights: dict[str, mx.array] = {}
+    for shard in sorted(source.glob(WEIGHT_PATTERN)):
+        loaded = mx.load(str(shard))
+        if not isinstance(loaded, dict):
+            raise RuntimeError(f"{shard} did not contain named tensors")
+        duplicate = set(weights).intersection(loaded)
+        if duplicate:
+            raise RuntimeError(
+                f"duplicate tensor across source shards: {sorted(duplicate)[0]}"
+            )
+        weights.update(loaded)
+    return weights
+
+
+def export_audio(
+    source_weights: dict[str, mx.array],
+    destination: Path,
+    metadata: dict[str, str],
+) -> tuple[int, int]:
+    output: dict[str, mx.array] = {}
+    parameter_count = 0
+    prefixes = ("model.whisper_encoder.", "model.vq_adaptor.")
+    for source_name, value in source_weights.items():
+        if not source_name.startswith(prefixes):
+            continue
+        name = source_name.removeprefix("model.")
+        array = value.astype(mx.float16)
+        if name in {
+            "whisper_encoder.conv1.weight",
+            "whisper_encoder.conv2.weight",
+        }:
+            # PyTorch Conv1d [out, in, kernel] -> MLX [out, kernel, in].
+            array = array.transpose(0, 2, 1)
+        mx.eval(array)
+        output[name] = array
+        parameter_count += value.size
+    if len(output) != EXPECTED_AUDIO_TENSORS:
+        raise RuntimeError(
+            f"expected {EXPECTED_AUDIO_TENSORS} audio tensors, got {len(output)}"
+        )
+    mx.save_safetensors(str(destination), output, metadata=metadata)
+    return len(output), parameter_count
+
+
+def export_decoder(
+    source_weights: dict[str, mx.array],
+    destination: Path,
+    bits: int,
+    group_size: int,
+    metadata: dict[str, str],
+) -> tuple[int, int, dict[str, float]]:
+    decoder_source = {
+        name.removeprefix("model.language_model."): value
+        for name, value in source_weights.items()
+        if name.startswith("model.language_model.")
+    }
+    if len(decoder_source) != EXPECTED_DECODER_SOURCE_TENSORS:
+        raise RuntimeError(
+            "expected "
+            f"{EXPECTED_DECODER_SOURCE_TENSORS} decoder source tensors, "
+            f"got {len(decoder_source)}"
+        )
+
+    output: dict[str, mx.array] = {}
+    matrix_count = 0
+    parameter_count = 0
+    validation: dict[str, float] | None = None
+    for name, value in decoder_source.items():
+        parameter_count += value.size
+        converted = value.astype(mx.float16)
+        if name.endswith(".weight") and converted.ndim >= 2:
+            if converted.shape[-1] % group_size != 0:
+                raise RuntimeError(
+                    f"{name} input dimension {converted.shape[-1]} is not "
+                    f"divisible by group size {group_size}"
+                )
+            quantized, scales, biases = mx.quantize(
+                converted,
+                group_size=group_size,
+                bits=bits,
+                mode="affine",
+            )
+            mx.eval(quantized, scales, biases)
+            base = name.removesuffix(".weight")
+            output[name] = quantized
+            output[f"{base}.scales"] = scales
+            output[f"{base}.biases"] = biases
+            matrix_count += 1
+            if name == VALIDATION_TENSOR:
+                restored = mx.dequantize(
+                    quantized,
+                    scales,
+                    biases,
+                    group_size=group_size,
+                    bits=bits,
+                    mode="affine",
+                    dtype=mx.float16,
+                )
+                source_flat = converted.flatten().astype(mx.float32)
+                restored_flat = restored.flatten().astype(mx.float32)
+                cosine = mx.sum(source_flat * restored_flat) / (
+                    mx.sqrt(mx.sum(source_flat * source_flat))
+                    * mx.sqrt(mx.sum(restored_flat * restored_flat))
+                )
+                maximum_error = mx.max(
+                    mx.abs(source_flat - restored_flat)
+                )
+                mx.eval(cosine, maximum_error)
+                validation = {
+                    "cosine": float(cosine.item()),
+                    "max_abs": float(maximum_error.item()),
+                }
+        else:
+            mx.eval(converted)
+            output[name] = converted
+
+    if matrix_count != EXPECTED_DECODER_MATRICES:
+        raise RuntimeError(
+            f"expected {EXPECTED_DECODER_MATRICES} decoder matrices, "
+            f"got {matrix_count}"
+        )
+    if validation is None:
+        raise RuntimeError(f"validation tensor {VALIDATION_TENSOR} is absent")
+    mx.save_safetensors(str(destination), output, metadata=metadata)
+    return len(output), parameter_count, validation
+
+
+def make_runtime_config(
+    source: dict[str, Any],
+    *,
+    bits: int,
+    group_size: int,
+    repo_id: str,
+    source_model: str,
+    source_revision: str,
+) -> dict[str, Any]:
+    audio = source["audio_config"]
+    text = source["text_config"]
+    return {
+        "audio_config": {
+            "hidden_size": audio["d_model"],
+            "intermediate_size": audio["encoder_ffn_dim"],
+            "layer_norm_eps": audio.get("layer_norm_eps", 1e-5),
+            "max_source_positions": audio["max_source_positions"],
+            "merge_size": source["audio_merge_size"],
+            "num_heads": audio["encoder_attention_heads"],
+            "num_layers": audio["encoder_layers"],
+            "num_mel_bins": audio["num_mel_bins"],
+        },
+        "audio_token_id": source["audio_token_id"],
+        "backend": "mlx",
+        "decoder_config": {
+            "head_dim": text["head_dim"],
+            "hidden_size": text["hidden_size"],
+            "intermediate_size": text["intermediate_size"],
+            "num_heads": text["num_attention_heads"],
+            "num_kv_heads": text["num_key_value_heads"],
+            "num_layers": text["num_hidden_layers"],
+            "rms_norm_eps": text["rms_norm_eps"],
+            "rope_theta": text["rope_theta"],
+            "vocab_size": text["vocab_size"],
+        },
+        "files": {
+            "audio_encoder": "audio_encoder.safetensors",
+            "decoder": "decoder.safetensors",
+        },
+        "max_context_tokens": text["max_position_embeddings"],
+        "model_type": "moss-transcribe-diarize-mlx",
+        "precision": f"fp16-audio-int{bits}-decoder",
+        "quantization_config": {
+            "bits": bits,
+            "group_size": group_size,
+            "mode": "affine",
+        },
+        "repo_id": repo_id,
+        "source_model": source_model,
+        "source_revision": source_revision,
+    }
+
+
+def make_model_card(
+    *,
+    bits: int,
+    group_size: int,
+    repo_id: str,
+    source_model: str,
+    source_revision: str,
+    audio_parameters: int,
+    decoder_parameters: int,
+) -> str:
+    total_parameters = audio_parameters + decoder_parameters
+    return f"""---
+license: apache-2.0
+library_name: mlx
+base_model: {source_model}
+pipeline_tag: automatic-speech-recognition
+tags:
+- mlx
+- speech-swift
+- asr
+- speaker-diarization
+- long-form-audio
+- multilingual
+---
+
+# MOSS-Transcribe-Diarize 0.9B MLX INT{bits}
+
+Native MLX weights for offline, speaker-attributed transcription on Apple
+Silicon. The Whisper encoder and VQ adaptor remain FP16; the tied Qwen3
+decoder uses {bits}-bit affine group-{group_size} weights.
+
+| Property | Value |
+|---|---|
+| Source | `{source_model}` |
+| Source revision | `{source_revision}` |
+| Parameters | {total_parameters:,} |
+| Audio/VQ precision | FP16 |
+| Decoder precision | INT{bits}, affine group {group_size} |
+| Context | 131,072 tokens |
+| License | Apache-2.0 |
+
+The model is offline, not streaming. Audio is encoded in 30-second chunks,
+then all audio embeddings are concatenated into one globally contextualized
+prompt. Transcript tokens are generated autoregressively after the complete
+recording is available.
+
+## speech-swift
+
+```bash
+speech transcribe meeting.wav \\
+  --engine moss \\
+  --backend mlx \\
+  --model {repo_id} \\
+  --kv-cache fp16
+```
+
+`--kv-cache int8` reduces long-context memory separately from decoder weight
+quantization. Use FP16 cache when comparing INT5 and INT8 model quality.
+INT4 KV cache is not exposed because it failed the structured-output quality
+gate.
+
+## Export provenance
+
+The bundle is produced by `scripts/export_moss_mlx.py` in speech-swift from
+the immutable source revision above. `export_config.json` records tensor
+counts, checksums, quantization verification, and the runtime contract.
+
+No training or fine-tuning was performed. Benchmark results are intentionally
+not claimed by the exporter; release WER/CER and DER/JER measurements belong
+in `validation.json` after running the ASR and diarization benchmarks.
+
+## Limitations
+
+The upstream project reports support for 50+ languages and recordings up to
+about 90 minutes, but does not publish an exhaustive language list. Actual
+duration is constrained by unified memory, KV-cache precision, transcript
+length, and the 131,072-token combined context. Speaker IDs are anonymous per
+recording. Timestamps may overlap or be malformed, and quantization can affect
+both word accuracy and speaker attribution.
+
+## License
+
+Apache License 2.0, inherited from the upstream model.
+"""
+
+
+def main() -> int:
+    args = parse_args()
+    output = args.output.expanduser().resolve()
+    prepare_output(output, args.overwrite)
+    source = resolve_source(args)
+    repo_id = args.repo_id or DEFAULT_REPOSITORIES[args.bits]
+
+    source_config = json.loads(
+        (source / "config.json").read_text(encoding="utf-8")
+    )
+    validate_source_config(source_config)
+    source_weights = load_source_weights(source)
+
+    print("Exporting FP16 Whisper encoder and VQ adaptor...", flush=True)
+    audio_count, audio_parameters = export_audio(
+        source_weights,
+        output / "audio_encoder.safetensors",
+        {
+            "format": "mlx",
+            "precision": "float16",
+        },
+    )
+    print(
+        f"Quantizing Qwen3 decoder to affine INT{args.bits} "
+        f"group {args.group_size}...",
+        flush=True,
+    )
+    decoder_count, decoder_parameters, verification = export_decoder(
+        source_weights,
+        output / "decoder.safetensors",
+        args.bits,
+        args.group_size,
+        {
+            "format": "mlx",
+            "group_size": str(args.group_size),
+            "precision": f"int{args.bits}",
+            "quantization": "affine",
+        },
+    )
+
+    for name in RUNTIME_ASSETS:
+        shutil.copy2(source / name, output / name)
+    shutil.copy2(source / "config.json", output / "source_config.json")
+    package_license = Path(__file__).resolve().parent.parent / "LICENSE"
+    if not package_license.is_file():
+        raise RuntimeError(f"Apache license file is missing: {package_license}")
+    shutil.copy2(package_license, output / "LICENSE")
+    (output / ".gitattributes").write_text(
+        "*.safetensors filter=lfs diff=lfs merge=lfs -text\n",
+        encoding="utf-8",
+    )
+
+    runtime_config = make_runtime_config(
+        source_config,
+        bits=args.bits,
+        group_size=args.group_size,
+        repo_id=repo_id,
+        source_model=args.source_model,
+        source_revision=args.source_revision,
+    )
+    json_dump(output / "config.json", runtime_config)
+    artifacts = {}
+    for name in ("audio_encoder.safetensors", "decoder.safetensors"):
+        path = output / name
+        artifacts[name] = {
+            "sha256": sha256(path),
+            "size_bytes": path.stat().st_size,
+        }
+    export_config = {
+        **runtime_config,
+        "artifacts": artifacts,
+        "host_contract": {
+            "audio_chunk_samples": 480_000,
+            "audio_tokens_per_second": 12.5,
+            "generation": (
+                "Greedy autoregressive decode; parse "
+                "[start][Sxx]text[end]"
+            ),
+            "processor": "Use copied assets from the pinned source revision",
+            "sample_rate": 16_000,
+        },
+        "parameter_counts": {
+            "audio_and_vq": audio_parameters,
+            "decoder": decoder_parameters,
+            "total": audio_parameters + decoder_parameters,
+        },
+        "runtime_assets": RUNTIME_ASSETS,
+        "schema_version": 1,
+        "tensor_counts": {
+            "audio": audio_count,
+            "decoder_exported": decoder_count,
+            "decoder_matrices_quantized": EXPECTED_DECODER_MATRICES,
+        },
+        "verification": {
+            **verification,
+            "status": "passed",
+            "tensor": VALIDATION_TENSOR,
+        },
+    }
+    json_dump(output / "export_config.json", export_config)
+    json_dump(
+        output / "validation.json",
+        {
+            "status": "not_run",
+            "required_comparisons": {
+                "asr": ["WER", "CER", "RTF", "peak RSS"],
+                "diarization": [
+                    "DER",
+                    "JER",
+                    "speaker-count accuracy",
+                    "RTF",
+                    "peak RSS",
+                ],
+            },
+            "quality_policy": (
+                "Compare INT5 and INT8 with the same FP16 audio weights, "
+                "greedy decoding, prompts, datasets, and FP16 KV cache."
+            ),
+            "kv_cache_policy": (
+                "FP16 is the quality baseline; INT8 requires separate "
+                "structured-output validation; INT4 is unsupported."
+            ),
+        },
+    )
+    (output / "README.md").write_text(
+        make_model_card(
+            bits=args.bits,
+            group_size=args.group_size,
+            repo_id=repo_id,
+            source_model=args.source_model,
+            source_revision=args.source_revision,
+            audio_parameters=audio_parameters,
+            decoder_parameters=decoder_parameters,
+        ),
+        encoding="utf-8",
+    )
+
+    print(f"Exported {repo_id} to {output}")
+    print(
+        "Decoder verification: "
+        f"cosine={verification['cosine']:.8f}, "
+        f"max_abs={verification['max_abs']:.8f}"
+    )
+    for name, artifact in artifacts.items():
+        size_mb = artifact["size_bytes"] / (1024 * 1024)
+        print(f"{name}: {size_mb:.1f} MiB {artifact['sha256']}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (KeyError, RuntimeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/prepare_fleurs_asr_manifest.py
+++ b/scripts/prepare_fleurs_asr_manifest.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Convert a local FLEURS split to the speech-swift ASR benchmark format."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a <wav path>\\t<reference text> manifest from a local "
+            "FLEURS language directory."
+        )
+    )
+    parser.add_argument(
+        "--fleurs-dir",
+        type=Path,
+        required=True,
+        help="Language directory containing test.tsv and audio/test/.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=("train", "validation", "test"),
+    )
+    parser.add_argument("--limit", type=int, help="Maximum number of rows.")
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def build_manifest(
+    fleurs_dir: Path,
+    split: str,
+    output: Path,
+    limit: int | None,
+) -> int:
+    source = fleurs_dir / f"{split}.tsv"
+    audio_dir = fleurs_dir / "audio" / split
+    if not source.is_file():
+        raise FileNotFoundError(f"FLEURS metadata is missing: {source}")
+    if not audio_dir.is_dir():
+        raise FileNotFoundError(f"FLEURS audio is missing: {audio_dir}")
+    if limit is not None and limit <= 0:
+        raise ValueError("--limit must be positive")
+
+    rows: list[str] = []
+    with source.open(encoding="utf-8", newline="") as handle:
+        for line_number, columns in enumerate(
+            csv.reader(handle, delimiter="\t"),
+            start=1,
+        ):
+            if len(columns) < 3:
+                raise ValueError(
+                    f"{source}:{line_number} has fewer than three columns"
+                )
+            audio = (audio_dir / columns[1]).resolve()
+            if not audio.is_file():
+                raise FileNotFoundError(
+                    f"FLEURS audio referenced at line {line_number} "
+                    f"is missing: {audio}"
+                )
+            transcript = columns[2].replace("\t", " ").strip()
+            rows.append(f"{audio}\t{transcript}\n")
+            if limit is not None and len(rows) >= limit:
+                break
+
+    if not rows:
+        raise ValueError(f"no usable rows in {source}")
+    output = output.expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("".join(rows), encoding="utf-8")
+    return len(rows)
+
+
+def main() -> None:
+    args = parse_args()
+    count = build_manifest(
+        args.fleurs_dir.expanduser().resolve(),
+        args.split,
+        args.output,
+        args.limit,
+    )
+    print(f"Wrote {count} utterances to {args.output.expanduser().resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a native Swift/MLX runtime for MOSS-Transcribe-Diarize 0.9B with the upstream 131,072-token context.
- Encode audio in bounded 30-second batches, concatenate all audio embeddings into one prompt, and decode one globally contextualized timestamped, speaker-attributed transcript.
- Publish affine group-64 INT5 and INT8 decoder variants; INT5 is the MLX default. The Whisper encoder and VQ adaptor remain FP16.
- Keep decoder weight precision independent from the dynamic KV cache (`fp16` or `int8`). INT4 cache is intentionally rejected after failing the structured-output quality gate.
- Add `speech transcribe --engine moss --backend mlx`, ASR and diarization benchmark engines, a pinned reproducible exporter, tests, benchmark documentation, and all README translations.

Published weights:

- [MLX INT5](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-5bit)
- [MLX INT8](https://huggingface.co/aufklarer/MOSS-Transcribe-Diarize-0.9B-MLX-INT8)

Follow-up to #388.

## Architecture fit

The implementation stays in the existing `MossTranscribe` product and reuses its exact Whisper frontend, prompt processor, output parser, metrics, and public transcript types. The existing Core ML backend and its default CLI behavior remain available. MLX is selected explicitly with `--backend mlx` and remains offline-only; `--stream` is rejected.

The runtime validates the model geometry, quantization metadata, exact weight filenames, tokenizer/audio token contract, and processor settings before loading. One model instance serializes inference because its growing cache is not re-entrant.

## Matched quality and performance

Release build on an Apple M5 Pro, greedy decode, FP16 KV cache for both variants:

| Variant | FLEURS en-US WER / CER | ASR speed | ASR peak RSS | VoxConverse DER / JER | Diarization speed | Diarization peak RSS |
|---|---:|---:|---:|---:|---:|---:|
| INT5 | 8.55% / 6.36% | 35.2× real time | 1,196 MiB | 28.05% / 26.56% | 15.5× | 1,281 MiB |
| INT8 | 8.27% / 5.98% | 31.6× real time | 1,407 MiB | 28.02% / 25.79% | 11.8× | 1,498 MiB |

ASR used 80 clips / 759.56 seconds. Diarization used five recordings / 2,346.56 seconds, including a 20-minute, 12-speaker file. The five-file DER result supports quantization parity, not a broad diarization-quality claim.

## Regression validation

- `make build`: passed, including the compiled MLX metallib.
- Curated regression suite: 258 tests passed, 0 failures.
- MOSS and CLI unit suite: 57 tests passed, 0 failures.
- Four isolated MLX E2E runs passed: INT5 and INT8 weights with both FP16 and INT8 KV caches. Every run produced the exact expected timestamp, speaker label, and transcript.
- Export scripts compile and both upload bundles pass tensor-count, geometry, checksum, and dequantization validation.
- INT8 self-export was compared tensor-by-tensor with the prior published INT8 bundle: all 373 audio tensors and 704 decoder tensors matched.

## Risk and limits

The principal risk is long-context unified-memory pressure, not a change to existing model behavior. At 67,500 audio tokens (about 90 minutes), the analytical KV-cache estimate is 7.74 GB in FP16 or 4.11 GB in INT8, before model weights, audio embeddings, generated text, and allocator overhead. The full 90-minute host path has not been run in this validation, so the upstream duration is documented as a capability rather than a device guarantee.

The upstream project reports 50+ languages but does not publish an exhaustive list. This quantization comparison covers English ASR and an English diarization slice; multilingual validation remains future work.
