### PR TITLE
Merge Gemma 4's BPE through a queue instead of rescanning every pair

### DIFF
--- a/Sources/Qwen3Chat/Gemma4Tokenizer.swift
+++ b/Sources/Qwen3Chat/Gemma4Tokenizer.swift
@@ -12,12 +12,23 @@ import Foundation
 public final class Gemma4Tokenizer: @unchecked Sendable {
     private var tokenToId: [String: Int] = [:]
     private var idToToken: [Int: String] = [:]
-    private var mergeRanks: [String: Int] = [:]
+    /// Merge rules keyed by the two symbol ids packed into one `UInt64`, valued by the rank and the
+    /// resulting symbol id packed the same way. Keying merges by `"\(left) \(right)"` cost a string
+    /// allocation and a hash of it for every pair the merge loop looked at, over half a million rules.
+    private var pairMerges: [UInt64: UInt64] = [:]
     /// content → id for the explicit added/control tokens (e.g. `<|turn>`, `<bos>`).
     private var specials: [(content: String, id: Int)] = []
     private var specialIds: Set<Int> = []
     /// `<0xXX>` byte-fallback token id for each byte value, when present.
     private var byteFallbackId: [Int] = Array(repeating: -1, count: 256)
+    /// Symbol id of each `<0xXX>` piece — its vocab id wherever the checkpoint carries one.
+    private var byteSymbolId: [Int32] = Array(repeating: -1, count: 256)
+    /// A symbol id is the piece's vocab id. A merge part or result the vocab does not carry — no
+    /// shipped Gemma checkpoint has one, but `tokenizer.json` does not forbid it — takes an id above
+    /// the vocab, so the rule still applies and the piece still byte-falls-back when it is emitted.
+    private var extraSymbols: [String] = []
+    private var extraSymbolIds: [String: Int32] = [:]
+    private var symbolIdCeiling: Int32 = 0
 
     public private(set) var bosTokenId: Int = 2
     /// Tokens that terminate a model turn: `<eos>`(1), `<turn|>`(106), `<|tool_response>`(50).
@@ -35,17 +46,6 @@ public final class Gemma4Tokenizer: @unchecked Sendable {
         }
         tokenToId = vocab
         idToToken = Dictionary(uniqueKeysWithValues: vocab.map { ($1, $0) })
-
-        if let merges = model["merges"] as? [[String]] {
-            for (i, pair) in merges.enumerated() where pair.count == 2 {
-                mergeRanks["\(pair[0]) \(pair[1])"] = i
-            }
-        } else if let merges = model["merges"] as? [String] {
-            for (i, m) in merges.enumerated() {
-                let p = m.split(separator: " ", maxSplits: 1)
-                if p.count == 2 { mergeRanks["\(p[0]) \(p[1])"] = i }
-            }
-        }
 
         if let added = root["added_tokens"] as? [[String: Any]] {
             for a in added {
@@ -65,6 +65,18 @@ public final class Gemma4Tokenizer: @unchecked Sendable {
             if let id = tokenToId[String(format: "<0x%02X>", b)] { byteFallbackId[b] = id }
         }
 
+        // Symbol ids pack two to a `UInt64` in the merge table, so the vocab has to fit in 32 bits.
+        let highestId = idToToken.keys.max() ?? -1
+        guard highestId < Int(Int32.max) else {
+            throw ChatModelError.tokenizerLoadFailed("Gemma vocab ids exceed the 32-bit symbol space")
+        }
+        symbolIdCeiling = Int32(highestId + 1)
+        // Merges resolve last so every part takes the id the *final* vocab gives it, added tokens
+        // included; interning a part before an added token could reassign it would split one piece
+        // across two symbol ids.
+        buildMergeTable(model["merges"])
+        for b in 0..<256 { byteSymbolId[b] = internSymbol(String(format: "<0x%02X>", b)) }
+
         let eosFromConfig = directory.appendingPathComponent("generation_config.json")
         if let d = try? Data(contentsOf: eosFromConfig),
            let j = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
@@ -75,6 +87,43 @@ public final class Gemma4Tokenizer: @unchecked Sendable {
     }
 
     public func isSpecialToken(_ id: Int) -> Bool { specialIds.contains(id) }
+
+    // MARK: - Merge table
+
+    /// `tokenizer.json` carries merges either as `[[left, right]]` or as `["left right"]`.
+    private func buildMergeTable(_ merges: Any?) {
+        func record(_ left: String, _ right: String, rank: Int) {
+            let key = Self.pairKey(internSymbol(left), internSymbol(right))
+            let merged = internSymbol(left + right)
+            pairMerges[key] = (UInt64(UInt32(rank)) << 32) | UInt64(UInt32(bitPattern: merged))
+        }
+        if let merges = merges as? [[String]] {
+            pairMerges.reserveCapacity(merges.count)
+            for (i, pair) in merges.enumerated() where pair.count == 2 {
+                record(pair[0], pair[1], rank: i)
+            }
+        } else if let merges = merges as? [String] {
+            pairMerges.reserveCapacity(merges.count)
+            for (i, m) in merges.enumerated() {
+                let p = m.split(separator: " ", maxSplits: 1)
+                if p.count == 2 { record(String(p[0]), String(p[1]), rank: i) }
+            }
+        }
+    }
+
+    private func internSymbol(_ piece: String) -> Int32 {
+        if let id = tokenToId[piece] { return Int32(id) }
+        if let id = extraSymbolIds[piece] { return id }
+        let id = symbolIdCeiling + Int32(extraSymbols.count)
+        extraSymbols.append(piece)
+        extraSymbolIds[piece] = id
+        return id
+    }
+
+    @inline(__always)
+    private static func pairKey(_ left: Int32, _ right: Int32) -> UInt64 {
+        (UInt64(UInt32(bitPattern: left)) << 32) | UInt64(UInt32(bitPattern: right))
+    }
 
     // MARK: - Encode
 
@@ -109,43 +158,91 @@ public final class Gemma4Tokenizer: @unchecked Sendable {
 
     /// SentencePiece BPE: normalize spaces→`▁`, split into characters (byte-fallback for any char
     /// with no single-char token), then merge by rank.
+    ///
+    /// Merging walks a linked list of symbols with a queue of candidate pairs. Re-scanning every
+    /// adjacent pair after every merge, splicing an array of growing strings, made this quadratic in
+    /// text length: measured against this vocabulary, 32k characters took 32.3s to tokenize and the
+    /// growth exponent over 2k…32k was 1.98. The queue picks the same merges in the same order — it
+    /// is ordered by `(rank, position)` and a merged symbol keeps its left operand's position, so the
+    /// lowest rank still wins and equal ranks still resolve leftmost.
+    ///
+    /// Splitting the text into words first, the usual bound on BPE cost, is *not* safe against this
+    /// vocabulary: 466 merge rules join a piece to one starting with `▁`, so runs of spaces (and
+    /// `>` before `▁</`) tokenize differently once a word boundary is imposed.
     private func bpeEncode(_ raw: String, into out: inout [Int]) {
         if raw.isEmpty { return }
         let normalized = raw.replacingOccurrences(of: " ", with: "\u{2581}")
 
         // Initial symbols: one per character, falling back to per-byte `<0xXX>` symbols.
-        var symbols: [String] = []
+        var symbols: [Int32] = []
+        symbols.reserveCapacity(normalized.count)
         for ch in normalized {
-            let s = String(ch)
-            if tokenToId[s] != nil {
-                symbols.append(s)
+            let piece = String(ch)
+            if let id = tokenToId[piece] {
+                symbols.append(Int32(id))
             } else {
-                for b in Array(s.utf8) { symbols.append("<0x" + String(format: "%02X", b) + ">") }
-            }
-        }
-        if symbols.isEmpty { return }
-
-        while symbols.count > 1 {
-            var bestRank = Int.max
-            var bestIdx = -1
-            for i in 0..<(symbols.count - 1) {
-                if let rank = mergeRanks["\(symbols[i]) \(symbols[i + 1])"], rank < bestRank {
-                    bestRank = rank; bestIdx = i
+                for b in piece.utf8 where byteSymbolId[Int(b)] >= 0 {
+                    symbols.append(byteSymbolId[Int(b)])
                 }
             }
-            if bestIdx < 0 { break }
-            symbols.replaceSubrange(bestIdx...bestIdx + 1, with: [symbols[bestIdx] + symbols[bestIdx + 1]])
+        }
+        let count = symbols.count
+        if count == 0 { return }
+
+        var prev = [Int32](repeating: 0, count: count)
+        var next = [Int32](repeating: 0, count: count)
+        var alive = [Bool](repeating: true, count: count)
+        for i in 0..<count {
+            prev[i] = Int32(i - 1)
+            next[i] = i + 1 < count ? Int32(i + 1) : -1
         }
 
-        for s in symbols {
-            if let id = tokenToId[s] {
-                out.append(id)
+        var queue = MergeQueue()
+        queue.reserveCapacity(count * 2)
+        for i in 0..<(count - 1) {
+            if let merge = pairMerges[Self.pairKey(symbols[i], symbols[i + 1])] {
+                queue.push((merge >> 32) << 32 | UInt64(UInt32(i)))
+            }
+        }
+
+        while let candidate = queue.pop() {
+            let left = Int(UInt32(truncatingIfNeeded: candidate))
+            guard alive[left] else { continue }
+            let right = Int(next[left])
+            guard right >= 0, let merge = pairMerges[Self.pairKey(symbols[left], symbols[right])],
+                  merge >> 32 == candidate >> 32 else { continue }
+            // A rank identifies exactly one pair, so an entry whose rank still matches the pair now
+            // at that position is the entry this pair pushed — anything else is a superseded copy.
+            symbols[left] = Int32(bitPattern: UInt32(truncatingIfNeeded: merge))
+            alive[right] = false
+            let after = next[right]
+            next[left] = after
+            if after >= 0 { prev[Int(after)] = Int32(left) }
+
+            let before = prev[left]
+            if before >= 0,
+               let m = pairMerges[Self.pairKey(symbols[Int(before)], symbols[left])] {
+                queue.push((m >> 32) << 32 | UInt64(UInt32(bitPattern: before)))
+            }
+            if after >= 0,
+               let m = pairMerges[Self.pairKey(symbols[left], symbols[Int(after)])] {
+                queue.push((m >> 32) << 32 | UInt64(UInt32(left)))
+            }
+        }
+
+        var cursor = 0
+        while cursor >= 0 {
+            let symbol = symbols[cursor]
+            if symbol < symbolIdCeiling {
+                out.append(Int(symbol))
             } else {
                 // Should not happen (byte-fallback guarantees coverage), but stay lossless.
-                for b in Array(s.utf8) where byteFallbackId[Int(b)] >= 0 {
+                for b in extraSymbols[Int(symbol - symbolIdCeiling)].utf8
+                where byteFallbackId[Int(b)] >= 0 {
                     out.append(byteFallbackId[Int(b)])
                 }
             }
+            cursor = Int(next[cursor])
         }
     }
 
@@ -167,5 +264,45 @@ public final class Gemma4Tokenizer: @unchecked Sendable {
         var bytes: [UInt8] = []
         for id in ids { bytes.append(contentsOf: tokenBytes(id)) }
         return String(decoding: bytes, as: UTF8.self)
+    }
+}
+
+/// Binary min-heap of merge candidates packed as `(rank << 32) | position`. Unsigned order over that
+/// one word is lowest rank first and, between two positions holding the same rule, leftmost first.
+/// Entries are never removed when a merge invalidates them; the pop side re-checks the rank instead,
+/// which is cheaper than finding them and bounds the heap at three entries per symbol.
+private struct MergeQueue {
+    private var items: [UInt64] = []
+
+    mutating func reserveCapacity(_ n: Int) { items.reserveCapacity(n) }
+
+    mutating func push(_ item: UInt64) {
+        items.append(item)
+        var child = items.count - 1
+        while child > 0 {
+            let parent = (child - 1) / 2
+            if items[parent] <= items[child] { break }
+            items.swapAt(parent, child)
+            child = parent
+        }
+    }
+
+    mutating func pop() -> UInt64? {
+        guard let top = items.first else { return nil }
+        let tail = items.removeLast()
+        if !items.isEmpty {
+            items[0] = tail
+            var parent = 0
+            while true {
+                let left = 2 * parent + 1
+                guard left < items.count else { break }
+                let right = left + 1
+                let child = (right < items.count && items[right] < items[left]) ? right : left
+                if items[parent] <= items[child] { break }
+                items.swapAt(parent, child)
+                parent = child
+            }
+        }
+        return top
     }
 }

--- a/Tests/Qwen3ChatTests/E2EGemma4TokenizerParityTests.swift
+++ b/Tests/Qwen3ChatTests/E2EGemma4TokenizerParityTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+import Foundation
+@testable import Qwen3Chat
+
+/// Exact token-id parity between the rewritten Gemma 4 BPE merge loop and the implementation it
+/// replaced, over the real 262,144-token vocabulary and its 514,906 merge rules.
+///
+/// The unit suite proves the algorithm on a vocabulary small enough to reason about; this proves it
+/// on the one that ships, where a rule can span a space, a merge can outrank a longer word, and the
+/// text is interleaved Russian, English and technical terms. Divergence here would change what the
+/// model reads with nothing in the pipeline reporting it, so the assertion is identity.
+final class E2EGemma4TokenizerParityTests: XCTestCase {
+    private static let modelDir: URL = {
+        if let p = ProcessInfo.processInfo.environment["GEMMA4_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return URL(fileURLWithPath:
+            "/Users/ivan/repos/runner-speech-models/speech-models/out/mlx/gemma-4-E2B-it-MLX-4bit")
+    }()
+
+    /// Sampled from one real 393-row meeting recording (~55k characters of Russian with English and
+    /// technical terms): the rows carrying digits, Latin-in-Cyrillic and the recording's one CJK
+    /// character, its four shortest and its longest utterance, and an even spread of the rest.
+    /// Point `GEMMA4_PARITY_CORPUS` at a transcript export to compare against all of it instead.
+    static let transcriptRows: [String] = [
+        "Ну, слушай, а вот про баварский диалекта. В каком кейсе он не мог понять, кто что-то говорит на баварском语?",
+        "А. Tom.",
+        "Такое R&amp;D.",
+        "Vision Lab называется.",
+        "more, tipa. Ну типа да, да, в том числе.",
+        "Good symbol. Почему? А ты работал в ходаже?",
+        "Ну а сколько ты за него платишь вот Plout Node?",
+        "Тот же, тот же сегмент B2B. Вот тебе я прям тебе стратегию расписал, что делать надо.",
+        "Если я звоню и мне удалось зацепить с первых 15 секунд, когда меня готовы слышать, да, слушать?",
+        "Ты рискуешь уйти вот этим, точнее не уйти, а обмануть себя тем, что у тебя будет А, такой бесконечный R&amp;D вы будете все вместе его делать. Вам будет всем это классно, интересно, по кайфу. А, но это будет такой кружок любителей шахмат, да? Вы будете обсуждать ход Е1 на Е12, блядь, и как бы...",
+        "no, on Ну он говорит около 40 тысяч человек клиентская база окей ну всех да то есть в принципе вот да то есть вот и и он тоже то есть и он там начинает там вот я вот это начал делать то это Я вот Лого бизнес, мы там разобрались, нет инвестиций, там нет трекшн, есть одни эти как их там. Интервью, интервью очень интересные, да, много вещающих, много пересечений с тем, что я делаю.",
+        "in",
+        "um",
+        "ah",
+        "на",
+        "может быть, они исчезнут, Если я да расскажу. То есть вот я сейчас делаю вот такую платформу, которая, то есть я по Клауду решению, Слишком много денег нужно на дотации, чтобы зайти в рынок. Соответственно, у меня, то есть локальный инференс, кажется, что решает эту проблему? Это что-то за что, на чем у меня нет колоссальных костов. То есть и соответственно здесь вот вот этот вот запись, транскрипция базовой intelligence, там там deep resarch over Your meeting's date, да, ну вот, вот, вот этих штук. А, то есть плюс, а, сейчас делают кейс Сказочки типа базовый кейс, это Если это типа мы подгружаем адженду митинга, которую ты в Клауд, в Клауде или в чадж пяти себе сделал, то есть ты подготовилась к митингу, сделала какую-то адженду, ты ее туда подгружаешь, и эта штука, она просто бежит и тебе помогает вспоминать то, о чем тебе говорить. Вот, а это все вот так вот такого рода интеллигенсность, эта платформа очень Это платформа очень легко будет расширяемая до кейса агента и поговорить голосом. То есть пока просто вся интеракция агентская такая, да? То есть она будет через текст, вот это такой Ask My Transcripts это все локально, да? Да, то локально, все красиво. А, то сейчас я вот кейс там типа отдела продаж, а, там отдел продаж, они начинают какую-то новую штуку продавать. Мы начинаем и вот. Просто каждому продажнику централизовано в промт по адженте начинаем добавлять там де- десяти, предложить вот это, да? И все, то Предложить вот это, да? И все, то есть и у нас у продажников уже им не нужно думать, у них там появляется какая-то структурная эээ Гайденс, сори про мой рунглиш, вот. И которая начинает их вести. То есть, грубо говоря, Я хочу начать тупо с руководителя отделов продаж. И то есть, ну это будет готово через пару недель на уровне MVP. Мы начнем это все как-то продвигать, и то есть я вот у себя на сайте, у меня куча народу есть, это все Это все в принципе кто-то чем-то пользоваться, собирать инфу. И тут я хочу из этого сделать платформу, на которой будет сейвс коучинг. Это как раз решение. Плюс другие люди, я поговорил, то есть вот там немцы есть, они... Ах, хотят делать коучинг, э, для... Эмигрантов, которые приехали сюда, потеряли работу и теперь их отправили на аусбилдинг пере- переучиваться. А, вот, и там есть куча всяких информационных систем, и кажется, что достаточно тоже большой рынок, ну то есть, ну человек переучивается быть конструктором, ну этим рабочим настройки, да. А, и вот есть ребята, которые пообщались и говорят, что, вообще говоря, очень много там людей, кот- которых... Готовы взять на работу, им нужно сдать аузбильдунг там. Пройти какой-то тест, там какие-то там нормы сдать, что-то еще. Я, я с трудом понимаю, там что, чтоб конкретно там Крытно там они Делают. Но там большая сложность в том, чтобы вот их кочить. То есть там можно навешать несколько разных кейсов. И кажется, что в принципе там достаточно много всего. Но для этого должна быть платформа. И вот в этой истории там инвесторы, то есть это уже дело вторичное просто. А там всё без них заведётся.",
+        "No.",
+        "April",
+        "Mm-hmm.",
+        "Вопрос, а",
+        "Dawai. Dawai.",
+        "Now, i said, ah,",
+        "Ну и тоже другое, ну и другое.",
+        "Ну вот как-то так. То есть как бы АСРМок?",
+        "будет Сегодня будет очередной этот взрыв, как и хит-вейф",
+        "Ну в смысле, что я читал что ли? Ну мои знакомые, те кто готовы мне помогать.",
+        "Что значит ты, что подразумеваешь, чтоб то, что ты себя не обманул? Что значит готовы комититься?",
+        "Ты говоришь, кость. А, у меня есть нечто. Что я разрабатываю, да? Какая-то там начинка, там не важно. значит а У меня Полигон?",
+        "Ah. То, что ты говоришь и sales, sale case это все, это все типа компоненты платформы. Они просто на платформу сажаются и если это все работает, будет там несколько серия много, да?",
+        "What's in your mind? What's your chance you will? Я вот назад иду. What, Yule? Yoon? Май, апрель, это четыре месяца назад. Четыре месяца назад у меня что-то случилось. Я сидел, вообще не понимал, что с этим делать. Вот вообще просто это какая хуйня какая. Ну что-то работает. Я вот, знаешь, я сейчас, я...",
+        "Значит одна из ну опять же там у меня на что я там там много их но я там понятно кто этот шивы все пропанил как бы да значит на что мне зацепил глаз это А у них есть Сирия, это чистая плоская история, правильно? И вот они сейчас разрабатывают, они планируют в конце двадцать седьмого года, но тоже не факт, но они сейчас разрабатывают сбор. Контекста каждого пользователя, чтобы это был сбор через Siri. Ну, то есть Примерно то же, что и я хочу. Да? Но только у Apple есть, ну помимо миллиардов, там триллионов, у Apple еще есть.",
+    ]
+
+    /// Reading the whole corpus needs the reference implementation, which is quadratic, so a debug
+    /// run stops where that still costs seconds. `GEMMA4_PARITY_FULL=1` compares all of it and times
+    /// the reference at every size, which is how the numbers in the change description were taken.
+    private static var full: Bool { ProcessInfo.processInfo.environment["GEMMA4_PARITY_FULL"] == "1" }
+    private static var referenceCeiling: Int {
+        if full { return .max }
+#if DEBUG
+        return 8_000
+#else
+        return .max
+#endif
+    }
+
+    private static func corpus() -> [String] {
+        guard let path = ProcessInfo.processInfo.environment["GEMMA4_PARITY_CORPUS"],
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return transcriptRows
+        }
+        return rows.compactMap { $0["text"] as? String }.filter { !$0.isEmpty }
+    }
+
+    /// Lowest id of each set of vocabulary entries Swift cannot tell apart.
+    ///
+    /// Swift compares and hashes strings by canonical equivalence, so the 434 groups of canonically
+    /// equal tokens in this vocabulary — `;` U+003B and U+037E GREEK QUESTION MARK among them, 868
+    /// ids in all — collapse to one entry when `tokenizer.json` bridges into a `[String: Int]`, and
+    /// *which* member survives is not stable from one load to the next. Two independently loaded
+    /// tokenizers therefore disagree on those ids on `main` exactly as they do here, so the ids are
+    /// compared by group. Nothing in this change can cause such a difference: the pair-keyed merge
+    /// table collapses those pieces through the same `[String: Int]` the string-keyed one used.
+    private static let canonicalId: [Int: Int] = {
+        guard let data = try? Data(contentsOf: modelDir.appendingPathComponent("tokenizer.json")),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let model = root["model"] as? [String: Any],
+              // The bridged Swift dictionary has already dropped the duplicates, so the byte-exact
+              // keys have to come off the `NSDictionary`.
+              let vocab = model["vocab"] as? NSDictionary else { return [:] }
+        var lowest: [String: Int] = [:]
+        var tokenById: [Int: String] = [:]
+        for (key, value) in vocab {
+            guard let token = key as? String, let id = value as? Int else { continue }
+            tokenById[id] = token
+            lowest[token] = min(lowest[token] ?? id, id)
+        }
+        return tokenById.mapValues { lowest[$0] ?? -1 }
+    }()
+
+    private static func grouped(_ ids: [Int]) -> [Int] { ids.map { canonicalId[$0] ?? $0 } }
+
+    private func loadPair() throws -> (Gemma4Tokenizer, ReferenceGemma4BPE) {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDir.appendingPathComponent("tokenizer.json").path) else {
+            throw XCTSkip("Gemma 4 tokenizer unavailable: \(Self.modelDir.path)")
+        }
+        let tokenizer = Gemma4Tokenizer()
+        try tokenizer.load(from: Self.modelDir)
+        let reference = ReferenceGemma4BPE()
+        try reference.load(from: Self.modelDir)
+        return (tokenizer, reference)
+    }
+
+    private func assertSameTokens(_ produced: [Int], _ expected: [Int], _ what: @autoclosure () -> String,
+                                  file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(Self.grouped(produced), Self.grouped(expected), what(), file: file, line: line)
+    }
+
+    func testTranscriptRowsTokenizeIdentically() throws {
+        let (tokenizer, reference) = try loadPair()
+        let rows = Self.corpus()
+        var tokens = 0
+        for (i, row) in rows.enumerated() {
+            let produced = tokenizer.encode(row)
+            assertSameTokens(produced, reference.encode(row),
+                             "row \(i) diverged: \(row.debugDescription)")
+            tokens += produced.count
+        }
+        print("[gemma4-parity] \(rows.count) rows, \(rows.reduce(0) { $0 + $1.count }) chars, \(tokens) tokens")
+    }
+
+    func testConcatenatedTranscriptAndItsPrefixesTokenizeIdentically() throws {
+        let (tokenizer, reference) = try loadPair()
+        let whole = Self.corpus().joined(separator: " ")
+        // Prefixes cut mid-word, mid-space-run and mid-multi-byte-character, which is where a merge
+        // loop carrying state across a boundary would show up.
+        var lengths = [1, 2, 17, 100, 512, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000]
+            .filter { $0 < whole.count }
+        lengths.append(whole.count)
+        lengths = lengths.filter { $0 <= Self.referenceCeiling }
+        for length in lengths {
+            let prefix = String(whole.prefix(length))
+            assertSameTokens(tokenizer.encode(prefix), reference.encode(prefix),
+                             "prefix of \(length) characters diverged")
+        }
+        print("[gemma4-parity] prefixes compared: \(lengths)")
+    }
+
+    func testChatTemplateShapedTextTokenizesIdentically() throws {
+        let (tokenizer, reference) = try loadPair()
+        // The template puts a special token hard against text on both sides, which is the shape a
+        // whitespace-splitting version of this optimization would have had to preserve.
+        for row in Self.corpus().prefix(12) {
+            for text in ["<|turn>user\n\(row)<turn|>\n",
+                         "<bos><|turn>system\n\(row)<turn|>\n<|turn>model\n",
+                         "\(row)<|turn>\(row)"] {
+                assertSameTokens(tokenizer.encode(text), reference.encode(text),
+                                 "template-shaped text diverged: \(text.prefix(60).debugDescription)")
+            }
+        }
+    }
+
+    func testEdgeCasesTokenizeIdenticallyOnTheRealVocabulary() throws {
+        let (tokenizer, reference) = try loadPair()
+        for text in [
+            "", " ", "  ", "   ", "\n", "\t", " \n\t ", "\u{2581}",
+            " leading", "trailing ", " both ", "double  space", "many     spaces",
+            "> </", "<div> </div>", "a>  </b",
+            "<bos>", "<eos>", "<|turn>", "<turn|>", "<|tool_response>", "<|think|>",
+            "<bos>hello", "hello<|turn>", "mid<|turn>sentence", "<bos><|turn><turn|>",
+            "你好世界", "😊", "👩‍💻", "🇺🇦", "é", "ﬁ", "\u{0}", "\u{7f}", "\u{FFFD}",
+            "Привет, мир!", "Привет 你好 hello 😊",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            String(repeating: "ЛЛ", count: 200),
+            String(repeating: " ", count: 64),
+        ] {
+            assertSameTokens(tokenizer.encode(text), reference.encode(text),
+                             "edge case diverged: \(text.debugDescription)")
+        }
+    }
+
+    /// Guards the defect this replaced: tokenization was quadratic in prompt length, so a
+    /// 32k-character prompt spent tens of seconds here before the model saw its first token.
+    func testTokenizationCostGrowsLinearly() throws {
+        let (tokenizer, reference) = try loadPair()
+        var filler = Self.corpus().joined(separator: " ")
+        while filler.count < 32_000 { filler += " " + filler }
+
+        func fastest(of rounds: Int, _ body: () -> Void) -> Double {
+            var best = Double.greatestFiniteMagnitude
+            for _ in 0..<rounds {
+                let start = DispatchTime.now().uptimeNanoseconds
+                body()
+                best = min(best, Double(DispatchTime.now().uptimeNanoseconds - start) / 1e9)
+            }
+            return best
+        }
+
+        _ = tokenizer.encode(String(filler.prefix(1_000)))
+        // The reference costs minutes at the top sizes; time it there only when asked.
+        let referenceLimit = Self.full ? Int.max : 8_000
+        var timings: [(size: Int, fast: Double, slow: Double?)] = []
+        for size in [2_000, 4_000, 8_000, 16_000, 32_000] {
+            let text = String(filler.prefix(size))
+            timings.append((size,
+                            fastest(of: 3) { _ = tokenizer.encode(text) },
+                            size <= referenceLimit ? fastest(of: 1) { _ = reference.encode(text) } : nil))
+        }
+
+        for (i, row) in timings.enumerated() {
+            let exponent = i == 0 ? nil
+                : log(row.fast / timings[i - 1].fast) / log(Double(row.size) / Double(timings[i - 1].size))
+            let slow = row.slow.map { String(format: "%.4fs", $0) } ?? "-"
+            print("[gemma4-parity] \(row.size) chars"
+                  + String(format: "  new %.4fs", row.fast)
+                  + "  reference \(slow)"
+                  + (exponent.map { String(format: "  exponent %.2f", $0) } ?? ""))
+        }
+
+        // Quadratic behaviour put this in the tens of seconds. The bound is loose enough to survive a
+        // loaded machine and tight enough that a return to a full rescan cannot pass it.
+        XCTAssertLessThan(timings[timings.count - 1].fast, 2.0,
+                          "32k characters must not take seconds to tokenize")
+    }
+}

--- a/Tests/Qwen3ChatTests/Gemma4TokenizerBPETests.swift
+++ b/Tests/Qwen3ChatTests/Gemma4TokenizerBPETests.swift
@@ -1,0 +1,270 @@
+import XCTest
+import Foundation
+@testable import Qwen3Chat
+
+/// Gemma 4 BPE against a miniature hand-built vocabulary, no model download needed.
+///
+/// Every case asserts the encoder's ids equal `ReferenceGemma4BPE`'s — the implementation as it
+/// stood before the merge loop was rewritten. A tokenizer that is fast and subtly different changes
+/// what the model reads and raises no error anywhere, so identity, not plausibility, is the gate.
+final class Gemma4TokenizerBPETests: XCTestCase {
+
+    // MARK: - Fixture
+
+    /// A vocabulary small enough to reason about that still reaches every branch of the encoder:
+    /// space runs, a merge that spans a space, byte fallback, one merge whose result the vocab does
+    /// not carry, and a rule that occurs twice in one string.
+    struct Fixture {
+        let directory: URL
+        let vocab: [String: Int]
+
+        func id(_ token: String) -> Int {
+            guard let id = vocab[token] else {
+                XCTFail("fixture vocabulary has no token \(token.debugDescription)")
+                return -1
+            }
+            return id
+        }
+    }
+
+    private static let specialTokens = ["<pad>", "<eos>", "<bos>", "<unk>",
+                                        "<|turn>", "<turn|>", "<|channel>"]
+
+    /// Dependencies first: BPE always applies the lowest rank available, so a rule can only fire
+    /// once the rules that build its operands rank below it.
+    private static let mergeRules: [(String, String)] = [
+        ("▁", "▁"), ("▁▁", "▁"),
+        ("<", "/"), ("▁", "</"), (">", "▁</"),
+        ("h", "e"), ("he", "l"), ("hel", "l"), ("hell", "o"), ("▁", "hello"),
+        ("w", "o"), ("wo", "r"), ("wor", "l"), ("worl", "d"), ("▁", "world"),
+        ("п", "р"), ("пр", "и"), ("при", "в"), ("прив", "е"), ("приве", "т"), ("▁", "привет"),
+        ("a", "b"), ("ab", "ab"),
+        ("q", "q"),
+    ]
+    /// `qq` is deliberately left out of the vocabulary: `tokenizer.json` does not require a merge
+    /// result to be a token, and the encoder must byte-fall-back on it exactly as it used to.
+    private static let mergeResultsOutsideVocab: Set<String> = ["qq"]
+
+    private static func buildVocab() -> [String: Int] {
+        var vocab: [String: Int] = [:]
+        var next = 0
+        func add(_ token: String) {
+            if vocab[token] == nil { vocab[token] = next; next += 1 }
+        }
+        for token in specialTokens { add(token) }
+        for b in 0..<256 { add(String(format: "<0x%02X>", b)) }
+        add("▁"); add("\n"); add("\t")
+        for scalar in UnicodeScalar("a").value...UnicodeScalar("z").value {
+            add(String(UnicodeScalar(scalar)!))
+        }
+        for scalar in UnicodeScalar("0").value...UnicodeScalar("9").value {
+            add(String(UnicodeScalar(scalar)!))
+        }
+        for ch in ".,!?<>/-:" { add(String(ch)) }
+        for ch in "абвгдежзийклмнопрстуфхцчшщъыьэюя" { add(String(ch)) }
+        for (left, right) in mergeRules where !mergeResultsOutsideVocab.contains(left + right) {
+            add(left + right)
+        }
+        return vocab
+    }
+
+    /// `mergesAsStrings` writes the `["left right"]` encoding of the merge list instead of
+    /// `[[left, right]]`; `load` accepts both and must read them the same way.
+    private static func makeFixture(mergesAsStrings: Bool) -> Fixture {
+        let vocab = buildVocab()
+        let merges: Any = mergesAsStrings
+            ? mergeRules.map { "\($0.0) \($0.1)" }
+            : mergeRules.map { [$0.0, $0.1] }
+        let json: [String: Any] = [
+            "model": ["vocab": vocab, "merges": merges],
+            "added_tokens": specialTokens.map {
+                ["content": $0, "id": vocab[$0]!, "special": true] as [String: Any]
+            },
+        ]
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gemma4-bpe-fixture-\(UUID().uuidString)")
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(withJSONObject: json)
+            try data.write(to: dir.appendingPathComponent("tokenizer.json"))
+        } catch {
+            fatalError("could not write Gemma 4 tokenizer fixture: \(error)")
+        }
+        return Fixture(directory: dir, vocab: vocab)
+    }
+
+    private static let fixture = makeFixture(mergesAsStrings: false)
+    private static let stringMergesFixture = makeFixture(mergesAsStrings: true)
+
+    private var tokenizer: Gemma4Tokenizer!
+    private var reference: ReferenceGemma4BPE!
+
+    override func setUpWithError() throws {
+        tokenizer = Gemma4Tokenizer()
+        try tokenizer.load(from: Self.fixture.directory)
+        reference = ReferenceGemma4BPE()
+        try reference.load(from: Self.fixture.directory)
+    }
+
+    /// Asserts the encoder agrees with the pre-rewrite implementation, and hands the ids back so a
+    /// case can also pin what they should be.
+    @discardableResult
+    private func assertParity(_ text: String,
+                              file: StaticString = #filePath, line: UInt = #line) -> [Int] {
+        let produced = tokenizer.encode(text)
+        XCTAssertEqual(produced, reference.encode(text),
+                       "ids diverged for \(text.debugDescription)", file: file, line: line)
+        return produced
+    }
+
+    // MARK: - Degenerate input
+
+    func testEmptyString() {
+        XCTAssertEqual(assertParity(""), [])
+    }
+
+    func testWhitespaceOnly() {
+        let v = Self.fixture
+        XCTAssertEqual(assertParity(" "), [v.id("▁")])
+        XCTAssertEqual(assertParity("  "), [v.id("▁▁")])
+        XCTAssertEqual(assertParity("   "), [v.id("▁▁▁")])
+        // Four spaces take the two-space rule twice rather than three-plus-one: the lowest rank
+        // available wins each round, wherever it sits.
+        XCTAssertEqual(assertParity("    "), [v.id("▁▁"), v.id("▁▁")])
+        XCTAssertEqual(assertParity("\n"), [v.id("\n")])
+        assertParity("\t")
+        assertParity(" \n\t ")
+    }
+
+    func testLeadingAndTrailingSpaces() {
+        let v = Self.fixture
+        XCTAssertEqual(assertParity(" hello"), [v.id("▁hello")])
+        XCTAssertEqual(assertParity("hello "), [v.id("hello"), v.id("▁")])
+        XCTAssertEqual(assertParity(" hello "), [v.id("▁hello"), v.id("▁")])
+        assertParity("  hello  ")
+        assertParity("\n hello \n")
+    }
+
+    func testRepeatedInteriorSpaces() {
+        let v = Self.fixture
+        XCTAssertEqual(assertParity(" hello world"), [v.id("▁hello"), v.id("▁world")])
+        // Two spaces merge with each other before either can start a word, so `world` loses its
+        // `▁world` form. This is exactly what a word-splitting pre-tokenizer would retokenize.
+        XCTAssertEqual(assertParity(" hello  world"),
+                       [v.id("▁hello"), v.id("▁▁"), v.id("world")])
+        assertParity(" hello   world")
+        assertParity("a   b")
+    }
+
+    // MARK: - Merges that span a space
+
+    func testMergeAcrossASpaceStillFires() {
+        let v = Self.fixture
+        // `>` + `▁</` is a real Gemma rule (the vocabulary has 466 rules whose right operand starts
+        // with `▁`). Splitting on whitespace before BPE would put the operands in different units.
+        XCTAssertEqual(assertParity("> </"), [v.id(">▁</")])
+        assertParity("a> </b")
+    }
+
+    func testTieBreakPrefersLeftmostOccurrence() {
+        let v = Self.fixture
+        // Two positions hold the `a`+`b` rule at the same rank; the leftmost has to merge first for
+        // `ab`+`ab` to become reachable.
+        XCTAssertEqual(assertParity("abab"), [v.id("abab")])
+        assertParity("ababab")
+        assertParity("abababab")
+    }
+
+    func testNoMergeAvailable() {
+        let v = Self.fixture
+        XCTAssertEqual(assertParity("xyz"), [v.id("x"), v.id("y"), v.id("z")])
+        assertParity("x y z")
+        assertParity("z")
+    }
+
+    // MARK: - Byte fallback
+
+    func testCharactersOutsideTheVocabularyByteFallBack() {
+        let v = Self.fixture
+        // No `你` token: it decomposes into its three UTF-8 bytes.
+        XCTAssertEqual(assertParity("你"),
+                       Array("你".utf8).map { v.id(String(format: "<0x%02X>", $0)) })
+        assertParity("你好")
+        assertParity("é")
+        assertParity(" hello 你好 world")
+    }
+
+    func testEmojiAndGraphemeClustersByteFallBack() {
+        assertParity("😊")
+        // A ZWJ sequence is one Swift Character but several scalars; the split is per character, so
+        // the whole cluster falls back together.
+        assertParity("👩‍💻")
+        assertParity("hello 😊 world")
+    }
+
+    func testMergeResultOutsideTheVocabularyByteFallsBack() {
+        let v = Self.fixture
+        // `q`+`q` merges to a piece the vocabulary lacks, so the merged symbol byte-falls-back.
+        XCTAssertEqual(assertParity("qq"),
+                       [v.id("<0x71>"), v.id("<0x71>")])
+        XCTAssertEqual(assertParity("qqq"),
+                       [v.id("<0x71>"), v.id("<0x71>"), v.id("q")])
+        assertParity("qq hello")
+    }
+
+    // MARK: - Special tokens
+
+    func testSpecialTokensAloneAndAdjacentToText() {
+        let v = Self.fixture
+        XCTAssertEqual(assertParity("<bos>"), [v.id("<bos>")])
+        XCTAssertEqual(assertParity("<|turn>"), [v.id("<|turn>")])
+        XCTAssertEqual(assertParity("<bos>hello"), [v.id("<bos>"), v.id("hello")])
+        XCTAssertEqual(assertParity("hello<|turn>"), [v.id("hello"), v.id("<|turn>")])
+        XCTAssertEqual(assertParity("<bos><|turn><turn|>"),
+                       [v.id("<bos>"), v.id("<|turn>"), v.id("<turn|>")])
+        assertParity("<|turn>user\nhello<turn|>\n")
+        assertParity(" hello <|turn> world ")
+        assertParity("a<|turn>b<turn|>c")
+    }
+
+    func testTextThatLooksLikeASpecialTokenButIsNot() {
+        assertParity("<turn>")
+        assertParity("<|turn")
+        assertParity("< bos >")
+    }
+
+    // MARK: - Mixed text
+
+    func testMixedScriptSentences() {
+        for text in [
+            " привет world",
+            "hello привет 你好 😊",
+            "abab qq > </ xyz",
+            " hello  world\n привет\t你好 ",
+        ] {
+            assertParity(text)
+        }
+    }
+
+    func testLongInputMatchesReference() {
+        let unit = " hello  world привет 你好 abab > </ xyz qq 😊\n"
+        var text = ""
+        while text.count < 4_000 { text += unit }
+        assertParity(text)
+        // And every prefix boundary, since the merge queue's state is carried across a whole run.
+        for length in [1, 7, 64, 512, 2_048] {
+            assertParity(String(text.prefix(length)))
+        }
+    }
+
+    // MARK: - Merge list encodings
+
+    func testStringAndPairMergeEncodingsAgree() throws {
+        let alternate = Gemma4Tokenizer()
+        try alternate.load(from: Self.stringMergesFixture.directory)
+        for text in [" hello  world", "abab", "> </", "привет 你好", "<bos>hello<|turn>"] {
+            XCTAssertEqual(alternate.encode(text), tokenizer.encode(text),
+                           "merge-list encoding changed the ids for \(text.debugDescription)")
+        }
+    }
+}

--- a/Tests/Qwen3ChatTests/ReferenceGemma4BPE.swift
+++ b/Tests/Qwen3ChatTests/ReferenceGemma4BPE.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// The Gemma 4 BPE encoder exactly as it stood before the linked-list/priority-queue rewrite,
+/// kept verbatim so parity is asserted against behaviour that actually shipped rather than against
+/// a transcription of what it was believed to do. A faster tokenizer that reads differently is
+/// worse than a slow one — nothing in the pipeline would report the difference.
+///
+/// Loads its own tables from the same `tokenizer.json`, so it shares no state with the encoder
+/// under test.
+final class ReferenceGemma4BPE {
+    private var tokenToId: [String: Int] = [:]
+    private var mergeRanks: [String: Int] = [:]
+    private var specials: [(content: String, id: Int)] = []
+    private var byteFallbackId: [Int] = Array(repeating: -1, count: 256)
+
+    enum LoadError: Error { case invalid(String) }
+
+    func load(from directory: URL) throws {
+        let url = directory.appendingPathComponent("tokenizer.json")
+        let data = try Data(contentsOf: url)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let model = root["model"] as? [String: Any],
+              let vocab = model["vocab"] as? [String: Int] else {
+            throw LoadError.invalid("Invalid Gemma tokenizer.json")
+        }
+        tokenToId = vocab
+
+        if let merges = model["merges"] as? [[String]] {
+            for (i, pair) in merges.enumerated() where pair.count == 2 {
+                mergeRanks["\(pair[0]) \(pair[1])"] = i
+            }
+        } else if let merges = model["merges"] as? [String] {
+            for (i, m) in merges.enumerated() {
+                let p = m.split(separator: " ", maxSplits: 1)
+                if p.count == 2 { mergeRanks["\(p[0]) \(p[1])"] = i }
+            }
+        }
+
+        if let added = root["added_tokens"] as? [[String: Any]] {
+            for a in added {
+                guard let content = a["content"] as? String, let id = a["id"] as? Int else { continue }
+                tokenToId[content] = id
+                if (a["special"] as? Bool) ?? false { specials.append((content, id)) }
+            }
+        }
+        specials.sort { $0.content.count > $1.content.count }
+
+        for b in 0..<256 {
+            if let id = tokenToId[String(format: "<0x%02X>", b)] { byteFallbackId[b] = id }
+        }
+    }
+
+    func encode(_ text: String) -> [Int] {
+        if text.isEmpty { return [] }
+        var out: [Int] = []
+        encodeSegment(Substring(text), into: &out)
+        return out
+    }
+
+    private func encodeSegment(_ text: Substring, into out: inout [Int]) {
+        if text.isEmpty { return }
+        var bestRange: Range<Substring.Index>? = nil
+        var bestId = -1
+        for (content, id) in specials {
+            if let r = text.range(of: content) {
+                if bestRange == nil || r.lowerBound < bestRange!.lowerBound {
+                    bestRange = r; bestId = id
+                }
+            }
+        }
+        guard let r = bestRange else {
+            bpeEncode(String(text), into: &out)
+            return
+        }
+        if r.lowerBound > text.startIndex {
+            bpeEncode(String(text[text.startIndex..<r.lowerBound]), into: &out)
+        }
+        out.append(bestId)
+        encodeSegment(text[r.upperBound...], into: &out)
+    }
+
+    private func bpeEncode(_ raw: String, into out: inout [Int]) {
+        if raw.isEmpty { return }
+        let normalized = raw.replacingOccurrences(of: " ", with: "\u{2581}")
+
+        var symbols: [String] = []
+        for ch in normalized {
+            let s = String(ch)
+            if tokenToId[s] != nil {
+                symbols.append(s)
+            } else {
+                for b in Array(s.utf8) { symbols.append("<0x" + String(format: "%02X", b) + ">") }
+            }
+        }
+        if symbols.isEmpty { return }
+
+        while symbols.count > 1 {
+            var bestRank = Int.max
+            var bestIdx = -1
+            for i in 0..<(symbols.count - 1) {
+                if let rank = mergeRanks["\(symbols[i]) \(symbols[i + 1])"], rank < bestRank {
+                    bestRank = rank; bestIdx = i
+                }
+            }
+            if bestIdx < 0 { break }
+            symbols.replaceSubrange(bestIdx...bestIdx + 1,
+                                    with: [symbols[bestIdx] + symbols[bestIdx + 1]])
+        }
+
+        for s in symbols {
+            if let id = tokenToId[s] {
+                out.append(id)
+            } else {
+                for b in Array(s.utf8) where byteFallbackId[Int(b)] >= 0 {
+                    out.append(byteFallbackId[Int(b)])
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What was wrong

`Gemma4Tokenizer.bpeEncode` took a whole run of text as one BPE unit, split it to one symbol per character, and then, for every merge, rescanned all adjacent pairs to find the lowest rank and spliced the winner into the array. Each pair cost an interpolated `"\(left) \(right)"` string and a hash of it against 514,906 rules; each splice moved the tail; each merge concatenated two strings that only grew.

Quadratic in text length, with a constant large enough to dominate everything around it. Measured against this vocabulary in release: 32,000 characters took **32.3s** to tokenize, and the growth exponent over 2k → 32k was **1.98**.

## What changed

Merges run over a doubly linked list of symbols with a binary min-heap of candidate pairs. Popping the lowest rank and pushing only the two pairs each merge creates chooses the same pair in the same order as the rescan did — the heap is keyed on `(rank << 32) | position`, a merged symbol keeps its left operand's position, and a rank identifies exactly one rule, so a superseded entry is recognized at pop time by its rank no longer matching the pair now at that position.

Symbols are vocabulary ids rather than strings. The merge table is keyed by the two ids packed into a `UInt64` and valued by the rank and merged id packed the same way, so the loop allocates and hashes nothing.

**Word splitting was rejected, not overlooked.** It is the usual way to bound BPE cost, and it is not safe against this vocabulary: 466 rules join a piece to one beginning with `▁`, so any run of two or more spaces retokenizes once a word boundary is imposed, and one rule joins `>` to `▁</` across a space outright. The queue needs no such assumption, and unlike splitting it is order-identical by construction rather than by luck.

## Measurements

Tokenizer seconds, release build, same text at each length:

| chars | before | after | speedup | exponent before → after |
|---:|---:|---:|---:|:---|
| 2,000 | 0.1250 | 0.0019 | 66× | |
| 4,000 | 0.4983 | 0.0038 | 131× | 2.00 → 1.01 |
| 8,000 | 2.0178 | 0.0079 | 254× | 2.02 → 1.07 |
| 16,000 | 8.1626 | 0.0155 | 525× | 2.02 → 0.97 |
| 32,000 | 32.2824 | 0.0316 | 1022× | 1.98 → 1.02 |

Loading costs **0.40s more** (0.58 → 0.98) because the pair table resolves every rule's operands and result through the vocabulary. Resident memory after load drops **12 MB** (185 → 173): the packed table replaces half a million string keys. The load cost is repaid by the first prompt over about 1,500 characters.

## Why this is safe

The gate is token-id equality, not speed — a tokenizer that is faster and subtly different changes what the model reads and reports nothing.

`ReferenceGemma4BPE` keeps the previous implementation verbatim, loading its own tables from the same `tokenizer.json`. Both new suites assert identity against it.

- **`Gemma4TokenizerBPETests`** (unit, runs in CI, no model needed) builds a miniature vocabulary reaching every branch — space runs, a merge spanning a space, byte fallback, a merge result absent from the vocabulary, one rule occurring twice in a string — and covers empty input, whitespace-only input, leading/trailing/repeated spaces, specials alone and adjacent to text, CJK, emoji and ZWJ sequences, text with no merge available, and both `merges` encodings.
- **`E2EGemma4TokenizerParityTests`** (model-gated) runs the real 262,144-token vocabulary over 393 rows of real mixed-script meeting transcript (54,917 characters, 16,119 tokens), their concatenation, prefixes from 1 character to all of it, chat-template-shaped text, and the edge-case matrix again on the real vocabulary. It also guards the regression with a cost budget at 32k characters.

Both pass, including the full-corpus run (`GEMMA4_PARITY_CORPUS`, `GEMMA4_PARITY_FULL=1`). CI unit suite: **1190 tests, 0 failures**, against **1175, 0 failures** on `main` — 15 added, none changed.

## A separate defect found while building the gate

The parity comparison groups ids that Swift's vocabulary cannot tell apart, and the reason is worth stating on its own.

This vocabulary has **434 sets of canonically equal tokens, 868 ids in all** — `;` U+003B and U+037E GREEK QUESTION MARK among them, plus many precomposed/decomposed Bengali, Devanagari, Arabic and accented Latin forms. Swift compares and hashes strings by canonical equivalence, so bridging `tokenizer.json` into a `[String: Int]` drops 437 entries, and **which member of each set survives is not stable from one load to the next**: two `Gemma4Tokenizer` instances loaded back to back in one process were observed to encode `;` as 248374 and 236793 respectively.

That is a defect in how the vocabulary is read, present on `main` and untouched here — this change collapses those pieces through the same dictionary the string-keyed table used. Fixing it means keying the vocabulary by bytes rather than by `String`, which changes ids for those 868 tokens and deserves its own change with its own equality analysis.
