### PR TITLE
Add native Nemotron MLX streaming runtime

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -103,7 +103,8 @@ state of a sequential multi-engine run.
 ## Available engines
 
 `qwen3-coreml`, `qwen3-mlx-{0.6b,1.7b}-{4bit,8bit}`, `parakeet`,
-`nemotron`, `omnilingual`, `omnilingual-mlx-{300m,1b,3b,7b}-4bit`,
+`nemotron`, `nemotron-mlx-{int5,int8}`, `omnilingual`,
+`omnilingual-mlx-{300m,1b,3b,7b}-4bit`,
 `whisperkit-{large-v3-turbo,large-v3,distil-large-v3}`.
 
 ## Performance targets (M2 Max)

--- a/Package.swift
+++ b/Package.swift
@@ -477,6 +477,10 @@ let package = Package(
             name: "NemotronStreamingASR",
             dependencies: [
                 "AudioCommon",
+                "MLXCommon",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
             ]
         ),
         .target(

--- a/Sources/AsrBenchmark/Engine.swift
+++ b/Sources/AsrBenchmark/Engine.swift
@@ -45,6 +45,8 @@ public enum EngineID: String, CaseIterable, Sendable {
     case qwen3MLX17b8bit = "qwen3-mlx-1.7b-8bit"
     case parakeet = "parakeet"
     case nemotron = "nemotron"
+    case nemotronMLXInt5 = "nemotron-mlx-int5"
+    case nemotronMLXInt8 = "nemotron-mlx-int8"
     case omnilingual = "omnilingual"
     case omnilingualMLX300m4bit = "omnilingual-mlx-300m-4bit"
     case omnilingualMLX1b4bit = "omnilingual-mlx-1b-4bit"
@@ -76,6 +78,10 @@ public enum EngineID: String, CaseIterable, Sendable {
         case .qwen3MLX17b8bit: return Qwen3MLXEngine(size: "1.7B", bits: 8)
         case .parakeet: return ParakeetEngine()
         case .nemotron: return NemotronEngine()
+        case .nemotronMLXInt5:
+            return NemotronMLXEngine(variant: .int5)
+        case .nemotronMLXInt8:
+            return NemotronMLXEngine(variant: .int8)
         case .omnilingual: return OmnilingualEngine()
         case .omnilingualMLX300m4bit: return OmnilingualMLXEngine(variant: .m300, bits: 4)
         case .omnilingualMLX1b4bit: return OmnilingualMLXEngine(variant: .b1, bits: 4)

--- a/Sources/AsrBenchmark/EngineNemotron.swift
+++ b/Sources/AsrBenchmark/EngineNemotron.swift
@@ -26,3 +26,60 @@ final class NemotronEngine: BenchEngine, @unchecked Sendable {
         return (result.text, Timings(elapsed: result.elapsed, audioDuration: dur))
     }
 }
+
+final class NemotronMLXEngine: BenchEngine, @unchecked Sendable {
+    let name: String
+    private(set) var loadElapsed: Double = 0
+    private let variant: NemotronMLXVariant
+    private var model: NemotronStreamingASRMLXModel?
+
+    init(variant: NemotronMLXVariant) {
+        self.variant = variant
+        name = "nemotron-streaming-mlx-\(variant.rawValue)"
+    }
+
+    func load(warmupAudio: [Float], sampleRate: Int) async throws {
+        let started = Date()
+        let environmentKey = variant == .int5
+            ? "NEMOTRON_MLX_LOCAL_BUNDLE"
+            : "NEMOTRON_MLX_INT8_LOCAL_BUNDLE"
+        let loaded: NemotronStreamingASRMLXModel
+        if let path = ProcessInfo.processInfo.environment[environmentKey],
+           !path.isEmpty
+        {
+            loaded = try await NemotronStreamingASRMLXModel.fromDirectory(
+                URL(fileURLWithPath: path, isDirectory: true))
+        } else {
+            loaded = try await NemotronStreamingASRMLXModel.fromPretrained(
+                variant: variant)
+        }
+        _ = try loaded.transcribeAudio(
+            warmupAudio,
+            sampleRate: sampleRate,
+            language: "en-US")
+        model = loaded
+        loadElapsed = Date().timeIntervalSince(started)
+    }
+
+    func transcribe(
+        audio: [Float],
+        sampleRate: Int,
+        language: String?
+    ) async throws -> (text: String, timings: Timings) {
+        guard let model else { throw BenchError.notLoaded(name) }
+        var result: (text: String, elapsed: Double)!
+        try autoreleasepool {
+            let started = Date()
+            let text = try model.transcribeAudio(
+                audio,
+                sampleRate: sampleRate,
+                language: language)
+            result = (text, Date().timeIntervalSince(started))
+        }
+        return (
+            result.text,
+            Timings(
+                elapsed: result.elapsed,
+                audioDuration: Double(audio.count) / Double(sampleRate)))
+    }
+}

--- a/Sources/NemotronStreamingASR/NemotronMLXConfiguration.swift
+++ b/Sources/NemotronStreamingASR/NemotronMLXConfiguration.swift
@@ -1,0 +1,259 @@
+import Foundation
+
+public enum NemotronMLXVariant: String, CaseIterable, Sendable {
+    case int5
+    case int8
+
+    public var modelId: String {
+        switch self {
+        case .int5:
+            return "aufklarer/Nemotron-3.5-ASR-Streaming-0.6B-MLX-5bit"
+        case .int8:
+            return "aufklarer/Nemotron-3.5-ASR-Streaming-0.6B-MLX-8bit"
+        }
+    }
+
+    public var quantizationBits: Int {
+        switch self {
+        case .int5: return 5
+        case .int8: return 8
+        }
+    }
+}
+
+public struct NemotronMLXQuantization: Codable, Equatable, Sendable {
+    public let mode: String
+    public let bits: Int
+    public let groupSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case mode
+        case bits
+        case groupSize = "group_size"
+    }
+}
+
+public struct NemotronMLXConfiguration: Decodable, Equatable, Sendable {
+    public struct Preprocessor: Decodable, Equatable, Sendable {
+        public let sampleRate: Int
+        public let features: Int
+        public let nFFT: Int
+        public let windowSize: Double
+        public let windowStride: Double
+        public let preEmphasis: Float
+
+        enum CodingKeys: String, CodingKey {
+            case sampleRate = "sample_rate"
+            case features
+            case nFFT = "n_fft"
+            case windowSize = "window_size"
+            case windowStride = "window_stride"
+            case preEmphasis = "preemph"
+        }
+    }
+
+    public struct Encoder: Decodable, Equatable, Sendable {
+        public let featureInput: Int
+        public let layers: Int
+        public let hiddenSize: Int
+        public let attentionHeads: Int
+        public let feedForwardExpansion: Int
+        public let subsamplingFactor: Int
+        public let convolutionKernelSize: Int
+        public let subsamplingChannels: Int
+        public let useBias: Bool
+        public let convolutionNormalization: String
+
+        enum CodingKeys: String, CodingKey {
+            case featureInput = "feat_in"
+            case layers = "n_layers"
+            case hiddenSize = "d_model"
+            case attentionHeads = "n_heads"
+            case feedForwardExpansion = "ff_expansion_factor"
+            case subsamplingFactor = "subsampling_factor"
+            case convolutionKernelSize = "conv_kernel_size"
+            case subsamplingChannels = "subsampling_conv_channels"
+            case useBias = "use_bias"
+            case convolutionNormalization = "conv_norm_type"
+        }
+    }
+
+    public struct Decoder: Decodable, Equatable, Sendable {
+        public struct PredictionNetwork: Decodable, Equatable, Sendable {
+            public let hiddenSize: Int
+            public let layers: Int
+
+            enum CodingKeys: String, CodingKey {
+                case hiddenSize = "pred_hidden"
+                case layers = "pred_rnn_layers"
+            }
+        }
+
+        public let blankAsPadding: Bool
+        public let vocabularySize: Int
+        public let predictionNetwork: PredictionNetwork
+
+        enum CodingKeys: String, CodingKey {
+            case blankAsPadding = "blank_as_pad"
+            case vocabularySize = "vocab_size"
+            case predictionNetwork = "prednet"
+        }
+    }
+
+    public struct Joint: Decodable, Equatable, Sendable {
+        public struct Network: Decodable, Equatable, Sendable {
+            public let hiddenSize: Int
+            public let activation: String
+            public let encoderHiddenSize: Int
+            public let predictionHiddenSize: Int
+
+            enum CodingKeys: String, CodingKey {
+                case hiddenSize = "joint_hidden"
+                case activation
+                case encoderHiddenSize = "encoder_hidden"
+                case predictionHiddenSize = "pred_hidden"
+            }
+        }
+
+        public let classes: Int
+        public let network: Network
+
+        enum CodingKeys: String, CodingKey {
+            case classes = "num_classes"
+            case network = "jointnet"
+        }
+    }
+
+    public struct PromptKernel: Decodable, Equatable, Sendable {
+        public let promptCount: Int
+        public let hiddenSize: Int
+        public let modelSize: Int
+
+        enum CodingKeys: String, CodingKey {
+            case promptCount = "num_prompts"
+            case hiddenSize = "hidden"
+            case modelSize = "d_model"
+        }
+    }
+
+    public struct Streaming: Decodable, Equatable, Sendable {
+        public let chunkMilliseconds: Int
+        public let melFrames: Int
+        public let preCacheSize: Int
+        public let outputFrames: Int
+        public let attentionLeftContext: Int
+        public let convolutionCacheSize: Int
+
+        enum CodingKeys: String, CodingKey {
+            case chunkMilliseconds = "chunk_ms"
+            case melFrames = "mel_frames"
+            case preCacheSize = "pre_cache_size"
+            case outputFrames = "output_frames"
+            case attentionLeftContext = "attention_left_context"
+            case convolutionCacheSize = "conv_cache_size"
+        }
+    }
+
+    public let modelType: String
+    public let sampleRate: Int
+    public let vocabularySize: Int
+    public let preprocessor: Preprocessor
+    public let encoder: Encoder
+    public let decoder: Decoder
+    public let joint: Joint
+    public let promptKernel: PromptKernel
+    public let streaming: Streaming
+    public let quantization: NemotronMLXQuantization
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case sampleRate = "sample_rate"
+        case vocabularySize = "vocab_size"
+        case preprocessor
+        case encoder
+        case decoder
+        case joint
+        case promptKernel = "prompt_kernel"
+        case streaming
+        case quantization
+    }
+
+    public func validate() throws {
+        guard modelType == "nemotron_streaming_rnnt_mlx" else {
+            throw NemotronMLXError.invalidConfiguration(
+                "unexpected model_type \(modelType)")
+        }
+        guard sampleRate == 16_000,
+              preprocessor.sampleRate == sampleRate,
+              preprocessor.features == 128,
+              preprocessor.nFFT == 512,
+              abs(preprocessor.windowSize - 0.025) < 1e-9,
+              abs(preprocessor.windowStride - 0.01) < 1e-9,
+              abs(preprocessor.preEmphasis - 0.97) < 1e-6
+        else {
+            throw NemotronMLXError.invalidConfiguration(
+                "unsupported audio frontend geometry")
+        }
+        guard vocabularySize == 13_087,
+              decoder.vocabularySize == vocabularySize,
+              joint.classes == vocabularySize,
+              encoder.featureInput == 128,
+              encoder.layers == 24,
+              encoder.hiddenSize == 1_024,
+              encoder.attentionHeads == 8,
+              encoder.feedForwardExpansion == 4,
+              encoder.subsamplingFactor == 8,
+              encoder.convolutionKernelSize == 9,
+              encoder.subsamplingChannels == 256,
+              !encoder.useBias,
+              encoder.convolutionNormalization == "layer_norm",
+              decoder.blankAsPadding,
+              decoder.predictionNetwork.hiddenSize == 640,
+              decoder.predictionNetwork.layers == 2,
+              joint.network.hiddenSize == 640,
+              joint.network.activation == "relu",
+              joint.network.encoderHiddenSize == 1_024,
+              joint.network.predictionHiddenSize == 640,
+              promptKernel.promptCount == 128,
+              promptKernel.hiddenSize == 2_048,
+              promptKernel.modelSize == 1_024
+        else {
+            throw NemotronMLXError.invalidConfiguration(
+                "unsupported Nemotron network geometry")
+        }
+        guard streaming.chunkMilliseconds == 320,
+              streaming.melFrames == 32,
+              streaming.preCacheSize == 9,
+              streaming.outputFrames == 4,
+              streaming.attentionLeftContext == 56,
+              streaming.convolutionCacheSize == 8
+        else {
+            throw NemotronMLXError.invalidConfiguration(
+                "unsupported streaming cache geometry")
+        }
+        guard quantization.mode == "affine",
+              [5, 8].contains(quantization.bits),
+              quantization.groupSize == 64
+        else {
+            throw NemotronMLXError.invalidConfiguration(
+                "only affine group-64 INT5 and INT8 bundles are supported")
+        }
+    }
+}
+
+public enum NemotronMLXError: LocalizedError {
+    case missingModelFile(String)
+    case invalidConfiguration(String)
+    case inferenceFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingModelFile(let file):
+            return "Missing Nemotron MLX model file: \(file)"
+        case .invalidConfiguration(let reason):
+            return "Invalid Nemotron MLX configuration: \(reason)"
+        case .inferenceFailed(let reason):
+            return "Nemotron MLX inference failed: \(reason)"
+        }
+    }
+}

