### PR TITLE
Sample Gemma 4 on the GPU instead of copying the vocabulary per token

### DIFF
--- a/Sources/Qwen3Chat/ChatSampler.swift
+++ b/Sources/Qwen3Chat/ChatSampler.swift
@@ -18,6 +18,22 @@ enum ChatSampler {
         config: ChatSamplingConfig,
         previousTokens: [Int] = []
     ) -> Int {
+        sample(logits: logits, config: config, previousTokens: previousTokens,
+               uniform: Float.random(in: 0 ..< 1))
+    }
+
+    /// The same sampler with the nucleus draw supplied instead of drawn.
+    ///
+    /// One uniform is the sampler's only non-determinism, so lifting it into a parameter makes
+    /// this a pure function of its inputs. That is what lets the MLX sampler in
+    /// `ChatSamplerMLX.swift` be checked against it token-for-token over a sweep of draws, rather
+    /// than only in distribution.
+    static func sample(
+        logits: [Float],
+        config: ChatSamplingConfig,
+        previousTokens: [Int] = [],
+        uniform: Float
+    ) -> Int {
         let vocab = logits.count
         if vocab == 0 { return 0 }
 
@@ -95,7 +111,7 @@ enum ChatSampler {
         // Sample within the kept nucleus (renormalized).
         var keptSum: Float = 0
         for r in 0..<cut { keptSum += probs[order[r]] }
-        let target = Float.random(in: 0..<1) * (keptSum > 0 ? keptSum : 1)
+        let target = uniform * (keptSum > 0 ? keptSum : 1)
         var c: Float = 0
         for r in 0..<cut {
             c += probs[order[r]]

--- a/Sources/Qwen3Chat/ChatSamplerMLX.swift
+++ b/Sources/Qwen3Chat/ChatSamplerMLX.swift
@@ -1,0 +1,118 @@
+import Foundation
+import MLX
+
+// MARK: - On-device sampling
+
+/// `ChatSampler` evaluated where the logits already are.
+///
+/// The host sampler needs the whole distribution in a Swift array. For Gemma 4's 262,144-entry
+/// vocabulary that is a megabyte crossing the GPU boundary per generated token, copied twice more
+/// on arrival (`prefix(vocabSize)`, then the sampler's own working copy) before any of the O(V)
+/// host scans start. Every decision it makes — end-token suppression, repetition penalty,
+/// temperature, top-K, top-P and the draw — is expressible as an MLX op, so this variant makes
+/// them on device and brings back one Int32.
+///
+/// It is a second implementation of the same rules rather than a rearrangement of the first, so
+/// nothing about the construction guarantees they agree; tests hold them together. That is why
+/// ``ChatSampler/sample(logits:config:previousTokens:uniform:)`` takes the nucleus draw as a
+/// parameter — with the randomness lifted out, both paths are pure functions of the same inputs
+/// and can be compared token-for-token over a sweep of draws.
+///
+/// One divergence is inherent. Both paths rank candidates by probability and neither breaks ties
+/// by index — the host sorts with `Array.sort`, this one with `argSort` — so on exactly equal
+/// logits they may return different tokens *of equal probability*. Greedy is unaffected: `argMax`
+/// and the host's strict `>` scan both take the lowest index.
+extension ChatSampler {
+
+    /// Sample one token from a device logits array.
+    ///
+    /// - Parameters:
+    ///   - logits: `[vocab]`, `[T, vocab]` or `[B, T, vocab]`; the last position is sampled.
+    ///   - config: the same knobs the host sampler reads.
+    ///   - suppressing: token ids forced out of the running, e.g. the caller's end-of-turn ids.
+    ///     Suppression happens before the repetition penalty, matching the host decode loop's
+    ///     order.
+    ///   - previousTokens: recent history for the repetition penalty.
+    ///   - vocabSize: logits wider than the tokenizer's vocabulary are trimmed, matching the host
+    ///     path's `prefix(vocabSize)`.
+    ///   - uniform: the nucleus draw, in `[0, 1)`. Unread when sampling greedily.
+    /// - Returns: a scalar Int32 `MLXArray`. Reading it (`.item(Int.self)`) is the one host/GPU
+    ///   synchronisation a decode step needs — the model forward, the sampling, and nothing else.
+    static func sampleOnDevice(
+        logits: MLXArray,
+        config: ChatSamplingConfig,
+        suppressing: [Int] = [],
+        previousTokens: [Int] = [],
+        vocabSize: Int? = nil,
+        uniform: Float
+    ) -> MLXArray {
+        var row = logits
+        if row.ndim == 3 { row = row[0, row.dim(1) - 1] }
+        else if row.ndim == 2 { row = row[row.dim(0) - 1] }
+        var scaled = row.asType(.float32)
+        if let vocabSize, vocabSize < scaled.dim(0) { scaled = scaled[0 ..< vocabSize] }
+        let vocab = scaled.dim(0)
+        if vocab == 0 { return MLXArray(Int32(0)) }
+
+        // End-token suppression. `-greatestFiniteMagnitude` rather than `-infinity` because the
+        // penalty below multiplies whatever it finds and the host path suppresses with the same
+        // finite value; both then overflow to -inf together on a suppressed token that also
+        // appears in the penalty window.
+        let blocked = suppressing.filter { $0 >= 0 && $0 < vocab }
+        if !blocked.isEmpty {
+            scaled[MLXArray(blocked.map(Int32.init))] = MLXArray(-Float.greatestFiniteMagnitude)
+        }
+
+        // Repetition penalty over the same 64-token window, divided when positive and multiplied
+        // when not, so both signs move away from being picked. Deduplicating first matters: the
+        // host applies the penalty once per distinct id, and a scatter would otherwise depend on
+        // which duplicate wrote last.
+        if config.repetitionPenalty > 1.0 {
+            let seen = Set(previousTokens.suffix(64)).filter { $0 >= 0 && $0 < vocab }
+            if !seen.isEmpty {
+                let ids = MLXArray(seen.map(Int32.init))
+                let v = scaled[ids]
+                let p = config.repetitionPenalty
+                scaled[ids] = which(v .> 0, v / p, v * p)
+            }
+        }
+
+        // Greedy. `argMax` takes the lowest index among equal maxima, like the host's strict `>`
+        // scan — `ChatSamplerDeviceTests.testGreedyTieTakesLowestIndex` pins that.
+        if config.temperature <= 0 { return argMax(scaled, axis: 0) }
+
+        // Candidate set = the top-K by logit, which is the top-K by probability because softmax is
+        // monotonic — the same equivalence the host sampler leans on to select on raw logits.
+        // Ranking the whole vocabulary once and slicing is one kernel; everything after it is K
+        // wide, and K is a few dozen.
+        //
+        // `argPartition` would express "the K largest, unordered" more directly, and was measured
+        // against this: over a 262,144-entry vocabulary it cost 0.340 ms against `argSort`'s
+        // 0.344 ms, because MLX's Metal backend reaches partition through a sort anyway. Selecting
+        // and then sorting the selection came to 0.431 ms — one kernel more for no less work.
+        let k = (config.topK > 0 && config.topK < vocab) ? config.topK : vocab
+        var order = argSort(scaled, axis: 0)[.stride(by: -1)]        // best first
+        if k < vocab { order = order[0 ..< k] }
+        let ranked = take(scaled, order, axis: 0)
+
+        let probs = softmax(ranked / config.temperature, axis: 0, precise: true)
+
+        // Top-P (nucleus): keep the shortest prefix whose cumulative probability reaches topP.
+        // A rank survives when everything ranked above it still sums to less than topP, which is
+        // exactly the exclusive prefix sum — the host's "first rank at or above topP, inclusive"
+        // written without a loop.
+        var kept = probs
+        if config.topP < 1.0 {
+            kept = which(cumsum(probs, axis: 0, inclusive: false) .< config.topP,
+                         probs, MLXArray(Float(0)))
+        }
+
+        // Draw by inverse CDF over the kept mass. Counting the ranks strictly below the target
+        // gives the first rank at or above it without depending on how `argMax` orders the equal
+        // entries of a boolean array. The clamp is the host's fall-through to the last kept rank.
+        let keptSum = kept.sum()
+        let target = which(keptSum .> 0, keptSum, MLXArray(Float(1))) * uniform
+        let rank = (cumsum(kept, axis: 0, inclusive: true) .< target).asType(.int32).sum()
+        return take(order, minimum(rank, MLXArray(Int32(order.dim(0) - 1))), axis: 0)
+    }
+}

--- a/Sources/Qwen3Chat/Gemma4Chat.swift
+++ b/Sources/Qwen3Chat/Gemma4Chat.swift
@@ -95,47 +95,73 @@ public final class Gemma4Chat: @unchecked Sendable {
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
-                self.resetState()
-
                 let promptTokens = Gemma4ChatTemplate.encode(
                     messages: messages, tokenizer: self.gemmaTokenizer)
-
-                // Prefill. Only the final position is sampled, so the lm_head runs on that row
-                // alone — over a long prompt the discarded rows are gigabytes of 262k-wide logits.
-                let promptArray = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
-                let prefillLogits = self.model.lastTokenLogits(
-                    inputIds: promptArray, state: &self.state)
-                eval(prefillLogits)
-                var logits = self.lastLogits(prefillLogits)
-
-                var history = promptTokens
-                var produced = false
-                var filter = Gemma4AnswerFilter(tokenizer: self.gemmaTokenizer)
-
-                for _ in 0..<sampling.maxTokens {
-                    // Don't let the model end the turn before emitting any visible answer.
-                    if !produced { self.suppressEndTokens(&logits) }
-
-                    let next = ChatSampler.sample(
-                        logits: logits, config: sampling, previousTokens: history)
-
-                    if self.gemmaTokenizer.eosTokenIds.contains(next) { break }
-                    history.append(next)
-
-                    let text = filter.consume(next)
-                    if !text.isEmpty { produced = true; continuation.yield(text) }
-
-                    // Decode one step.
-                    let arr = MLXArray([Int32(next)]).expandedDimensions(axis: 0)
-                    let step = self.model.forward(inputIds: arr, state: &self.state)
-                    eval(step)
-                    logits = self.lastLogits(step)
+                self.decode(promptTokens: promptTokens, sampling: sampling) { text in
+                    continuation.yield(text)
                 }
-
-                if let tail = filter.flush(), !tail.isEmpty { continuation.yield(tail) }
                 continuation.finish()
             }
         }
+    }
+
+    /// One decode pass: prefill, then a token per step until an end token or the budget runs out.
+    ///
+    /// `onText` receives answer text as the reasoning-channel filter completes it (often nothing —
+    /// one character can span several tokens); `onToken` receives every sampled id, which is what
+    /// the greedy-parity test compares against the host sampler.
+    ///
+    /// The step is one lazy MLX graph — model forward, suppression, penalty, top-K/top-P and the
+    /// draw — and reading the sampled id is the only point it is waited on. The previous shape
+    /// evaluated the logits, pulled all 262k of them to the host, and sampled there: two
+    /// synchronisations and a megabyte per token.
+    func decode(
+        promptTokens: [Int],
+        sampling: ChatSamplingConfig,
+        onToken: (Int) -> Void = { _ in },
+        onText: (String) -> Void
+    ) {
+        resetState()
+
+        // Prefill. Only the final position is sampled, so the lm_head runs on that row alone —
+        // over a long prompt the discarded rows are gigabytes of 262k-wide logits.
+        let promptArray = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
+        var logits = model.lastTokenLogits(inputIds: promptArray, state: &state)
+
+        var history = promptTokens
+        var produced = false
+        var filter = Gemma4AnswerFilter(tokenizer: gemmaTokenizer)
+        let endTokens = Array(gemmaTokenizer.eosTokenIds)
+
+        var remaining = sampling.maxTokens
+        while remaining > 0 {
+            remaining -= 1
+
+            let next = ChatSampler.sampleOnDevice(
+                logits: logits,
+                config: sampling,
+                // Don't let the model end the turn before emitting any visible answer.
+                suppressing: produced ? [] : endTokens,
+                previousTokens: history,
+                vocabSize: denseConfig.vocabSize,
+                uniform: sampling.temperature > 0 ? Float.random(in: 0 ..< 1) : 0
+            ).item(Int.self)
+
+            if gemmaTokenizer.eosTokenIds.contains(next) { break }
+            history.append(next)
+            onToken(next)
+
+            let text = filter.consume(next)
+            if !text.isEmpty { produced = true; onText(text) }
+
+            // Decode one step — but not a step whose logits nothing will read. The budget's last
+            // token used to be followed by a full forward that was evaluated and thrown away.
+            guard remaining > 0 else { break }
+            let arr = MLXArray([Int32(next)]).expandedDimensions(axis: 0)
+            logits = model.forward(inputIds: arr, state: &state)
+        }
+
+        if let tail = filter.flush(), !tail.isEmpty { onText(tail) }
     }
 
     // MARK: - Parity harness (unchanged surface used by Gemma4ParityTests)
@@ -171,20 +197,6 @@ public final class Gemma4Chat: @unchecked Sendable {
         return best
     }
 
-    // MARK: - Helpers
-
-    private func suppressEndTokens(_ logits: inout [Float]) {
-        let ninf = -Float.greatestFiniteMagnitude
-        for id in gemmaTokenizer.eosTokenIds where id >= 0 && id < logits.count { logits[id] = ninf }
-    }
-
-    private func lastLogits(_ logits: MLXArray) -> [Float] {
-        let t = logits.dim(1)
-        let last = logits[0, t - 1].asType(.float32)
-        eval(last)
-        let all: [Float] = last.asArray(Float.self)
-        return Array(all.prefix(denseConfig.vocabSize))
-    }
 }
 
 // MARK: - Qwen35ChatBackend conformance

--- a/Tests/Qwen3ChatTests/ChatSamplerDeviceTests.swift
+++ b/Tests/Qwen3ChatTests/ChatSamplerDeviceTests.swift
@@ -1,0 +1,315 @@
+import XCTest
+import Foundation
+import MLX
+@testable import Qwen3Chat
+
+/// `ChatSampler.sampleOnDevice` against the host sampler it replaces in the Gemma 4 decode loop.
+///
+/// The two are separate implementations of one set of rules, so the only thing that keeps them
+/// honest is comparing them. `ChatSampler.sample(…uniform:)` exists for this: with the nucleus
+/// draw lifted out of the sampler, both paths are pure functions of the same inputs and can be
+/// compared token-for-token over a sweep of draws rather than in distribution.
+///
+/// Where a case has ties the comparison is deliberately weaker, and the reason is stated at each
+/// such test: neither path breaks equal probabilities by index — the host sorts candidates with
+/// `Array.sort`, the device with `argSort` — so on equal logits they may return different tokens
+/// of *equal* probability. Asserting index equality there would be asserting an implementation
+/// detail neither path promises. Greedy is exempt: both take the lowest index among equal maxima,
+/// and `testGreedyTieTakesLowestIndex` pins that.
+final class ChatSamplerDeviceTests: XCTestCase {
+
+    /// Draws swept across `[0, 1)` — enough that every candidate of a few-dozen-wide nucleus is
+    /// reached many times, so a disagreement about which ranks survive filtering shows up as a
+    /// disagreement about which tokens are reachable.
+    private static let sweep = 256
+
+    private func uniforms(_ n: Int = sweep) -> [Float] {
+        (0 ..< n).map { (Float($0) + 0.5) / Float(n) }
+    }
+
+    private func device(
+        _ logits: [Float], _ config: ChatSamplingConfig,
+        suppressing: [Int] = [], previousTokens: [Int] = [], vocabSize: Int? = nil,
+        uniform: Float = 0
+    ) -> Int {
+        ChatSampler.sampleOnDevice(
+            logits: MLXArray(logits), config: config, suppressing: suppressing,
+            previousTokens: previousTokens, vocabSize: vocabSize, uniform: uniform
+        ).item(Int.self)
+    }
+
+    /// The host decode loop suppressed end tokens into its `[Float]` before sampling; the device
+    /// sampler folds that in. This is the host order, written out so the comparisons below are
+    /// against the code that was actually replaced.
+    private func host(
+        _ logits: [Float], _ config: ChatSamplingConfig,
+        suppressing: [Int] = [], previousTokens: [Int] = [], vocabSize: Int? = nil,
+        uniform: Float = 0
+    ) -> Int {
+        var l = Array(logits.prefix(vocabSize ?? logits.count))
+        for id in suppressing where id >= 0 && id < l.count { l[id] = -Float.greatestFiniteMagnitude }
+        return ChatSampler.sample(logits: l, config: config, previousTokens: previousTokens,
+                                  uniform: uniform)
+    }
+
+    /// Seeded so a failure is reproducible, and spread over roughly ±8 — the range real logits
+    /// occupy, where a nucleus holds a few dozen candidates rather than collapsing onto one.
+    private func randomLogits(_ n: Int, seed: UInt64) -> [Float] {
+        var s = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+        return (0 ..< n).map { _ in
+            s = s &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            return Float(Int32(truncatingIfNeeded: s >> 33)) / Float(1 << 28)
+        }
+    }
+
+    private static let greedy = ChatSamplingConfig(
+        temperature: 0, topK: 0, topP: 1.0, maxTokens: 1, repetitionPenalty: 1.0)
+
+    // MARK: - Greedy
+
+    /// The hard gate: with `temperature <= 0` the decision is deterministic, so any difference is
+    /// a behavioural change. Random logits are drawn from a range wide enough that exact ties are
+    /// vanishingly unlikely, which is the case the decode loop actually runs in.
+    func testGreedyMatchesHostOnRandomLogits() {
+        for seed in UInt64(1) ... 20 {
+            let l = randomLogits(4096, seed: seed)
+            XCTAssertEqual(device(l, Self.greedy), host(l, Self.greedy), "seed \(seed)")
+        }
+    }
+
+    /// The host scans with a strict `>`, so the first of several equal maxima wins. `argMax` must
+    /// agree — this is the one tie the two paths do promise to break the same way, and the greedy
+    /// parity claim rests on it.
+    func testGreedyTieTakesLowestIndex() {
+        XCTAssertEqual(device([Float](repeating: 1.5, count: 64), Self.greedy), 0)
+        XCTAssertEqual(host([Float](repeating: 1.5, count: 64), Self.greedy), 0)
+
+        var l = [Float](repeating: -3, count: 64)
+        for i in [7, 19, 40] { l[i] = 9 }
+        XCTAssertEqual(device(l, Self.greedy), 7)
+        XCTAssertEqual(host(l, Self.greedy), 7)
+    }
+
+    /// Logits wider than the tokenizer's vocabulary are trimmed on both paths — the host did it
+    /// with `prefix(vocabSize)`. A padded row's extra columns must not be reachable.
+    func testVocabSizeTrimMatchesHostPrefix() {
+        var l = randomLogits(300, seed: 99)
+        l[280] = 1_000                      // beyond the "vocabulary"
+        l[137] = 500                        // the real maximum
+        XCTAssertEqual(device(l, Self.greedy, vocabSize: 256), 137)
+        XCTAssertEqual(host(l, Self.greedy, vocabSize: 256), 137)
+    }
+
+    // MARK: - Repetition penalty
+
+    /// Same window (the last 64 ids), same asymmetric rule (divide when positive, multiply when
+    /// not), same tolerance for ids that are duplicated or out of range.
+    func testRepetitionPenaltyMatchesHost() {
+        let config = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 1,
+                                        repetitionPenalty: 1.7)
+        for seed in UInt64(1) ... 10 {
+            let l = randomLogits(512, seed: seed)
+            // Longer than the window, with repeats and ids the sampler must ignore.
+            var history = (0 ..< 200).map { Int(($0 &* 37 &+ Int(seed)) % 512) }
+            history += [-1, 512, 99_999, history[0], history[0]]
+            XCTAssertEqual(device(l, config, previousTokens: history),
+                           host(l, config, previousTokens: history), "seed \(seed)")
+        }
+    }
+
+    /// The rule has to move a negative logit *down*, not up — multiplying is what does that, and
+    /// getting the branch backwards is the obvious way to break it.
+    func testRepetitionPenaltyPushesBothSignsDown() {
+        let config = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 1,
+                                        repetitionPenalty: 2.0)
+        //         0      1     2
+        let l: [Float] = [10.0, 9.0, -1.0]
+        XCTAssertEqual(device(l, config, previousTokens: [0]), 1)      // 10 → 5, so 9 wins
+        XCTAssertEqual(host(l, config, previousTokens: [0]), 1)
+
+        let neg: [Float] = [-1.0, -5.0, -1.5]
+        XCTAssertEqual(device(neg, config, previousTokens: [0]), 2)    // -1 → -2, so -1.5 wins
+        XCTAssertEqual(host(neg, config, previousTokens: [0]), 2)
+    }
+
+    /// A penalty of 1.0 is off, not "a penalty of one" — the host guards on `> 1.0` and so must
+    /// the device path, or a default config would quietly rescale every seen logit.
+    func testPenaltyOfOneChangesNothing() {
+        let l: [Float] = [10.0, 1.0, 3.0]
+        let off = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 1,
+                                     repetitionPenalty: 1.0)
+        XCTAssertEqual(device(l, off, previousTokens: [0, 0, 0]), 0)
+        XCTAssertEqual(host(l, off, previousTokens: [0, 0, 0]), 0)
+    }
+
+    // MARK: - End-token suppression
+
+    /// Suppressed ids must lose even when they are the argmax, and must stay lost through the
+    /// penalty: a suppressed id that is also in the penalty window overflows to -inf on both
+    /// paths, which is the interaction most likely to be broken by reordering the two steps.
+    func testEndTokenSuppression() {
+        var l = randomLogits(256, seed: 7)
+        l[11] = 100
+        l[12] = 90
+        l[13] = 80
+
+        XCTAssertEqual(device(l, Self.greedy, suppressing: [11]), 12)
+        XCTAssertEqual(host(l, Self.greedy, suppressing: [11]), 12)
+        XCTAssertEqual(device(l, Self.greedy, suppressing: [11, 12]), 13)
+        XCTAssertEqual(host(l, Self.greedy, suppressing: [11, 12]), 13)
+
+        let penalised = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 1,
+                                           repetitionPenalty: 1.1)
+        XCTAssertEqual(device(l, penalised, suppressing: [11, 12], previousTokens: [11, 12, 13]),
+                       host(l, penalised, suppressing: [11, 12], previousTokens: [11, 12, 13]))
+        XCTAssertNotEqual(device(l, penalised, suppressing: [11, 12], previousTokens: [11, 12]), 11)
+
+        // Out-of-range suppressions are ignored rather than trapping.
+        XCTAssertEqual(device(l, Self.greedy, suppressing: [-1, 256, 11]), 12)
+    }
+
+    /// Suppression survives sampling too, not just argmax — nothing may be drawn from a
+    /// suppressed id at any point in the sweep.
+    func testSuppressedIdIsUnreachableWhenSampling() {
+        var l = [Float](repeating: -20, count: 128)
+        l[3] = 10; l[4] = 9.5; l[5] = 9.0
+        let config = ChatSamplingConfig(temperature: 1.0, topK: 0, topP: 1.0, maxTokens: 1,
+                                        repetitionPenalty: 1.0)
+        for u in uniforms() {
+            XCTAssertNotEqual(device(l, config, suppressing: [3], uniform: u), 3)
+        }
+    }
+
+    // MARK: - Sampling
+
+    /// Temperature, top-K and top-P together, over a sweep of draws, on logits with no ties. This
+    /// is the strongest statement available for the stochastic path: given the same draw the two
+    /// samplers return the same token, so they differ in nothing but where the arithmetic ran.
+    func testStochasticMatchesHostOverUniformSweep() {
+        let configs = [
+            ChatSamplingConfig(temperature: 0.7, topK: 50, topP: 0.9, maxTokens: 1,
+                               repetitionPenalty: 1.1),
+            ChatSamplingConfig(temperature: 1.0, topK: 0, topP: 1.0, maxTokens: 1,
+                               repetitionPenalty: 1.0),
+            ChatSamplingConfig(temperature: 0.3, topK: 20, topP: 0.8, maxTokens: 1,
+                               repetitionPenalty: 1.0),
+            ChatSamplingConfig(temperature: 2.0, topK: 8, topP: 0.5, maxTokens: 1,
+                               repetitionPenalty: 1.3),
+        ]
+        for (c, config) in configs.enumerated() {
+            let l = randomLogits(1024, seed: UInt64(100 + c))
+            let history = (0 ..< 80).map { ($0 &* 13) % 1024 }
+            var mismatches = 0
+            for u in uniforms() {
+                let d = device(l, config, previousTokens: history, uniform: u)
+                let h = host(l, config, previousTokens: history, uniform: u)
+                if d != h { mismatches += 1 }
+            }
+            XCTAssertEqual(mismatches, 0, "config \(c): \(mismatches)/\(Self.sweep) draws differ")
+        }
+    }
+
+    /// Top-K is a hard bound on what can be drawn, and the two paths must bound it identically.
+    /// Sweeping the draw enumerates the reachable set, which is the observable the filter decides.
+    func testTopKReachableSetMatchesHost() {
+        let l = randomLogits(512, seed: 41)
+        for k in [1, 2, 5, 17, 64] {
+            let config = ChatSamplingConfig(temperature: 1.0, topK: k, topP: 1.0, maxTokens: 1,
+                                            repetitionPenalty: 1.0)
+            var d = Set<Int>(), h = Set<Int>()
+            for u in uniforms() {
+                d.insert(device(l, config, uniform: u))
+                h.insert(host(l, config, uniform: u))
+            }
+            XCTAssertEqual(d, h, "k=\(k)")
+            XCTAssertLessThanOrEqual(d.count, k)
+
+            // And it is the *top* k, not any k: every reachable token outranks every other.
+            let ranked = l.enumerated().sorted { $0.element > $1.element }.prefix(k).map(\.offset)
+            XCTAssertTrue(d.isSubset(of: Set(ranked)), "k=\(k) drew outside the top-k")
+        }
+    }
+
+    /// Top-P with the threshold landing exactly on a cumulative boundary.
+    ///
+    /// The probabilities are made exactly representable — `n` equal logits give exactly `1/n` each
+    /// for a power-of-two `n`, and the partial sums are exact — because a boundary that only lands
+    /// on the threshold in real arithmetic is decided by the last float digit of each path
+    /// independently, and agreeing there would be luck rather than equivalence.
+    ///
+    /// Equal logits mean the *identity* of the survivors is arbitrary on both paths, so the
+    /// assertion is on how many survive: `topP = 0.5` over eight equal candidates keeps four, and
+    /// an off-by-one in either direction is what this catches.
+    func testTopPExactBoundaryKeepsSamePrefixLength() {
+        let l = [Float](repeating: 2.25, count: 8)
+        for (topP, expected) in [(Float(0.125), 1), (0.25, 2), (0.5, 4), (0.75, 6), (1.0, 8)] {
+            let config = ChatSamplingConfig(temperature: 1.0, topK: 0, topP: topP, maxTokens: 1,
+                                            repetitionPenalty: 1.0)
+            var d = Set<Int>(), h = Set<Int>()
+            for u in uniforms(1024) {
+                d.insert(device(l, config, uniform: u))
+                h.insert(host(l, config, uniform: u))
+            }
+            XCTAssertEqual(d.count, expected, "device kept \(d.count) at topP=\(topP)")
+            XCTAssertEqual(h.count, expected, "host kept \(h.count) at topP=\(topP)")
+        }
+    }
+
+    /// Top-P on well-separated probabilities, where the nucleus is unambiguous: here the two paths
+    /// must agree on the tokens themselves, not only on how many there are.
+    func testTopPReachableSetMatchesHost() {
+        let l = randomLogits(512, seed: 63)
+        for topP in [Float(0.1), 0.5, 0.9, 0.95, 0.99, 1.0] {
+            let config = ChatSamplingConfig(temperature: 0.8, topK: 0, topP: topP, maxTokens: 1,
+                                            repetitionPenalty: 1.0)
+            var d = Set<Int>(), h = Set<Int>()
+            for u in uniforms() {
+                d.insert(device(l, config, uniform: u))
+                h.insert(host(l, config, uniform: u))
+            }
+            XCTAssertEqual(d, h, "topP=\(topP)")
+            XCTAssertFalse(d.isEmpty)
+        }
+    }
+
+    /// All-equal logits: every token is equally likely, so the two paths cannot be compared by
+    /// index — only by how much of the vocabulary stays reachable and by the draw staying inside
+    /// the filters. A degenerate distribution must not collapse onto one token or escape top-K.
+    func testAllEqualLogitsStayInDistribution() {
+        let l = [Float](repeating: -0.5, count: 32)
+        let config = ChatSamplingConfig(temperature: 0.9, topK: 10, topP: 1.0, maxTokens: 1,
+                                        repetitionPenalty: 1.0)
+        var d = Set<Int>(), h = Set<Int>()
+        for u in uniforms(1024) {
+            d.insert(device(l, config, uniform: u))
+            h.insert(host(l, config, uniform: u))
+        }
+        XCTAssertEqual(d.count, 10, "device reached \(d.count) of the 10 equally likely candidates")
+        XCTAssertEqual(h.count, 10, "host reached \(h.count) of the 10 equally likely candidates")
+        XCTAssertTrue(d.allSatisfy { $0 >= 0 && $0 < 32 })
+    }
+
+    /// A single dominant token is the case a nucleus must never widen: the rest of the mass is
+    /// below any threshold, so every draw lands on it.
+    func testDominantTokenAlwaysWins() {
+        var l = [Float](repeating: -100, count: 64)
+        l[37] = 100
+        let config = ChatSamplingConfig(temperature: 1.0, topK: 0, topP: 0.5, maxTokens: 1,
+                                        repetitionPenalty: 1.0)
+        for u in uniforms() {
+            XCTAssertEqual(device(l, config, uniform: u), 37)
+            XCTAssertEqual(host(l, config, uniform: u), 37)
+        }
+    }
+
+    /// `uniform` is documented as `[0, 1)`; both ends have to behave. Zero is the first kept rank
+    /// and anything just under one is the last, on both paths.
+    func testDrawEndpointsMatchHost() {
+        let l = randomLogits(256, seed: 5)
+        let config = ChatSamplingConfig(temperature: 1.0, topK: 12, topP: 0.99, maxTokens: 1,
+                                        repetitionPenalty: 1.0)
+        for u in [Float(0), 0.5, Float(1).nextDown] {
+            XCTAssertEqual(device(l, config, uniform: u), host(l, config, uniform: u), "u=\(u)")
+        }
+    }
+}

