### PR TITLE
Fix microphone resampling drift

### DIFF
--- a/Sources/AudioCommon/AudioIO.swift
+++ b/Sources/AudioCommon/AudioIO.swift
@@ -163,22 +163,14 @@ public final class AudioIO {
             monoBuffer.frameLength = buffer.frameLength
             memcpy(monoBuffer.floatChannelData![0], srcData[0], frameLen * MemoryLayout<Float>.size)
 
-            // Resample
-            let outFrameCount = AVAudioFrameCount(Double(frameLen) * Double(targetSampleRate) / hwFormat.sampleRate)
-            guard outFrameCount > 0,
-                  let outBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outFrameCount) else { return }
-
-            var error: NSError?
-            resampler.convert(to: outBuffer, error: &error) { _, outStatus in
-                outStatus.pointee = .haveData
-                return monoBuffer
-            }
-            if error != nil { return }
-
-            guard let outData = outBuffer.floatChannelData else { return }
-            let count = Int(outBuffer.frameLength)
-            guard count > 0 else { return }
-            let samples = Array(UnsafeBufferPointer(start: outData[0], count: count))
+            // Keep the streaming converter's fractional output from one
+            // hardware callback to the next. Truncating every 48 kHz -> 16 kHz
+            // callback loses one sample per three 1024-frame buffers, causing
+            // independently captured playback and microphone clocks to drift.
+            guard let samples = Self.resampleMicrophoneBuffer(
+                monoBuffer, with: resampler, to: targetFormat),
+                  !samples.isEmpty else { return }
+            let count = samples.count
 
             // RMS for audio level
             var sum: Float = 0
@@ -250,6 +242,43 @@ public final class AudioIO {
 
     static func hostTime(from time: AVAudioTime) -> UInt64? {
         time.isHostTimeValid ? time.hostTime : nil
+    }
+
+    /// Resample one microphone callback while preserving converter carry.
+    ///
+    /// `AVAudioConverter` may emit a fractional-rate remainder on a later
+    /// call. The destination therefore needs headroom beyond the truncated
+    /// per-buffer ratio, and the input block must supply each hardware buffer
+    /// exactly once. Internal for deterministic long-stream regression tests.
+    static func resampleMicrophoneBuffer(
+        _ inputBuffer: AVAudioPCMBuffer,
+        with converter: AVAudioConverter,
+        to targetFormat: AVAudioFormat
+    ) -> [Float]? {
+        let ratio = targetFormat.sampleRate / inputBuffer.format.sampleRate
+        let capacity = AVAudioFrameCount(
+            (Double(inputBuffer.frameLength) * ratio).rounded(.up) + 16)
+        guard capacity > 0,
+              let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: targetFormat, frameCapacity: capacity)
+        else { return nil }
+
+        var conversionError: NSError?
+        var consumed = false
+        converter.convert(to: outputBuffer, error: &conversionError) { _, status in
+            if consumed {
+                status.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            status.pointee = .haveData
+            return inputBuffer
+        }
+        guard conversionError == nil else { return nil }
+
+        let count = Int(outputBuffer.frameLength)
+        guard count > 0, let data = outputBuffer.floatChannelData else { return [] }
+        return Array(UnsafeBufferPointer(start: data[0], count: count))
     }
 }
 #endif

--- a/Tests/AudioCommonTests/MicrophoneResamplingTests.swift
+++ b/Tests/AudioCommonTests/MicrophoneResamplingTests.swift
@@ -1,0 +1,54 @@
+#if canImport(AVFoundation)
+import AVFoundation
+import XCTest
+@testable import AudioCommon
+
+final class MicrophoneResamplingTests: XCTestCase {
+    /// Regression for live AEC: a 1024-frame 48 kHz callback represents
+    /// 341 1/3 samples at 16 kHz. Truncating each callback independently made
+    /// the microphone lose 2,000 samples in 128 seconds while a system-audio
+    /// reference kept correct time, invalidating a previously acquired delay.
+    func testStreamingConversionDoesNotAccumulatePerCallbackRoundingDrift() throws {
+        let inputRate = 48_000.0
+        let outputRate = 16_000.0
+        let inputFormat = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: inputRate,
+            channels: 1,
+            interleaved: false))
+        let outputFormat = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: outputRate,
+            channels: 1,
+            interleaved: false))
+        let converter = try XCTUnwrap(AVAudioConverter(
+            from: inputFormat, to: outputFormat))
+
+        let callbackCount = 6_000
+        let inputFramesPerCallback = 1_024
+        var actualOutputFrames = 0
+        for callback in 0..<callbackCount {
+            let input = try XCTUnwrap(AVAudioPCMBuffer(
+                pcmFormat: inputFormat,
+                frameCapacity: AVAudioFrameCount(inputFramesPerCallback)))
+            input.frameLength = AVAudioFrameCount(inputFramesPerCallback)
+            if let samples = input.floatChannelData?[0] {
+                for frame in 0..<inputFramesPerCallback {
+                    samples[frame] = sin(Float(callback * inputFramesPerCallback + frame) * 0.01)
+                }
+            }
+            let output = try XCTUnwrap(AudioIO.resampleMicrophoneBuffer(
+                input, with: converter, to: outputFormat))
+            actualOutputFrames += output.count
+        }
+
+        let expectedOutputFrames = Int((
+            Double(callbackCount * inputFramesPerCallback)
+                * outputRate / inputRate).rounded())
+        XCTAssertLessThanOrEqual(
+            abs(actualOutputFrames - expectedOutputFrames),
+            16,
+            "Streaming conversion accumulated callback-by-callback clock drift")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- preserve `AVAudioConverter` fractional carry across microphone callbacks
- provide each hardware input buffer to the converter exactly once
- allocate enough destination headroom for deferred output
- add a 128-second 48 kHz to 16 kHz sample-conservation regression

## Motivation

A 1024-frame callback at 48 kHz represents 341⅓ frames at 16 kHz. Truncating every callback to 341 frames loses 2,000 samples over 6,000 callbacks, allowing microphone audio to drift from an independently captured playback reference and invalidating an AEC delay alignment.

## Verification

- `swift test --skip E2E --disable-sandbox`
- 1,551 tests passed, 35 skipped, 0 failures
