### PR TITLE
Default the Qwen3.5 chat MLX loader to INT5 instead of INT4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ The same skills are exposed to agents that scan `.codex/skills/` through relativ
 - `Sources/Audio2Face3D/` — Speech-driven avatar motion (NVIDIA Audio2Face-3D, timestamped coefficient frames, MLX; `speech avatar-motion` CLI command)
 
 **On-Device LLM**
-- `Sources/Qwen3Chat/` — On-device LLM chat (Qwen3.5-0.8B, MLX + CoreML, INT4/INT8)
+- `Sources/Qwen3Chat/` — On-device LLM chat (Qwen3.5-0.8B, MLX INT5/INT8 + CoreML INT8)
 - `Sources/FunctionGemma/` — On-device Gemma function-calling (swift-transformers)
 
 **Infrastructure**

--- a/Sources/Qwen3Chat/MLXGenerator.swift
+++ b/Sources/Qwen3Chat/MLXGenerator.swift
@@ -76,11 +76,32 @@ public final class Qwen35MLXChat: @unchecked Sendable {
 
     // MARK: - Factory
 
-    /// Quantization variant.
+    /// Quantization variant. The raw value names a subdirectory in the model repo.
+    ///
+    /// `int4` is retained for local checkpoints exported before INT5 existed. It is no longer
+    /// the default, and the repo's `int4/` directory is being retired — see
+    /// `defaultQuantization` for the measurement that decided it.
     public enum Quantization: String {
         case int4
+        case int5
         case int8
     }
+
+    /// The variant `fromPretrained` loads when the caller does not choose one.
+    ///
+    /// INT5, not INT4. Scored over 32,768 tokens per corpus against the bf16 reference, INT4
+    /// costs +19.90% wikitext perplexity, agrees with bf16 on 78.3% of top-1 tokens, and emits
+    /// valid strict JSON in 18 of 24 attempts — five of those six failures were unbalanced
+    /// braces, which a parser rejects outright rather than merely dislikes. INT5 costs
+    /// +2.19% / 89.6% / 23-of-24 for 90 MB more, so INT4's saving buys nothing this model can
+    /// afford to lose.
+    ///
+    /// INT8 (+0.19% / 97.9% / 24-of-24, 763 MB) is still worth asking for explicitly, because
+    /// INT5's 23-of-24 is roughly a 4% per-pass failure rate and that compounds over a
+    /// sequence of calls: about a 56% chance of at least one unparseable reply across 20
+    /// structured-output passes. Pass `.int8` when every reply has to parse; take the default
+    /// when replies are read rather than parsed.
+    public static let defaultQuantization: Quantization = .int5
 
     /// Load a pre-trained Qwen3.5 chat model from HuggingFace.
     ///
@@ -88,12 +109,13 @@ public final class Qwen35MLXChat: @unchecked Sendable {
     /// Model is loaded into MLX for GPU inference on Apple Silicon.
     ///
     /// - Parameters:
-    ///   - modelId: HuggingFace model ID (repo with int4/ and int8/ subdirs)
-    ///   - quantization: INT4 (404 MB) or INT8 (763 MB)
+    ///   - modelId: HuggingFace model ID (repo with int5/ and int8/ subdirs)
+    ///   - quantization: INT5 (494 MB, default) or INT8 (763 MB). INT4 (404 MB) resolves only
+    ///     against a local checkout — see `Quantization`.
     ///   - progressHandler: Optional callback for download/load progress
     public static func fromPretrained(
         modelId: String = defaultModelId,
-        quantization: Quantization = .int4,
+        quantization: Quantization = defaultQuantization,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
         progressHandler: ((Double, String) -> Void)? = nil
@@ -101,7 +123,7 @@ public final class Qwen35MLXChat: @unchecked Sendable {
         let cacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
         let variant = quantization.rawValue
 
-        // Download model files from variant subdirectory (int4/ or int8/)
+        // Download model files from variant subdirectory (int5/ or int8/)
         progressHandler?(0.05, "Downloading \(variant) model...")
         try await HuggingFaceDownloader.downloadWeights(
             modelId: modelId,

--- a/Tests/Qwen3ChatTests/Qwen35QuantizationTests.swift
+++ b/Tests/Qwen3ChatTests/Qwen35QuantizationTests.swift
@@ -103,6 +103,47 @@ final class Qwen35QuantizationConfigTests: XCTestCase {
     }
 }
 
+/// Which variant `Qwen35MLXChat.fromPretrained` downloads when the caller names none.
+///
+/// The default is not cosmetic: `fromPretrained` builds the download path from
+/// `Quantization.rawValue`, so this value decides which subdirectory of the model repo is
+/// fetched. INT4 was retired for measured quality loss (+19.90% wikitext perplexity, 78.3%
+/// top-1 agreement, 18-of-24 strict JSON against the bf16 reference) and the repo's `int4/`
+/// directory is being removed, so a default that drifted back to `.int4` would not merely load
+/// a worse model — it would 404.
+final class Qwen35MLXQuantizationDefaultTests: XCTestCase {
+
+    func testDefaultQuantizationIsInt5() {
+        XCTAssertEqual(Qwen35MLXChat.defaultQuantization, .int5)
+    }
+
+    /// The raw value is a path segment in the model repo, so the spelling is load-bearing.
+    func testDefaultVariantNamesThePublishedSubdirectory() {
+        XCTAssertEqual(Qwen35MLXChat.defaultQuantization.rawValue, "int5")
+    }
+
+    /// INT4 stays reachable for a local checkpoint exported before INT5 existed; the point of
+    /// the change is that nothing defaults to it, not that it became unloadable.
+    func testInt4RemainsSelectable() {
+        XCTAssertEqual(Qwen35MLXChat.Quantization.int4.rawValue, "int4")
+        XCTAssertEqual(Qwen35MLXChat.Quantization(rawValue: "int4"), .int4)
+    }
+
+    func testEveryVariantRoundTripsThroughItsRawValue() {
+        for variant: Qwen35MLXChat.Quantization in [.int4, .int5, .int8] {
+            XCTAssertEqual(Qwen35MLXChat.Quantization(rawValue: variant.rawValue), variant)
+        }
+    }
+
+    /// The download variant and the width the loader builds its layers at have to agree, or
+    /// the checkpoint fetched from `int5/` fails the load-time shape check. `int5/config.json`
+    /// carries the label, and `ChatQuantization` has to read 5 bits out of it.
+    func testDefaultVariantLabelResolvesToItsBitWidth() {
+        XCTAssertEqual(
+            ChatQuantization.bits(fromLabel: Qwen35MLXChat.defaultQuantization.rawValue), 5)
+    }
+}
+
 /// The layers a config actually builds, and the load-time check that refuses a
 /// checkpoint packed at some other width.
 final class Qwen35QuantizedLayerTests: XCTestCase {

--- a/docs/models/qwen35-chat.md
+++ b/docs/models/qwen35-chat.md
@@ -220,5 +220,5 @@ By default, generation uses `enableThinking: false` which injects an empty `<thi
 
 ## Conversion
 
-- **MLX**: `scripts/convert_qwen35_chat_mlx.py` — quantizes FP16 HuggingFace weights to INT4/INT8 using MLX native quantization
+- **MLX**: `scripts/convert_qwen35_chat_mlx.py` — quantizes FP16 HuggingFace weights to INT5/INT8 using MLX native quantization
 - **CoreML**: `scripts/convert_qwen35_chat_coreml.py` — converts FP16 HuggingFace weights to CoreML with INT4/INT8 quantization

--- a/docs/models/qwen35-chat.md
+++ b/docs/models/qwen35-chat.md
@@ -86,12 +86,24 @@ Standard multi-head attention with these specifics:
 
 ### Qwen3.5 MLX (Mac GPU)
 
-Repo: `aufklarer/Qwen3.5-0.8B-Chat-MLX` with `int4/` and `int8/` subdirectories.
+Repo: `aufklarer/Qwen3.5-0.8B-Chat-MLX` with `int5/` and `int8/` subdirectories.
 
-| Variant | Size | Group size |
-|---------|------|-----------|
-| INT4 | 404 MB | 64 |
-| INT8 | 763 MB | 64 |
+| Variant | Size | Group size | Wikitext PPL | Top-1 agreement | Strict JSON |
+|---------|------|-----------|--------------|-----------------|-------------|
+| INT5 (default) | 494 MB | 64 | +2.19% | 89.6% | 23 / 24 |
+| INT8 | 763 MB | 64 | +0.19% | 97.9% | 24 / 24 |
+
+Quality columns are measured against the bf16 reference over 32,768 scored tokens per corpus.
+
+**INT5 is the floor, and INT4 is retired.** INT4 measured +19.90% perplexity, 78.3% top-1
+agreement, and 18-of-24 strict JSON at 404 MB; five of those six JSON failures were unbalanced
+braces, which a parser rejects outright rather than merely dislikes. INT5 buys all of that back
+for 90 MB. `Quantization.int4` still exists so a local pre-INT5 checkpoint loads, but nothing
+defaults to it and the repo's `int4/` directory is being removed.
+
+Prefer `.int8` when every reply has to parse. INT5's 23-of-24 is roughly a 4% per-pass failure
+rate, which compounds across a sequence — about a 56% chance of at least one unparseable reply
+over 20 structured-output passes.
 
 Weights are in safetensors format with quantized linear layers (`weight` uint32, `scales` bfloat16, `biases` bfloat16).
 
@@ -166,8 +178,8 @@ Gemma 4 uses a `<|turn>role\n...<turn|>` chat template, not ChatML. The streamin
 ```swift
 import Qwen3Chat
 
-// MLX (Mac)
-let model = try await Qwen35MLXChat.fromPretrained(quantization: .int4)
+// MLX (Mac) — defaults to .int5; pass .int8 when replies must parse as JSON
+let model = try await Qwen35MLXChat.fromPretrained()
 let response = try model.generate(
     messages: [
         ChatMessage(role: .system, content: "You are a helpful assistant."),


### PR DESCRIPTION
## What changed

`Qwen35MLXChat.fromPretrained` now defaults to `.int5`. It builds its download path from `Quantization.rawValue`, so the old default meant every caller who named no variant fetched `int4/` from `aufklarer/Qwen3.5-0.8B-Chat-MLX`.

- `case int5` added to `Quantization`. The repo already published `int5/`; the enum never gained the case, so it was unreachable from Swift.
- The default moved from a literal in the parameter list to `Qwen35MLXChat.defaultQuantization`, so a test can assert it — Swift cannot read a default argument expression reflectively.
- `case int4` stays. It costs nothing and a local pre-INT5 checkpoint still loads through it; the point is that nothing defaults to it.
- Doc comments and `docs/models/qwen35-chat.md` corrected — both stated `int4/ and int8/` and quoted only the INT4/INT8 sizes.

## Why

Measured over 32,768 scored tokens per corpus against the bf16 reference:

| Variant | Size | Wikitext PPL | Top-1 agreement | Strict JSON |
|---|---|---|---|---|
| INT4 | 404 MB | +19.90% | 78.3% | 18 / 24 |
| INT5 | 494 MB | +2.19% | 89.6% | 23 / 24 |
| INT8 | 763 MB | +0.19% | 97.9% | 24 / 24 |

Five of INT4's six JSON failures were unbalanced braces — output a parser rejects outright rather than merely dislikes. INT4's 90 MB saving over INT5 buys nothing this model can afford to lose.

This also has to land before the `int4/` directory is removed from the model repo, or callers relying on the default get a 404.

## The tradeoff, recorded at the default

INT5's 23-of-24 is roughly a 4% per-pass failure rate, and that compounds across a sequence of calls — about a 56% chance of at least one unparseable reply over 20 structured-output passes. A caller that needs every reply to parse should pass `.int8` explicitly. This is written into the `defaultQuantization` doc comment and the model doc rather than left for someone to rediscover.

## Regression risk

Low, and confined to the download path. Callers passing an explicit variant are unaffected. Callers taking the default fetch `int5/` instead of `int4/`, which is 90 MB larger and strictly better on every measured axis. Bit width already comes from the checkpoint (#434), so the INT5 config resolves to 5-bit layers and the load-time shape check verifies it — a mismatch fails closed rather than dequantizing garbage.

## Tests

`Qwen35MLXQuantizationDefaultTests` (new, unit, no downloads) pins the default to `.int5`, pins its raw value to the `int5` path segment, confirms `.int4` stays selectable, round-trips every variant, and checks `ChatQuantization` reads 5 bits out of the `int5` label so the download variant and the layer width cannot disagree.

Verified the guard fails when the default is moved back to `.int4` — 3 of the 5 tests break.

Ran:
- `swift build --disable-sandbox` — clean
- `swift build --build-tests --disable-sandbox` — clean
- `swift test --skip-build --no-parallel --filter Qwen3ChatTests --skip E2E` — 103 tests, 0 failures

Skipped the E2E chat suites, which download or require cached model weights: `E2EQwen35QuantizationLoadTests`, `E2EQwen35MLXChatTests`, `E2EQwen35CoreMLChatTests`, `E2EGemma4GenTests`, `E2EGemma4ParityTests`. These match CI's `--skip E2E`.

## Recommendation

Merge before the `int4/` directory is deleted from the model repo. Nothing here depends on that deletion having happened.