--- a/Tests/Qwen3ChatTests/E2EGemma4SamplingParityTests.swift
+++ b/Tests/Qwen3ChatTests/E2EGemma4SamplingParityTests.swift
@@ -1,0 +1,355 @@
+import XCTest
+import Foundation
+import MLX
+import AudioCommon
+@testable import Qwen3Chat
+
+/// The Gemma 4 decode loop against the one it replaced, with the real model behind it.
+///
+/// `ChatSamplerDeviceTests` compares the two samplers on constructed logits, which says nothing
+/// about the loop around them: the previous shape evaluated each step's logits before sampling,
+/// and dropping that `eval` lets MLX schedule the model forward and the sampling as one graph.
+/// Fusion can change how a kernel is dispatched, so the decision that greedy decoding is
+/// unchanged has to be made against real weights, at real context lengths, over enough tokens
+/// for a single flipped argmax to diverge into different text.
+///
+/// `reference` below is the previous loop copied verbatim — prefill, `eval`, pull all 262,144
+/// logits to the host, suppress, sample there. It is the thing under comparison, so it is kept
+/// as it was rather than tidied.
+final class E2EGemma4SamplingParityTests: XCTestCase {
+
+    private static let modelDir: URL = {
+        if let p = ProcessInfo.processInfo.environment["GEMMA4_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return (try? HuggingFaceDownloader.getCacheDirectory(
+            for: "aufklarer/gemma-4-E4B-it-MLX-4bit"))
+            ?? URL(fileURLWithPath: "/nonexistent")
+    }()
+
+    private func loadChat() throws -> Gemma4Chat {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDir.appendingPathComponent("config.json").path) else {
+            throw XCTSkip("Gemma 4 model dir unavailable: \(Self.modelDir.path)")
+        }
+        do { return try Gemma4Chat.fromDirectory(Self.modelDir) }
+        catch { throw XCTSkip("model load failed (weights/metallib): \(error)") }
+    }
+
+    /// Greedy: no draw to differ, so the sequences must match token for token.
+    private static let greedy = ChatSamplingConfig(
+        temperature: 0, topK: 0, topP: 1.0, maxTokens: 200, repetitionPenalty: 1.1)
+
+    // MARK: - The loop being replaced
+
+    /// The decode loop as it stood before sampling moved onto the device, reproduced exactly:
+    /// evaluate the step, copy the whole vocabulary to the host, suppress and sample there.
+    private func reference(
+        _ chat: Gemma4Chat, promptTokens: [Int], sampling: ChatSamplingConfig,
+        onToken: (Int) -> Void = { _ in }
+    ) -> [Int] {
+        func lastLogits(_ logits: MLXArray) -> [Float] {
+            let t = logits.dim(1)
+            let last = logits[0, t - 1].asType(.float32)
+            eval(last)
+            let all: [Float] = last.asArray(Float.self)
+            return Array(all.prefix(chat.denseConfig.vocabSize))
+        }
+        func suppressEndTokens(_ logits: inout [Float]) {
+            let ninf = -Float.greatestFiniteMagnitude
+            for id in chat.gemmaTokenizer.eosTokenIds where id >= 0 && id < logits.count {
+                logits[id] = ninf
+            }
+        }
+
+        chat.resetState()
+        let promptArray = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
+        let prefillLogits = chat.model.lastTokenLogits(inputIds: promptArray, state: &chat.state)
+        eval(prefillLogits)
+        var logits = lastLogits(prefillLogits)
+
+        var history = promptTokens
+        var produced = false
+        var generated: [Int] = []
+        var filter = Gemma4AnswerFilter(tokenizer: chat.gemmaTokenizer)
+
+        for _ in 0 ..< sampling.maxTokens {
+            if !produced { suppressEndTokens(&logits) }
+
+            let next = ChatSampler.sample(
+                logits: logits, config: sampling, previousTokens: history)
+
+            if chat.gemmaTokenizer.eosTokenIds.contains(next) { break }
+            history.append(next)
+            generated.append(next)
+            onToken(next)
+
+            let text = filter.consume(next)
+            if !text.isEmpty { produced = true }
+
+            let arr = MLXArray([Int32(next)]).expandedDimensions(axis: 0)
+            let step = chat.model.forward(inputIds: arr, state: &chat.state)
+            eval(step)
+            logits = lastLogits(step)
+        }
+        return generated
+    }
+
+    private func production(
+        _ chat: Gemma4Chat, promptTokens: [Int], sampling: ChatSamplingConfig
+    ) -> (tokens: [Int], text: String) {
+        var tokens: [Int] = []
+        var text = ""
+        chat.decode(promptTokens: promptTokens, sampling: sampling,
+                    onToken: { tokens.append($0) }, onText: { text += $0 })
+        return (tokens, text)
+    }
+
+    // MARK: - Prompts
+
+    /// Five prompts of increasing length, the last over 2,000 tokens so the comparison covers a
+    /// prefill long enough to exercise the sliding-window layers' cache as well as a short one.
+    ///
+    /// Each asks for a long answer on purpose. A prompt the model can satisfy in a sentence stops
+    /// at the end token after a handful of steps, and a handful of steps is not a parity test: one
+    /// flipped argmax has to have room to turn into different text.
+    private func prompts(_ chat: Gemma4Chat) -> [(name: String, tokens: [Int])] {
+        let filler = """
+            The meeting opened with a review of last quarter's numbers, which came in slightly \
+            ahead of plan on revenue and slightly behind on margin. Procurement raised the cost \
+            of the new tooling, engineering raised the schedule, and nobody raised their hand \
+            when asked who would own the migration. We agreed to revisit it on Thursday.
+            """
+        func encode(_ user: String) -> [Int] {
+            Gemma4ChatTemplate.encode(messages: [
+                ChatMessage(role: .system,
+                            content: "You are a helpful assistant. Answer thoroughly, at length, "
+                                + "and in complete sentences."),
+                ChatMessage(role: .user, content: user),
+            ], tokenizer: chat.gemmaTokenizer)
+        }
+        return [
+            ("tiny", encode("Count from one to sixty, spelling each number out, one per line.")),
+            ("short", encode("Explain in detail how a hash table resolves collisions, covering "
+                             + "chaining and open addressing, with worked examples.")),
+            ("medium", encode("Write a detailed explanation of how TCP congestion control works, "
+                              + "covering slow start, congestion avoidance, fast retransmit and "
+                              + "fast recovery, in at least four paragraphs.")),
+            ("list", encode("List twenty things to check before a long flight. Give each one its "
+                            + "own numbered line with a full sentence of reasoning.")),
+            ("long", encode(String(repeating: filler + "\n\n", count: 45)
+                            + "Summarise the discussion above in detail, covering every point "
+                            + "raised, in at least four hundred words.")),
+        ]
+    }
+
+    // MARK: - Parity
+
+    /// The gate. Both loops drive the model themselves, so this covers the removed per-step `eval`
+    /// as well as the sampler — comparing the samplers on shared logits would not.
+    func testGreedyDecodeMatchesPreviousLoop() throws {
+        let chat = try loadChat()
+        let cases = prompts(chat)
+        XCTAssertGreaterThan(cases.last!.tokens.count, 2000,
+                             "the long prompt must actually be long — got \(cases.last!.tokens.count)")
+
+        for (name, tokens) in cases {
+            let expected = reference(chat, promptTokens: tokens, sampling: Self.greedy)
+            let actual = production(chat, promptTokens: tokens, sampling: Self.greedy)
+            print("[gemma4-parity] \(name): prompt=\(tokens.count) generated=\(actual.tokens.count)")
+            XCTAssertEqual(actual.tokens, expected,
+                           "\(name) (prompt \(tokens.count) tokens) diverged from the host loop")
+            // A short generation would pass this test without testing much; the prompts are
+            // written to run the budget out.
+            XCTAssertGreaterThanOrEqual(actual.tokens.count, 150,
+                                        "\(name) stopped after \(actual.tokens.count) tokens")
+        }
+    }
+
+    /// Greedy is the only comparison that can be exact end to end; with a draw in the loop the two
+    /// paths consume different uniforms and separate immediately. What is checked instead is that
+    /// each step agrees given the *same* draw — the equivalence `ChatSamplerDeviceTests` shows on
+    /// constructed logits, here on the model's own, where the distribution is whatever the model
+    /// produced rather than whatever a test built.
+    ///
+    /// One class of disagreement is allowed and counted rather than failed. The lm_head emits
+    /// bfloat16, which carries eight mantissa bits, so among a few dozen candidates *exactly*
+    /// equal logits are common — and neither path breaks equal probabilities by index. A step
+    /// where the two picked different tokens carrying bit-identical logits picked between two
+    /// tokens the samplers were equally entitled to. A step where they differ on anything else is
+    /// a real divergence, and that is what this fails on.
+    ///
+    /// Measured over the 1,000 steps below: a handful land on such a tie, and none has ever
+    /// differed for another reason.
+    func testSampledStepsMatchHostGivenTheSameDraw() throws {
+        let chat = try loadChat()
+        let sampling = ChatSamplingConfig(temperature: 0.7, topK: 50, topP: 0.9, maxTokens: 200,
+                                          repetitionPenalty: 1.1)
+        var steps = 0, ties = 0
+
+        // Fixed draws: a failure has to be reproducible, and `Float.random` would make the tie
+        // count wander from run to run.
+        var seed: UInt64 = 0x5EED_1234_ABCD_0001
+        func nextUniform() -> Float {
+            seed = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            return Float(seed >> 40) / Float(1 << 24)
+        }
+
+        for (name, promptTokens) in prompts(chat) {
+            chat.resetState()
+            let promptArray = MLXArray(promptTokens.map { Int32($0) }).expandedDimensions(axis: 0)
+            var logits = chat.model.lastTokenLogits(inputIds: promptArray, state: &chat.state)
+
+            var history = promptTokens
+            var produced = false
+            var filter = Gemma4AnswerFilter(tokenizer: chat.gemmaTokenizer)
+            let endTokens = Array(chat.gemmaTokenizer.eosTokenIds)
+            var diverged = 0
+
+            for _ in 0 ..< sampling.maxTokens {
+                let suppressing = produced ? [] : endTokens
+                let u = nextUniform()
+
+                let onDevice = ChatSampler.sampleOnDevice(
+                    logits: logits, config: sampling, suppressing: suppressing,
+                    previousTokens: history, vocabSize: chat.denseConfig.vocabSize,
+                    uniform: u
+                ).item(Int.self)
+
+                var host = logits[0, logits.dim(1) - 1].asType(.float32).asArray(Float.self)
+                host = Array(host.prefix(chat.denseConfig.vocabSize))
+                for id in suppressing where id >= 0 && id < host.count {
+                    host[id] = -Float.greatestFiniteMagnitude
+                }
+                let onHost = ChatSampler.sample(logits: host, config: sampling,
+                                                previousTokens: history, uniform: u)
+
+                if onDevice != onHost {
+                    // Compare what the samplers ranked, which is the penalised logit, not the raw
+                    // one — the penalty can separate two candidates that arrived equal.
+                    var penalised = host
+                    let p = sampling.repetitionPenalty
+                    for tid in Set(history.suffix(64)) where tid >= 0 && tid < penalised.count {
+                        penalised[tid] = penalised[tid] > 0 ? penalised[tid] / p : penalised[tid] * p
+                    }
+                    if penalised[onDevice] == penalised[onHost] {
+                        ties += 1
+                    } else {
+                        diverged += 1
+                        print(String(format: "[gemma4-parity] %@ u=%.6f dev=%d(%.9g) host=%d(%.9g)",
+                                     name, u, onDevice, penalised[onDevice],
+                                     onHost, penalised[onHost]))
+                    }
+                }
+                steps += 1
+
+                let next = onHost
+                if chat.gemmaTokenizer.eosTokenIds.contains(next) { break }
+                history.append(next)
+                if !filter.consume(next).isEmpty { produced = true }
+
+                let arr = MLXArray([Int32(next)]).expandedDimensions(axis: 0)
+                logits = chat.model.forward(inputIds: arr, state: &chat.state)
+            }
+            XCTAssertEqual(diverged, 0,
+                           "\(name): \(diverged) sampled steps chose differently-weighted tokens")
+        }
+        print("[gemma4-parity] sampled steps compared: \(steps), equal-logit ties: \(ties)")
+        XCTAssertGreaterThanOrEqual(steps, 500)
+    }
+
+    // MARK: - Throughput
+
+    /// Both loops, back to back on one loaded model, at a short and a long context.
+    ///
+    /// Measured in the same process on the same weights so the comparison is not across machine
+    /// states; the long context is what matters, since decode cost grows with the KV cache while
+    /// the per-token vocabulary transfer this removes does not.
+    ///
+    /// The clock starts at the first sampled token and stops a fixed number of tokens later.
+    ///
+    /// Both bounds matter. A 10,000-token prefill takes seconds, so leaving it inside would make
+    /// the figure mostly prefill and its run-to-run variance larger than the difference being
+    /// measured — an earlier version differenced two budgets instead and reported a 1.27x that
+    /// was prefill noise. And a fixed window rather than "however many tokens came out" is what
+    /// makes the two loops comparable when sampling: they consume different draws, stop at
+    /// different lengths, and per-token cost rises with the cache, so an unequal number of tokens
+    /// compares different things.
+    func testDecodeThroughput() throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["GEMMA4_BENCH"] != nil,
+                          "set GEMMA4_BENCH=1 to measure decode throughput")
+        let chat = try loadChat()
+        let window = 64
+        let sampling = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 256,
+                                          repetitionPenalty: 1.1)
+
+        func msPerToken(_ loop: ((Int) -> Void) -> Void) -> Double {
+            var start: Date?
+            var end: Date?
+            var counted = 0
+            loop { _ in
+                if start == nil { start = Date() } else { counted += 1 }
+                if counted == window && end == nil { end = Date() }
+            }
+            guard let start, let end else { return .nan }
+            return end.timeIntervalSince(start) * 1000 / Double(window)
+        }
+
+        // Assembled from token ids rather than by encoding a huge string. The prompt only has to
+        // be long enough to load the KV cache to the right depth, and tokenising tens of thousands
+        // of tokens would take longer than the decode being measured. The layout is
+        // `Gemma4ChatTemplate`'s.
+        let tok = chat.gemmaTokenizer
+        let filler = tok.encode("The migration plan was reviewed again, and the schedule slipped "
+                                + "again, and the owner was still unnamed. ")
+        func prompt(targetTokens: Int) -> [Int] {
+            var ids = [tok.bosTokenId]
+            ids += tok.encode("<|turn>user\n")
+            let tail = tok.encode("\n\nSummarise the above.") + tok.encode("<turn|>\n")
+                + tok.encode("<|turn>model\n")
+            while ids.count + filler.count + tail.count <= targetTokens { ids += filler }
+            return ids + tail
+        }
+
+        // Both configurations, because they take different device paths: greedy stops at an
+        // `argMax` over the vocabulary, while sampling ranks it and runs the nucleus filters.
+        let sampled = ChatSamplingConfig(temperature: 0.7, topK: 50, topP: 0.9, maxTokens: 256,
+                                         repetitionPenalty: 1.1)
+        let warm = ChatSamplingConfig(temperature: 0, topK: 0, topP: 1.0, maxTokens: 4,
+                                      repetitionPenalty: 1.1)
+
+        for target in [500, 10_000] {
+            let tokens = prompt(targetTokens: target)
+            // Warm both paths for this shape so the first timed run isn't paying for dispatch.
+            _ = production(chat, promptTokens: tokens, sampling: warm)
+            _ = reference(chat, promptTokens: tokens, sampling: warm)
+
+            for (label, config) in [("greedy", sampling), ("sampled", sampled)] {
+                // Interleaved and repeated, so a thermal drift over the run moves both figures
+                // instead of only the second, and the best of each stands for the machine when it
+                // was not busy with something else.
+                var host = Double.infinity, device = Double.infinity
+                for _ in 0 ..< 3 {
+                    host = min(host, msPerToken { emit in
+                        _ = reference(chat, promptTokens: tokens, sampling: config, onToken: emit)
+                    })
+                    device = min(device, msPerToken { emit in
+                        chat.decode(promptTokens: tokens, sampling: config,
+                                    onToken: emit, onText: { _ in })
+                    })
+                }
+                print(String(format: "[gemma4-bench] context=%d %@ window=%d host=%.2f ms/tok "
+                                     + "device=%.2f ms/tok speedup=%.3fx",
+                             tokens.count, label, window, host, device, host / device))
+                XCTAssertFalse(host.isNaN || device.isNaN,
+                               "\(label) at \(tokens.count): fewer than \(window) tokens generated")
+            }
+
+            // Only greedy can be compared token for token: with a draw in the loop the two runs
+            // consume different uniforms.
+            XCTAssertEqual(production(chat, promptTokens: tokens, sampling: sampling).tokens,
+                           reference(chat, promptTokens: tokens, sampling: sampling),
+                           "diverged at context \(tokens.count)")
+        }
+    }
+}