--- a/Sources/NemotronStreamingASR/NemotronMLXNetwork.swift
+++ b/Sources/NemotronStreamingASR/NemotronMLXNetwork.swift
@@ -1,0 +1,744 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+private func nemotronQuantizedLinear(
+    _ inputDimensions: Int,
+    _ outputDimensions: Int,
+    bias: Bool = true,
+    quantization: NemotronMLXQuantization
+) -> Linear {
+    QuantizedLinear(
+        inputDimensions,
+        outputDimensions,
+        bias: bias,
+        groupSize: quantization.groupSize,
+        bits: quantization.bits,
+        mode: .affine
+    )
+}
+
+final class NemotronMLXCausalConv2D: Module {
+    @ModuleInfo var conv: Conv2d
+
+    init(
+        inputChannels: Int,
+        outputChannels: Int,
+        groups: Int = 1
+    ) {
+        _conv.wrappedValue = Conv2d(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: 3,
+            stride: 2,
+            padding: 0,
+            groups: groups
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let paddedInput = MLX.padded(
+            input,
+            widths: [
+                IntOrPair((0, 0)),
+                IntOrPair((2, 1)),
+                IntOrPair((2, 1)),
+                IntOrPair((0, 0)),
+            ]
+        )
+        return conv(paddedInput)
+    }
+}
+
+final class NemotronMLXSubsampling: Module {
+    // This must remain an array, rather than a wrapper with numeric property
+    // keys. Python MLX serializes Sequential/list children as array nodes, and
+    // MLX-Swift's quantizer/strict loader preserves that tree distinction.
+    @ModuleInfo var conv: [Module]
+    @ModuleInfo var out: Linear
+
+    init(
+        _ configuration: NemotronMLXConfiguration.Encoder,
+        quantization: NemotronMLXQuantization
+    ) {
+        let channels = configuration.subsamplingChannels
+        _conv.wrappedValue = [
+            NemotronMLXCausalConv2D(
+                inputChannels: 1,
+                outputChannels: channels
+            ),
+            ReLU(),
+            NemotronMLXCausalConv2D(
+                inputChannels: channels,
+                outputChannels: channels,
+                groups: channels
+            ),
+            Conv2d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: 1
+            ),
+            ReLU(),
+            NemotronMLXCausalConv2D(
+                inputChannels: channels,
+                outputChannels: channels,
+                groups: channels
+            ),
+            Conv2d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: 1
+            ),
+            ReLU(),
+        ]
+        _out.wrappedValue = nemotronQuantizedLinear(
+            configuration.subsamplingChannels * 17,
+            configuration.hiddenSize,
+            quantization: quantization
+        )
+        super.init()
+    }
+
+    /// `[batch, mel frames, mel bins]` to `[batch, encoder frames, hidden]`.
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden = (conv[0] as! NemotronMLXCausalConv2D)(
+            input.expandedDimensions(axis: -1)
+        )
+        hidden = (conv[1] as! ReLU)(hidden)
+        hidden = (conv[2] as! NemotronMLXCausalConv2D)(hidden)
+        hidden = (conv[3] as! Conv2d)(hidden)
+        hidden = (conv[4] as! ReLU)(hidden)
+        hidden = (conv[5] as! NemotronMLXCausalConv2D)(hidden)
+        hidden = (conv[6] as! Conv2d)(hidden)
+        hidden = (conv[7] as! ReLU)(hidden)
+        let batch = hidden.dim(0)
+        let time = hidden.dim(1)
+        let frequency = hidden.dim(2)
+        let channels = hidden.dim(3)
+        hidden = hidden
+            .transposed(0, 1, 3, 2)
+            .reshaped(batch, time, channels * frequency)
+        return out(hidden)
+    }
+}
+
+final class NemotronMLXFeedForward: Module {
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
+
+    init(
+        hiddenSize: Int,
+        expansion: Int,
+        quantization: NemotronMLXQuantization
+    ) {
+        _linear1.wrappedValue = nemotronQuantizedLinear(
+            hiddenSize,
+            hiddenSize * expansion,
+            bias: false,
+            quantization: quantization
+        )
+        _linear2.wrappedValue = nemotronQuantizedLinear(
+            hiddenSize * expansion,
+            hiddenSize,
+            bias: false,
+            quantization: quantization
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        linear2(silu(linear1(input)))
+    }
+}
+
+final class NemotronMLXLayerCache {
+    var key: MLXArray?
+    var value: MLXArray?
+    var convolution: MLXArray?
+
+    func append(
+        key newKey: MLXArray,
+        value newValue: MLXArray,
+        leftContext: Int
+    ) -> (MLXArray, MLXArray) {
+        var combinedKey = key.map {
+            MLX.concatenated([$0, newKey], axis: 2)
+        } ?? newKey
+        var combinedValue = value.map {
+            MLX.concatenated([$0, newValue], axis: 2)
+        } ?? newValue
+
+        let retained = leftContext + newKey.dim(2)
+        if combinedKey.dim(2) > retained {
+            let start = combinedKey.dim(2) - retained
+            combinedKey = combinedKey[0..., 0..., start..., 0...]
+            combinedValue = combinedValue[0..., 0..., start..., 0...]
+        }
+        key = combinedKey
+        value = combinedValue
+        return (combinedKey, combinedValue)
+    }
+
+    func prependConvolution(
+        _ input: MLXArray,
+        cacheSize: Int
+    ) -> MLXArray {
+        if convolution == nil {
+            convolution = MLXArray.zeros(
+                [input.dim(0), cacheSize, input.dim(2)],
+                dtype: input.dtype
+            )
+        }
+        let combined = MLX.concatenated([convolution!, input], axis: 1)
+        convolution = combined[
+            0...,
+            (combined.dim(1) - cacheSize)...,
+            0...
+        ]
+        return combined
+    }
+
+    var evaluatedArrays: [MLXArray] {
+        [key, value, convolution].compactMap { $0 }
+    }
+}
+
+final class NemotronMLXRelativeAttention: Module {
+    let heads: Int
+    let headSize: Int
+    let scale: Float
+
+    @ModuleInfo(key: "linear_q") var query: Linear
+    @ModuleInfo(key: "linear_k") var key: Linear
+    @ModuleInfo(key: "linear_v") var value: Linear
+    @ModuleInfo(key: "linear_out") var output: Linear
+    @ModuleInfo(key: "linear_pos") var position: Linear
+    @ParameterInfo(key: "pos_bias_u") var positionBiasU: MLXArray
+    @ParameterInfo(key: "pos_bias_v") var positionBiasV: MLXArray
+
+    init(
+        hiddenSize: Int,
+        heads: Int,
+        quantization: NemotronMLXQuantization
+    ) {
+        self.heads = heads
+        headSize = hiddenSize / heads
+        scale = 1 / sqrt(Float(headSize))
+        _query.wrappedValue = nemotronQuantizedLinear(
+            hiddenSize,
+            hiddenSize,
+            bias: false,
+            quantization: quantization
+        )
+        _key.wrappedValue = nemotronQuantizedLinear(
+            hiddenSize,
+            hiddenSize,
+            bias: false,
+            quantization: quantization
+        )
+        _value.wrappedValue = nemotronQuantizedLinear(
+            hiddenSize,
+            hiddenSize,
+            bias: false,
+            quantization: quantization
+        )
+        _output.wrappedValue = nemotronQuantizedLinear(
+            hiddenSize,
+            hiddenSize,
+            bias: false,
+            quantization: quantization
+        )
+        _position.wrappedValue = nemotronQuantizedLinear(
+            hiddenSize,
+            hiddenSize,
+            bias: false,
+            quantization: quantization
+        )
+        _positionBiasU.wrappedValue = MLXArray.zeros([heads, headSize])
+        _positionBiasV.wrappedValue = MLXArray.zeros([heads, headSize])
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        positionEmbedding: MLXArray,
+        cache: NemotronMLXLayerCache,
+        leftContext: Int
+    ) -> MLXArray {
+        let batch = input.dim(0)
+        let queryLength = input.dim(1)
+
+        let projectedQuery = query(input)
+            .reshaped(batch, queryLength, heads, headSize)
+        let queryU = (projectedQuery + positionBiasU)
+            .transposed(0, 2, 1, 3)
+        let queryV = (projectedQuery + positionBiasV)
+            .transposed(0, 2, 1, 3)
+        let newKey = key(input)
+            .reshaped(batch, queryLength, heads, headSize)
+            .transposed(0, 2, 1, 3)
+        let newValue = value(input)
+            .reshaped(batch, queryLength, heads, headSize)
+            .transposed(0, 2, 1, 3)
+        let (allKey, allValue) = cache.append(
+            key: newKey,
+            value: newValue,
+            leftContext: leftContext
+        )
+
+        let positionLength = positionEmbedding.dim(1)
+        let projectedPosition = position(positionEmbedding)
+            .reshaped(1, positionLength, heads, headSize)
+            .transposed(0, 2, 1, 3)
+        var relativeScores = MLX.matmul(
+            queryV,
+            projectedPosition.swappedAxes(-2, -1)
+        )
+        relativeScores = relativeShift(relativeScores)
+        relativeScores = relativeScores[
+            0...,
+            0...,
+            0...,
+            0..<allKey.dim(2)
+        ] * scale
+
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queryU,
+            keys: allKey,
+            values: allValue,
+            scale: scale,
+            mask: relativeScores
+        )
+        return output(
+            attended
+                .transposed(0, 2, 1, 3)
+                .reshaped(batch, queryLength, heads * headSize)
+        )
+    }
+
+    private func relativeShift(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let headCount = input.dim(1)
+        let queryLength = input.dim(2)
+        let positionLength = input.dim(3)
+        var shifted = MLX.padded(
+            input,
+            widths: [
+                IntOrPair((0, 0)),
+                IntOrPair((0, 0)),
+                IntOrPair((0, 0)),
+                IntOrPair((1, 0)),
+            ]
+        )
+        shifted = shifted.reshaped(
+            batch,
+            headCount,
+            positionLength + 1,
+            queryLength
+        )
+        shifted = shifted[0..., 0..., 1..., 0...]
+        return shifted.reshaped(
+            batch,
+            headCount,
+            queryLength,
+            positionLength
+        )
+    }
+}
+
+final class NemotronMLXConvolution: Module {
+    @ModuleInfo(key: "pointwise_conv1") var pointwise1: Conv1d
+    @ModuleInfo(key: "depthwise_conv") var depthwise: Conv1d
+    @ModuleInfo(key: "batch_norm") var normalization: LayerNorm
+    @ModuleInfo(key: "pointwise_conv2") var pointwise2: Conv1d
+
+    init(hiddenSize: Int, kernelSize: Int) {
+        _pointwise1.wrappedValue = Conv1d(
+            inputChannels: hiddenSize,
+            outputChannels: hiddenSize * 2,
+            kernelSize: 1,
+            bias: false
+        )
+        _depthwise.wrappedValue = Conv1d(
+            inputChannels: hiddenSize,
+            outputChannels: hiddenSize,
+            kernelSize: kernelSize,
+            groups: hiddenSize,
+            bias: false
+        )
+        _normalization.wrappedValue = LayerNorm(dimensions: hiddenSize)
+        _pointwise2.wrappedValue = Conv1d(
+            inputChannels: hiddenSize,
+            outputChannels: hiddenSize,
+            kernelSize: 1,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        cache: NemotronMLXLayerCache,
+        cacheSize: Int
+    ) -> MLXArray {
+        var hidden = MLXNN.glu(pointwise1(input), axis: 2)
+        hidden = cache.prependConvolution(hidden, cacheSize: cacheSize)
+        hidden = depthwise(hidden)
+        hidden = silu(normalization(hidden))
+        return pointwise2(hidden)
+    }
+}
+
+final class NemotronMLXConformerLayer: Module {
+    @ModuleInfo(key: "norm_feed_forward1") var feedForwardNorm1: LayerNorm
+    @ModuleInfo(key: "feed_forward1") var feedForward1: NemotronMLXFeedForward
+    @ModuleInfo(key: "norm_self_att") var attentionNorm: LayerNorm
+    @ModuleInfo(key: "self_attn") var attention: NemotronMLXRelativeAttention
+    @ModuleInfo(key: "norm_conv") var convolutionNorm: LayerNorm
+    @ModuleInfo var conv: NemotronMLXConvolution
+    @ModuleInfo(key: "norm_feed_forward2") var feedForwardNorm2: LayerNorm
+    @ModuleInfo(key: "feed_forward2") var feedForward2: NemotronMLXFeedForward
+    @ModuleInfo(key: "norm_out") var outputNorm: LayerNorm
+
+    init(
+        _ configuration: NemotronMLXConfiguration.Encoder,
+        quantization: NemotronMLXQuantization
+    ) {
+        let hiddenSize = configuration.hiddenSize
+        _feedForwardNorm1.wrappedValue = LayerNorm(dimensions: hiddenSize)
+        _feedForward1.wrappedValue = NemotronMLXFeedForward(
+            hiddenSize: hiddenSize,
+            expansion: configuration.feedForwardExpansion,
+            quantization: quantization
+        )
+        _attentionNorm.wrappedValue = LayerNorm(dimensions: hiddenSize)
+        _attention.wrappedValue = NemotronMLXRelativeAttention(
+            hiddenSize: hiddenSize,
+            heads: configuration.attentionHeads,
+            quantization: quantization
+        )
+        _convolutionNorm.wrappedValue = LayerNorm(dimensions: hiddenSize)
+        _conv.wrappedValue = NemotronMLXConvolution(
+            hiddenSize: hiddenSize,
+            kernelSize: configuration.convolutionKernelSize
+        )
+        _feedForwardNorm2.wrappedValue = LayerNorm(dimensions: hiddenSize)
+        _feedForward2.wrappedValue = NemotronMLXFeedForward(
+            hiddenSize: hiddenSize,
+            expansion: configuration.feedForwardExpansion,
+            quantization: quantization
+        )
+        _outputNorm.wrappedValue = LayerNorm(dimensions: hiddenSize)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        positionEmbedding: MLXArray,
+        cache: NemotronMLXLayerCache,
+        leftContext: Int,
+        convolutionCacheSize: Int
+    ) -> MLXArray {
+        var hidden = input
+            + 0.5 * feedForward1(feedForwardNorm1(input))
+        hidden = hidden + attention(
+            attentionNorm(hidden),
+            positionEmbedding: positionEmbedding,
+            cache: cache,
+            leftContext: leftContext
+        )
+        hidden = hidden + conv(
+            convolutionNorm(hidden),
+            cache: cache,
+            cacheSize: convolutionCacheSize
+        )
+        hidden = hidden
+            + 0.5 * feedForward2(feedForwardNorm2(hidden))
+        return outputNorm(hidden)
+    }
+}
+
+final class NemotronMLXEncoder: Module {
+    let configuration: NemotronMLXConfiguration
+
+    @ModuleInfo(key: "pre_encode") var preEncode: NemotronMLXSubsampling
+    @ModuleInfo var layers: [NemotronMLXConformerLayer]
+
+    init(_ configuration: NemotronMLXConfiguration) {
+        self.configuration = configuration
+        _preEncode.wrappedValue = NemotronMLXSubsampling(
+            configuration.encoder,
+            quantization: configuration.quantization
+        )
+        _layers.wrappedValue = (0..<configuration.encoder.layers).map { _ in
+            NemotronMLXConformerLayer(
+                configuration.encoder,
+                quantization: configuration.quantization
+            )
+        }
+        super.init()
+    }
+
+    func stream(
+        mel: MLXArray,
+        caches: [NemotronMLXLayerCache]
+    ) -> MLXArray {
+        precondition(caches.count == layers.count)
+        let outputFrames = configuration.streaming.outputFrames
+        var hidden = preEncode(mel)
+        hidden = hidden[
+            0...,
+            (hidden.dim(1) - outputFrames)...,
+            0...
+        ]
+        hidden = hidden * sqrt(Float(configuration.encoder.hiddenSize))
+
+        let seen = caches.first?.key?.dim(2) ?? 0
+        let keyFrames =
+            min(configuration.streaming.attentionLeftContext, seen)
+            + hidden.dim(1)
+        let positionEmbedding = Self.relativePositionEmbedding(
+            keyFrames: keyFrames,
+            hiddenSize: configuration.encoder.hiddenSize,
+            dtype: hidden.dtype
+        )
+        for index in layers.indices {
+            hidden = layers[index](
+                hidden,
+                positionEmbedding: positionEmbedding,
+                cache: caches[index],
+                leftContext:
+                    configuration.streaming.attentionLeftContext,
+                convolutionCacheSize:
+                    configuration.streaming.convolutionCacheSize
+            )
+        }
+        return hidden
+    }
+
+    static func relativePositionEmbedding(
+        keyFrames: Int,
+        hiddenSize: Int,
+        dtype: DType
+    ) -> MLXArray {
+        let positions = MLXArray(
+            stride(
+                from: keyFrames - 1,
+                through: -(keyFrames - 1),
+                by: -1
+            )
+        )
+        .asType(.float32)
+        .expandedDimensions(axis: 1)
+        let evenDimensions = MLXArray(
+            stride(from: 0, to: hiddenSize, by: 2)
+        ).asType(.float32)
+        let divisor = MLX.exp(
+            evenDimensions
+                * Float(-Foundation.log(10_000) / Double(hiddenSize))
+        )
+        let angles = positions * divisor
+        return MLX.stacked(
+            [MLX.sin(angles), MLX.cos(angles)],
+            axis: -1
+        )
+        .reshaped(1, positions.dim(0), hiddenSize)
+        .asType(dtype)
+    }
+}
+
+final class NemotronMLXPredictionNetworkBody: Module {
+    @ModuleInfo var embed: Embedding
+    @ModuleInfo(key: "dec_rnn") var recurrent: NemotronMLXStackedLSTM
+
+    init(_ configuration: NemotronMLXConfiguration.Decoder) {
+        _embed.wrappedValue = Embedding(
+            embeddingCount:
+                configuration.vocabularySize
+                + (configuration.blankAsPadding ? 1 : 0),
+            dimensions: configuration.predictionNetwork.hiddenSize
+        )
+        _recurrent.wrappedValue = NemotronMLXStackedLSTM(
+            hiddenSize: configuration.predictionNetwork.hiddenSize,
+            layers: configuration.predictionNetwork.layers
+        )
+        super.init()
+    }
+}
+
+final class NemotronMLXStackedLSTM: Module {
+    @ModuleInfo var lstm: [LSTM]
+
+    init(hiddenSize: Int, layers: Int) {
+        _lstm.wrappedValue = (0..<layers).map { _ in
+            LSTM(inputSize: hiddenSize, hiddenSize: hiddenSize)
+        }
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        hidden: MLXArray?,
+        cell: MLXArray?
+    ) -> (output: MLXArray, hidden: MLXArray, cell: MLXArray) {
+        var output = input
+        var nextHidden: [MLXArray] = []
+        var nextCell: [MLXArray] = []
+        nextHidden.reserveCapacity(lstm.count)
+        nextCell.reserveCapacity(lstm.count)
+        for index in lstm.indices {
+            let layerHidden = hidden.map { $0[index, 0..., 0...] }
+            let layerCell = cell.map { $0[index, 0..., 0...] }
+            let result = lstm[index](
+                output,
+                hidden: layerHidden,
+                cell: layerCell
+            )
+            output = result.0
+            nextHidden.append(result.0[0..., -1, 0...])
+            nextCell.append(result.1[0..., -1, 0...])
+        }
+        return (
+            output,
+            MLX.stacked(nextHidden, axis: 0),
+            MLX.stacked(nextCell, axis: 0)
+        )
+    }
+}
+
+final class NemotronMLXPredictionNetwork: Module {
+    let hiddenSize: Int
+    @ModuleInfo var prediction: NemotronMLXPredictionNetworkBody
+
+    init(_ configuration: NemotronMLXConfiguration.Decoder) {
+        hiddenSize = configuration.predictionNetwork.hiddenSize
+        _prediction.wrappedValue = NemotronMLXPredictionNetworkBody(
+            configuration
+        )
+        super.init()
+    }
+
+    func step(
+        token: Int?,
+        hidden: MLXArray?,
+        cell: MLXArray?
+    ) -> (output: MLXArray, hidden: MLXArray, cell: MLXArray) {
+        let input: MLXArray
+        if let token {
+            input = prediction.embed(
+                MLXArray([Int32(token)]).reshaped(1, 1)
+            )
+        } else {
+            input = MLXArray.zeros([1, 1, hiddenSize])
+        }
+        return prediction.recurrent(
+            input,
+            hidden: hidden,
+            cell: cell
+        )
+    }
+}
+
+final class NemotronMLXJointNetwork: Module {
+    @ModuleInfo var pred: Linear
+    @ModuleInfo var enc: Linear
+    @ModuleInfo(key: "joint_net") var output: [Module]
+
+    init(
+        _ configuration: NemotronMLXConfiguration.Joint,
+        quantization: NemotronMLXQuantization
+    ) {
+        _pred.wrappedValue = nemotronQuantizedLinear(
+            configuration.network.predictionHiddenSize,
+            configuration.network.hiddenSize,
+            quantization: quantization
+        )
+        _enc.wrappedValue = nemotronQuantizedLinear(
+            configuration.network.encoderHiddenSize,
+            configuration.network.hiddenSize,
+            quantization: quantization
+        )
+        _output.wrappedValue = [
+            ReLU(),
+            Identity(),
+            nemotronQuantizedLinear(
+                configuration.network.hiddenSize,
+                configuration.classes + 1,
+                quantization: quantization
+            ),
+        ]
+        super.init()
+    }
+
+    func callAsFunction(
+        encoder: MLXArray,
+        prediction: MLXArray
+    ) -> MLXArray {
+        let joined =
+            enc(encoder).expandedDimensions(axis: 2)
+            + pred(prediction).expandedDimensions(axis: 1)
+        var hidden = (output[0] as! ReLU)(joined)
+        hidden = (output[1] as! Identity)(hidden)
+        return (output[2] as! Linear)(hidden)
+    }
+}
+
+final class NemotronMLXPromptKernel: Module {
+    let promptCount: Int
+    @ModuleInfo var layers: [Module]
+
+    init(_ configuration: NemotronMLXConfiguration.PromptKernel) {
+        promptCount = configuration.promptCount
+        _layers.wrappedValue = [
+            Linear(
+                configuration.modelSize + configuration.promptCount,
+                configuration.hiddenSize
+            ),
+            ReLU(),
+            Linear(
+                configuration.hiddenSize,
+                configuration.modelSize
+            ),
+        ]
+        super.init()
+    }
+
+    func callAsFunction(
+        _ encoded: MLXArray,
+        languageMask: MLXArray
+    ) -> MLXArray {
+        let mask = MLX.broadcast(
+            languageMask.expandedDimensions(axis: 1),
+            to: [encoded.dim(0), encoded.dim(1), promptCount]
+        )
+        var hidden = (layers[0] as! Linear)(
+            MLX.concatenated([encoded, mask], axis: -1)
+        )
+        hidden = (layers[1] as! ReLU)(hidden)
+        return (layers[2] as! Linear)(hidden)
+    }
+}
+
+final class NemotronMLXNetwork: Module {
+    @ModuleInfo var encoder: NemotronMLXEncoder
+    @ModuleInfo var decoder: NemotronMLXPredictionNetwork
+    @ModuleInfo var joint: NemotronMLXJointNetwork
+    @ModuleInfo(key: "prompt_kernel") var promptKernel: NemotronMLXPromptKernel
+
+    init(_ configuration: NemotronMLXConfiguration) {
+        _encoder.wrappedValue = NemotronMLXEncoder(configuration)
+        _decoder.wrappedValue = NemotronMLXPredictionNetwork(
+            configuration.decoder
+        )
+        _joint.wrappedValue = NemotronMLXJointNetwork(
+            configuration.joint,
+            quantization: configuration.quantization
+        )
+        _promptKernel.wrappedValue = NemotronMLXPromptKernel(
+            configuration.promptKernel
+        )
+        super.init()
+    }
+}

--- a/Sources/NemotronStreamingASR/NemotronMLXRuntime.swift
+++ b/Sources/NemotronStreamingASR/NemotronMLXRuntime.swift
@@ -1,0 +1,564 @@
+import AudioCommon
+import Foundation
+import MLX
+import MLXNN
+
+/// Native MLX runtime for Nemotron-3.5 Streaming ASR.
+///
+/// The encoder, convolution, and RNN-T predictor caches advance in 320 ms
+/// increments, so partial text arrives without reprocessing the recording.
+/// INT5 and INT8 use the same BF16 recurrent state and streaming geometry.
+public final class NemotronStreamingASRMLXModel: @unchecked Sendable {
+    public static let defaultModelId = NemotronMLXVariant.int5.modelId
+    public static let inputSampleRate = 16_000
+
+    static let requiredBundleFiles = [
+        "config.json",
+        "model.safetensors",
+        "vocab.json",
+    ]
+
+    static let downloadAdditionalFiles = [
+        "model.safetensors",
+        "vocab.json",
+        "languages.json",
+        "lang2slot.json",
+        "tokenizer.model",
+        "speech_models_export.json",
+    ]
+
+    public let modelId: String
+    public let modelFolder: URL
+    public let configuration: NemotronMLXConfiguration
+    public let languages: NemotronLanguages
+    public var quantizationBits: Int {
+        configuration.quantization.bits
+    }
+
+    let network: NemotronMLXNetwork
+    let vocabulary: NemotronVocabulary
+    let melPreprocessor: StreamingMelPreprocessor
+    let inferenceLock = NSLock()
+
+    private init(
+        modelId: String,
+        modelFolder: URL,
+        configuration: NemotronMLXConfiguration,
+        languages: NemotronLanguages,
+        network: NemotronMLXNetwork,
+        vocabulary: NemotronVocabulary
+    ) {
+        self.modelId = modelId
+        self.modelFolder = modelFolder
+        self.configuration = configuration
+        self.languages = languages
+        self.network = network
+        self.vocabulary = vocabulary
+        melPreprocessor = StreamingMelPreprocessor(
+            config: Self.coreStreamingConfiguration
+        )
+    }
+
+    public static func fromPretrained(
+        variant: NemotronMLXVariant = .int5,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> NemotronStreamingASRMLXModel {
+        let model = try await fromPretrained(
+            modelId: variant.modelId,
+            cacheDir: cacheDir,
+            offlineMode: offlineMode,
+            progressHandler: progressHandler
+        )
+        guard model.quantizationBits == variant.quantizationBits else {
+            throw NemotronMLXError.invalidConfiguration(
+                "\(variant.modelId) declares INT\(model.quantizationBits); "
+                    + "expected INT\(variant.quantizationBits)"
+            )
+        }
+        return model
+    }
+
+    public static func fromPretrained(
+        modelId: String,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> NemotronStreamingASRMLXModel {
+        let directory: URL
+        do {
+            directory = try cacheDir
+                ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: modelId,
+                reason: "Failed to resolve the Nemotron MLX cache directory",
+                underlying: error
+            )
+        }
+
+        progressHandler?(0, "Preparing Nemotron MLX bundle...")
+        do {
+            try await HuggingFaceDownloader.downloadWeights(
+                modelId: modelId,
+                to: directory,
+                additionalFiles: downloadAdditionalFiles,
+                offlineMode: offlineMode
+            ) { fraction in
+                progressHandler?(
+                    fraction * 0.75,
+                    "Downloading Nemotron MLX bundle..."
+                )
+            }
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: modelId,
+                reason: "Failed to download the Nemotron MLX bundle",
+                underlying: error
+            )
+        }
+        return try await fromDirectory(
+            directory,
+            modelId: modelId
+        ) { fraction, message in
+            progressHandler?(0.75 + fraction * 0.25, message)
+        }
+    }
+
+    public static func fromDirectory(
+        _ directory: URL,
+        modelId: String = "local/Nemotron-3.5-Streaming-MLX",
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> NemotronStreamingASRMLXModel {
+        for file in requiredBundleFiles where !FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(file).path
+        ) {
+            throw NemotronMLXError.missingModelFile(file)
+        }
+
+        progressHandler?(0.05, "Loading Nemotron MLX configuration...")
+        let configuration = try JSONDecoder().decode(
+            NemotronMLXConfiguration.self,
+            from: Data(
+                contentsOf: directory.appendingPathComponent("config.json")
+            )
+        )
+        try configuration.validate()
+
+        progressHandler?(0.1, "Loading Nemotron vocabulary...")
+        let vocabulary = try NemotronVocabulary.load(
+            from: directory.appendingPathComponent("vocab.json")
+        )
+        guard vocabulary.count == configuration.vocabularySize else {
+            throw NemotronMLXError.invalidConfiguration(
+                "vocabulary contains \(vocabulary.count) entries; expected "
+                    + "\(configuration.vocabularySize)")
+        }
+
+        let wrappedLanguages =
+            directory.appendingPathComponent("languages.json")
+        let flatLanguages = directory.appendingPathComponent("lang2slot.json")
+        let languageURL: URL
+        if FileManager.default.fileExists(atPath: wrappedLanguages.path) {
+            languageURL = wrappedLanguages
+        } else if FileManager.default.fileExists(atPath: flatLanguages.path) {
+            languageURL = flatLanguages
+        } else {
+            throw NemotronMLXError.missingModelFile(
+                "languages.json or lang2slot.json")
+        }
+        let languages = try NemotronLanguages.load(from: languageURL)
+        guard
+            languages.promptDictionary["auto"] != nil,
+            languages.promptDictionary.values.allSatisfy({
+                (0..<configuration.promptKernel.promptCount).contains($0)
+            })
+        else {
+            throw NemotronMLXError.invalidConfiguration(
+                "language map must contain auto and use prompt slots 0..<"
+                    + "\(configuration.promptKernel.promptCount)"
+            )
+        }
+
+        progressHandler?(0.2, "Loading quantized Nemotron MLX weights...")
+        let weights = try MLX.loadArrays(
+            url: directory.appendingPathComponent("model.safetensors")
+        )
+        let network = NemotronMLXNetwork(configuration)
+        do {
+            try network.update(
+                parameters: ModuleParameters.unflattened(weights),
+                verify: .all
+            )
+        } catch {
+            throw NemotronMLXError.invalidConfiguration(
+                "incompatible MLX weights: \(error.localizedDescription)")
+        }
+        network.train(false)
+        MLX.eval(network.parameters())
+        Memory.clearCache()
+        progressHandler?(1, "Nemotron MLX ready")
+
+        return NemotronStreamingASRMLXModel(
+            modelId: modelId,
+            modelFolder: directory,
+            configuration: configuration,
+            languages: languages,
+            network: network,
+            vocabulary: vocabulary
+        )
+    }
+
+    public func createSession(
+        language: String? = nil
+    ) throws -> NemotronMLXStreamingSession {
+        inferenceLock.lock()
+        defer { inferenceLock.unlock() }
+        return try NemotronMLXStreamingSession(
+            model: self,
+            languageSlot: languages.slot(for: language)
+        )
+    }
+
+    public func transcribeStream(
+        audio: [Float],
+        sampleRate: Int,
+        language: String? = nil
+    ) -> AsyncStream<NemotronStreamingASRModel.PartialTranscript> {
+        AsyncStream { continuation in
+            Task {
+                do {
+                    let samples =
+                        sampleRate == Self.inputSampleRate
+                        ? audio
+                        : AudioFileLoader.resample(
+                            audio,
+                            from: sampleRate,
+                            to: Self.inputSampleRate
+                        )
+                    let session = try self.createSession(language: language)
+                    let chunkSamples =
+                        self.configuration.streaming.melFrames
+                        * Int(
+                            self.configuration.preprocessor.windowStride
+                                * Double(Self.inputSampleRate)
+                        )
+                    var offset = 0
+                    while offset < samples.count {
+                        let end = min(offset + chunkSamples, samples.count)
+                        for partial in try session.pushAudio(
+                            Array(samples[offset..<end])
+                        ) {
+                            continuation.yield(partial)
+                        }
+                        offset = end
+                    }
+                    for final in try session.finalize() {
+                        continuation.yield(final)
+                    }
+                    continuation.finish()
+                } catch {
+                    AudioLog.inference.error(
+                        "Nemotron MLX streaming failed: \(error)")
+                    continuation.finish()
+                }
+            }
+        }
+    }
+
+    public func transcribeAudio(
+        _ audio: [Float],
+        sampleRate: Int,
+        language: String? = nil
+    ) throws -> String {
+        let samples =
+            sampleRate == Self.inputSampleRate
+            ? audio
+            : AudioFileLoader.resample(
+                audio,
+                from: sampleRate,
+                to: Self.inputSampleRate
+            )
+        let session = try createSession(language: language)
+        var results = try session.pushAudio(samples)
+        results.append(contentsOf: try session.finalize())
+        return results.last?.text ?? ""
+    }
+
+    public func warmUp() throws {
+        let session = try createSession(language: "en-US")
+        _ = try session.pushAudio(
+            [Float](
+                repeating: 0,
+                count: configuration.streaming.melFrames
+                    * Self.coreStreamingConfiguration.hopLength
+            )
+        )
+        _ = try session.finalize()
+    }
+
+    static let coreStreamingConfiguration = NemotronStreamingConfig.default
+}
+
+public final class NemotronMLXStreamingSession {
+    private let model: NemotronStreamingASRMLXModel
+    private let configuration: NemotronMLXConfiguration
+    private let languageMask: MLXArray
+    private let caches: [NemotronMLXLayerCache]
+
+    private var preCache: MLXArray
+    private var decoderHidden: MLXArray
+    private var decoderCell: MLXArray
+    private var decoderOutput: MLXArray
+    private var sampleBuffer: [Float] = []
+    private var audioTail = [Float](repeating: 0, count: 480)
+    private var allTokens: [Int] = []
+    private var allLogProbabilities: [Float] = []
+    private var allTokenFrames: [Int] = []
+    private var encoderFrameOffset = 0
+    private var lastPublishedText = ""
+
+    init(
+        model: NemotronStreamingASRMLXModel,
+        languageSlot: Int
+    ) throws {
+        self.model = model
+        configuration = model.configuration
+        guard
+            (0..<configuration.promptKernel.promptCount)
+                .contains(languageSlot)
+        else {
+            throw NemotronMLXError.invalidConfiguration(
+                "language slot \(languageSlot) is outside the prompt kernel"
+            )
+        }
+        caches = (0..<configuration.encoder.layers).map { _ in
+            NemotronMLXLayerCache()
+        }
+        preCache = MLXArray.zeros(
+            [
+                1,
+                configuration.streaming.preCacheSize,
+                configuration.preprocessor.features,
+            ],
+            dtype: .bfloat16
+        )
+        var mask = [Float](
+            repeating: 0,
+            count: configuration.promptKernel.promptCount
+        )
+        mask[languageSlot] = 1
+        languageMask = MLXArray(mask)
+            .reshaped(1, configuration.promptKernel.promptCount)
+            .asType(.bfloat16)
+
+        let initial = model.network.decoder.step(
+            token: nil,
+            hidden: nil,
+            cell: nil
+        )
+        decoderOutput = initial.output
+        decoderHidden = initial.hidden
+        decoderCell = initial.cell
+        MLX.eval(decoderOutput, decoderHidden, decoderCell)
+    }
+
+    public var frameDurationSeconds: Double {
+        Double(configuration.encoder.subsamplingFactor)
+            * configuration.preprocessor.windowStride
+    }
+
+    public func pushAudio(
+        _ samples: [Float]
+    ) throws -> [NemotronStreamingASRModel.PartialTranscript] {
+        model.inferenceLock.lock()
+        defer { model.inferenceLock.unlock() }
+        sampleBuffer.append(contentsOf: samples)
+        let samplesPerChunk =
+            configuration.streaming.melFrames
+            * NemotronStreamingASRMLXModel.coreStreamingConfiguration.hopLength
+        var results: [NemotronStreamingASRModel.PartialTranscript] = []
+        var consumedSamples = 0
+        defer {
+            if consumedSamples > 0 {
+                sampleBuffer.removeFirst(consumedSamples)
+            }
+        }
+        while sampleBuffer.count - consumedSamples >= samplesPerChunk {
+            let end = consumedSamples + samplesPerChunk
+            let chunk = Array(sampleBuffer[consumedSamples..<end])
+            consumedSamples = end
+            if let partial = try processChunk(chunk) {
+                results.append(partial)
+            }
+        }
+        return results
+    }
+
+    public func finalize(
+    ) throws -> [NemotronStreamingASRModel.PartialTranscript] {
+        model.inferenceLock.lock()
+        defer { model.inferenceLock.unlock() }
+        if !sampleBuffer.isEmpty {
+            let samplesPerChunk =
+                configuration.streaming.melFrames
+                * NemotronStreamingASRMLXModel
+                    .coreStreamingConfiguration.hopLength
+            let padded = sampleBuffer
+                + [Float](
+                    repeating: 0,
+                    count: max(0, samplesPerChunk - sampleBuffer.count)
+                )
+            sampleBuffer.removeAll(keepingCapacity: false)
+            _ = try processChunk(Array(padded.prefix(samplesPerChunk)))
+        }
+        guard !allTokens.isEmpty else { return [] }
+        return [makePartial(isFinal: true)]
+    }
+
+    private func processChunk(
+        _ audio: [Float]
+    ) throws -> NemotronStreamingASRModel.PartialTranscript? {
+        let chunkMel = try makeMelArray(audio)
+        let fullMel = MLX.concatenated([preCache, chunkMel], axis: 1)
+        preCache = fullMel[
+            0...,
+            (fullMel.dim(1) - configuration.streaming.preCacheSize)...,
+            0...
+        ]
+
+        var encoded = model.network.encoder.stream(
+            mel: fullMel,
+            caches: caches
+        )
+        encoded = model.network.promptKernel(
+            encoded,
+            languageMask: languageMask
+        )
+        var evaluated = [encoded, preCache]
+        evaluated.append(contentsOf: caches.flatMap(\.evaluatedArrays))
+        MLX.eval(evaluated)
+
+        for frameIndex in 0..<encoded.dim(1) {
+            let frame = encoded[0..., frameIndex..<(frameIndex + 1), 0...]
+            for _ in 0..<10 {
+                let logits = model.network.joint(
+                    encoder: frame,
+                    prediction: decoderOutput
+                )
+                MLX.eval(logits)
+                let token = logits.argMax(axis: -1).item(Int.self)
+                if token == configuration.vocabularySize {
+                    break
+                }
+
+                let flattened = logits.reshaped(-1).asType(.float32)
+                let logProbability = logSoftmax(
+                    flattened,
+                    axis: -1
+                )[token].item(Float.self)
+                let next = model.network.decoder.step(
+                    token: token,
+                    hidden: decoderHidden,
+                    cell: decoderCell
+                )
+                MLX.eval(next.output, next.hidden, next.cell)
+                decoderOutput = next.output
+                decoderHidden = next.hidden
+                decoderCell = next.cell
+                allTokens.append(token)
+                allLogProbabilities.append(logProbability)
+                allTokenFrames.append(
+                    encoderFrameOffset + frameIndex
+                )
+            }
+        }
+        encoderFrameOffset += encoded.dim(1)
+        Memory.clearCache()
+
+        let text = model.vocabulary.decode(allTokens)
+        guard !text.isEmpty, text != lastPublishedText else {
+            return nil
+        }
+        lastPublishedText = text
+        return makePartial(isFinal: false)
+    }
+
+    private func makeMelArray(_ audio: [Float]) throws -> MLXArray {
+        // Keep three STFT hops of raw context. Computing every 320 ms chunk
+        // independently would reflect-pad each internal boundary and gradually
+        // diverge from the continuous-audio frontend used for export testing.
+        let tailFrames =
+            audioTail.count
+            / NemotronStreamingASRMLXModel.coreStreamingConfiguration.hopLength
+        let contextualAudio = audioTail + audio
+        audioTail = Array(
+            contextualAudio.suffix(audioTail.count)
+        )
+        let extracted = try model.melPreprocessor.extractRaw(contextualAudio)
+        let source = extracted.mel
+        let targetFrames = configuration.streaming.melFrames
+        let sourceFrames = source.shape[2].intValue
+        let bins = configuration.preprocessor.features
+        let pointer = source.dataPointer.assumingMemoryBound(to: Float.self)
+        var values = [Float](
+            repeating: 0,
+            count: targetFrames * bins
+        )
+        let copiedFrames = min(
+            max(0, sourceFrames - tailFrames),
+            targetFrames
+        )
+        for frame in 0..<copiedFrames {
+            for bin in 0..<bins {
+                values[frame * bins + bin] =
+                    pointer[
+                        bin * sourceFrames
+                            + tailFrames
+                            + frame
+                    ]
+            }
+        }
+        return MLXArray(values)
+            .reshaped(1, targetFrames, bins)
+            .asType(.bfloat16)
+    }
+
+    private func makePartial(
+        isFinal: Bool
+    ) -> NemotronStreamingASRModel.PartialTranscript {
+        let confidence: Float
+        if allLogProbabilities.isEmpty {
+            confidence = 0
+        } else {
+            confidence = min(
+                1,
+                exp(
+                    allLogProbabilities.reduce(0, +)
+                        / Float(allLogProbabilities.count)
+                )
+            )
+        }
+        let words = model.vocabulary.decodeTimedWords(
+            allTokens,
+            frames: allTokenFrames
+        ).map {
+            TimedWord(
+                text: $0.word,
+                startTime:
+                    Double($0.startFrame) * frameDurationSeconds,
+                endTime:
+                    Double($0.endFrame + 1) * frameDurationSeconds
+            )
+        }
+        return NemotronStreamingASRModel.PartialTranscript(
+            text: model.vocabulary.decode(allTokens),
+            isFinal: isFinal,
+            confidence: confidence,
+            segmentIndex: 0,
+            wordBoostingChangedDecisions: 0,
+            words: words
+        )
+    }
+}

--- a/Sources/NemotronStreamingASR/Vocabulary.swift
+++ b/Sources/NemotronStreamingASR/Vocabulary.swift
@@ -36,10 +36,23 @@ public struct NemotronVocabulary: Sendable {
         self.tokenToId = reverse
     }
 
-    /// Load vocabulary from vocab.json (format: `{"0": "▁the", "1": "▁a", ...}`).
+    /// Load vocabulary from either the Core ML dictionary form
+    /// (`{"0": "▁the"}`) or the MLX ordered-array form (`["▁the", ...]`).
     public static func load(from url: URL) throws -> NemotronVocabulary {
         let data = try Data(contentsOf: url)
-        let raw = try JSONDecoder().decode([String: String].self, from: data)
+        if let ordered = try? JSONDecoder().decode([String].self, from: data) {
+            return NemotronVocabulary(
+                idToToken: Dictionary(
+                    uniqueKeysWithValues: ordered.enumerated().map {
+                        ($0.offset, $0.element)
+                    }
+                )
+            )
+        }
+        let raw = try JSONDecoder().decode(
+            [String: String].self,
+            from: data
+        )
         var mapping: [Int: String] = [:]
         for (key, value) in raw {
             if let id = Int(key) {

--- a/Tests/NemotronStreamingASRTests/NemotronMLXTests.swift
+++ b/Tests/NemotronStreamingASRTests/NemotronMLXTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import XCTest
+@testable import AudioCommon
+@testable import NemotronStreamingASR
+
+private func nemotronMLXConfiguration(bits: Int = 5) throws
+    -> NemotronMLXConfiguration
+{
+    let json = """
+    {
+      "model_type": "nemotron_streaming_rnnt_mlx",
+      "sample_rate": 16000,
+      "vocab_size": 13087,
+      "preprocessor": {
+        "sample_rate": 16000,
+        "features": 128,
+        "n_fft": 512,
+        "window_size": 0.025,
+        "window_stride": 0.01,
+        "preemph": 0.97
+      },
+      "encoder": {
+        "feat_in": 128,
+        "n_layers": 24,
+        "d_model": 1024,
+        "n_heads": 8,
+        "ff_expansion_factor": 4,
+        "subsampling_factor": 8,
+        "conv_kernel_size": 9,
+        "subsampling_conv_channels": 256,
+        "use_bias": false,
+        "conv_norm_type": "layer_norm"
+      },
+      "decoder": {
+        "blank_as_pad": true,
+        "vocab_size": 13087,
+        "prednet": {
+          "pred_hidden": 640,
+          "pred_rnn_layers": 2
+        }
+      },
+      "joint": {
+        "num_classes": 13087,
+        "jointnet": {
+          "joint_hidden": 640,
+          "activation": "relu",
+          "encoder_hidden": 1024,
+          "pred_hidden": 640
+        }
+      },
+      "prompt_kernel": {
+        "num_prompts": 128,
+        "hidden": 2048,
+        "d_model": 1024
+      },
+      "streaming": {
+        "chunk_ms": 320,
+        "mel_frames": 32,
+        "pre_cache_size": 9,
+        "output_frames": 4,
+        "attention_left_context": 56,
+        "conv_cache_size": 8
+      },
+      "quantization": {
+        "mode": "affine",
+        "bits": \(bits),
+        "group_size": 64
+      }
+    }
+    """
+    return try JSONDecoder().decode(
+        NemotronMLXConfiguration.self,
+        from: Data(json.utf8)
+    )
+}
+
+final class NemotronMLXTests: XCTestCase {
+    func testDefaultPretrainedLoaderIsUnambiguous() {
+        let loader = {
+            try await NemotronStreamingASRMLXModel.fromPretrained(
+                offlineMode: true
+            )
+        }
+        _ = loader
+    }
+
+    func testPublishedVariantIdentifiersAndPrecisions() {
+        XCTAssertEqual(
+            NemotronMLXVariant.int5.modelId,
+            "aufklarer/Nemotron-3.5-ASR-Streaming-0.6B-MLX-5bit"
+        )
+        XCTAssertEqual(NemotronMLXVariant.int5.quantizationBits, 5)
+        XCTAssertEqual(
+            NemotronMLXVariant.int8.modelId,
+            "aufklarer/Nemotron-3.5-ASR-Streaming-0.6B-MLX-8bit"
+        )
+        XCTAssertEqual(NemotronMLXVariant.int8.quantizationBits, 8)
+        XCTAssertEqual(
+            NemotronStreamingASRMLXModel.defaultModelId,
+            NemotronMLXVariant.int5.modelId
+        )
+    }
+
+    func testPublishedInt5AndInt8ConfigurationsValidate() throws {
+        try nemotronMLXConfiguration(bits: 5).validate()
+        try nemotronMLXConfiguration(bits: 8).validate()
+    }
+
+    func testUnsupportedQuantizationFailsClosed() throws {
+        let configuration = try nemotronMLXConfiguration(bits: 4)
+        XCTAssertThrowsError(try configuration.validate()) { error in
+            XCTAssertTrue(
+                error.localizedDescription.contains(
+                    "only affine group-64 INT5 and INT8"
+                )
+            )
+        }
+    }
+
+    func testMLXOrderedVocabularyLoadsWithoutRenumbering() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nemotron-mlx-vocab-\(UUID()).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("[\"▁zero\",\"one\",\"▁two\"]".utf8).write(to: url)
+
+        let vocabulary = try NemotronVocabulary.load(from: url)
+
+        XCTAssertEqual(vocabulary.count, 3)
+        XCTAssertEqual(vocabulary.decode([0, 1, 2]), "zeroone two")
+    }
+}
+
+final class E2ENemotronMLXTests: XCTestCase {
+    func testLocalINT5BundleStreamsBundledSpeech() async throws {
+        try await assertLocalBundle(
+            environmentVariable: "NEMOTRON_MLX_LOCAL_BUNDLE",
+            expectedBits: 5
+        )
+    }
+
+    func testLocalINT8BundleStreamsBundledSpeech() async throws {
+        try await assertLocalBundle(
+            environmentVariable: "NEMOTRON_MLX_INT8_LOCAL_BUNDLE",
+            expectedBits: 8
+        )
+    }
+
+    private func assertLocalBundle(
+        environmentVariable: String,
+        expectedBits: Int
+    ) async throws {
+        guard
+            let path = ProcessInfo.processInfo.environment[
+                environmentVariable
+            ],
+            !path.isEmpty
+        else {
+            throw XCTSkip(
+                "Set \(environmentVariable) to an exported INT\(expectedBits) bundle"
+            )
+        }
+
+        let model = try await NemotronStreamingASRMLXModel.fromDirectory(
+            URL(fileURLWithPath: path)
+        )
+        XCTAssertEqual(model.quantizationBits, expectedBits)
+        let audioURL = try XCTUnwrap(
+            Bundle.module.url(
+                forResource: "test_audio",
+                withExtension: "wav"
+            )
+        )
+        let audio = try AudioFileLoader.load(
+            url: audioURL,
+            targetSampleRate: 16_000
+        )
+
+        var partials: [NemotronStreamingASRModel.PartialTranscript] = []
+        for await partial in model.transcribeStream(
+            audio: audio,
+            sampleRate: 16_000,
+            language: "en-US"
+        ) {
+            partials.append(partial)
+        }
+
+        XCTAssertGreaterThan(partials.count, 1)
+        XCTAssertEqual(partials.last?.isFinal, true)
+        let finalText = try XCTUnwrap(partials.last?.text)
+        XCTAssertFalse(finalText.isEmpty)
+        XCTAssertTrue(
+            finalText.localizedCaseInsensitiveContains("replacement")
+        )
+        XCTAssertTrue(
+            finalText.localizedCaseInsensitiveContains("tomorrow")
+        )
+        XCTAssertFalse(finalText.contains("<en-US>"))
+        print("Nemotron MLX INT\(expectedBits) final: \(finalText)")
+    }
+}

--- a/docs/benchmarks/nemotron-asr-streaming.md
+++ b/docs/benchmarks/nemotron-asr-streaming.md
@@ -1,8 +1,16 @@
 # Nemotron-3.5 ASR Streaming — benchmarks
 
-All numbers from M5 Pro / 48 GB. 50 samples per language from FLEURS test split (chunk 320 ms). Methodology matches NVIDIA's published table: `EnglishTextNormalizer` for English, `BasicTextNormalizer` for European/Arabic, `BasicTextNormalizer(split_letters=True)` for CJK + Indic (char-level scoring).
+All numbers are from an M5 Pro / 48 GB. Quality uses 50 samples per
+language from the FLEURS test split. Methodology matches NVIDIA's published
+table: `EnglishTextNormalizer` for English, `BasicTextNormalizer` for
+European/Arabic, and `BasicTextNormalizer(split_letters=True)` for CJK +
+Indic (character-level scoring).
 
-## WER % vs upstream
+## Whole-utterance conversion diagnostic
+
+This historical table checks exported weights without advancing the release
+streaming caches. Use the next section for the published INT5/INT8 runtime
+quality.
 
 | lang | NVIDIA dev | fp32 NeMo | CoreML INT8 | MLX bf16 | MLX int8 | MLX int4 |
 |------|-:|-:|-:|-:|-:|-:|
@@ -24,16 +32,57 @@ All numbers from M5 Pro / 48 GB. 50 samples per language from FLEURS test split 
 | hi-IN |  4.37 |  3.61 |  4.31 |  4.47 |  6.52 |
 | ja-JP | 11.27 | 12.09 | 11.50 | 11.97 | 12.89 |
 
-## Streaming throughput + memory (60 s long-form en_us, chunk 320 ms)
+## Published MLX 320 ms streaming quality
 
-| variant | on-disk | RSS post-load | RSS peak | offline RTF | streaming RTF | p50 / p99 chunk ms |
-|---------|--------:|--------------:|---------:|-:|-:|-:|
-| CoreML INT8 |  612 MB |  1046 MB |  1238 MB | 0.059 | 0.068 | 18.6 / 23.4 |
-| MLX bf16    | 1217 MB |   192 MB |  1474 MB | 0.014 | 0.062 | 18.4 / 23.5 |
-| MLX int8    |  732 MB |   262 MB |   997 MB | 0.013 | 0.044 | 13.5 / 16.8 |
-| MLX int4    |  473 MB |   270 MB |   747 MB | 0.012 | 0.041 | 12.8 / 15.6 |
+These results use the exact cache-aware runtime shipped with the release
+bundles.
 
-MLX int4 has the lowest absolute streaming peak (747 MB). CoreML INT8 has the smallest in-streaming Δ (+192 MB above post-load) because the encoder mmap is fully resident after first chunk.
+| lang | INT5 WER | INT5 CER | INT8 WER | INT8 CER |
+|------|---------:|---------:|---------:|---------:|
+| en-US | 8.64 | 3.77 | 8.98 | 3.96 |
+| de-DE | 11.15 | 6.25 | 10.59 | 5.73 |
+| fr-FR | 13.10 | 5.18 | 11.83 | 4.66 |
+| ar | 13.66 | 3.94 | 13.37 | 3.77 |
+| hi-IN | 4.77 | 3.85 | 4.28 | 3.50 |
+| ja-JP | 17.86 | 12.11 | 17.01 | 11.42 |
+| **Mean** | **11.53** | **5.85** | **11.01** | **5.51** |
+
+INT5 costs 0.52 percentage points mean WER and 0.34 points mean CER
+versus INT8.
+
+## Streaming throughput + memory (63.7 s long-form en-US, 320 ms chunks)
+
+| variant | on-disk | RSS post-load | RSS peak | streaming RTF | p50 / p95 / p99 chunk ms |
+|---------|--------:|--------------:|---------:|--------------:|--------------------------:|
+| CoreML INT8 | 612 MB | 1046 MB | 1238 MB | 0.068 | 18.6 / — / 23.4 |
+| MLX bf16 | 1217 MB | 192 MB | 1474 MB | 0.062 | 18.4 / — / 23.5 |
+| **MLX INT5** | **538.6 MB** | **196 MB** | **800 MB** | **0.0467** | **13.8 / 15.9 / 16.8** |
+| MLX INT8 | 732.6 MB | 196 MB | 992 MB | 0.0485 | 14.3 / 16.2 / 18.9 |
+| MLX int4 | 473 MB | 270 MB | 747 MB | 0.041 | 12.8 / — / 15.6 |
+
+INT5 saves about 193 MB on disk and 192 MB of peak RSS versus INT8 while
+remaining slightly faster in this run. INT4 has the lowest absolute peak, but
+the native Swift runtime deliberately supports only the quality-gated INT5
+and INT8 releases.
+
+## Native Swift regression gate
+
+The release `asr-bench` executable was also run three times with a fresh
+isolated process per variant. The fixture is one 20-second English utterance
+(11 reference words); model warmup is excluded from RTF. Values below are
+three-run medians on the same M5 Pro / 48 GB host.
+
+| variant | WER / CER | RTF | throughput | peak RSS | RSS delta | peak physical footprint |
+|---------|----------:|----:|-----------:|---------:|----------:|------------------------:|
+| **MLX INT5** | **0 / 0** | **0.0360** | **27.8×** | **611 MB** | **587 MB** | **676 MB** |
+| MLX INT8 | 0 / 0 | 0.0375 | 26.7× | 805 MB | 781 MB | 870 MB |
+
+The maximum observed RTF was 0.0362 for INT5 and 0.0379 for INT8. INT5 saved
+194 MB of peak process RSS in the native runtime. This short fixture is a
+repeatable performance and exact-output smoke gate, not a replacement for the
+six-language quality benchmark above. Its workload also differs from the
+63.7-second Python benchmark, so absolute Python and Swift RTF values should
+not be compared directly.
 
 ## Round-trip equivalence Δ-CER vs fp32 source
 
@@ -46,11 +95,18 @@ Per-variant Δ-CER averaged over 6 languages, same audio through fp32 NeMo + var
 | MLX int8    | +0.32 pp |
 | MLX int4    | +2.32 pp |
 
-CoreML INT8, MLX bf16, and MLX int8 are essentially lossless. MLX int4 trades +2.3 pp avg CER for the smallest disk + streaming footprint.
+CoreML INT8, MLX bf16, and MLX int8 are essentially lossless in this
+whole-utterance diagnostic. MLX int4 trades +2.3 pp average CER for the
+smallest disk + streaming footprint.
 
 ## Bench setup notes
 
-- All MLX runs used `mx.set_cache_limit` defaults — sweep showed cache_limit changes don't affect peak RSS (peak Δ ≈ weight size for any variant, structural cost of forward through 24-layer Conformer).
+- INT5 and INT8 release memory figures are fresh-process runs over 199
+  chunks; RSS is process memory, not only active MLX allocations.
+- All MLX runs used `mx.set_cache_limit` defaults — sweep showed cache-limit
+  changes do not affect peak RSS (peak delta is approximately the weight
+  size for any variant, a structural cost of forwarding through the
+  24-layer Conformer).
 - Per-N-layer `mx.eval` sweep showed N=8 gives a small free RTF speedup (-5–8 %) on bf16 with no peak / accuracy effect. N=1 is harmful.
 - The Swift bench uses `autoreleasepool` per utterance + per-language model reload to avoid CoreML IOSurface exhaustion (~250+ predicts in one MLModel lifetime triggers segfault).
 - All Swift WER numbers match the Python pipeline byte-for-byte on every sample (49/50 on Hindi; the 1 divergence is a real model-level non-determinism in CoreML ANE scheduling, not a wrapper bug).
@@ -62,12 +118,40 @@ CoreML INT8, MLX bf16, and MLX int8 are essentially lossless. MLX int4 trades +2
 cd speech-models/models/nemotron-asr-streaming-multilingual/export
 poetry run python bench_wer_torch_fp32.py --langs en_us,de_de,fr_fr,ar_eg,hi_in,ja_jp --limit 50
 poetry run python bench_wer_coreml.py --bundle /tmp/Nemotron-3.5-CoreML-320ms --langs en_us,de_de,fr_fr,ar_eg,hi_in,ja_jp --limit 50
-poetry run python bench_wer_mlx.py --root /tmp/Nemotron-3.5-MLX --variants bf16,int8,int4 --limit 50
+python bench_wer_mlx.py \
+  --root /tmp/Nemotron-3.5-MLX \
+  --variants int5,int8 \
+  --langs en_us,de_de,fr_fr,ar_eg,hi_in,ja_jp \
+  --streaming \
+  --limit 50
+python bench_stream_all.py \
+  --root /tmp/Nemotron-3.5-MLX \
+  --runs mlx_int5 \
+  --seconds 60
+python bench_stream_all.py \
+  --root /tmp/Nemotron-3.5-MLX \
+  --runs mlx_int8 \
+  --seconds 60
 
 # Swift
-cd speech-swift-asr-bench  # or your worktree
+cd speech-swift
 NEMOTRON_35_LOCAL_BUNDLE=/tmp/Nemotron-3.5-CoreML-320ms \
   swift test --filter E2ENemotronMultilingualBench
+NEMOTRON_MLX_LOCAL_BUNDLE=/tmp/Nemotron-3.5-MLX/int5 \
+NEMOTRON_MLX_INT8_LOCAL_BUNDLE=/tmp/Nemotron-3.5-MLX/int8 \
+  swift test --filter E2ENemotronMLXTests
+
+# Native isolated WER / RTF / RSS gate. The TSV contains:
+# /absolute/path/to/audio.wav<TAB>reference transcript
+make build
+NEMOTRON_MLX_LOCAL_BUNDLE=/tmp/Nemotron-3.5-MLX/int5 \
+NEMOTRON_MLX_INT8_LOCAL_BUNDLE=/tmp/Nemotron-3.5-MLX/int8 \
+  .build/release/asr-bench \
+    --dataset /path/to/benchmark.tsv \
+    --engines nemotron-mlx-int5 nemotron-mlx-int8 \
+    --language en-US \
+    --isolated \
+    --output /tmp/nemotron-swift-bench.json
 ```
 
 Results land in `/tmp/nem35-logs/wer_*.json` (Python) and `/tmp/nem35-logs/wer_swift.json` (Swift).

--- a/docs/inference/nemotron-asr-streaming.md
+++ b/docs/inference/nemotron-asr-streaming.md
@@ -1,8 +1,10 @@
 # Nemotron-3.5 ASR Streaming — inference
 
-Swift bindings for the Nemotron-3.5 multilingual streaming ASR bundle (CoreML, 600 M params, 40 language-locales). Lives in `Sources/NemotronStreamingASR/`.
+Swift bindings for the Nemotron-3.5 multilingual streaming ASR bundle
+(Core ML or native MLX, 600 M parameters, 40 language-locales). Lives in
+`Sources/NemotronStreamingASR/`.
 
-## Two ways to consume
+## Core ML API
 
 ```swift
 import NemotronStreamingASR
@@ -25,7 +27,53 @@ for chunk in audioChunks {
 let finals = try session.finalize()
 ```
 
-## Word boosting
+## Native MLX INT5 and INT8
+
+`NemotronStreamingASRMLXModel` runs the quantized encoder, prompt kernel,
+RNN-T predictor, and joint network directly with MLX. INT5 is the default
+because it saves about 193 MB on disk and 192 MB of peak RSS versus INT8,
+while the six-language streaming benchmark costs 0.52 percentage points of
+mean WER. Select INT8 when the small accuracy gain matters more than memory.
+
+```swift
+import NemotronStreamingASR
+
+// Downloads the 538.6 MB INT5 bundle by default.
+let model = try await NemotronStreamingASRMLXModel.fromPretrained(
+    variant: .int5
+)
+
+let session = try model.createSession(language: "en-US")
+for chunk in microphoneChunks16kHz {
+    for partial in try session.pushAudio(chunk) {
+        print(partial.text)
+    }
+}
+let final = try session.finalize().last?.text
+```
+
+Use `.int8` for the 732.6 MB release, or load an already downloaded bundle:
+
+```swift
+let int8 = try await NemotronStreamingASRMLXModel.fromPretrained(
+    variant: .int8
+)
+
+let local = try await NemotronStreamingASRMLXModel.fromDirectory(
+    URL(fileURLWithPath: "/path/to/Nemotron-MLX-5bit")
+)
+```
+
+Both variants require the bundle-declared 320 ms geometry. The model may
+serve multiple source-local sessions, but it serializes model creation,
+`pushAudio`, and `finalize` inference because the sessions share one set of
+resident MLX weights. Each session keeps independent mel, attention,
+convolution, language, and RNN-T state.
+
+The MLX API currently uses greedy decoding only. Word boosting remains a
+Core ML API feature.
+
+## Word boosting (Core ML)
 
 Nemotron word boosting biases RNN-T decoding toward caller-provided words or phrases. It is not transcript post-processing: the decoder adjusts token scores after the joint network produces logits and before greedy token selection.
 
@@ -177,7 +225,7 @@ Bad:
 
 The full list of 121 aliases is in the `languages` property of the loaded model.
 
-## Loading
+## Core ML loading
 
 ```swift
 // From the HF cache (default repo aufklarer/Nemotron-3.5-ASR-Streaming-0.6B-CoreML-INT8)
@@ -193,7 +241,10 @@ let bundleURL = URL(fileURLWithPath: "/tmp/Nemotron-3.5-CoreML-320ms")
 let model = try await NemotronStreamingASRModel.fromLocal(bundleDir: bundleURL)
 ```
 
-The loader expects the standard bundle layout described in `docs/models/nemotron-asr-streaming.md`. Compute units default to `.all` (encoder on ANE + GPU + CPU, decoder/joint on CPU) — measured ~40% faster RTF than `.cpuAndGPU` on M-series.
+The Core ML loader expects the standard bundle layout described in
+`docs/models/nemotron-asr-streaming.md`. Compute units default to `.all`
+(encoder on ANE + GPU + CPU, decoder/joint on CPU) — measured about 40%
+faster RTF than `.cpuAndGPU` on M-series.
 
 ## Streaming geometry
 
@@ -206,10 +257,18 @@ The loader expects the standard bundle layout described in `docs/models/nemotron
 | Sample rate | 16 kHz mono Float32 |
 
 `transcribeStream` slices audio at the configured chunk size; `pushAudio` accepts any chunk size and buffers internally until enough samples accumulate.
+Published MLX bundles accept only the validated 320 ms row. Alternate chunk
+geometries are research/export options, not a runtime override for those
+weights.
 
 ## TTS round-trip and short-audio padding
 
-`transcribeAudio` adds 100 ms of silence at both ends by default to prime the all-zero streaming cache (otherwise short TTS clips with sharp onsets can drop the first word). For natural recorded speech (FLEURS-style microphone capture), pass `padSilence: false` to skip the pad — measured ~0–5 pp WER drop on the harder languages.
+Core ML `transcribeAudio` adds 100 ms of silence at both ends by default to
+prime the all-zero streaming cache (otherwise short TTS clips with sharp
+onsets can drop the first word). For natural recorded speech (FLEURS-style
+microphone capture), pass `padSilence: false` to skip the pad — measured
+about 0–5 pp WER drop on the harder languages. The MLX API does not add this
+Core ML compatibility padding.
 
 ```swift
 // TTS-style (short clip, padding helps): default true
@@ -224,18 +283,22 @@ let recText = try model.transcribeAudio(micAudio, sampleRate: 16000,
 
 60 s synthetic FLEURS en_us long-form streamed in 320 ms chunks (compute units `.all`):
 
-| metric | value |
-|--------|------:|
-| RSS pre-load | 56 MB |
-| RSS post-load | 652 MB |
-| RSS peak (mid-stream) | 1.2 GB |
-| RTF (encode + decode) | 0.06 |
-| p50 chunk latency | 18.6 ms |
-| p99 chunk latency | 23.4 ms |
+| runtime | bundle | RSS peak | streaming RTF | p50 / p95 / p99 chunk |
+|---------|-------:|---------:|--------------:|----------------------:|
+| MLX INT5 | 538.6 MB | 800 MB | 0.0467 | 13.8 / 15.9 / 16.8 ms |
+| MLX INT8 | 732.6 MB | 992 MB | 0.0485 | 14.3 / 16.2 / 18.9 ms |
+| Core ML INT8 | 612 MB | 1.2 GB | 0.068 | 18.6 / — / 23.4 ms |
+
+The native Swift release regression gate uses `asr-bench --isolated` and a
+20-second English fixture. Across three fresh-process runs per variant, INT5
+had median RTF 0.0360 and 611 MB peak RSS; INT8 had median RTF 0.0375 and
+805 MB peak RSS. Both reproduced the 11-word reference exactly. See
+`docs/benchmarks/nemotron-asr-streaming.md` for methodology and the
+reproduction command.
 
 ## Memory management
 
-Conforms to `ModelMemoryManageable`:
+The Core ML model conforms to `ModelMemoryManageable`:
 
 ```swift
 if memoryPressure { model.unload() }
@@ -263,11 +326,34 @@ Methodology: Whisper `EnglishTextNormalizer` for English; `BasicTextNormalizer` 
 
 Remaining gaps are scoring methodology (NVIDIA's exact normalizer + full FLEURS test split — 600 samples per lang — would close most), not model quality. Quantization is essentially lossless: CoreML INT8 is within ±1 pp of fp32 on every language.
 
+The release MLX benchmark exercises the actual cache-aware 320 ms path
+(50 samples per language):
+
+| lang | MLX INT5 WER / CER | MLX INT8 WER / CER |
+|------|-------------------:|-------------------:|
+| en-US | 8.64 / 3.77 | 8.98 / 3.96 |
+| de-DE | 11.15 / 6.25 | 10.59 / 5.73 |
+| fr-FR | 13.10 / 5.18 | 11.83 / 4.66 |
+| ar | 13.66 / 3.94 | 13.37 / 3.77 |
+| hi-IN | 4.77 / 3.85 | 4.28 / 3.50 |
+| ja-JP | 17.86 / 12.11 | 17.01 / 11.42 |
+| **Mean** | **11.53 / 5.85** | **11.01 / 5.51** |
+
 ## Tests
 
 ```bash
 make test                                          # unit + E2E (downloads HF model first time)
 swift test --filter WordBoosting                  # word boosting unit tests + E2E A/B smoke test
+swift test --filter NemotronMLXTests              # model-free MLX loader/config tests
+NEMOTRON_MLX_LOCAL_BUNDLE=/path/to/int5 \
+NEMOTRON_MLX_INT8_LOCAL_BUNDLE=/path/to/int8 \
+  swift test --filter E2ENemotronMLXTests         # native MLX streaming E2E
+NEMOTRON_MLX_LOCAL_BUNDLE=/path/to/int5 \
+NEMOTRON_MLX_INT8_LOCAL_BUNDLE=/path/to/int8 \
+  .build/release/asr-bench \
+    --dataset /path/to/benchmark.tsv \
+    --engines nemotron-mlx-int5 nemotron-mlx-int8 \
+    --language en-US --isolated                   # WER + RTF + peak RSS
 swift test --filter E2ENemotronMultilingualBench   # 6-lang FLEURS bench, writes /tmp/nem35-logs/wer_swift.json
 swift test --filter E2EHiBisect                    # Hindi divergence diagnostic (Python diff)
 ```

--- a/docs/models/nemotron-asr-streaming.md
+++ b/docs/models/nemotron-asr-streaming.md
@@ -1,6 +1,9 @@
 # Nemotron-3.5 ASR Streaming — architecture
 
-Multilingual streaming ASR from NVIDIA, ported to CoreML for Apple Silicon via the `NemotronStreamingASR` target. 600 M parameters, 40 language-locales, native punctuation and capitalization. Cache-aware FastConformer encoder with a prompt-conditioned RNN-T decoder.
+Multilingual streaming ASR from NVIDIA, available through Core ML and native
+MLX backends on Apple Silicon via the `NemotronStreamingASR` target. 600 M
+parameters, 40 language-locales, native punctuation and capitalization.
+Cache-aware FastConformer encoder with a prompt-conditioned RNN-T decoder.
 
 ## Source
 
@@ -16,11 +19,14 @@ raw 16 kHz audio
   → cache-aware Conformer encoder (24 layers, d_model=1024, 580 M params)
   → prompt-kernel language conditioning (one-hot 128-slot → concat → 2-layer MLP)
   → RNN-T greedy decoder (2-layer LSTM, pred_hidden=640, blank id=13087)
-  → optional word boosting over joint logits
-  → text tokens (vocab 13087, with `<lang-XX>` markers)
+  → optional word boosting over joint logits (Core ML backend)
+  → user text (vocab 13087; emitted `<lang-XX>` markers are filtered)
 ```
 
-The encoder produces one frame every 80 ms (8× subsampling from 10 ms mel hop). All four chunk modes share the same encoder and decoder weights; only the attention right-context changes.
+The encoder produces one frame every 80 ms (8× subsampling from a 10 ms mel
+hop). The Core ML exporter can generate four chunk modes from the same source
+weights. Published MLX INT5 and INT8 bundles intentionally expose only the
+quality-tested 320 ms geometry.
 
 ## Cache-aware streaming
 
@@ -37,7 +43,16 @@ The decoder LSTM state (`h`, `c`) is also persisted between chunks; the joint ne
 
 ## Word boosting
 
-`NemotronStreamingASR` implements word boosting decoder-side, between `joint.prediction(...)` and greedy token selection in `RNNTGreedyDecoder`. Boosted phrases are tokenized with the Nemotron SentencePiece tokenizer when `tokenizer.model` is present, stored in a phrase-prefix trie, and applied as token-level logit bias during decoding. This is RNN-T shallow fusion, not the full NVIDIA CTC-WS algorithm: CTC-WS needs an auxiliary CTC head, and the public `nvidia/nemotron-3.5-asr-streaming-0.6b` checkpoint (inspected June 10, 2026) is RNNT-only — its `model_config.yaml` target is `EncDecRNNTBPEModelWithPrompt`, it has no `aux_ctc` section, and its weights contain no CTC tensors.
+The Core ML runtime implements word boosting decoder-side, between
+`joint.prediction(...)` and greedy token selection in `RNNTGreedyDecoder`.
+Boosted phrases are tokenized with the Nemotron SentencePiece tokenizer when
+`tokenizer.model` is present, stored in a phrase-prefix trie, and applied as
+token-level logit bias during decoding. This is RNN-T shallow fusion, not the
+full NVIDIA CTC-WS algorithm: CTC-WS needs an auxiliary CTC head, and the
+public `nvidia/nemotron-3.5-asr-streaming-0.6b` checkpoint (inspected June 10,
+2026) is RNNT-only — its `model_config.yaml` target is
+`EncDecRNNTBPEModelWithPrompt`, it has no `aux_ctc` section, and its weights
+contain no CTC tensors. Native MLX currently uses unboosted greedy decoding.
 
 The implementation does not allow word boosting to replace the RNN-T blank token. Blank advances decoding to the next encoder frame; letting a boosted phrase beat blank can pin the decoder on one frame and produce repeated-token garbage. Boosting is only applied when the unboosted greedy token is non-blank.
 
@@ -50,7 +65,9 @@ The implementation does not allow word boosting to replace the RNN-T blank token
 | 560  | 7  | 6  | balanced |
 | 1120 | 14 | 13 | near-offline |
 
-Bundles published as `aufklarer/Nemotron-3.5-ASR-Streaming-0.6B-CoreML-INT8` use chunk_ms = 320.
+The published Core ML INT8, MLX INT5, and MLX INT8 bundles use
+`chunk_ms = 320`. MLX rejects any caller-selected geometry that differs from
+the bundle declaration.
 
 ## Prompt-kernel language conditioning
 
@@ -68,7 +85,9 @@ Slot mapping ships in `languages.json` (e.g. `"en-US": 0`, `"de-DE": 9`, `"ja-JP
 
 - 13 087 SentencePiece pieces + 1 blank id (13087)
 - Native punctuation tokens (`.`, `,`, `?`, `!`, etc.) as regular vocab entries
-- Per-language tag tokens (`<en-US>`, `<de-DE>`, ...) emitted as suffix on each utterance; the Swift wrapper strips these via a regex in WER-style normalization
+- Per-language tag tokens (`<en-US>`, `<de-DE>`, ...) may be emitted in the
+  token stream; `NemotronVocabulary.decode` filters angle-bracket special
+  tokens before returning user-facing text
 
 ## CoreML bundle layout
 
@@ -86,6 +105,27 @@ languages.json        promptDictionary: lang tag → slot
 
 `.mlmodelc` (compiled) ships rather than `.mlpackage` per the speech-models policy — on-device `MLModel.compileModel()` produces non-deterministic output across simulator vs device runtimes, breaking parity.
 
+## MLX bundle layout
+
+The deterministic MLX exporter produces one self-describing directory:
+
+```
+model.safetensors          quantized MLX parameter tree
+config.json                exact network, quantization, and 320 ms cache geometry
+vocab.json                 ordered token array
+tokenizer.model            SentencePiece source tokenizer
+languages.json             wrapped promptDictionary language map
+lang2slot.json             flat language map for non-Swift runtimes
+speech_models_export.json  pinned source revision plus artifact hashes
+```
+
+The native loader instantiates `QuantizedLinear` layers directly with the
+declared affine group-64 INT5 or INT8 precision, loads with strict parameter
+verification, and rejects unsupported network/cache geometry. Encoder and
+decoder recurrent state remains BF16 for both variants. Multiple sessions can
+share one loaded model; their caches remain separate while inference calls are
+serialized.
+
 ## Differences vs older `nemotron-speech-streaming-en-0.6b`
 
 | | English 0.6b (older) | Multilingual 3.5 0.6b |
@@ -99,7 +139,7 @@ languages.json        promptDictionary: lang tag → slot
 
 The Swift `NemotronStreamingConfig` decoder accepts both layouts — older English bundles missing `numPrompts` default to 128, and `attentionContext` accepts either the new `attentionLeftContext` field name or the old `attentionContext` name.
 
-## Conversion equivalence
+## Conversion quality
 
 Round-trip verified Δ-CER vs the fp32 NeMo source on 6 languages × 50 FLEURS samples each (50 + 60 chunks per sample):
 
@@ -111,6 +151,26 @@ Round-trip verified Δ-CER vs the fp32 NeMo source on 6 languages × 50 FLEURS s
 | MLX int4    | +2.32 pp |
 
 CoreML INT8 / MLX bf16 / MLX int8 are essentially lossless; int4 is meaningfully lossier especially on Hindi and Japanese.
+
+Those figures are the original whole-utterance conversion diagnostic. The
+release gate also scores the actual cache-aware 320 ms runtime on the same six
+languages:
+
+| variant | mean WER | mean CER | bundle | streaming peak |
+|---------|---------:|---------:|-------:|---------------:|
+| MLX INT5 | 11.53 | 5.85 | 538.6 MB | 800 MB |
+| MLX INT8 | 11.01 | 5.51 | 732.6 MB | 992 MB |
+
+INT5 is the native runtime default: it saves about 193 MB of storage and
+192 MB of peak RSS for +0.52 percentage points mean WER versus INT8. INT4
+remains an export/research artifact and is not accepted by the native Swift
+runtime because its measured quality loss is substantially larger.
+
+An additional three-run, fresh-process Swift regression gate on a 20-second
+English fixture measured 0.0360 median RTF / 611 MB peak RSS for INT5 and
+0.0375 / 805 MB for INT8, with exact reference text from both variants. That
+short gate checks native runtime performance and output stability; the
+six-language table remains the quality comparison.
 
 ## References
 


### PR DESCRIPTION
## Summary

- add native MLX INT5 and INT8 Nemotron-3.5 streaming inference
- preserve independent cache state per session while serializing shared-model inference
- validate the published 320 ms affine group-64 bundles strictly
- add standard asr-bench engines and document quality, RTF, and memory baselines

## Verification

- `make build`
- `swift test --skip E2E`: 1,549 passed, 35 expected skips, 0 failures
- isolated INT5 real-model streaming E2E: exact expected transcript
- isolated INT8 real-model streaming E2E: exact expected transcript
- three fresh-process native benchmark rounds per variant

| Variant | Median RTF | Peak RSS | WER / CER |
|---|---:|---:|---:|
| INT5 | 0.0360 | 611 MB | 0 / 0 |
| INT8 | 0.0375 | 805 MB | 0 / 0 |

The native smoke fixture is 20 seconds / 11 words. The six-language quality results and separate 63.7-second export benchmark remain documented as the broader quality and throughput gates.