### PR TITLE
feat: add MLX engine for DeepFilterNet3 speech enhancement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -443,6 +443,8 @@ let package = Package(
                 "AudioCommon",
                 "MLXCommon",
                 "LocalVQEAECFrontend",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
             ]
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs
 
 **Enhancement, Separation & Audio Generation**
 
-- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Real-time noise suppression (2.1M params, 48 kHz). Long-form audio above the 60 s single-shot cap is auto-chunked with crossfade — see `enhanceChunked(...)`
+- **[DeepFilterNet3](https://soniqo.audio/guides/denoise)** — Real-time noise suppression (2.1M params, 48 kHz) on Core ML (Neural Engine) or MLX (GPU, fp32). Long-form audio above the 60 s single-shot cap is auto-chunked with crossfade — see `enhanceChunked(...)`
 - **[LocalVQE v1.4-AEC](https://soniqo.audio/guides/echo-cancellation)** — Streaming acoustic echo cancellation from separate, synchronized microphone and playback-reference streams (Core ML + native adaptive filter, 16 kHz, 16 ms algorithmic latency)
 - **[Source Separation](https://soniqo.audio/guides/separate)** — Music source separation via HTDemucs (Demucs v4) + Open-Unmix (UMX-HQ / UMX-L, 4 stems: vocals/drums/bass/other, 44.1 kHz stereo)
 - **[MAGNeT](https://soniqo.audio/guides/compose)** — Text-to-music generation (Meta MAGNeT Small 300M / Medium 1.5B, MLX INT8, 30 s clips at 32 kHz mono, masked parallel decoding)
@@ -218,7 +218,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 | [Pyannote Community-1](https://huggingface.co/aufklarer/Pyannote-Community-1-CoreML) | Diarization + speaker embeddings | CoreML (ANE) + Swift VBx | 8.35M | Agnostic |
 | [Sortformer](https://huggingface.co/aufklarer/Sortformer-Diarization-CoreML) | [Diarization (E2E), incremental streaming](https://soniqo.audio/guides/diarize) | CoreML (ANE) | 117M | Agnostic |
 | [Ultra-Sortformer 8spk](https://huggingface.co/aufklarer/Ultra-Sortformer-Diarization-CoreML) | Diarization (E2E, up to 8 speakers, experimental) | CoreML (ANE) | 117M | Agnostic |
-| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Speech Enhancement | CoreML | 2.1M | Agnostic |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise) | Speech Enhancement | CoreML / MLX | 2.1M | Agnostic |
 | [LocalVQE v1.4-AEC](https://soniqo.audio/guides/echo-cancellation) | Acoustic Echo Cancellation | CoreML + C++ | 200K + 2,742 | Agnostic |
 | [Sidon](https://soniqo.audio/guides/restore) | Speech Restoration (denoise + dereverb, 48 kHz) | CoreML | w2v-BERT 2.0 + DAC (fp16/int8) | Agnostic |
 | [HTDemucs (Demucs v4)](https://soniqo.audio/guides/separate) | Source Separation | MLX | 168M | Agnostic |
@@ -447,7 +447,8 @@ for s in segments { print("Speaker \(s.speakerId): \(s.startTime)s - \(s.endTime
 ```swift
 import SpeechEnhancement
 
-let denoiser = try await DeepFilterNet3Model.fromPretrained()
+let denoiser = try await SpeechEnhancer.fromPretrained()             // CoreML (Neural Engine)
+// let denoiser = try await SpeechEnhancer.fromPretrained(engine: .mlx)  // MLX (GPU, fp32)
 let clean = try denoiser.enhance(audio: noisySamples, sampleRate: 48000)
 ```
 

--- a/Sources/AudioCLILib/DenoiseCommand.swift
+++ b/Sources/AudioCLILib/DenoiseCommand.swift
@@ -15,8 +15,11 @@ public struct DenoiseCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Output file path (default: input_clean.wav)")
     public var output: String?
 
-    @Option(name: .shortAndLong, help: "Model ID on HuggingFace")
-    public var model: String = SpeechEnhancer.defaultModelId
+    @Option(name: .shortAndLong, help: "Model ID on HuggingFace (default: per --engine)")
+    public var model: String?
+
+    @Option(name: .long, help: "Inference engine: coreml (Neural Engine) or mlx (GPU)")
+    public var engine: String = "coreml"
 
     @Option(name: .long, help: "Window size in seconds when auto-chunking long inputs (default: 45.0)")
     public var chunkSeconds: Double = 45.0
@@ -37,9 +40,16 @@ public struct DenoiseCommand: ParsableCommand {
             let duration = Double(audio.count) / 48000.0
             print("  Loaded \(audio.count) samples (\(String(format: "%.2f", duration))s @ 48kHz)")
 
-            print("Loading DeepFilterNet3 model: \(model)")
+            guard let resolvedEngine = SpeechEnhancerEngine(rawValue: engine.lowercased()) else {
+                throw ValidationError("Unknown engine '\(engine)' — expected 'coreml' or 'mlx'")
+            }
+            let resolvedModel = model
+                ?? (resolvedEngine == .mlx
+                    ? SpeechEnhancer.defaultMLXModelId : SpeechEnhancer.defaultModelId)
+            print("Loading DeepFilterNet3 model: \(resolvedModel) (\(resolvedEngine.rawValue))")
             let enhancer = try await SpeechEnhancer.fromPretrained(
-                modelId: model,
+                modelId: resolvedModel,
+                engine: resolvedEngine,
                 progressHandler: reportProgress
             )
 

--- a/Sources/AudioServer/ModelRegistry.swift
+++ b/Sources/AudioServer/ModelRegistry.swift
@@ -227,6 +227,11 @@ public let MODEL_REGISTRY: [ModelVariant] = [
           modelId: SpeechEnhancer.defaultModelId,
           aliases: ["deepfilternet3", "denoise", "dfn3"],
           kind: .enhance),
+    .init(name: "deepfilternet3-mlx",
+          engine: "deepfilternet3",
+          modelId: SpeechEnhancer.defaultMLXModelId,
+          aliases: ["denoise-mlx", "dfn3-mlx"],
+          kind: .enhance),
 
     // ─── Music / SFX generation ────────────────────────────────────────────
     .init(name: "magnet-small-30s-mlx-int4",

--- a/Sources/SpeechEnhancement/MLXDeepFilterNet3Network.swift
+++ b/Sources/SpeechEnhancement/MLXDeepFilterNet3Network.swift
@@ -1,0 +1,402 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXCommon
+import AudioCommon
+
+/// MLX implementation of the DeepFilterNet3 neural network.
+///
+/// Loads the fp32 safetensors published by ``aufklarer/DeepFilterNet3-MLX``
+/// and mirrors the inference graph of the CoreML export: 2-frame lookahead
+/// shift on the input features, encoder, ERB decoder, DF decoder, DF-output
+/// reshape. The DSP around it (STFT, ERB features, normalization, deep
+/// filtering, iSTFT) is shared with the CoreML path in ``SpeechEnhancer``.
+///
+/// Layout is channels-last `[B, T, F, C]` (time = conv H axis, frequency =
+/// conv W axis). All GRUs run with an explicit zero initial hidden state —
+/// `MLXNN.GRU`'s `hidden: nil` path skips the `r ⊙ bhn` term on the first
+/// frame, so this class implements the recurrence directly.
+///
+/// The weight layouts and the GRU bias folding
+/// (`b = bias_ih + [bias_hh_r; bias_hh_z; 0]`, `bhn = bias_hh_n`) are
+/// produced by the publishing pipeline and validated against the PyTorch
+/// reference to ~1e-6 (CPU stream).
+final class MLXDeepFilterNet3Network {
+
+    // ── weight bundles ──
+
+    /// Full or grouped input conv (3×3) + optional BN-fused pointwise.
+    private struct InputConv {
+        let conv: MLXArray        // [O, 3, 3, I/groups]
+        let convBias: MLXArray?   // erb_conv0: BN fused into the conv itself
+        let pw: MLXArray?         // df_conv0: BN fused into the pointwise
+        let pwBias: MLXArray?
+        let groups: Int
+    }
+
+    /// Separable block: depthwise (1,3) conv + BN-fused pointwise.
+    private struct SepConv {
+        let dw: MLXArray          // [C, 1, 3, 1]
+        let pw: MLXArray          // [C, 1, 1, C]
+        let pwBias: MLXArray      // [C]
+        let fstride: Int
+    }
+
+    /// Pathway block: depthwise 1×1 conv with BN fused (per-channel affine).
+    private struct Pathway {
+        let w: MLXArray           // [C, 1, 1, 1]
+        let bias: MLXArray        // [C]
+    }
+
+    /// Transposed separable block: depthwise transposed (1,3) conv with
+    /// frequency stride 2 + BN-fused pointwise. The depthwise kernel is
+    /// pre-flipped along frequency for the zero-stuff formulation.
+    private struct SepConvT {
+        let dwFlipped: MLXArray   // [C, 1, 3, 1]
+        let pw: MLXArray          // [C, 1, 1, C]
+        let pwBias: MLXArray      // [C]
+    }
+
+    /// One GRU layer in the mlx convention.
+    private struct GRULayer {
+        let wx: MLXArray          // [3H, I]
+        let wh: MLXArray          // [3H, H]
+        let b: MLXArray           // [3H]
+        let bhn: MLXArray         // [H]
+        let hidden: Int
+    }
+
+    /// SqueezedGRU_S: grouped linear in → GRU stack → optional grouped linear out.
+    private struct SqueezedGRU {
+        let linearIn: MLXArray    // [g, I/g, H/g]
+        let layers: [GRULayer]
+        let linearOut: MLXArray?  // [g, H/g, O/g]
+    }
+
+    // ── encoder ──
+    private let erbConv0: InputConv
+    private let erbConv1: SepConv
+    private let erbConv2: SepConv
+    private let erbConv3: SepConv
+    private let dfConv0: InputConv
+    private let dfConv1: SepConv
+    private let dfFcEmb: MLXArray            // [32, 96, 16]
+    private let encEmbGru: SqueezedGRU
+
+    // ── ERB decoder ──
+    private let erbDecEmbGru: SqueezedGRU
+    private let conv3p: Pathway
+    private let convt3: SepConv
+    private let conv2p: Pathway
+    private let convt2: SepConvT
+    private let conv1p: Pathway
+    private let convt1: SepConvT
+    private let conv0p: Pathway
+    private let conv0OutW: MLXArray          // [1, 1, 3, 64]
+    private let conv0OutBias: MLXArray       // [1]
+
+    // ── DF decoder ──
+    private let dfConvpConv: MLXArray        // [10, 5, 1, 32] (groups=2)
+    private let dfConvpPw: MLXArray          // [10, 1, 1, 10]
+    private let dfConvpPwBias: MLXArray      // [10]
+    private let dfGru: SqueezedGRU
+    private let dfSkip: MLXArray             // [16, 32, 16]
+    private let dfOut: MLXArray              // [16, 16, 60]
+
+    private let config: DeepFilterNet3Config
+
+    enum MLXDeepFilterNet3Error: Error, LocalizedError {
+        case missingWeight(String)
+        case badShape(String, [Int])
+
+        var errorDescription: String? {
+            switch self {
+            case .missingWeight(let key):
+                return "MLX DeepFilterNet3 weight missing: \(key)"
+            case .badShape(let key, let shape):
+                return "MLX DeepFilterNet3 weight \(key) has unexpected shape \(shape)"
+            }
+        }
+    }
+
+    init(weights: [String: MLXArray], config: DeepFilterNet3Config) throws {
+        func take(_ key: String) throws -> MLXArray {
+            guard let w = weights[key] else {
+                throw MLXDeepFilterNet3Error.missingWeight(key)
+            }
+            return w.dtype == .float32 ? w : w.asType(.float32)
+        }
+        func sep(_ prefix: String, fstride: Int) throws -> SepConv {
+            SepConv(
+                dw: try take("\(prefix).dw.weight"),
+                pw: try take("\(prefix).pw.weight"),
+                pwBias: try take("\(prefix).pw.bias"),
+                fstride: fstride)
+        }
+        func pathway(_ prefix: String) throws -> Pathway {
+            Pathway(w: try take("\(prefix).dw.weight"), bias: try take("\(prefix).dw.bias"))
+        }
+        func sepT(_ prefix: String) throws -> SepConvT {
+            // Flip the depthwise transposed kernel along frequency (axis 2)
+            // once at load: conv_transpose(x, w) == conv(zeroStuffed(x), flip(w)).
+            let dw = try take("\(prefix).dwt.weight")
+            let flipped = dw[0..., 0..., .stride(by: -1), 0...]
+            return SepConvT(
+                dwFlipped: flipped,
+                pw: try take("\(prefix).pw.weight"),
+                pwBias: try take("\(prefix).pw.bias"))
+        }
+        func gruLayer(_ prefix: String) throws -> GRULayer {
+            let wh = try take("\(prefix).Wh")
+            return GRULayer(
+                wx: try take("\(prefix).Wx"),
+                wh: wh,
+                b: try take("\(prefix).b"),
+                bhn: try take("\(prefix).bhn"),
+                hidden: wh.dim(1))
+        }
+        func squeezedGRU(_ prefix: String, layers: Int, hasLinearOut: Bool) throws -> SqueezedGRU {
+            let gruLayers: [GRULayer]
+            if layers == 1 {
+                gruLayers = [try gruLayer("\(prefix).gru")]
+            } else {
+                gruLayers = try (0..<layers).map { try gruLayer("\(prefix).gru.layers.\($0)") }
+            }
+            return SqueezedGRU(
+                linearIn: try take("\(prefix).linear_in.weight"),
+                layers: gruLayers,
+                linearOut: hasLinearOut ? try take("\(prefix).linear_out.weight") : nil)
+        }
+
+        self.config = config
+
+        self.erbConv0 = InputConv(
+            conv: try take("enc.erb_conv0.conv.weight"),
+            convBias: try take("enc.erb_conv0.conv.bias"),
+            pw: nil, pwBias: nil, groups: 1)
+        self.erbConv1 = try sep("enc.erb_conv1", fstride: 2)
+        self.erbConv2 = try sep("enc.erb_conv2", fstride: 2)
+        self.erbConv3 = try sep("enc.erb_conv3", fstride: 1)
+        self.dfConv0 = InputConv(
+            conv: try take("enc.df_conv0.conv.weight"),
+            convBias: nil,
+            pw: try take("enc.df_conv0.pw.weight"),
+            pwBias: try take("enc.df_conv0.pw.bias"),
+            groups: 2)
+        self.dfConv1 = try sep("enc.df_conv1", fstride: 2)
+        self.dfFcEmb = try take("enc.df_fc_emb.weight")
+        self.encEmbGru = try squeezedGRU("enc.emb_gru", layers: config.encGruLayers, hasLinearOut: true)
+
+        self.erbDecEmbGru = try squeezedGRU(
+            "erb_dec.emb_gru", layers: config.erbDecGruLayers, hasLinearOut: true)
+        self.conv3p = try pathway("erb_dec.conv3p")
+        self.convt3 = try sep("erb_dec.convt3", fstride: 1)
+        self.conv2p = try pathway("erb_dec.conv2p")
+        self.convt2 = try sepT("erb_dec.convt2")
+        self.conv1p = try pathway("erb_dec.conv1p")
+        self.convt1 = try sepT("erb_dec.convt1")
+        self.conv0p = try pathway("erb_dec.conv0p")
+        self.conv0OutW = try take("erb_dec.conv0_out.conv.weight")
+        self.conv0OutBias = try take("erb_dec.conv0_out.conv.bias")
+
+        self.dfConvpConv = try take("df_dec.df_convp.conv.weight")
+        self.dfConvpPw = try take("df_dec.df_convp.pw.weight")
+        self.dfConvpPwBias = try take("df_dec.df_convp.pw.bias")
+        self.dfGru = try squeezedGRU("df_dec.df_gru", layers: config.dfGruLayers, hasLinearOut: false)
+        self.dfSkip = try take("df_dec.df_skip.weight")
+        self.dfOut = try take("df_dec.df_out.weight")
+
+        // Sanity-check a couple of load-bearing shapes so a mispublished repo
+        // fails fast instead of producing garbage audio.
+        guard encEmbGru.layers[0].wx.shape == [3 * config.embHidden, config.embHidden] else {
+            throw MLXDeepFilterNet3Error.badShape(
+                "enc.emb_gru.gru.Wx", encEmbGru.layers[0].wx.shape)
+        }
+        guard conv0OutW.shape == [1, 1, 3, config.convCh] else {
+            throw MLXDeepFilterNet3Error.badShape("erb_dec.conv0_out.conv.weight", conv0OutW.shape)
+        }
+    }
+
+    // ── building blocks ──
+
+    private func relu(_ x: MLXArray) -> MLXArray {
+        maximum(x, 0)
+    }
+
+    /// Grouped linear: x `[B, T, I]`, w `[g, I/g, H/g]` → `[B, T, H]`.
+    private func groupedLinear(_ x: MLXArray, _ w: MLXArray) -> MLXArray {
+        let (b, t) = (x.dim(0), x.dim(1))
+        let (g, gi, gh) = (w.dim(0), w.dim(1), w.dim(2))
+        let grouped = x.reshaped([b, t, g, gi])
+        return einsum("btgi,gih->btgh", grouped, w).reshaped([b, t, g * gh])
+    }
+
+    /// GRU recurrence with an explicit zero initial hidden state
+    /// (gate order r, z, n — identical to PyTorch).
+    private func runGRULayer(_ x: MLXArray, _ layer: GRULayer) -> MLXArray {
+        let hSize = layer.hidden
+        let xp = matmul(x, layer.wx.T) + layer.b        // [B, T, 3H]
+        let xRz = xp[0..., 0..., ..<(2 * hSize)]
+        let xN = xp[0..., 0..., (2 * hSize)...]
+        var h = MLXArray.zeros([x.dim(0), hSize])
+        var outputs = [MLXArray]()
+        outputs.reserveCapacity(x.dim(1))
+        for t in 0..<x.dim(1) {
+            let hp = matmul(h, layer.wh.T)              // [B, 3H]
+            let rz = sigmoid(xRz[0..., t, 0...] + hp[0..., ..<(2 * hSize)])
+            let r = rz[0..., ..<hSize]
+            let z = rz[0..., hSize...]
+            let n = tanh(xN[0..., t, 0...] + r * (hp[0..., (2 * hSize)...] + layer.bhn))
+            h = (1 - z) * n + z * h
+            outputs.append(h)
+        }
+        return stacked(outputs, axis: 1)                // [B, T, H]
+    }
+
+    private func runSqueezedGRU(_ x: MLXArray, _ gru: SqueezedGRU) -> MLXArray {
+        var y = relu(groupedLinear(x, gru.linearIn))
+        for layer in gru.layers {
+            y = runGRULayer(y, layer)
+        }
+        if let linearOut = gru.linearOut {
+            y = relu(groupedLinear(y, linearOut))
+        }
+        return y
+    }
+
+    /// pad(t=2, causal) + 3×3 conv (grouped) [+ BN-fused pointwise] + ReLU.
+    private func runInputConv(_ x: MLXArray, _ block: InputConv) -> MLXArray {
+        let padded2 = padded(x, widths: [IntOrPair(0), IntOrPair((2, 0)), IntOrPair(0), IntOrPair(0)])
+        var y = conv2d(padded2, block.conv, stride: 1, padding: [0, 1], groups: block.groups)
+        if let bias = block.convBias {
+            y = y + bias
+        }
+        if let pw = block.pw, let pwBias = block.pwBias {
+            y = conv2d(y, pw) + pwBias
+        }
+        return relu(y)
+    }
+
+    /// Depthwise (1,3) conv + BN-fused pointwise + ReLU.
+    private func runSepConv(_ x: MLXArray, _ block: SepConv) -> MLXArray {
+        let channels = x.dim(3)
+        var y = conv2d(x, block.dw, stride: [1, block.fstride], padding: [0, 1], groups: channels)
+        y = conv2d(y, block.pw) + block.pwBias
+        return relu(y)
+    }
+
+    /// Depthwise 1×1 conv (BN-fused per-channel affine) + ReLU.
+    private func runPathway(_ x: MLXArray, _ block: Pathway) -> MLXArray {
+        let y = conv2d(x, block.w, groups: x.dim(3)) + block.bias
+        return relu(y)
+    }
+
+    /// Depthwise transposed conv over frequency (k=3, stride 2, padding 1,
+    /// output padding 1) via zero-stuffing, + BN-fused pointwise + ReLU.
+    private func runSepConvT(_ x: MLXArray, _ block: SepConvT) -> MLXArray {
+        let (b, t, f, c) = (x.dim(0), x.dim(1), x.dim(2), x.dim(3))
+        let stuffed = stacked([x, MLXArray.zeros(like: x)], axis: 3).reshaped([b, t, 2 * f, c])
+        let paddedStuffed = padded(
+            stuffed, widths: [IntOrPair(0), IntOrPair(0), IntOrPair((1, 1)), IntOrPair(0)])
+        var y = conv2d(paddedStuffed, block.dwFlipped, groups: c)
+        y = conv2d(y, block.pw) + block.pwBias
+        return relu(y)
+    }
+
+    // ── inference ──
+
+    /// Run the network.
+    ///
+    /// - Parameters:
+    ///   - erbFeats: normalized ERB features, `[T × 32]` row-major
+    ///   - specReal/specImag: normalized complex spec features, `[T × 96]`
+    ///   - numFrames: `T`
+    /// - Returns: `erbMask` flat `[T × 32]`, `coefs` flat in `[O, T, F, 2]`
+    ///   order — the same layouts the CoreML path produces.
+    func predict(
+        erbFeats: [Float], specReal: [Float], specImag: [Float], numFrames: Int
+    ) -> (erbMask: [Float], coefs: [Float]) {
+        let erbBands = config.erbBands
+        let dfBins = config.dfBins
+        let la = config.convLookahead
+
+        var featErb = MLXArray(erbFeats, [1, numFrames, erbBands, 1])
+        let real = MLXArray(specReal, [1, numFrames, dfBins, 1])
+        let imag = MLXArray(specImag, [1, numFrames, dfBins, 1])
+        var featSpec = concatenated([real, imag], axis: 3)   // [1, T, 96, 2]
+
+        // Lookahead shift — matches the CoreML export: drop the first `la`
+        // frames, append `la` zero frames.
+        if la > 0 && numFrames > la {
+            let shiftWidths = [IntOrPair(0), IntOrPair((0, la)), IntOrPair(0), IntOrPair(0)]
+            featErb = padded(featErb[0..., la..., 0..., 0...], widths: shiftWidths)
+            featSpec = padded(featSpec[0..., la..., 0..., 0...], widths: shiftWidths)
+        }
+
+        // Encoder
+        let e0 = runInputConv(featErb, erbConv0)             // [1, T, 32, 64]
+        let e1 = runSepConv(e0, erbConv1)                    // [1, T, 16, 64]
+        let e2 = runSepConv(e1, erbConv2)                    // [1, T, 8, 64]
+        let e3 = runSepConv(e2, erbConv3)                    // [1, T, 8, 64]
+        let c0 = runInputConv(featSpec, dfConv0)             // [1, T, 96, 64]
+        let c1 = runSepConv(c0, dfConv1)                     // [1, T, 48, 64]
+
+        let cemb = relu(groupedLinear(c1.reshaped([1, numFrames, -1]), dfFcEmb))
+        var emb = e3.reshaped([1, numFrames, -1]) + cemb     // [1, T, 512]
+        emb = runSqueezedGRU(emb, encEmbGru)
+
+        // ERB decoder
+        var d = runSqueezedGRU(emb, erbDecEmbGru)
+        d = d.reshaped([1, numFrames, e3.dim(2), -1])        // [1, T, 8, 64]
+        let d3 = runSepConv(runPathway(e3, conv3p) + d, convt3)
+        let d2 = runSepConvT(runPathway(e2, conv2p) + d3, convt2)
+        let d1 = runSepConvT(runPathway(e1, conv1p) + d2, convt1)
+        var m = runPathway(e0, conv0p) + d1
+        m = conv2d(m, conv0OutW, padding: [0, 1]) + conv0OutBias
+        let erbMask = sigmoid(m)                             // [1, T, 32, 1]
+
+        // DF decoder
+        var c = runSqueezedGRU(emb, dfGru)                   // [1, T, 256]
+        c = c + groupedLinear(emb, dfSkip)
+        var cp = padded(c0, widths: [IntOrPair(0), IntOrPair((4, 0)), IntOrPair(0), IntOrPair(0)])
+        cp = conv2d(cp, dfConvpConv, groups: 2)
+        cp = relu(conv2d(cp, dfConvpPw) + dfConvpPwBias)     // [1, T, 96, 10]
+        var cf = tanh(groupedLinear(c, dfOut))               // [1, T, 960]
+        cf = cf.reshaped([1, numFrames, dfBins, config.dfOrder * 2]) + cp
+        let coefs = cf
+            .reshaped([1, numFrames, dfBins, config.dfOrder, 2])
+            .transposed(0, 3, 1, 2, 4)                       // [1, 5, T, 96, 2]
+
+        eval(erbMask, coefs)
+        return (erbMask.asArray(Float.self), coefs.asArray(Float.self))
+    }
+}
+
+// ── weight loading ──
+
+extension DeepFilterNet3WeightLoader {
+
+    /// Load the MLX safetensors export and auxiliary DSP data.
+    ///
+    /// - Parameter directory: directory containing `model.safetensors` and
+    ///   `auxiliary.npz` (as published by `aufklarer/DeepFilterNet3-MLX`)
+    static func loadMLX(
+        from directory: URL, config: DeepFilterNet3Config
+    ) throws -> (MLXDeepFilterNet3Network, AuxiliaryData) {
+        let weightsURL = directory.appendingPathComponent("model.safetensors")
+        let auxURL = directory.appendingPathComponent("auxiliary.npz")
+
+        guard FileManager.default.fileExists(atPath: weightsURL.path) else {
+            throw WeightLoadingError.noWeightsFound(directory)
+        }
+        guard FileManager.default.fileExists(atPath: auxURL.path) else {
+            throw WeightLoadingError.missingRequiredWeight(
+                "auxiliary.npz not found in \(directory.path)")
+        }
+
+        let weights = try CommonWeightLoader.loadSafetensors(url: weightsURL)
+        let network = try MLXDeepFilterNet3Network(weights: weights, config: config)
+        let auxData = try loadAuxiliaryData(from: auxURL)
+        return (network, auxData)
+    }
+}

--- a/Sources/SpeechEnhancement/SpeechEnhancement.swift
+++ b/Sources/SpeechEnhancement/SpeechEnhancement.swift
@@ -3,30 +3,46 @@ import MLXCommon
 import CoreML
 import AudioCommon
 
-/// Speech enhancement using DeepFilterNet3 on Core ML (8-bit palettized
-/// weights, FP16 compute, Neural Engine).
+/// Inference engine for DeepFilterNet3 speech enhancement.
+public enum SpeechEnhancerEngine: String, Sendable {
+    /// CoreML backend — 8-bit palettized weights on the Neural Engine.
+    case coreml
+    /// MLX backend — fp32 weights on the GPU via Metal.
+    case mlx
+}
+
+/// Speech enhancement using DeepFilterNet3.
 ///
 /// Removes background noise from speech audio. The neural network runs on
-/// Apple's Neural Engine via Core ML, while signal processing (STFT, ERB
-/// filterbank, deep filtering) runs on CPU via Accelerate/vDSP.
+/// Apple's Neural Engine via Core ML (default) or on the GPU via MLX, while
+/// signal processing (STFT, ERB filterbank, deep filtering) runs on CPU via
+/// Accelerate/vDSP either way.
 ///
 /// ```swift
-/// let enhancer = try await SpeechEnhancer.fromPretrained()
+/// let enhancer = try await SpeechEnhancer.fromPretrained()             // CoreML
+/// let enhancer = try await SpeechEnhancer.fromPretrained(engine: .mlx) // MLX
 /// let cleanAudio = try enhancer.enhance(audio: noisyAudio, sampleRate: 48000)
 /// ```
 public final class SpeechEnhancer {
 
-    /// Default HuggingFace model ID
+    /// Default HuggingFace model ID (CoreML weights)
     public static let defaultModelId = "aufklarer/DeepFilterNet3-CoreML"
+
+    /// Default HuggingFace model ID (MLX weights)
+    public static let defaultMLXModelId = "aufklarer/DeepFilterNet3-MLX"
 
     /// Native sample rate (48kHz)
     public static let sampleRate = 48000
+
+    /// The inference engine in use.
+    public let engine: SpeechEnhancerEngine
 
     /// Whether the model is loaded and ready for inference.
     var _isLoaded = true
 
     let config: DeepFilterNet3Config
     var network: DeepFilterNet3Network?
+    var mlxNetwork: MLXDeepFilterNet3Network?
     let stft: STFTProcessor
 
     // ERB filterbank matrices
@@ -48,7 +64,36 @@ public final class SpeechEnhancer {
         config: DeepFilterNet3Config,
         auxData: DeepFilterNet3WeightLoader.AuxiliaryData
     ) {
+        self.engine = .coreml
         self.network = network
+        self.mlxNetwork = nil
+        self.config = config
+
+        self.stft = STFTProcessor(
+            fftSize: config.fftSize,
+            hopSize: config.hopSize,
+            window: auxData.window)
+
+        self.erbFb = auxData.erbFb
+        self.erbInvFb = auxData.erbInvFb
+
+        self.meanNormState = auxData.meanNormState
+        self.unitNormState = auxData.unitNormState
+        self.meanNormStateInit = auxData.meanNormState
+        self.unitNormStateInit = auxData.unitNormState
+
+        self.analysisMem = [Float](repeating: 0, count: config.fftSize - config.hopSize)
+        self.synthesisMem = [Float](repeating: 0, count: config.fftSize - config.hopSize)
+    }
+
+    init(
+        mlxNetwork: MLXDeepFilterNet3Network,
+        config: DeepFilterNet3Config,
+        auxData: DeepFilterNet3WeightLoader.AuxiliaryData
+    ) {
+        self.engine = .mlx
+        self.network = nil
+        self.mlxNetwork = mlxNetwork
         self.config = config
 
         self.stft = STFTProcessor(
@@ -75,7 +120,8 @@ public final class SpeechEnhancer {
     ///
     /// **Length limit**: the CoreML model is exported with a `RangeDim(1, 6000)`
     /// on the time axis (~60 s at 48 kHz / 10 ms hop). Inputs exceeding this
-    /// throw a CoreML prediction error. For longer audio use `enhanceChunked`,
+    /// throw a CoreML prediction error. The MLX engine has no hard cap, but
+    /// memory grows with input length. For longer audio use `enhanceChunked`,
     /// which slices into windows that fit the cap and stitches with a
     /// crossfade.
     ///
@@ -139,43 +185,57 @@ public final class SpeechEnhancer {
             alpha: config.normAlpha,
             dfBins: config.dfBins, numFrames: numFrames)
 
-        // No lookahead padding here — the Core ML model applies it internally
+        // No lookahead padding here — both backends apply it internally
 
-        // Create Core ML input arrays
-        // ERB: [1, 1, T, 32] (NCHW)
-        let erbInput = try MLMultiArray(shape: [1, 1, numFrames as NSNumber, config.erbBands as NSNumber], dataType: .float32)
-        let erbPtr = erbInput.dataPointer.assumingMemoryBound(to: Float.self)
-        erbFeats.withUnsafeBufferPointer { src in
-            erbPtr.update(from: src.baseAddress!, count: numFrames * config.erbBands)
-        }
-
-        // Spec: [1, 2, T, 96] (NCHW: channel 0=real, channel 1=imag)
-        let specInput = try MLMultiArray(shape: [1, 2, numFrames as NSNumber, config.dfBins as NSNumber], dataType: .float32)
-        let specPtr = specInput.dataPointer.assumingMemoryBound(to: Float.self)
-        let specChannelStride = numFrames * config.dfBins
-        specFeatReal.withUnsafeBufferPointer { src in
-            specPtr.update(from: src.baseAddress!, count: specChannelStride)
-        }
-        specFeatImag.withUnsafeBufferPointer { src in
-            (specPtr + specChannelStride).update(from: src.baseAddress!, count: specChannelStride)
-        }
-
-        // Run neural network (single pass — GRU state is sequential, can't be chunked)
-        guard let network else { throw DeepFilterNet3Network.DeepFilterNet3Error.predictionFailed }
-        let (erbMaskArray, coefsArray) = try network.predict(featErb: erbInput, featSpec: specInput)
-
-        // Extract ERB mask [1, 1, T, 32] — handle float16 output from Core ML
+        // Run neural network (single pass — GRU state is sequential, can't be
+        // chunked). Both branches produce the same flat layouts:
+        // erbMaskFlat [T, 32] and coefsRaw [O, T, F, 2].
         let erbMaskCount = numFrames * config.erbBands
-        var erbMaskFlat = [Float](repeating: 0, count: erbMaskCount)
-        extractMLMultiArrayFlat(erbMaskArray, into: &erbMaskFlat, count: erbMaskCount)
-
-        // Extract DF coefficients [1, 5, T, 96, 2] → [T, F, O, C=2]
         let dfOrder = config.dfOrder
         let coefsCount = dfOrder * numFrames * config.dfBins * 2
-        var coefsRaw = [Float](repeating: 0, count: coefsCount)
-        extractMLMultiArrayFlat(coefsArray, into: &coefsRaw, count: coefsCount)
+        let erbMaskFlat: [Float]
+        let coefsRaw: [Float]
 
-        // Reshape from Core ML layout [O, T, F, 2] to [T, F, O, 2]
+        if let mlxNetwork {
+            (erbMaskFlat, coefsRaw) = mlxNetwork.predict(
+                erbFeats: erbFeats,
+                specReal: specFeatReal, specImag: specFeatImag,
+                numFrames: numFrames)
+        } else {
+            // Create Core ML input arrays
+            // ERB: [1, 1, T, 32] (NCHW)
+            let erbInput = try MLMultiArray(shape: [1, 1, numFrames as NSNumber, config.erbBands as NSNumber], dataType: .float32)
+            let erbPtr = erbInput.dataPointer.assumingMemoryBound(to: Float.self)
+            erbFeats.withUnsafeBufferPointer { src in
+                erbPtr.update(from: src.baseAddress!, count: numFrames * config.erbBands)
+            }
+
+            // Spec: [1, 2, T, 96] (NCHW: channel 0=real, channel 1=imag)
+            let specInput = try MLMultiArray(shape: [1, 2, numFrames as NSNumber, config.dfBins as NSNumber], dataType: .float32)
+            let specPtr = specInput.dataPointer.assumingMemoryBound(to: Float.self)
+            let specChannelStride = numFrames * config.dfBins
+            specFeatReal.withUnsafeBufferPointer { src in
+                specPtr.update(from: src.baseAddress!, count: specChannelStride)
+            }
+            specFeatImag.withUnsafeBufferPointer { src in
+                (specPtr + specChannelStride).update(from: src.baseAddress!, count: specChannelStride)
+            }
+
+            guard let network else { throw DeepFilterNet3Network.DeepFilterNet3Error.predictionFailed }
+            let (erbMaskArray, coefsArray) = try network.predict(featErb: erbInput, featSpec: specInput)
+
+            // Extract ERB mask [1, 1, T, 32] — handle float16 output from Core ML
+            var maskBuffer = [Float](repeating: 0, count: erbMaskCount)
+            extractMLMultiArrayFlat(erbMaskArray, into: &maskBuffer, count: erbMaskCount)
+            erbMaskFlat = maskBuffer
+
+            // Extract DF coefficients [1, 5, T, 96, 2]
+            var coefsBuffer = [Float](repeating: 0, count: coefsCount)
+            extractMLMultiArrayFlat(coefsArray, into: &coefsBuffer, count: coefsCount)
+            coefsRaw = coefsBuffer
+        }
+
+        // Reshape from network layout [O, T, F, 2] to [T, F, O, 2]
         var coefsFlat = [Float](repeating: 0, count: coefsCount)
         for t in 0..<numFrames {
             for f in 0..<config.dfBins {
@@ -360,26 +420,37 @@ public final class SpeechEnhancer {
 
     /// Load a pretrained DeepFilterNet3 model.
     ///
-    /// Downloads Core ML model and auxiliary data on first use, then caches locally.
+    /// Downloads the model and auxiliary data on first use, then caches locally.
     ///
     /// - Parameters:
-    ///   - modelId: HuggingFace model ID
+    ///   - modelId: HuggingFace model ID (auto-selected by engine if not specified)
+    ///   - engine: inference backend. When `nil`, inferred from the model ID
+    ///     (IDs containing "MLX" load the MLX backend), defaulting to CoreML.
     ///   - progressHandler: Callback for download progress
     /// - Returns: Ready-to-use speech enhancer
     public static func fromPretrained(
-        modelId: String = defaultModelId,
+        modelId: String? = nil,
+        engine: SpeechEnhancerEngine? = nil,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> SpeechEnhancer {
+        let resolvedEngine = engine
+            ?? ((modelId?.uppercased().contains("MLX") ?? false) ? .mlx : .coreml)
+        let resolvedModelId = modelId
+            ?? (resolvedEngine == .mlx ? defaultMLXModelId : defaultModelId)
+
         progressHandler?(0.0, "Downloading model...")
 
-        let cacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
+        let cacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: resolvedModelId)
 
-        try await HuggingFaceDownloader.downloadWeights(
-            modelId: modelId,
-            to: cacheDir,
-            additionalFiles: [
+        let additionalFiles: [String]
+        switch resolvedEngine {
+        case .mlx:
+            // Default globs already fetch model.safetensors + config.json.
+            additionalFiles = ["auxiliary.npz"]
+        case .coreml:
+            additionalFiles = [
                 "no_weights.safetensors",  // suppress default *.safetensors glob
                 // Pre-compiled CoreML — shipped by aufklarer/DeepFilterNet3-CoreML
                 // alongside the legacy .mlpackage. On-device compileModel() is
@@ -387,7 +458,13 @@ public final class SpeechEnhancer {
                 // the goal is to never reach that code path for new installs.
                 "DeepFilterNet3.mlmodelc/**",
                 "auxiliary.npz",
-            ],
+            ]
+        }
+
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: resolvedModelId,
+            to: cacheDir,
+            additionalFiles: additionalFiles,
             offlineMode: offlineMode,
             progressHandler: { progress in
                 progressHandler?(progress * 0.8, "Downloading model...")
@@ -397,11 +474,18 @@ public final class SpeechEnhancer {
         progressHandler?(0.8, "Loading model...")
 
         let config = DeepFilterNet3Config.default
-        let (network, auxData) = try DeepFilterNet3WeightLoader.load(from: cacheDir)
 
-        progressHandler?(1.0, "Ready")
-
-        return SpeechEnhancer(network: network, config: config, auxData: auxData)
+        switch resolvedEngine {
+        case .mlx:
+            let (network, auxData) = try DeepFilterNet3WeightLoader.loadMLX(
+                from: cacheDir, config: config)
+            progressHandler?(1.0, "Ready")
+            return SpeechEnhancer(mlxNetwork: network, config: config, auxData: auxData)
+        case .coreml:
+            let (network, auxData) = try DeepFilterNet3WeightLoader.load(from: cacheDir)
+            progressHandler?(1.0, "Ready")
+            return SpeechEnhancer(network: network, config: config, auxData: auxData)
+        }
     }
 
     /// Extract float32 data from an MLMultiArray, handling float16 output from Core ML.

--- a/Sources/SpeechEnhancement/WeightLoading.swift
+++ b/Sources/SpeechEnhancement/WeightLoading.swift
@@ -40,7 +40,9 @@ enum DeepFilterNet3WeightLoader {
     }
 
     /// Parse the auxiliary.npz file containing signal processing constants.
-    private static func loadAuxiliaryData(from url: URL) throws -> AuxiliaryData {
+    /// (Internal so the MLX loader in ``MLXDeepFilterNet3Network.swift`` can
+    /// reuse it — both backends ship the identical npz.)
+    static func loadAuxiliaryData(from url: URL) throws -> AuxiliaryData {
         let arrays = try NpzReader.read(url: url)
 
         guard let erbFb = arrays["erb_fb"],

--- a/Tests/SpeechEnhancementTests/MLXDeepFilterNet3E2ETests.swift
+++ b/Tests/SpeechEnhancementTests/MLXDeepFilterNet3E2ETests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import SpeechEnhancement
+
+/// E2E tests for the MLX DeepFilterNet3 engine.
+///
+/// Downloads ``aufklarer/DeepFilterNet3-MLX`` (fp32 safetensors) on first
+/// run. CI filters this class out via the `--skip E2E` regex, matching the
+/// CoreML E2E tests.
+final class MLXDeepFilterNet3E2ETests: XCTestCase {
+
+    /// Deterministic pseudo-noise (LCG) so runs are reproducible.
+    private func whiteNoise(count: Int, amplitude: Float, seed: UInt64 = 0x5EED) -> [Float] {
+        var state = seed
+        return (0..<count).map { _ in
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            let unit = Float(state >> 40) / Float(1 << 24)   // [0, 1)
+            return (unit * 2 - 1) * amplitude
+        }
+    }
+
+    /// Speech-band test signal: amplitude-modulated harmonic stack at 48 kHz.
+    private func syntheticSpeech(seconds: Double, sampleRate: Int) -> [Float] {
+        let count = Int(seconds * Double(sampleRate))
+        let fundamental: Float = 180
+        return (0..<count).map { i in
+            let t = Float(i) / Float(sampleRate)
+            let envelope = 0.5 + 0.5 * sin(2 * .pi * 3.1 * t)   // syllable-rate AM
+            let harmonics = sin(2 * .pi * fundamental * t)
+                + 0.5 * sin(2 * .pi * fundamental * 2 * t)
+                + 0.25 * sin(2 * .pi * fundamental * 3 * t)
+            return 0.2 * envelope * harmonics
+        }
+    }
+
+    /// Full pipeline through the MLX engine: download, safetensors load,
+    /// DSP, network, iSTFT. Mirrors the CoreML `testHubFromPretrained`.
+    func testHubFromPretrainedMLX() async throws {
+        let enhancer = try await SpeechEnhancer.fromPretrained(engine: .mlx)
+        XCTAssertEqual(enhancer.engine, .mlx)
+
+        let sampleRate = 48000
+        let samples = [Float](repeating: 0, count: sampleRate + 1)
+        let enhanced = try enhancer.enhance(audio: samples, sampleRate: sampleRate)
+
+        XCTAssertEqual(enhanced.count, samples.count,
+                       "Enhanced signal should match input length")
+        let peak = enhanced.map(abs).max() ?? 0
+        XCTAssertLessThan(peak, 0.01, "Enhanced silence should stay near 0")
+    }
+
+    /// Engine auto-detection: an "MLX" model ID must select the MLX backend
+    /// without an explicit engine parameter (server + CLI path).
+    func testEngineAutoDetectionFromModelIdE2E() async throws {
+        let enhancer = try await SpeechEnhancer.fromPretrained(
+            modelId: SpeechEnhancer.defaultMLXModelId)
+        XCTAssertEqual(enhancer.engine, .mlx)
+    }
+
+    /// The two engines run different numerics (INT8-palettized fp16 CoreML vs
+    /// fp32 MLX) but the same model — outputs on noisy speech must agree
+    /// closely and both must attenuate the added noise.
+    func testMLXMatchesCoreMLOnNoisySpeech() async throws {
+        let sampleRate = 48000
+        let clean = syntheticSpeech(seconds: 2.0, sampleRate: sampleRate)
+        let noise = whiteNoise(count: clean.count, amplitude: 0.05)
+        let noisy = zip(clean, noise).map(+)
+
+        let coreml = try await SpeechEnhancer.fromPretrained(engine: .coreml)
+        let mlx = try await SpeechEnhancer.fromPretrained(engine: .mlx)
+
+        let outCoreML = try coreml.enhance(audio: noisy, sampleRate: sampleRate)
+        let outMLX = try mlx.enhance(audio: noisy, sampleRate: sampleRate)
+
+        XCTAssertEqual(outCoreML.count, outMLX.count)
+
+        // Pearson correlation between the two engine outputs.
+        let n = Float(outMLX.count)
+        let meanA = outCoreML.reduce(0, +) / n
+        let meanB = outMLX.reduce(0, +) / n
+        var num: Float = 0, varA: Float = 0, varB: Float = 0
+        for i in 0..<outCoreML.count {
+            let a = outCoreML[i] - meanA
+            let b = outMLX[i] - meanB
+            num += a * b
+            varA += a * a
+            varB += b * b
+        }
+        let correlation = num / max(sqrt(varA * varB), .leastNormalMagnitude)
+        XCTAssertGreaterThan(correlation, 0.90,
+                             "CoreML and MLX outputs should be strongly correlated")
+
+        // Both engines should reduce the noise energy: compare residual vs the
+        // clean signal against the injected noise energy.
+        func residualEnergy(_ output: [Float]) -> Float {
+            var energy: Float = 0
+            for i in 0..<output.count {
+                let r = output[i] - clean[i]
+                energy += r * r
+            }
+            return energy
+        }
+        let noiseEnergy = noise.reduce(Float(0)) { $0 + $1 * $1 }
+        XCTAssertLessThan(residualEnergy(outCoreML), noiseEnergy * 0.5,
+                          "CoreML engine should remove at least half the noise energy")
+        XCTAssertLessThan(residualEnergy(outMLX), noiseEnergy * 0.5,
+                          "MLX engine should remove at least half the noise energy")
+    }
+}

--- a/docs/inference/speech-enhancement.md
+++ b/docs/inference/speech-enhancement.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-DeepFilterNet3 (Interspeech 2023) removes background noise from speech in real-time. Runs on Apple Neural Engine via Core ML (~2.1M params, 8-bit palettized weights with FP16 compute, ~2.2 MB).
+DeepFilterNet3 (Interspeech 2023) removes background noise from speech in real-time. Two interchangeable engines run the neural network:
+
+- **Core ML** (default) — Apple Neural Engine, 8-bit palettized weights with FP16 compute, ~2.2 MB
+- **MLX** — GPU via Metal, fp32 safetensors, ~8.1 MB, no single-shot length cap
 
 ```
 Audio 48kHz → STFT (960-pt, 480 hop, Vorbis window, 1/960 analysis scale) → 481 complex bins
@@ -12,7 +15,32 @@ Audio 48kHz → STFT (960-pt, 480 hop, Vorbis window, 1/960 analysis scale) → 
   → iSTFT → Enhanced audio 48kHz
 ```
 
-Neural network runs on **Neural Engine** (Core ML). Signal processing (STFT, ERB filterbank, deep filtering) runs on **CPU** (Accelerate/vDSP).
+Signal processing (STFT, ERB filterbank, deep filtering) runs on **CPU** (Accelerate/vDSP) with either engine.
+
+## Engines
+
+```swift
+let enhancer = try await SpeechEnhancer.fromPretrained()             // Core ML (default)
+let enhancer = try await SpeechEnhancer.fromPretrained(engine: .mlx) // MLX
+```
+
+Passing a model ID whose name contains "MLX" selects the MLX engine
+automatically, so `--model aufklarer/DeepFilterNet3-MLX` and the
+`deepfilternet3-mlx` server registry entry work without an explicit engine
+parameter.
+
+| | Core ML (`.coreml`) | MLX (`.mlx`) |
+|---|---|---|
+| Model repo | `aufklarer/DeepFilterNet3-CoreML` | `aufklarer/DeepFilterNet3-MLX` |
+| Weights | 8-bit palettized, FP16 compute, 2.2 MB | fp32 safetensors, 8.1 MB |
+| Compute | Neural Engine + CPU | GPU (Metal) |
+| Single-shot cap | ~60 s (`RangeDim(1, 6000)`) | none (memory-bound) |
+| Quality | PESQ 2.907 (VoiceBank-DEMAND 30-clip) | PESQ 2.900–2.902, matches the fp32 PyTorch reference |
+
+Both engines share the DSP path and the `auxiliary.npz` constants; the MLX
+network is validated against the PyTorch reference to ~1e-6 at the tensor
+level (CPU stream). The GRU hidden state re-zeros per `predict` call on both
+engines, so `enhanceChunked` behaves identically.
 
 The STFT follows the reference `libdf` normalization convention: the forward
 DFT is scaled by `1 / fftSize` and the inverse DFT is unscaled. Moving that
@@ -115,6 +143,9 @@ swift run speech denoise long_meeting.wav
 # Tune the chunk window or disable chunking entirely:
 swift run speech denoise long.wav --chunk-seconds 30 --overlap-ms 300
 swift run speech denoise short.wav --no-chunk     # error if > 60 s
+
+# MLX engine (GPU, fp32):
+swift run speech denoise noisy.wav --engine mlx
 ```
 
 ## Model bundle
@@ -124,6 +155,13 @@ DSP constants. speech-swift downloads the compiled bundle directly:
 
 - `DeepFilterNet3.mlmodelc` (~2.2 MB) — pre-compiled Core ML model with 8-bit palettized weights and FP16 compute
 - `auxiliary.npz` (~126 KB) — ERB filterbank, Vorbis window, normalization states
+
+The MLX repository (`aufklarer/DeepFilterNet3-MLX`) ships:
+
+- `model.safetensors` (~8.1 MB) — fp32 weights in MLX layouts (BatchNorm fused, mlx GRU bias convention)
+- `auxiliary.npz` — identical DSP constants
+- `config.json` — model + DSP hyperparameters
+- `dfn3_mlx.py` — pure-Python-MLX reference implementation of the network
 
 ## References
 


### PR DESCRIPTION
## What changed

- New `MLXDeepFilterNet3Network`: the DeepFilterNet3 neural network on MLX (GPU via Metal), loading the fp32 safetensors published at `aufklarer/DeepFilterNet3-MLX`. Convs run channels-last; the GRU recurrence is implemented explicitly with a zero initial hidden state (MLXNN.GRU's `hidden: nil` path skips the `r ⊙ bhn` term on the first frame, and its `b`/`bhn` are not registered parameters); the depthwise transposed convs use a zero-stuffing formulation with pre-flipped kernels.
- `SpeechEnhancer.fromPretrained(engine:)` — `.coreml` (default) or `.mlx`. When no engine is passed, model IDs containing "MLX" select the MLX backend, so `loadEnhancer(modelId:)` in the server and `--model` in the CLI route correctly with no signature changes.
- `deepfilternet3-mlx` registry entry (aliases `denoise-mlx`, `dfn3-mlx`); CoreML entry stays first so `defaultVariant` resolution is unchanged.
- `speech denoise --engine mlx` CLI option.
- Docs: Engines section in `docs/inference/speech-enhancement.md`, README capability/table updates, and a fix for the README quickstart which referenced a nonexistent `DeepFilterNet3Model` symbol (the API is `SpeechEnhancer`).

## Architecture fit

Mirrors the WeSpeaker dual-engine pattern (engine enum, per-engine default model IDs, optional network fields). The DSP path (STFT/ERB/deep filtering on vDSP) is fully shared: `enhanceCore` branches only for the NN forward, and both branches produce identical flat layouts (`erbMask [T,32]`, `coefs [O,T,F,2]`). `enhanceChunked` and state handling are engine-agnostic.

## Regression risk

Low. The CoreML path is byte-identical logic moved inside an else-branch; `fromPretrained` keeps its defaults (no callers change). The MLX weights are validated upstream against the PyTorch reference to ~1e-6 at the tensor level, and quality was measured at PESQ 2.900 / STOI 0.947 / SI-SDR 18.19 on VoiceBank-DEMAND (30 clips) — identical to the fp32 reference.

## Tests run

- `swift test --filter MLXDeepFilterNet3E2ETests --disable-sandbox` (after `./scripts/build_mlx_metallib.sh debug`): 3/3 passed — hub `fromPretrained`, engine auto-detection, CoreML↔MLX parity on synthetic noisy speech (output correlation > 0.9, both engines remove ≥ half the injected noise energy).
- `swift test --filter SpeechEnhancementTests --disable-sandbox`: 44 tests, 0 failures (all existing DSP unit tests, CoreML E2E, and chunking suites included).

## Recommendation

Merge. CoreML remains the default engine; MLX is opt-in via `engine: .mlx`, the `-MLX` model ID, or `--engine mlx`.