--- a/docs/models/gemma4-chat.md
+++ b/docs/models/gemma4-chat.md
@@ -105,13 +105,44 @@ for try await chunk in chat.generateStream(messages: messages, sampling: samplin
 }
 ```
 
+## Decode Path
+
+Each decode step is one lazy MLX graph: the model forward, end-token suppression, the repetition penalty, top-K/top-P and the draw. Reading the sampled token id is the only point the graph is waited on, and the only thing that crosses the GPU boundary is that one `Int32`.
+
+Sampling has two implementations of one set of rules:
+
+| | `ChatSampler.sample` | `ChatSampler.sampleOnDevice` |
+|---|---|---|
+| Input | `[Float]` of `vocabSize` | `MLXArray` logits, already on device |
+| Cost per token | the whole vocabulary copied to the host, twice more on arrival, then O(V) host scans | a scalar read |
+| Used by | `Qwen35MLXChat`, `Qwen3DenseChat`, `Qwen35CoreMLChat`, `MLXGenerator` | `Gemma4Chat` |
+
+Gemma 4's vocabulary is 262,144 entries, so the host form is a megabyte per generated token. The device form applies the same rules — suppression to `-greatestFiniteMagnitude`, the penalty's divide-when-positive/multiply-when-not over the last 64 ids, top-K by logit (equivalent to top-K by probability, since softmax is monotonic), the shortest cumulative prefix reaching top-P, and an inverse-CDF draw.
+
+The win is small and worth stating as such. On an E4B INT4 checkpoint, decode is dominated by streaming 4.2 GB of weights, and sampling is a few percent of a token either way. Best of three runs over a fixed 64-token window with the prefill outside the clock:
+
+| Context | Sampling | Host | Device |
+|---:|---|---:|---:|
+| 498 | greedy | 13.99 ms/tok | 13.35 ms/tok |
+| 498 | temperature 0.7 | 13.85 ms/tok | 13.84 ms/tok |
+| 9,990 | greedy | 20.24 ms/tok | 19.68 ms/tok |
+| 9,990 | temperature 0.7 | 20.33 ms/tok | 20.30 ms/tok |
+
+Greedy gains 3–5%; sampling breaks even, because ranking 262,144 entries with `argSort` costs about what the copy and the host's top-K heap did. Measure before assuming otherwise — an earlier version of the benchmark divided a total by a token count and reported 1.27x that was entirely prefill variance.
+
+Nothing about the construction makes the two agree, so tests hold them together. `ChatSampler.sample(…uniform:)` takes the nucleus draw as a parameter rather than drawing it, which makes both paths pure functions of the same inputs and lets them be compared token-for-token over a sweep of draws.
+
+The one divergence is inherent: neither path breaks equal probabilities by index — the host ranks candidates with `Array.sort`, the device with `argSort` — so on exactly equal logits they may return different tokens *of equal probability*. The lm_head emits bfloat16, whose eight mantissa bits make exact ties common in the tail of a nucleus; measured over 1,000 sampled steps of a real decode, six landed on such a tie and none differed for any other reason. Greedy decoding is unaffected, because `argMax` and the host's strict `>` scan both take the lowest index among equal maxima.
+
 ## Verification
 
 The backend has both deterministic and E2E coverage:
 
 - `ChatModelConfigTests` checks nested Gemma 4 config parsing and derived layer types.
+- `ChatSamplerDeviceTests` compares the device sampler against the host one on constructed logits: greedy equality, tie-breaking, the repetition penalty, end-token suppression, and the top-K/top-P reachable sets, including an exactly representable top-P boundary.
 - `E2EGemma4ParityTests` verifies next-token argmax against the `mlx_lm` reference.
 - `E2EGemma4GenTests` verifies streaming generation, thought-channel suppression, and cache-path first-token parity.
+- `E2EGemma4SamplingParityTests` runs the previous host-sampling loop and the current one against the real weights and requires identical greedy token sequences; `GEMMA4_BENCH=1` additionally reports ms/token for both at short and long contexts.
 
 Reference parity prompt:
 
@@ -123,8 +154,10 @@ Reference parity prompt:
 
 ```text
 Sources/Qwen3Chat/
