### PR TITLE
Band Gemma 4's sliding attention instead of masking a full score matrix

### DIFF
--- a/Sources/Qwen3Chat/Gemma4Chat.swift
+++ b/Sources/Qwen3Chat/Gemma4Chat.swift
@@ -100,9 +100,11 @@ public final class Gemma4Chat: @unchecked Sendable {
                 let promptTokens = Gemma4ChatTemplate.encode(
                     messages: messages, tokenizer: self.gemmaTokenizer)
 
-                // Prefill.
+                // Prefill. Only the final position is sampled, so the lm_head runs on that row
+                // alone — over a long prompt the discarded rows are gigabytes of 262k-wide logits.
                 let promptArray = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
-                let prefillLogits = self.model.forward(inputIds: promptArray, state: &self.state)
+                let prefillLogits = self.model.lastTokenLogits(
+                    inputIds: promptArray, state: &self.state)
                 eval(prefillLogits)
                 var logits = self.lastLogits(prefillLogits)
 

--- a/Sources/Qwen3Chat/Gemma4Model.swift
+++ b/Sources/Qwen3Chat/Gemma4Model.swift
@@ -195,6 +195,24 @@ public final class Gemma4ProportionalRoPE {
     }
 }
 
+// MARK: - Blocked attention geometry
+
+/// One query block of a blocked attention pass: which of this call's queries it covers, which
+/// slice of the key axis those queries can reach, and how that block is masked.
+///
+/// A sliding layer's query only reaches `sliding_window` keys back, so a block of `Q` consecutive
+/// queries reaches at most `Q + sliding_window - 1` of them. Scoring the block against that slice
+/// is what makes prefill near-linear in prompt length. The single `[1,1,Tq,Tk]` mask this replaced
+/// let the window decide which scores *survived*, never how many were *computed*: all 42 layers
+/// built the complete Tq×Tk matrix and then threw ~97% of it away.
+struct Gemma4AttentionBlock {
+    let queryStart: Int   // half-open range into this call's query axis
+    let queryEnd: Int
+    let keyStart: Int     // half-open range into the (cache-concatenated) key axis
+    let keyEnd: Int
+    let mask: MLXFast.ScaledDotProductAttentionMaskMode
+}
+
 // MARK: - Attention
 
 public final class Gemma4Attention: Module {
@@ -270,13 +288,11 @@ public final class Gemma4Attention: Module {
     ///     When non-nil this is the FULL cache to attend over (no past is concatenated).
     ///   - pastKV: previously cached post-RoPE (keys, values) for a *producing* layer in incremental
     ///     decode; this step's new K/V are concatenated onto it. Ignored when `sharedKV` is set.
-    ///   - mask: additive float mask [1,1,Tq,Tk] (already causal / windowed).
     ///   - offset: RoPE position offset for the *new* tokens (== number of cached positions).
-    /// - Returns: (output [B,T,hidden], full (keys,values) attended over [B,Hkv,Tk,D]).
-    public func callAsFunction(
-        _ x: MLXArray, mask: MLXArray, sharedKV: (MLXArray, MLXArray)?,
-        pastKV: (MLXArray, MLXArray)? = nil, offset: Int
-    ) -> (MLXArray, (MLXArray, MLXArray)) {
+    /// - Returns: (q [B,Hq,T,D], full keys, full values [B,Hkv,Tk,D]).
+    private func projectQKV(
+        _ x: MLXArray, sharedKV: (MLXArray, MLXArray)?, pastKV: (MLXArray, MLXArray)?, offset: Int
+    ) -> (MLXArray, MLXArray, MLXArray) {
         let b = x.dim(0), t = x.dim(1)
 
         var q = qNorm(qProj(x).reshaped(b, t, nHeads, headDim))   // q_norm before transpose
@@ -306,10 +322,63 @@ public final class Gemma4Attention: Module {
 
         q = q.transposed(0, 2, 1, 3)
         q = applyRope(q, offset: offset)
+        return (q, keys, values)
+    }
 
+    /// Reference path: one SDPA call against the whole key axis with a precomputed additive
+    /// `[1,1,Tq,Tk]` mask. Superseded by the blocked overload below and retained because it is the
+    /// implementation the blocked one is measured against.
+    ///
+    /// - Returns: (output [B,T,hidden], full (keys,values) attended over [B,Hkv,Tk,D]).
+    public func callAsFunction(
+        _ x: MLXArray, mask: MLXArray, sharedKV: (MLXArray, MLXArray)?,
+        pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let (q, keys, values) = projectQKV(x, sharedKV: sharedKV, pastKV: pastKV, offset: offset)
         let attnOut = SDPA.attendAndMerge(
             qHeads: q, kHeads: keys, vHeads: values, scale: scale, mask: mask)
         return (oProj(attnOut), (keys, values))
+    }
+
+    /// Blocked path: each block scores its queries against only the keys they can reach, so a
+    /// sliding layer never materialises a score matrix wider than its window. Q/K/V projections and
+    /// RoPE still run once over the whole call — they are linear in length and cheap to share — and
+    /// the full (keys, values) are returned unsliced so they can still be cached and shared.
+    ///
+    /// The per-block outputs are concatenated along the token axis before `o_proj`, so the output
+    /// projection stays one matmul rather than one per block.
+    func callAsFunction(
+        _ x: MLXArray, blocks: [Gemma4AttentionBlock], sharedKV: (MLXArray, MLXArray)?,
+        pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let (q, keys, values) = projectQKV(x, sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+
+        let attnOut: MLXArray
+        if blocks.count == 1 {
+            let block = blocks[0]
+            attnOut = SDPA.attendAndMerge(
+                qHeads: q, kHeads: keySlice(keys, block), vHeads: keySlice(values, block),
+                scale: scale, mask: block.mask)
+        } else {
+            var parts: [MLXArray] = []
+            parts.reserveCapacity(blocks.count)
+            for block in blocks {
+                parts.append(SDPA.attendAndMerge(
+                    qHeads: q[0..., 0..., block.queryStart ..< block.queryEnd, 0...],
+                    kHeads: keySlice(keys, block), vHeads: keySlice(values, block),
+                    scale: scale, mask: block.mask))
+            }
+            attnOut = concatenated(parts, axis: 1)
+        }
+        return (oProj(attnOut), (keys, values))
+    }
+
+    /// Key/value slice a block attends over, left alone when the block already spans everything
+    /// (short prompts and single-block passes) so nothing pays for a no-op view.
+    @inline(__always)
+    private func keySlice(_ kv: MLXArray, _ block: Gemma4AttentionBlock) -> MLXArray {
+        (block.keyStart == 0 && block.keyEnd == kv.dim(2))
+            ? kv : kv[0..., 0..., block.keyStart ..< block.keyEnd, 0...]
     }
 }
 
@@ -379,14 +448,31 @@ public final class Gemma4Layer: Module {
         _ x: MLXArray, mask: MLXArray, perLayerInput: MLXArray,
         sharedKV: (MLXArray, MLXArray)?, pastKV: (MLXArray, MLXArray)? = nil, offset: Int
     ) -> (MLXArray, (MLXArray, MLXArray)) {
-        var residual = x
+        let (attnOut, kv) = attn(inputLayerNorm(x), mask: mask, sharedKV: sharedKV,
+                                 pastKV: pastKV, offset: offset)
+        return (feedForward(residual: x, attnOut: attnOut, perLayerInput: perLayerInput), kv)
+    }
 
-        var h = inputLayerNorm(x)
-        let (attnOut, kv) = attn(h, mask: mask, sharedKV: sharedKV, pastKV: pastKV, offset: offset)
-        h = postAttentionLayerNorm(attnOut)   // post-attn norm applied BEFORE the residual add
-        h = residual + h
+    /// Blocked attention variant — identical outside the attention call itself.
+    func callAsFunction(
+        _ x: MLXArray, blocks: [Gemma4AttentionBlock], perLayerInput: MLXArray,
+        sharedKV: (MLXArray, MLXArray)?, pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let (attnOut, kv) = attn(inputLayerNorm(x), blocks: blocks, sharedKV: sharedKV,
+                                 pastKV: pastKV, offset: offset)
+        return (feedForward(residual: x, attnOut: attnOut, perLayerInput: perLayerInput), kv)
+    }
 
-        residual = h
+    /// Everything after the attention call: post-attn norm, the sandwiched FFN, per-layer input
+    /// gating, and the layer scalar. Shared by both attention paths so they can only differ in how
+    /// the scores were computed.
+    private func feedForward(
+        residual attnResidual: MLXArray, attnOut: MLXArray, perLayerInput: MLXArray
+    ) -> MLXArray {
+        var h = postAttentionLayerNorm(attnOut)   // post-attn norm applied BEFORE the residual add
+        h = attnResidual + h
+
+        var residual = h
         h = preFeedforwardLayerNorm(h)
         h = mlp(h)
         h = postFeedforwardLayerNorm(h)
@@ -401,8 +487,7 @@ public final class Gemma4Layer: Module {
         gate = postPerLayerInputNorm(gate)
         h = residual + gate
 
-        h = h * layerScalar
-        return (h, kv)
+        return h * layerScalar
     }
 }
 
@@ -465,16 +550,141 @@ public final class Gemma4Model: Module {
         return (proj + perLayerInputs) * perLayerInputScale
     }
 
-    /// Build an additive float mask [1,1,T,T]: causal, with an optional sliding window.
-    private func makeMask(seqLen t: Int, windowSize: Int?, dtype: DType) -> MLXArray {
-        makeMask(queryLen: t, keyLen: t, offset: 0, windowSize: windowSize, dtype: dtype)
+    // MARK: - Attention geometry
+
+    /// Queries per attention block.
+    ///
+    /// A sliding layer's per-block key span is `queryBlock + sliding_window - 1`, so its whole pass
+    /// costs `T · (queryBlock + window - 1)` key comparisons against the `T²` the full mask paid: at
+    /// the checkpoint's 512-token window and a 17k prompt that is a 17× reduction, and the ratio
+    /// keeps improving with length. Smaller blocks shave a little more arithmetic but launch more
+    /// kernels; 512 keeps each block's matmul large (8 heads × 512 queries × ~1023 keys) while the
+    /// cost is already within 2× of the `T · window` floor. The value is deliberately independent of
+    /// `sliding_window` — every interior block has the same relative geometry whatever it is, so one
+    /// mask array serves all of them and all 35 sliding layers.
+    ///
+    /// The seven global layers are blocked at the same size even though they have no band to
+    /// exploit, which looks pointless and is not. Handing MLX a single end-aligned causal call over
+    /// the whole prompt instead was measured at 17,408 tokens to raise peak memory from 7.03 GB to
+    /// 11.30 GB — a figure that is deterministic and repeated exactly run to run, unlike the wall
+    /// times beside it, which drifted further with the machine's thermal state than the two variants
+    /// differed. So MLX's SDPA reserves against the whole Tq×Tk score matrix rather than against the
+    /// half a causal mask keeps, and bounding Tk per block is what caps the reservation, exactly as
+    /// it does on the sliding layers. Do not special-case global layers back to one call without
+    /// re-measuring peak memory.
+    private static let queryBlock = 512
+
+    /// Geometry that decides a block's mask: how many queries, how many keys, and where the block's
+    /// first query sits inside its key slice. Interior blocks agree on all three.
+    struct BlockMaskKey: Hashable {
+        let queries: Int
+        let keys: Int
+        let queryOffset: Int
     }
 
-    /// Build an additive float mask [1,1,Tq,Tk] for incremental decode: the `Tq` new queries
-    /// live at absolute positions `offset ..< offset+Tq`; the `Tk` keys at `0 ..< Tk`
-    /// (`Tk == offset + Tq` for a contiguous cache). Causal, with an optional sliding window.
-    private func makeMask(queryLen tq: Int, keyLen tk: Int, offset: Int,
-                          windowSize: Int?, dtype: DType) -> MLXArray {
+    /// Plan one attention pass: `tq` new queries at absolute positions `offset ..< offset+tq`,
+    /// keys covering absolute `0 ..< tk`. `windowSize` nil means global attention.
+    ///
+    /// Two block shapes need no mask array at all. A one-query block (every decode step) reaches
+    /// every key in its own slice, and a block whose slice starts at position 0 with no query's
+    /// window biting is exactly the end-aligned causal case MLX derives itself — which is every
+    /// block of a full-attention layer, so those layers now allocate no mask whatever the length.
+    static func attentionBlocks(queryLen tq: Int, keyLen tk: Int, offset: Int,
+                                windowSize: Int?, dtype: DType) -> [Gemma4AttentionBlock] {
+        var blocks: [Gemma4AttentionBlock] = []
+        var masks: [BlockMaskKey: MLXArray] = [:]
+        var start = 0
+        while start < tq {
+            let end = min(start + queryBlock, tq)
+            let firstQuery = offset + start
+            let lastQuery = offset + end - 1
+            // Causal: nothing above the block's last query. Windowed: nothing below the first
+            // query's window floor, since a later query's floor is only ever higher.
+            let keyEnd = min(lastQuery + 1, tk)
+            let keyStart = windowSize.map { max(0, firstQuery - $0 + 1) } ?? 0
+
+            let mask: MLXFast.ScaledDotProductAttentionMaskMode
+            if end - start == 1 {
+                mask = .none
+            } else if keyStart == 0, windowSize.map({ lastQuery < $0 }) ?? true {
+                mask = .causal
+            } else {
+                let key = BlockMaskKey(queries: end - start, keys: keyEnd - keyStart,
+                                       queryOffset: firstQuery - keyStart)
+                let array = masks[key] ?? blockMask(key, windowSize: windowSize, dtype: dtype)
+                masks[key] = array
+                mask = .array(array)
+            }
+
+            blocks.append(Gemma4AttentionBlock(queryStart: start, queryEnd: end,
+                                               keyStart: keyStart, keyEnd: keyEnd, mask: mask))
+            start = end
+        }
+        return blocks
+    }
+
+    /// Additive mask for one block — `[1,1,queries,keys]`, in the block's own coordinates: query `i`
+    /// sits at key-slice position `queryOffset + i`, key `j` at position `j`.
+    static func blockMask(_ key: BlockMaskKey, windowSize: Int?, dtype: DType) -> MLXArray {
+        let qInds = (MLXArray(Int32(0)..<Int32(key.queries)) + Int32(key.queryOffset))
+            .reshaped(key.queries, 1)
+        let kInds = MLXArray(Int32(0)..<Int32(key.keys)).reshaped(1, key.keys)
+        var keep = qInds .>= kInds                       // causal
+        if let w = windowSize {
+            keep = logicalAnd(keep, qInds .< (kInds + w)) // sliding window
+        }
+        let zeros = MLXArray.zeros([key.queries, key.keys], dtype: dtype)
+        let neg = MLXArray(-Float.greatestFiniteMagnitude).asType(dtype)
+        return MLX.where(keep, zeros, neg).reshaped(1, 1, key.queries, key.keys)
+    }
+
+    /// How a pass drives its layers: the blocked geometry production uses, or the single full-size
+    /// mask it replaced. The reference stays reachable so the parity test can hold one against the
+    /// other on the same weights and the same prompt; nothing in production selects it.
+    private enum AttentionPlan {
+        case blocks(full: [Gemma4AttentionBlock], sliding: [Gemma4AttentionBlock])
+        case referenceMasks(full: MLXArray, sliding: MLXArray)
+    }
+
+    /// Test-only: fall back to the full `[1,1,Tq,Tk]` mask for every layer.
+    static var usesReferenceFullMask = false
+
+    private func attentionPlan(queryLen tq: Int, keyLen tk: Int, offset: Int,
+                               dtype: DType) -> AttentionPlan {
+        if Gemma4Model.usesReferenceFullMask {
+            return .referenceMasks(
+                full: Self.makeMask(queryLen: tq, keyLen: tk, offset: offset,
+                                    windowSize: nil, dtype: dtype),
+                sliding: Self.makeMask(queryLen: tq, keyLen: tk, offset: offset,
+                                       windowSize: config.slidingWindow, dtype: dtype))
+        }
+        return .blocks(
+            full: Self.attentionBlocks(queryLen: tq, keyLen: tk, offset: offset,
+                                       windowSize: nil, dtype: dtype),
+            sliding: Self.attentionBlocks(queryLen: tq, keyLen: tk, offset: offset,
+                                          windowSize: config.slidingWindow, dtype: dtype))
+    }
+
+    /// Run one layer under the pass's plan.
+    private func run(_ layer: Gemma4Layer, _ h: MLXArray, plan: AttentionPlan, isFull: Bool,
+                     perLayerInput: MLXArray, sharedKV: (MLXArray, MLXArray)?,
+                     pastKV: (MLXArray, MLXArray)?, offset: Int)
+        -> (MLXArray, (MLXArray, MLXArray)) {
+        switch plan {
+        case .blocks(let full, let sliding):
+            return layer(h, blocks: isFull ? full : sliding, perLayerInput: perLayerInput,
+                         sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+        case .referenceMasks(let full, let sliding):
+            return layer(h, mask: isFull ? full : sliding, perLayerInput: perLayerInput,
+                         sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+        }
+    }
+
+    /// Build an additive float mask [1,1,Tq,Tk]: the `Tq` new queries live at absolute positions
+    /// `offset ..< offset+Tq`; the `Tk` keys at `0 ..< Tk` (`Tk == offset + Tq` for a contiguous
+    /// cache). Causal, with an optional sliding window. Reference geometry only — see `AttentionPlan`.
+    static func makeMask(queryLen tq: Int, keyLen tk: Int, offset: Int,
+                         windowSize: Int?, dtype: DType) -> MLXArray {
         // query absolute pos qi = offset + i ; key absolute pos kj = j.
         let qInds = (MLXArray(Int32(0)..<Int32(tq)) + Int32(offset)).reshaped(tq, 1)
         let kInds = MLXArray(Int32(0)..<Int32(tk)).reshaped(1, tk)
@@ -519,20 +729,18 @@ public final class Gemma4Model: Module {
         let perLayer = projectPerLayerInputs(h, pleRaw)        // [B,T,L,256]
         stat("ple_proj", perLayer)
 
-        // Masks per layer type.
-        let fullMask = makeMask(seqLen: t, windowSize: nil, dtype: dtype)
-        let slidingMask = makeMask(seqLen: t, windowSize: config.slidingWindow, dtype: dtype)
+        // Attention geometry per layer type — planned once and shared by every layer of that type.
+        let plan = attentionPlan(queryLen: t, keyLen: t, offset: 0, dtype: dtype)
 
         let prevKVs = config.previousKVs
         var produced: [(MLXArray, MLXArray)?] = Array(repeating: nil, count: layers.count)
 
         for (i, layer) in layers.enumerated() {
             let isFull = config.layerTypes[i] == "full_attention"
-            let mask = isFull ? fullMask : slidingMask
             let perLayerInput = perLayer[0..., 0..., i, 0...]    // [B,T,256]
             let shared = (prevKVs[i] == i) ? nil : produced[prevKVs[i]]
-            let (nh, kv) = layer(h, mask: mask, perLayerInput: perLayerInput,
-                                 sharedKV: shared, offset: 0)
+            let (nh, kv) = run(layer, h, plan: plan, isFull: isFull, perLayerInput: perLayerInput,
+                               sharedKV: shared, pastKV: nil, offset: 0)
             h = nh
             produced[i] = kv
             if Gemma4Model.debugStats, i < 3 || i == 14 || i == 15 || i == 34 {
@@ -547,11 +755,13 @@ public final class Gemma4Model: Module {
 
     /// - Returns: logits `[B,T,vocab]` with the final logit softcap applied.
     public func forward(inputIds: MLXArray) -> MLXArray {
-        let h = hidden(inputIds: inputIds)
-        var logits = embedTokens.asLinear(h)   // tied lm_head
+        softcapped(embedTokens.asLinear(hidden(inputIds: inputIds)))   // tied lm_head
+    }
+
+    /// `tanh(logits / cap) * cap` — Gemma 4's final logit softcap.
+    private func softcapped(_ logits: MLXArray) -> MLXArray {
         let cap = config.finalLogitSoftcapping
-        logits = MLX.tanh(logits / cap) * cap
-        return logits
+        return MLX.tanh(logits / cap) * cap
     }
 
     // MARK: - Incremental generation (KV-cache + cross-layer KV sharing)
@@ -575,11 +785,30 @@ public final class Gemma4Model: Module {
     /// passes a single token (T = 1). Producing layers append their post-RoPE K/V to their cache;
     /// shared layers read the producing layer's (now-updated) cache read-only.
     ///
-    /// NOTE: sliding-window layers use a simple growing cache (no eviction). For the short voice
-    /// turns this backend targets, sequence length stays well under `slidingWindow`, so the
-    /// windowed mask alone already reproduces the reference attention; eviction would only matter
-    /// for very long contexts.
+    /// NOTE: sliding-window layers keep a simple growing cache (no eviction). Their attention only
+    /// ever *reads* the newest `slidingWindow` entries of it — see `attentionBlocks` — so eviction
+    /// would save cache memory at long contexts but change no result.
     public func forward(inputIds: MLXArray, state: inout InferenceState) -> MLXArray {
+        softcapped(embedTokens.asLinear(hidden(inputIds: inputIds, state: &state)))  // tied lm_head
+    }
+
+    /// Logits for the final position only — `[B,1,vocab]`, softcapped like `forward`'s.
+    ///
+    /// The lm_head projects onto a 262k vocabulary, so running it over every position turns a
+    /// 17k-token prompt into a `[1,17408,262144]` bfloat16 array — 9 GB, and again as much for the
+    /// softcap's intermediates — to produce the one row generation samples from. Prefill takes this
+    /// path instead. The token axis is kept so callers can index the last position either way.
+    ///
+    /// Internal: `forward` remains the whole public surface, so nothing outside the module has to
+    /// choose between two ways of prefilling.
+    func lastTokenLogits(inputIds: MLXArray, state: inout InferenceState) -> MLXArray {
+        let hn = hidden(inputIds: inputIds, state: &state)
+        let t = hn.dim(1)
+        return softcapped(embedTokens.asLinear(hn[0..., (t - 1) ..< t, 0...]))
+    }
+
+    /// Hidden states after the final norm for `T` new tokens, updating `state`'s caches in place.
+    private func hidden(inputIds: MLXArray, state: inout InferenceState) -> MLXArray {
         let t = inputIds.dim(1)
         let offset = state.position
 
@@ -590,33 +819,25 @@ public final class Gemma4Model: Module {
         let pleRaw = getPerLayerInputs(inputIds)
         let perLayer = projectPerLayerInputs(h, pleRaw)        // [B,T,L,256]
 
-        // Masks: keys span [0, offset+t) — a contiguous growing cache. Tq = t, Tk = offset+t.
+        // Keys span [0, offset+t) — a contiguous growing cache. Tq = t, Tk = offset+t.
         let tk = offset + t
-        let fullMask = makeMask(queryLen: t, keyLen: tk, offset: offset, windowSize: nil, dtype: dtype)
-        let slidingMask = makeMask(queryLen: t, keyLen: tk, offset: offset,
-                                   windowSize: config.slidingWindow, dtype: dtype)
+        let plan = attentionPlan(queryLen: t, keyLen: tk, offset: offset, dtype: dtype)
 
         let prevKVs = config.previousKVs
         for (i, layer) in layers.enumerated() {
             let isFull = config.layerTypes[i] == "full_attention"
-            let mask = isFull ? fullMask : slidingMask
             let perLayerInput = perLayer[0..., 0..., i, 0...]    // [B,T,256]
 
             let isProducing = (prevKVs[i] == i)
             let shared = isProducing ? nil : state.kvCaches[prevKVs[i]]
             let past = isProducing ? state.kvCaches[i] : nil
-            let (nh, kv) = layer(h, mask: mask, perLayerInput: perLayerInput,
-                                 sharedKV: shared, pastKV: past, offset: offset)
+            let (nh, kv) = run(layer, h, plan: plan, isFull: isFull, perLayerInput: perLayerInput,
+                               sharedKV: shared, pastKV: past, offset: offset)
             h = nh
             if isProducing { state.kvCaches[i] = kv }
         }
 
         state.position = tk
-
-        let hn = norm(h)
-        var logits = embedTokens.asLinear(hn)   // tied lm_head
-        let cap = config.finalLogitSoftcapping
-        logits = MLX.tanh(logits / cap) * cap
-        return logits
+        return norm(h)
     }
 }

--- a/Tests/Qwen3ChatTests/E2EGemma4SlidingWindowTests.swift
+++ b/Tests/Qwen3ChatTests/E2EGemma4SlidingWindowTests.swift
@@ -1,0 +1,257 @@
+import XCTest
+import Foundation
+import MLX
+import AudioCommon
+@testable import Qwen3Chat
+
+/// Blocked sliding-window attention must be a pure compute change.
+///
+/// `Gemma4Model` scores each query block against only the keys that block can reach, so a
+/// sliding layer never builds a matrix wider than its 512-token window. The implementation it
+/// replaced built one `[1,1,T,T]` mask per layer type and let all 42 layers compute the complete
+/// score matrix before masking ~97% of it to `-inf`. Both paths are still reachable
+/// (`Gemma4Model.usesReferenceFullMask`), so the two can be compared on the same weights, the same
+/// prompt, and the same process — which is what these tests do.
+///
+/// Prompt lengths straddle the window deliberately: under it (100) the two paths are the same
+/// single call, at it (512) the first block ends exactly on the boundary, one past it (513) adds
+/// the first genuinely banded block, and 1600 / 4000 exercise interior blocks that share one
+/// reused mask plus a short trailing block that needs its own.
+final class E2EGemma4SlidingWindowTests: XCTestCase {
+    private static let modelDir: URL? = {
+        if let p = ProcessInfo.processInfo.environment["GEMMA4_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return try? HuggingFaceDownloader.getCacheDirectory(for: "aufklarer/gemma-4-E4B-it-MLX-4bit")
+    }()
+
+    /// Logits come out in bfloat16, whose spacing at the softcap's ±30 is 0.125 — so no tolerance
+    /// below ~0.13 is even expressible here, and one has to be stated in units of that grid. A change
+    /// of tiling alone costs 1 to 2 of those steps: running the lm_head on one row instead of all of
+    /// them, which cannot change a result, already moves logits by 0.19. Blocking, measured across
+    /// these lengths, costs at most 0.69 ≈ 5 steps, accumulated over 42 layers of shortened score
+    /// rows and softmax denominators. 1.0 is 8 steps.
+    ///
+    /// The argmax is asserted exactly, and separately shown to clear this tolerance by more than an
+    /// order of magnitude — the smallest top-1/top-2 gap these prompts produce is 14.3 — so the token
+    /// greedy sampling takes cannot turn on rounding. Deeper ranks are not asserted and must not be:
+    /// candidates 4 and 5 come out within one bfloat16 step of each other, so their order is not
+    /// reproducible under *any* retiling, including changes that provably cannot alter a result. The
+    /// numbers are printed so a regression reads as a number rather than as a pass.
+    private static let logitTolerance: Float = 1.0
+
+    private func loadChat() throws -> Gemma4Chat {
+        guard let dir = Self.modelDir,
+              FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.json").path)
+        else { throw XCTSkip("Gemma 4 model dir unavailable") }
+        do { return try Gemma4Chat.fromDirectory(dir) }
+        catch { throw XCTSkip("model load failed (weights/metallib): \(error)") }
+    }
+
+    /// Realistic token ids: tokenize a meeting-shaped paragraph and repeat it to length.
+    static func promptTokens(_ count: Int, _ tok: Gemma4Tokenizer) -> [Int] {
+        let paragraph = """
+        We walked through the retrieval budget again. Ivan said the lexical arm returns nothing when \
+        the planner writes a function word into the query, and Yeran wanted the passages per branch \
+        raised from six to eight before we measure anything else. The index rebuild took eleven \
+        minutes on the laptop and the outbox drained cleanly afterwards.
+        """
+        var ids: [Int] = [tok.bosTokenId]
+        while ids.count < count { ids.append(contentsOf: tok.encode(paragraph)) }
+        return Array(ids.prefix(count))
+    }
+
+    /// Softcapped logits for the final position, through the no-cache single forward.
+    private func singleForwardLogits(_ chat: Gemma4Chat, _ tokens: [Int]) -> [Float] {
+        let arr = MLXArray(tokens.map { Int32($0) }).expandedDimensions(axis: 0)
+        let logits = chat.model.forward(inputIds: arr)
+        let last = logits[0, logits.dim(1) - 1].asType(.float32)
+        eval(last)
+        return Array(last.asArray(Float.self).prefix(chat.denseConfig.vocabSize))
+    }
+
+    /// Softcapped logits for the final position, through the incremental KV-cache prefill.
+    private func cachedPrefillLogits(_ chat: Gemma4Chat, _ tokens: [Int]) -> [Float] {
+        var state = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+        let arr = MLXArray(tokens.map { Int32($0) }).expandedDimensions(axis: 0)
+        let logits = chat.model.lastTokenLogits(inputIds: arr, state: &state)
+        let last = logits[0, 0].asType(.float32)
+        eval(last)
+        return Array(last.asArray(Float.self).prefix(chat.denseConfig.vocabSize))
+    }
+
+    private func withReferenceMask<R>(_ body: () throws -> R) rethrows -> R {
+        Gemma4Model.usesReferenceFullMask = true
+        defer { Gemma4Model.usesReferenceFullMask = false }
+        return try body()
+    }
+
+    private func argmax(_ l: [Float]) -> Int {
+        var best = 0
+        for i in 1..<l.count where l[i] > l[best] { best = i }
+        return best
+    }
+
+    /// The five most likely token ids in order — what sampling actually reads.
+    private func top5(_ l: [Float]) -> [Int] {
+        l.enumerated().sorted { $0.element > $1.element }.prefix(5).map(\.offset)
+    }
+
+    /// Top-1 minus top-2: the margin the argmax survives on, so the tolerance can be read against
+    /// something rather than asserted in a vacuum.
+    private func topMargin(_ l: [Float]) -> Float {
+        var best = -Float.greatestFiniteMagnitude, second = -Float.greatestFiniteMagnitude
+        for v in l where v > second { if v > best { second = best; best = v } else { second = v } }
+        return best - second
+    }
+
+    func testBlockedAttentionMatchesFullMask() throws {
+        let chat = try loadChat()
+        for n in [100, 512, 513, 1600, 4000] {
+            let tokens = Self.promptTokens(n, chat.gemmaTokenizer)
+            XCTAssertEqual(tokens.count, n)
+
+            let reference = withReferenceMask { singleForwardLogits(chat, tokens) }
+            let blocked = singleForwardLogits(chat, tokens)
+            let cached = cachedPrefillLogits(chat, tokens)
+
+            var blockedDiff: Float = 0, cachedDiff: Float = 0
+            for i in 0..<reference.count {
+                blockedDiff = max(blockedDiff, abs(reference[i] - blocked[i]))
+                cachedDiff = max(cachedDiff, abs(reference[i] - cached[i]))
+            }
+            let margin = topMargin(reference)
+            print(String(format:
+                "[gemma4-band] tokens=%d argmax ref=%d blocked=%d cached=%d "
+                + "maxAbsDiff blocked=%.4f cached=%.4f topMargin=%.3f top5=%@",
+                n, argmax(reference), argmax(blocked), argmax(cached),
+                blockedDiff, cachedDiff, margin, "\(top5(reference))"))
+
+            XCTAssertEqual(argmax(blocked), argmax(reference),
+                           "blocked attention changed the next token at \(n) tokens")
+            XCTAssertEqual(argmax(cached), argmax(reference),
+                           "blocked KV-cache prefill changed the next token at \(n) tokens")
+            XCTAssertLessThan(blockedDiff, Self.logitTolerance,
+                              "blocked attention logits drifted at \(n) tokens")
+            XCTAssertLessThan(cachedDiff, Self.logitTolerance,
+                              "blocked KV-cache prefill logits drifted at \(n) tokens")
+            // The argmax survives on a gap far wider than the tolerance, so it is not a coin toss.
+            XCTAssertGreaterThan(margin, 10 * Self.logitTolerance,
+                                 "top-1 margin at \(n) tokens is too narrow to conclude anything")
+            Memory.clearCache()
+        }
+    }
+
+    /// Decode, not just prefill: at one query the sliding layers now read the newest 512 cache
+    /// entries with no mask at all instead of the whole cache behind one. Greedy generation over a
+    /// prompt past the window must still produce the same tokens.
+    func testBlockedDecodeMatchesFullMask() throws {
+        let chat = try loadChat()
+        let filler = Self.promptTokens(1200, chat.gemmaTokenizer)
+        let transcript = chat.gemmaTokenizer.decode(filler)
+        let messages = [
+            ChatMessage(role: .system, content: "You are a helpful assistant. Give short direct answers."),
+            ChatMessage(role: .user, content: transcript + "\n\nWho wanted more passages per branch?"),
+        ]
+        let sampling = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 24,
+                                          repetitionPenalty: 1.0)
+
+        let reference = try withReferenceMask { try chat.generate(messages: messages, sampling: sampling) }
+        let blocked = try chat.generate(messages: messages, sampling: sampling)
+        print("[gemma4-band] greedy reference=\(reference.debugDescription) blocked=\(blocked.debugDescription)")
+        XCTAssertEqual(blocked, reference, "blocked attention changed greedy generation")
+    }
+
+    /// `lastTokenLogits` runs the 262k-wide lm_head on the final row only; it must agree with the
+    /// final row of the all-positions `forward`.
+    func testLastTokenLogitsMatchFullForward() throws {
+        let chat = try loadChat()
+        let tokens = Self.promptTokens(1600, chat.gemmaTokenizer)
+        var state = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+        let arr = MLXArray(tokens.map { Int32($0) }).expandedDimensions(axis: 0)
+
+        let all = chat.model.forward(inputIds: arr, state: &state)
+        let allLast = all[0, all.dim(1) - 1].asType(.float32)
+        eval(allLast)
+        let expected = Array(allLast.asArray(Float.self).prefix(chat.denseConfig.vocabSize))
+        let actual = cachedPrefillLogits(chat, tokens)
+
+        var diff: Float = 0
+        for i in 0..<expected.count { diff = max(diff, abs(expected[i] - actual[i])) }
+        print(String(format: "[gemma4-band] lastTokenLogits maxAbsDiff=%.4f", diff))
+        XCTAssertEqual(argmax(actual), argmax(expected))
+        XCTAssertLessThan(diff, Self.logitTolerance)
+    }
+
+    /// Prefill, timed, in a frame of its own so its logits are released before the caller decodes.
+    /// The all-rows array is 9 GB at 17k tokens; holding it across the decode loop charged that
+    /// variant's per-token cost for memory pressure rather than for the attention geometry being
+    /// compared, and did so unreproducibly — 101 ms/tok in one run and 71 in the next.
+    private func timedPrefill(_ chat: Gemma4Chat, _ arr: MLXArray,
+                              state: inout Gemma4Model.InferenceState,
+                              allPositions: Bool) -> Double {
+        let start = CFAbsoluteTimeGetCurrent()
+        let logits = allPositions
+            ? chat.model.forward(inputIds: arr, state: &state)
+            : chat.model.lastTokenLogits(inputIds: arr, state: &state)
+        eval(logits)
+        return CFAbsoluteTimeGetCurrent() - start
+    }
+
+    /// Wall-clock prefill and decode, decomposed over the two changes: the full mask with the
+    /// lm_head over every position (what this replaced), the same mask with the lm_head on the final
+    /// row alone, and blocked attention with it. Gated on `GEMMA4_PREFILL_BENCH` — it loads the 4.2 GB
+    /// checkpoint and runs 17k-token forwards, so it is a measurement harness, not a test.
+    func testPrefillScaling() throws {
+        guard ProcessInfo.processInfo.environment["GEMMA4_PREFILL_BENCH"] != nil else {
+            throw XCTSkip("set GEMMA4_PREFILL_BENCH=1 to measure prefill")
+        }
+        let chat = try loadChat()
+        let variants: [(label: String, referenceMask: Bool, allPositionLogits: Bool)] = [
+            ("full+allrows", true, true),
+            ("full+lastrow", true, false),
+            ("blocked", false, false),
+        ]
+        // Warm up both paths first: the first prefill after a load pays for paging 4.2 GB of weights
+        // in and for whatever kernels have yet to be specialised, which at 1k tokens is most of the
+        // measurement and would be charged to whichever variant happened to run first.
+        for warmUp in [true, false] {
+            Gemma4Model.usesReferenceFullMask = warmUp
+            var state = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+            let tokens = Self.promptTokens(2048, chat.gemmaTokenizer)
+            let arr = MLXArray(tokens.map { Int32($0) }).expandedDimensions(axis: 0)
+            eval(chat.model.lastTokenLogits(inputIds: arr, state: &state))
+        }
+        Gemma4Model.usesReferenceFullMask = false
+
+        for n in [1024, 4096, 10240, 17408] {
+            let tokens = Self.promptTokens(n, chat.gemmaTokenizer)
+            for variant in variants {
+                Gemma4Model.usesReferenceFullMask = variant.referenceMask
+                defer { Gemma4Model.usesReferenceFullMask = false }
+                Memory.clearCache()
+                GPU.resetPeakMemory()
+
+                let arr = MLXArray(tokens.map { Int32($0) }).expandedDimensions(axis: 0)
+                var state = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+                let prefillSeconds = timedPrefill(chat, arr, state: &state,
+                                                  allPositions: variant.allPositionLogits)
+                let prefillPeak = Double(Memory.peakMemory) / 1_073_741_824
+
+                // Eight decode steps off that cache, so the per-step cost at long context is
+                // measured rather than inferred.
+                let step = MLXArray([Int32(tokens[0])]).expandedDimensions(axis: 0)
+                let start = CFAbsoluteTimeGetCurrent()
+                for _ in 0..<8 {
+                    let out = chat.model.lastTokenLogits(inputIds: step, state: &state)
+                    eval(out)
+                }
+                let decodeMs = (CFAbsoluteTimeGetCurrent() - start) / 8 * 1000
+
+                print(String(format: "[gemma4-prefill] tokens=%5d %-12@ prefill=%6.2fs "
+                             + "decode=%5.1fms/tok peak=%5.2fGB",
+                             n, variant.label, prefillSeconds, decodeMs, prefillPeak))
+            }
+        }
+    }
+}

--- a/Tests/Qwen3ChatTests/Gemma4AttentionBlockTests.swift
+++ b/Tests/Qwen3ChatTests/Gemma4AttentionBlockTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+import Foundation
+import MLX
+import MLXRandom
+import MLXCommon
+@testable import Qwen3Chat
+
+/// Geometry of Gemma 4's blocked attention, with no model involved.
+///
+/// `Gemma4Model.attentionBlocks` decides which keys a block of queries may reach; everything about
+/// the speedup rests on that being exactly the set the full `[1,1,Tq,Tk]` mask would have kept.
+///
+/// Each case is checked twice. Against the full mask it replaces, where the two must agree to within
+/// the difference between MLX kernels — a one-query block dispatches to the vector kernel while a
+/// 512-query block dispatches to the full one, and those disagree in the last float32 digits for
+/// reasons unrelated to masking. And against attention written out with plain precise ops, which
+/// pins both paths to the same distance from explicit arithmetic rather than only to each other.
+///
+/// `testWrongBandIsCaught` is the other half of the argument: it shifts the window by one key and
+/// shows both bounds reject it by orders of magnitude, so the tolerances are loose enough for
+/// arithmetic and tight enough for the defect they guard.
+final class Gemma4AttentionBlockTests: XCTestCase {
+    private static let window = 512
+
+    /// Blocked against the full mask. Observed worst case is 4.4e-4, where a trailing one-query
+    /// block lands on a different kernel from the reference's single call.
+    private static let kernelTolerance: Float = 2e-3
+
+    /// Either fused path against explicit precise arithmetic. MLX's attention kernels are further
+    /// from a written-out softmax (~1e-3 to 4e-3 here) than they are from each other, so this bound
+    /// is the looser of the two and says nothing about blocking on its own — it is here to catch a
+    /// band that is wrong in both paths at once, which comparing them to each other cannot.
+    private static let exactTolerance: Float = 1e-2
+
+    /// Attention over the whole key axis behind one full mask — the implementation being replaced.
+    private func reference(_ q: MLXArray, _ k: MLXArray, _ v: MLXArray, scale: Float,
+                           queryLen: Int, keyLen: Int, offset: Int, window: Int?) -> MLXArray {
+        SDPA.attendAndMerge(
+            qHeads: q, kHeads: k, vHeads: v, scale: scale,
+            mask: Gemma4Model.makeMask(queryLen: queryLen, keyLen: keyLen, offset: offset,
+                                       windowSize: window, dtype: .float32))
+    }
+
+    /// Attention block by block, each against only the keys its queries can reach.
+    private func blocked(_ q: MLXArray, _ k: MLXArray, _ v: MLXArray, scale: Float,
+                         queryLen: Int, keyLen: Int, offset: Int, window: Int?) -> MLXArray {
+        let blocks = Gemma4Model.attentionBlocks(queryLen: queryLen, keyLen: keyLen, offset: offset,
+                                                 windowSize: window, dtype: .float32)
+        var parts: [MLXArray] = []
+        for block in blocks {
+            parts.append(SDPA.attendAndMerge(
+                qHeads: q[0..., 0..., block.queryStart ..< block.queryEnd, 0...],
+                kHeads: k[0..., 0..., block.keyStart ..< block.keyEnd, 0...],
+                vHeads: v[0..., 0..., block.keyStart ..< block.keyEnd, 0...],
+                scale: scale, mask: block.mask))
+        }
+        return parts.count == 1 ? parts[0] : concatenated(parts, axis: 1)
+    }
+
+    /// Attention written out: score, mask, precise softmax, weight — no fused kernel, no blocking.
+    /// The grouped kv heads are expanded by hand into the block layout MLX's own fallback uses (kv
+    /// head `j` serves query heads `j*repeats ..< (j+1)*repeats`) so nothing here rests on how a
+    /// kernel chooses to repeat them.
+    private func exact(_ q: MLXArray, _ k: MLXArray, _ v: MLXArray, scale: Float,
+                       queryLen: Int, keyLen: Int, offset: Int, window: Int?) -> MLXArray {
+        let heads = q.dim(1), kvHeads = k.dim(1), headDim = q.dim(3)
+        let repeats = heads / kvHeads
+        func expand(_ kv: MLXArray) -> MLXArray {
+            broadcast(kv.expandedDimensions(axis: 2), to: [1, kvHeads, repeats, keyLen, headDim])
+                .reshaped(1, heads, keyLen, headDim)
+        }
+        let mask = Gemma4Model.makeMask(queryLen: queryLen, keyLen: keyLen, offset: offset,
+                                        windowSize: window, dtype: .float32)
+        let scores = matmul(q * scale, expand(k).transposed(0, 1, 3, 2)) + mask
+        return SDPA.mergeHeads(matmul(softmax(scores, axis: -1, precise: true), expand(v)))
+    }
+
+    private func maxAbsDiff(_ a: MLXArray, _ b: MLXArray) -> Float {
+        let d = MLX.abs(a - b).max()
+        eval(d)
+        return d.item(Float.self)
+    }
+
+    /// Runs all three implementations. `plannedWindow` is what the blocked path is told the window is
+    /// — normally `window`, and deliberately wrong only in `testWrongBandIsCaught`.
+    @discardableResult
+    private func compare(queryLen: Int, keyLen: Int, offset: Int, window: Int?,
+                         plannedWindow: Int?? = nil,
+                         heads: Int = 8, kvHeads: Int = 2, headDim: Int = 64)
+        -> (blockedVsReference: Float, blockedVsExact: Float, referenceVsExact: Float) {
+        MLXRandom.seed(7)
+        let q = MLXRandom.normal([1, heads, queryLen, headDim]).asType(.float32)
+        let k = MLXRandom.normal([1, kvHeads, keyLen, headDim]).asType(.float32)
+        let v = MLXRandom.normal([1, kvHeads, keyLen, headDim]).asType(.float32)
+        // 1/sqrt(d) rather than Gemma 4's own scale of 1: with unnormalised N(0,1) inputs a scale of
+        // 1 drives scores to a standard deviation of 8, and a softmax that peaked collapses onto a
+        // single key, so every path returns nearly the same row whatever it attended over. A tame
+        // softmax spreads the weight and makes a wrong band visible.
+        let scale = 1.0 / Float(headDim).squareRoot()
+
+        let truth = exact(q, k, v, scale: scale, queryLen: queryLen, keyLen: keyLen,
+                          offset: offset, window: window)
+        let ref = reference(q, k, v, scale: scale, queryLen: queryLen, keyLen: keyLen,
+                            offset: offset, window: window)
+        let band = blocked(q, k, v, scale: scale, queryLen: queryLen, keyLen: keyLen,
+                           offset: offset, window: plannedWindow ?? window)
+        return (maxAbsDiff(band, ref), maxAbsDiff(band, truth), maxAbsDiff(ref, truth))
+    }
+
+    private func check(queryLen: Int, keyLen: Int, offset: Int, window: Int?,
+                      heads: Int = 8, kvHeads: Int = 2, headDim: Int = 64) {
+        let d = compare(queryLen: queryLen, keyLen: keyLen, offset: offset, window: window,
+                        heads: heads, kvHeads: kvHeads, headDim: headDim)
+        let at = "q=\(queryLen) k=\(keyLen) offset=\(offset) "
+            + "window=\(window.map(String.init) ?? "none")"
+        XCTAssertLessThan(d.blockedVsReference, Self.kernelTolerance,
+                          "blocked diverged from the full mask: \(at) diff=\(d.blockedVsReference)")
+        XCTAssertLessThan(d.blockedVsExact, Self.exactTolerance,
+                          "blocked diverged from explicit attention: \(at) "
+                          + "diff=\(d.blockedVsExact) (full mask: \(d.referenceVsExact))")
+    }
+
+    /// Prefill at lengths that straddle the window: under it, exactly on it, one past it (the first
+    /// genuinely banded block), and multiples over it (interior blocks that share one reused mask,
+    /// plus a trailing block that needs its own).
+    func testSlidingPrefillLengths() {
+        for n in [1, 8, 100, 511, 512, 513, 1024, 1600, 2048, 4000] {
+            check(queryLen: n, keyLen: n, offset: 0, window: Self.window)
+        }
+    }
+
+    /// Global layers are unbanded but still blocked, and every one of their blocks is end-aligned
+    /// causal — so this also checks that handing MLX `.causal` reproduces the explicit mask.
+    func testGlobalPrefillLengths() {
+        for n in [1, 100, 512, 513, 1600, 4000] {
+            check(queryLen: n, keyLen: n, offset: 0, window: nil)
+        }
+    }
+
+    /// Decode steps: one query against a cache far longer than the window. The sliding case reads
+    /// the newest `window` entries with no mask at all, which must equal masking the whole cache.
+    func testIncrementalDecodeAgainstLongCache() {
+        for offset in [0, 1, 511, 512, 900, 2048] {
+            check(queryLen: 1, keyLen: offset + 1, offset: offset, window: Self.window)
+            check(queryLen: 1, keyLen: offset + 1, offset: offset, window: nil)
+        }
+    }
+
+    /// A second prefill chunk appended to an existing cache — queries start mid-sequence, so the
+    /// block bounds depend on the offset rather than on the local index.
+    func testChunkedPrefillWithOffset() {
+        for (offset, queries) in [(300, 200), (512, 600), (1000, 1024), (2048, 700)] {
+            check(queryLen: queries, keyLen: offset + queries, offset: offset, window: Self.window)
+            check(queryLen: queries, keyLen: offset + queries, offset: offset, window: nil)
+        }
+    }
+
+    /// A window narrower than the query block, so the band is bounded inside the very first block.
+    func testWindowNarrowerThanQueryBlock() {
+        for n in [64, 300, 1024] {
+            check(queryLen: n, keyLen: n, offset: 0, window: 128)
+        }
+    }
+
+    /// The tolerances above are only worth something if they reject a band that reaches the wrong
+    /// keys. One key too many or too few moves the output by ~9e-2 — 47× the kernel tolerance and 9×
+    /// the looser one — so both bounds catch it with room to spare rather than by a whisker.
+    func testWrongBandIsCaught() {
+        let floor: Float = 4e-2
+        for wrong in [Self.window - 1, Self.window + 1] {
+            let d = compare(queryLen: 1600, keyLen: 1600, offset: 0, window: Self.window,
+                            plannedWindow: .some(wrong))
+            XCTAssertGreaterThan(d.blockedVsReference, floor,
+                                 "window \(wrong) went unnoticed against the full mask")
+            XCTAssertGreaterThan(d.blockedVsExact, floor,
+                                 "window \(wrong) went unnoticed against explicit attention")
+        }
+    }
+
+    /// Every block must cover its queries exactly once and reach no key outside the causal window.
+    func testBlocksTileQueriesAndRespectBounds() {
+        let window = Self.window
+        for (offset, tq) in [(0, 4000), (0, 512), (0, 1), (777, 900), (2048, 1)] {
+            let tk = offset + tq
+            let blocks = Gemma4Model.attentionBlocks(queryLen: tq, keyLen: tk, offset: offset,
+                                                     windowSize: window, dtype: .float32)
+            XCTAssertEqual(blocks.first?.queryStart, 0)
+            XCTAssertEqual(blocks.last?.queryEnd, tq)
+            for (i, block) in blocks.enumerated() {
+                if i > 0 { XCTAssertEqual(block.queryStart, blocks[i - 1].queryEnd, "blocks must tile") }
+                XCTAssertLessThan(block.queryStart, block.queryEnd)
+                // Causal upper bound and window lower bound, in absolute positions.
+                XCTAssertEqual(block.keyEnd, min(offset + block.queryEnd, tk))
+                XCTAssertEqual(block.keyStart, max(0, offset + block.queryStart - window + 1))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Gemma 4 E4B repeats five `sliding_attention` layers to one `full_attention`, so 35 of its 42 layers only ever reach 512 keys back. `makeMask` expressed that as a condition inside a single additive `[1,1,Tq,Tk]` mask, which decides which scores *survive* and not how many are *computed* — every layer built the complete Tq×Tk matrix and then discarded ~97% of it. Prefill cost `42·n²` where the architecture only asks for `7·n² + 35·n·512`.

Attention now plans blocks: 512 consecutive queries scored against only the keys they can reach. Q/K/V projection and RoPE still run once over the whole call, and the full keys/values are returned unsliced, so cross-layer KV sharing and the growing cache are untouched. Per-block outputs are concatenated before `o_proj`, so the output projection stays one matmul.

A second, independent change: prefill runs the `lm_head` on the final row only.

## Two changes, decomposed

The benchmark measures three variants back to back — the full mask with all-position logits (what this replaces), the full mask with last-row logits, and blocked attention with them.

**Banding is the entire wall-time speedup.** Last-row logits moved prefill by between −2.8s and +0.3s at 17k across three runs, inside the run-to-run spread. What it delivers instead is memory: projecting a 17k prompt onto the 262k vocabulary builds a 9 GB bfloat16 array to read one row of, and removing it cuts peak by a reproducible 2.63 GB.

Prefill seconds, debug build, M5 Pro:

| tokens | before | last-row only | after (both) |
|---|---|---|---|
| 1,024 | 0.43 | 0.37 | 0.37 |
| 4,096 | 2.00 | 1.76 | 1.52 |
| 10,240 | 6.60 | 6.11 | 4.12 |
| 17,408 | 15.52 | 15.23 | 8.97 |

Peak GPU memory (deterministic — identical run to run):

| tokens | before | last-row only | after (both) |
|---|---|---|---|
| 1,024 | 5.09 | 4.67 | 4.71 GB |
| 4,096 | 6.84 | 5.26 | 4.94 GB |
| 10,240 | 10.38 | 7.54 | 5.91 GB |
| 17,408 | 14.78 | 12.15 | 7.03 GB |

Decode off a 17k cache goes 38.5 → 32.7 ms/tok, since a sliding layer now reads 512 cache entries per step rather than all 17,408. Absolute times drift with thermal state across runs; the ratios held across three.

## Global layers are blocked too

They have no band to exploit, so one causal call looks obviously better. It was measured and rejected: at 17,408 tokens it raised peak memory from 7.03 GB to 11.30 GB. MLX's SDPA reserves against the whole Tq×Tk score matrix rather than against the half a causal mask keeps, so bounding Tk per block is what caps the reservation. Wall times in that comparison drifted further with thermal state than the variants differed, so memory settled it; the constant carries that note.

## Parity

Both paths stay reachable behind `usesReferenceFullMask`, so they are compared on the same weights in one process.

Next-token argmax is **identical** at 100, 512, 513, 1,600 and 4,000 tokens, through both the no-cache forward and the KV-cache prefill. Greedy generation over a 1.2k-token prompt returns the same text.

Logits agree to within **0.69**, tolerance stated at 1.0. bfloat16 spacing at the softcap's ±30 is 0.125, so no tolerance below ~0.13 is expressible; retiling alone costs 1–2 of those steps. The smallest top-1/top-2 margin across these prompts is 14.3 — an order of magnitude above the tolerance — so the sampled token cannot turn on the difference. Deeper ranks are deliberately not asserted: candidates 4 and 5 fall within one bfloat16 step and their order survives no retiling at all.

`Gemma4AttentionBlockTests` pins the geometry with no model loaded, against both the full mask and attention written out with precise ops, over prefill, decode against a long cache, chunked prefill at an offset, and a window narrower than the block. Shifting the band by one key moves the output by 9e-2, 47× the tolerance.

## Suite

CI unit filter on `main` before: 1163 tests, 35 skipped, 0 failures. With this change: 1170 tests (the 7 new geometry tests), 35 skipped, 0 failures. No public API changed — `lastTokenLogits` is internal.