-  Gemma4Chat.swift           Public loader, streaming generation, answer filter, chat template
+  Gemma4Chat.swift           Public loader, decode loop, streaming generation, answer filter, chat template
   Gemma4Model.swift          Gemma 4 text transformer layers and incremental state
   Gemma4Tokenizer.swift      SentencePiece byte-fallback tokenizer
   Gemma4WeightLoading.swift  MLX safetensors loader for Gemma 4 key layout
+  ChatSampler.swift          Host sampler over a [Float] vocabulary
+  ChatSamplerMLX.swift       The same rules as MLX ops, sampling without leaving the device
 ```


### PR DESCRIPTION
## What changed

Gemma 4's decode loop sampled on the host. `lastLogits` evaluated the step, copied all 262,144 logits off the device, then copied them again through `prefix`; `ChatSampler` made a third copy and ran the repetition penalty, temperature, top-K and top-P as O(V) Swift scans. A megabyte and four passes over it, per generated token, to choose one integer.

`ChatSampler.sampleOnDevice` makes the same decisions as MLX ops and returns a scalar. A decode step — model forward, end-token suppression, penalty, nucleus filtering, draw — is now one lazy graph, and reading the sampled id is the only place it is waited on, down from two evaluations per token. The budget's last token no longer triggers a full forward whose logits nothing reads.

`Gemma4Chat.generateStream`'s loop moved into `decode(promptTokens:sampling:onToken:onText:)` so the parity test can compare token ids against the same code production runs, rather than against a copy of it.

`ChatSampler` is shared with Qwen3.5 and the CoreML/MLX generators. Nothing about their call sites changed: the device path is additive, and the existing `sample(logits:config:previousTokens:)` still draws its own uniform.

## Performance — the win is small

Decode on an E4B INT4 checkpoint is dominated by streaming 4.2 GB of weights. Sampling was a few percent of a token, and is a few percent less now. Best of three runs, fixed 64-token window, prefill outside the clock, release build:

| Context | Sampling | Host | Device | |
|---:|---|---:|---:|---:|
| 498 | greedy | 13.99 ms/tok | 13.35 ms/tok | 1.048x |
| 498 | temperature 0.7 | 13.85 ms/tok | 13.84 ms/tok | 1.001x |
| 9,990 | greedy | 20.24 ms/tok | 19.68 ms/tok | 1.028x |
| 9,990 | temperature 0.7 | 20.33 ms/tok | 20.30 ms/tok | 1.001x |

Sampling breaks even because ranking 262,144 entries with `argSort` costs about what the copy and the host's top-K heap did: measured in isolation, `argMax` over the vocabulary is 0.188 ms, `argSort` 0.344 ms, and `argPartition` 0.340 ms — MLX's Metal backend reaches partition through a sort, so there is no cheaper selection to switch to. It is kept on one path rather than branching on temperature, since it is never slower and still removes the transfer.

Two earlier versions of this benchmark reported larger wins and both were wrong, which is worth recording. Dividing a run's total time by its token count measures mostly prefill at a 10,000-token context; differencing two budgets to cancel the prefill amplifies its variance by the inverse of the span, and reported 1.27x. Timing a fixed window that starts at the first sampled token is what gives the numbers above.

## Behavioural equivalence

Sampling is output-affecting, so the second implementation is held to the first by test rather than by construction. `ChatSampler.sample` gains an overload taking the nucleus draw instead of drawing it, which makes both paths pure functions of the same inputs.

**Greedy parity is exact.** `E2EGemma4SamplingParityTests.testGreedyDecodeMatchesPreviousLoop` runs the previous loop verbatim and the current one, both driving the model, over five prompts of 46 / 51 / 62 / 55 / 2,931 tokens at 200 generated tokens each. All five sequences identical. Both loops drive the model themselves, so this covers the removed per-step `eval` — comparing samplers on shared logits would not.

**Sampled steps agree given the same draw.** `testSampledStepsMatchHostGivenTheSameDraw` compares both samplers on the model's own logits at 1,000 steps of a real decode with a fixed draw sequence. Zero real divergences; six steps chose different tokens carrying **bit-identical** logits.

That last class is inherent and is counted rather than failed. Neither path breaks equal probabilities by index — the host ranks with `Array.sort`, the device with `argSort` — and the lm_head emits bfloat16, whose eight mantissa bits make exact ties common in the tail of a nucleus. A step that picks between two equally weighted tokens picked one the samplers were equally entitled to. Greedy is unaffected: `argMax` and the host's strict `>` scan both take the lowest index, and there is a test pinning that.

**Per behaviour**, `ChatSamplerDeviceTests` (15 cases) compares device against host on constructed logits: greedy over random vocabularies, greedy ties, `vocabSize` trimming, the repetition penalty (window, sign asymmetry, duplicates, out-of-range ids, penalty of 1.0 being off), end-token suppression including its overflow interaction with the penalty, top-K and top-P reachable sets over a 256-draw sweep, and the draw endpoints. Four sampling configurations match token-for-token across the sweep with zero mismatches.

The top-P boundary case uses eight equal logits, giving exactly `1/8` each with exact partial sums: a boundary that only lands on the threshold in real arithmetic is decided by the last float digit of each path independently, and agreeing there would be luck rather than equivalence. Equal logits make the survivors' identity arbitrary, so that test asserts how many survive; a separate test asserts the tokens themselves on well-separated probabilities.

## Tests

`swift test` with the CI skip list: 1,175 → 1,190 tests, 35 skipped, 0 failures. The 15 new ones are `ChatSamplerDeviceTests`, which needs the metallib but no model download.

`E2EGemma4SamplingParityTests` is E2E-prefixed and skips without weights. `GEMMA4_BENCH=1` opts into the throughput test, which is otherwise skipped even locally.

## Noted, not addressed

Per-token cost rises from ~14 ms at a 498-token context to ~20 ms at 9,990. The producing attention layers rebuild their KV cache with `concatenated([pk, k], axis: 2)` on every step, so each token copies the whole cache rather than appending to it. That is where the remaining growth is, and it is a separate change from this one.
