### PR TITLE
Append Gemma 4's KV cache in place and bound its sliding layers

### DIFF
--- a/Sources/Qwen3Chat/Gemma4Model.swift
+++ b/Sources/Qwen3Chat/Gemma4Model.swift
@@ -260,10 +260,11 @@ public final class Gemma4KVCache {
     private let retention: Int?
 
     /// Entries left spare at the end of the buffer when it is rebuilt — how many decode steps can
-    /// then be written in place before the next rebuild. One window's worth: it adds 1 MB to the
-    /// 21 MB a bounded sliding cache already takes, and it amortises a global layer's rebuild —
-    /// which copies the whole cache, since none of it may be dropped — over 512 steps, half a
-    /// megabyte a step at 17k tokens against the 975 MB a step this replaced.
+    /// then be written in place before the next rebuild. One window's worth, which costs a sliding
+    /// layer as much again as it keeps: 21 MB of spare across the twenty of them beside the 21 MB
+    /// they hold. That is bought against the global caches, which may drop nothing and so rebuild
+    /// the whole 285 MB they reach at 17k tokens — amortised over 512 steps, half a megabyte a step
+    /// against the 975 MB a step this replaced.
     private static let spareCapacity = 512
 
     init(retention: Int?, startingAt position: Int) {
@@ -1006,7 +1007,7 @@ public final class Gemma4Model: Module {
         for i in producingLayers where state.kvCaches[i] == nil {
             state.kvCaches[i] = Gemma4KVCache(
                 retention: config.layerTypes[i] == "full_attention"
-                    ? nil : config.slidingWindow - 1,
+                    ? nil : max(0, config.slidingWindow - 1),
                 startingAt: offset)
         }
 

--- a/Sources/Qwen3Chat/Gemma4Model.swift
+++ b/Sources/Qwen3Chat/Gemma4Model.swift
@@ -19,8 +19,10 @@ import MLXCommon
 //   • Per-layer input gating after the FFN block; per-layer layer_scalar.
 //   • Final: norm → tied lm_head → logit_softcap(30).
 //
-// This is a parity port — a single forward pass over the prompt (no incremental KV cache object);
-// shared layers reuse the (keys, values) computed by their producing layer in the same pass.
+// `hidden(inputIds:)` is the parity port: one forward pass over the prompt with nothing cached,
+// where shared layers reuse the (keys, values) their producing layer computed in the same pass.
+// Generation goes through `Gemma4KVCache` instead, and the two are held against each other by
+// `E2EGemma4KVCacheTests`.
 
 // MARK: - Config
 
@@ -213,6 +215,155 @@ struct Gemma4AttentionBlock {
     let mask: MLXFast.ScaledDotProductAttentionMaskMode
 }
 
+// MARK: - KV cache
+
+/// The key axis one attention pass runs over: `length` keys, the first of which holds absolute
+/// token position `base`.
+///
+/// `base` is 0 for a cache that still starts where the sequence does, and only moves once a sliding
+/// layer begins dropping what it can no longer read.
+struct Gemma4KeyAxis {
+    var base: Int
+    var length: Int
+}
+
+/// One producing layer's post-RoPE K/V cache.
+///
+/// The arrays attention reads *are* this buffer, so a decode step writes its one token into spare
+/// capacity instead of allocating a new array and copying every cached token into it to add one.
+/// What that replaces is `concatenated([past, new])`, once per producing layer per step: 57 KB per
+/// token of context across the 24 of them, so 975 MB copied on every step at 17k tokens and O(n²)
+/// over a generation. MLX donates a slice assignment's input buffer when nothing else holds it, so
+/// the write lands in place and the per-step cost stops depending on how much is cached.
+///
+/// `base` is the absolute token position of entry 0. A sliding layer's attention cannot read
+/// further back than `slidingWindow`, so entries that fall out of it are dropped and `base` moves;
+/// every key range in `attentionBlocks` is derived in absolute positions and translated through it.
+/// Global layers keep everything, so their `base` stays 0.
+///
+/// A reference type deliberately. The write above is visible through every reference to the cache,
+/// so a value type would promise a copy it does not make.
+public final class Gemma4KVCache {
+    /// `[B, Hkv, capacity, D]`, nil until the first append. Only `0 ..< count` along the token axis
+    /// holds real entries; the rest is the room the next decode steps write into.
+    private var storedKeys: MLXArray?
+    private var storedValues: MLXArray?
+
+    /// Live entries — the post-RoPE K/V for absolute positions `base ..< base + count`.
+    public private(set) var count = 0
+    /// Absolute token position of entry 0.
+    public private(set) var base = 0
+
+    /// How many of the newest entries a later query can still reach, or nil where none of them ever
+    /// expire. A sliding layer's next query reaches `slidingWindow - 1` tokens behind itself and no
+    /// further, so that is exactly what has to survive it; a global layer's reaches everything.
+    private let retention: Int?
+
+    /// Entries left spare at the end of the buffer when it is rebuilt — how many decode steps can
+    /// then be written in place before the next rebuild. One window's worth: it adds 1 MB to the
+    /// 21 MB a bounded sliding cache already takes, and it amortises a global layer's rebuild —
+    /// which copies the whole cache, since none of it may be dropped — over 512 steps, half a
+    /// megabyte a step at 17k tokens against the 975 MB a step this replaced.
+    private static let spareCapacity = 512
+
+    init(retention: Int?, startingAt position: Int) {
+        self.retention = retention
+        self.base = position
+    }
+
+    private var capacity: Int { storedKeys?.dim(2) ?? 0 }
+
+    /// How many of the oldest entries `append` will drop to fit `t` more.
+    ///
+    /// Only a rebuild can drop anything — while the buffer has room the write goes in place and
+    /// nothing moves — and a rebuild drops only what has expired. Everything else is kept, so this
+    /// is 0 far more often than not.
+    private func dropped(appending t: Int) -> Int {
+        guard storedKeys != nil, count + t > capacity, let retention else { return 0 }
+        return count - min(count, retention)
+    }
+
+    /// The key axis the pass appending `t` entries will attend over.
+    ///
+    /// The pass has to ask before it appends, because it plans one geometry for every layer of a
+    /// type and the append is what moves `base`. Asking the cache rather than re-deriving the rule
+    /// keeps the answer and the act the same decision.
+    func keyAxis(appending t: Int) -> Gemma4KeyAxis {
+        let expired = dropped(appending: t)
+        return Gemma4KeyAxis(base: base + expired, length: count - expired + t)
+    }
+
+    /// The keys and values attention reads: entries `0 ..< count`, with the spare room excluded.
+    /// Valid only once this pass's tokens have been appended, which for a KV-shared layer its
+    /// producing layer has always already done.
+    func window() -> (MLXArray, MLXArray) {
+        guard let storedKeys, let storedValues else {
+            preconditionFailure("Gemma4KVCache read before anything was appended to it")
+        }
+        guard count < capacity else { return (storedKeys, storedValues) }
+        return (storedKeys[0..., 0..., 0 ..< count, 0...],
+                storedValues[0..., 0..., 0 ..< count, 0...])
+    }
+
+    /// Append this pass's post-RoPE K/V, in place wherever the buffer still has room for them.
+    func append(keys k: MLXArray, values v: MLXArray) {
+        let t = k.dim(2)
+        guard let storedKeys, let storedValues else {
+            // Nothing cached yet, so there is nothing to copy these onto: the projection's own
+            // arrays become the buffer, and a prompt prefill costs no copy at all. `trim` hands a
+            // sliding layer its spare room back immediately afterwards; a global layer, which may
+            // drop nothing, grows on its first decode step instead.
+            self.storedKeys = k
+            self.storedValues = v
+            count = t
+            return
+        }
+        guard count + t <= capacity else {
+            rebuild(keeping: count - dropped(appending: t), appending: (k, v))
+            return
+        }
+        storedKeys[0..., 0..., count ..< (count + t), 0...] = k
+        storedValues[0..., 0..., count ..< (count + t), 0...] = v
+        count += t
+    }
+
+    /// Drop whatever no later query can reach, between passes.
+    ///
+    /// `append` already drops what has expired whenever it has to rebuild, so in steady decode this
+    /// changes nothing. It is for the pass that stored a whole prompt into a window-bounded cache —
+    /// its own early queries needed all of it — which would otherwise hold the entire prompt in
+    /// twenty sliding layers until the next token asked for room.
+    func trim() {
+        guard let retention, count > retention + Self.spareCapacity else { return }
+        rebuild(keeping: retention, appending: nil)
+    }
+
+    /// Move the newest `keep` entries, plus any new ones, into a buffer sized for them and the
+    /// spare room, and advance `base` past what was left behind.
+    private func rebuild(keeping keep: Int, appending new: (MLXArray, MLXArray)?) {
+        guard let oldKeys = storedKeys, let oldValues = storedValues else { return }
+        let dropped = count - keep
+        let added = new?.0.dim(2) ?? 0
+        let live = keep + added
+        let capacity = live + Self.spareCapacity
+
+        func rebuilt(_ old: MLXArray, _ appended: MLXArray?) -> MLXArray {
+            let grown = MLXArray.zeros([old.dim(0), old.dim(1), capacity, old.dim(3)],
+                                       dtype: old.dtype)
+            if keep > 0 {
+                grown[0..., 0..., 0 ..< keep, 0...] = old[0..., 0..., dropped ..< count, 0...]
+            }
+            if let appended { grown[0..., 0..., keep ..< live, 0...] = appended }
+            return grown
+        }
+
+        storedKeys = rebuilt(oldKeys, new?.0)
+        storedValues = rebuilt(oldValues, new?.1)
+        base += dropped
+        count = live
+    }
+}
+
 // MARK: - Attention
 
 public final class Gemma4Attention: Module {
@@ -285,13 +436,14 @@ public final class Gemma4Attention: Module {
 
     /// - Parameters:
     ///   - sharedKV: post-RoPE (keys, values) from the producing layer (KV-shared layers only).
-    ///     When non-nil this is the FULL cache to attend over (no past is concatenated).
-    ///   - pastKV: previously cached post-RoPE (keys, values) for a *producing* layer in incremental
-    ///     decode; this step's new K/V are concatenated onto it. Ignored when `sharedKV` is set.
-    ///   - offset: RoPE position offset for the *new* tokens (== number of cached positions).
+    ///     When non-nil this is the FULL cache to attend over (nothing of this call's is added).
+    ///   - cache: a *producing* layer's running cache in incremental decode. This call's post-RoPE
+    ///     K/V are appended to it and the keys attended over are the window it then holds. Ignored
+    ///     when `sharedKV` is set, and nil for the whole-prompt forward, which caches nothing.
+    ///   - offset: RoPE position offset for the *new* tokens (== number of positions already seen).
     /// - Returns: (q [B,Hq,T,D], full keys, full values [B,Hkv,Tk,D]).
     private func projectQKV(
-        _ x: MLXArray, sharedKV: (MLXArray, MLXArray)?, pastKV: (MLXArray, MLXArray)?, offset: Int
+        _ x: MLXArray, sharedKV: (MLXArray, MLXArray)?, cache: Gemma4KVCache?, offset: Int
     ) -> (MLXArray, MLXArray, MLXArray) {
         let b = x.dim(0), t = x.dim(1)
 
@@ -300,7 +452,7 @@ public final class Gemma4Attention: Module {
         let keys: MLXArray
         let values: MLXArray
         if let (sk, sv) = sharedKV {
-            // KV-shared layer: attend over the producing layer's full cache, read-only.
+            // KV-shared layer: attend over the producing layer's window, read-only.
             keys = sk
             values = sv
         } else {
@@ -311,13 +463,17 @@ public final class Gemma4Attention: Module {
             var v = vNorm!(vProj!(x).reshaped(b, t, nKVHeads, headDim))
             v = v.transposed(0, 2, 1, 3)
 
-            // Producing layer: append this step's post-RoPE K/V to the running cache.
-            if let (pk, pv) = pastKV {
-                k = concatenated([pk, k], axis: 2)
-                v = concatenated([pv, v], axis: 2)
+            // Producing layer: hand this step's post-RoPE K/V to the cache, which writes them into
+            // spare capacity rather than rebuilding an array around them.
+            if let cache {
+                cache.append(keys: k, values: v)
+                let window = cache.window()
+                keys = window.0
+                values = window.1
+            } else {
+                keys = k
+                values = v
             }
-            keys = k
-            values = v
         }
 
         q = q.transposed(0, 2, 1, 3)
@@ -332,9 +488,9 @@ public final class Gemma4Attention: Module {
     /// - Returns: (output [B,T,hidden], full (keys,values) attended over [B,Hkv,Tk,D]).
     public func callAsFunction(
         _ x: MLXArray, mask: MLXArray, sharedKV: (MLXArray, MLXArray)?,
-        pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+        cache: Gemma4KVCache? = nil, offset: Int
     ) -> (MLXArray, (MLXArray, MLXArray)) {
-        let (q, keys, values) = projectQKV(x, sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+        let (q, keys, values) = projectQKV(x, sharedKV: sharedKV, cache: cache, offset: offset)
         let attnOut = SDPA.attendAndMerge(
             qHeads: q, kHeads: keys, vHeads: values, scale: scale, mask: mask)
         return (oProj(attnOut), (keys, values))
@@ -349,9 +505,9 @@ public final class Gemma4Attention: Module {
     /// projection stays one matmul rather than one per block.
     func callAsFunction(
         _ x: MLXArray, blocks: [Gemma4AttentionBlock], sharedKV: (MLXArray, MLXArray)?,
-        pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+        cache: Gemma4KVCache? = nil, offset: Int
     ) -> (MLXArray, (MLXArray, MLXArray)) {
-        let (q, keys, values) = projectQKV(x, sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+        let (q, keys, values) = projectQKV(x, sharedKV: sharedKV, cache: cache, offset: offset)
 
         let attnOut: MLXArray
         if blocks.count == 1 {
@@ -446,20 +602,20 @@ public final class Gemma4Layer: Module {
     /// - Returns: (hidden_out, (keys,values) this layer used) so producing layers' K/V can be shared.
     public func callAsFunction(
         _ x: MLXArray, mask: MLXArray, perLayerInput: MLXArray,
-        sharedKV: (MLXArray, MLXArray)?, pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+        sharedKV: (MLXArray, MLXArray)?, cache: Gemma4KVCache? = nil, offset: Int
     ) -> (MLXArray, (MLXArray, MLXArray)) {
         let (attnOut, kv) = attn(inputLayerNorm(x), mask: mask, sharedKV: sharedKV,
-                                 pastKV: pastKV, offset: offset)
+                                 cache: cache, offset: offset)
         return (feedForward(residual: x, attnOut: attnOut, perLayerInput: perLayerInput), kv)
     }
 
     /// Blocked attention variant — identical outside the attention call itself.
     func callAsFunction(
         _ x: MLXArray, blocks: [Gemma4AttentionBlock], perLayerInput: MLXArray,
-        sharedKV: (MLXArray, MLXArray)?, pastKV: (MLXArray, MLXArray)? = nil, offset: Int
+        sharedKV: (MLXArray, MLXArray)?, cache: Gemma4KVCache? = nil, offset: Int
     ) -> (MLXArray, (MLXArray, MLXArray)) {
         let (attnOut, kv) = attn(inputLayerNorm(x), blocks: blocks, sharedKV: sharedKV,
-                                 pastKV: pastKV, offset: offset)
+                                 cache: cache, offset: offset)
         return (feedForward(residual: x, attnOut: attnOut, perLayerInput: perLayerInput), kv)
     }
 
@@ -507,8 +663,19 @@ public final class Gemma4Model: Module {
     @ModuleInfo var layers: [Gemma4Layer]
     @ModuleInfo var norm: RMSNorm
 
+    /// Layers that own a KV cache — the ones `previousKVs` maps to themselves.
+    private let producingLayers: [Int]
+    /// The first producing layer of each type. Its cache answers for every cache of that type,
+    /// since they are all appended to and trimmed together — see `hidden(inputIds:state:)`.
+    private let fullProducer: Int?
+    private let slidingProducer: Int?
+
     public init(config c: Gemma4DenseConfig) {
         self.config = c
+        let previous = c.previousKVs
+        self.producingLayers = (0..<c.numHiddenLayers).filter { previous[$0] == $0 }
+        self.fullProducer = producingLayers.first { c.layerTypes[$0] == "full_attention" }
+        self.slidingProducer = producingLayers.first { c.layerTypes[$0] != "full_attention" }
         self.embedScale = sqrt(Float(c.hiddenSize))
         self.perLayerInputScale = pow(2.0, -0.5)
         self.perLayerProjectionScale = pow(Float(c.hiddenSize), -0.5)
@@ -582,14 +749,19 @@ public final class Gemma4Model: Module {
         let queryOffset: Int
     }
 
-    /// Plan one attention pass: `tq` new queries at absolute positions `offset ..< offset+tq`,
-    /// keys covering absolute `0 ..< tk`. `windowSize` nil means global attention.
+    /// Plan one attention pass: `tq` new queries at absolute positions `offset ..< offset+tq`, over
+    /// `tk` keys whose first holds absolute position `keyBase`. `windowSize` nil means global.
+    ///
+    /// `keyBase` is what a window-bounded cache costs. A sliding layer drops the entries it can no
+    /// longer read, so key `j` is token `keyBase + j` rather than token `j`; every bound below is
+    /// derived in absolute positions and translated onto the key axis once, at the end. Leave it 0
+    /// for a cache that still starts where the sequence does.
     ///
     /// Two block shapes need no mask array at all. A one-query block (every decode step) reaches
-    /// every key in its own slice, and a block whose slice starts at position 0 with no query's
-    /// window biting is exactly the end-aligned causal case MLX derives itself — which is every
-    /// block of a full-attention layer, so those layers now allocate no mask whatever the length.
-    static func attentionBlocks(queryLen tq: Int, keyLen tk: Int, offset: Int,
+    /// every key in its own slice, and a block whose slice starts at the first cached key with no
+    /// query's window biting is exactly the end-aligned causal case MLX derives itself — which is
+    /// every block of a full-attention layer, so those allocate no mask whatever the length.
+    static func attentionBlocks(queryLen tq: Int, keyLen tk: Int, offset: Int, keyBase: Int = 0,
                                 windowSize: Int?, dtype: DType) -> [Gemma4AttentionBlock] {
         var blocks: [Gemma4AttentionBlock] = []
         var masks: [BlockMaskKey: MLXArray] = [:]
@@ -599,18 +771,19 @@ public final class Gemma4Model: Module {
             let firstQuery = offset + start
             let lastQuery = offset + end - 1
             // Causal: nothing above the block's last query. Windowed: nothing below the first
-            // query's window floor, since a later query's floor is only ever higher.
-            let keyEnd = min(lastQuery + 1, tk)
-            let keyStart = windowSize.map { max(0, firstQuery - $0 + 1) } ?? 0
+            // query's window floor, since a later query's floor is only ever higher. Both are
+            // absolute positions, so both shift down by the position the key axis starts at.
+            let keyEnd = min(lastQuery + 1 - keyBase, tk)
+            let keyStart = windowSize.map { max(0, firstQuery - $0 + 1 - keyBase) } ?? 0
 
             let mask: MLXFast.ScaledDotProductAttentionMaskMode
             if end - start == 1 {
                 mask = .none
-            } else if keyStart == 0, windowSize.map({ lastQuery < $0 }) ?? true {
+            } else if keyStart == 0, windowSize.map({ lastQuery < $0 + keyBase }) ?? true {
                 mask = .causal
             } else {
                 let key = BlockMaskKey(queries: end - start, keys: keyEnd - keyStart,
-                                       queryOffset: firstQuery - keyStart)
+                                       queryOffset: firstQuery - keyBase - keyStart)
                 let array = masks[key] ?? blockMask(key, windowSize: windowSize, dtype: dtype)
                 masks[key] = array
                 mask = .array(array)
@@ -649,45 +822,51 @@ public final class Gemma4Model: Module {
     /// Test-only: fall back to the full `[1,1,Tq,Tk]` mask for every layer.
     static var usesReferenceFullMask = false
 
-    private func attentionPlan(queryLen tq: Int, keyLen tk: Int, offset: Int,
-                               dtype: DType) -> AttentionPlan {
+    /// The two layer types no longer share a key axis: a sliding layer's cache is bounded to its
+    /// window and starts wherever eviction has left it, while a global layer's still holds the whole
+    /// sequence from position 0. So each is planned against the axis its own caches will present.
+    private func attentionPlan(queryLen tq: Int, offset: Int, dtype: DType,
+                               full: Gemma4KeyAxis, sliding: Gemma4KeyAxis) -> AttentionPlan {
         if Gemma4Model.usesReferenceFullMask {
             return .referenceMasks(
-                full: Self.makeMask(queryLen: tq, keyLen: tk, offset: offset,
-                                    windowSize: nil, dtype: dtype),
-                sliding: Self.makeMask(queryLen: tq, keyLen: tk, offset: offset,
-                                       windowSize: config.slidingWindow, dtype: dtype))
+                full: Self.makeMask(queryLen: tq, keyLen: full.length, offset: offset,
+                                    keyBase: full.base, windowSize: nil, dtype: dtype),
+                sliding: Self.makeMask(queryLen: tq, keyLen: sliding.length, offset: offset,
+                                       keyBase: sliding.base, windowSize: config.slidingWindow,
+                                       dtype: dtype))
         }
         return .blocks(
-            full: Self.attentionBlocks(queryLen: tq, keyLen: tk, offset: offset,
-                                       windowSize: nil, dtype: dtype),
-            sliding: Self.attentionBlocks(queryLen: tq, keyLen: tk, offset: offset,
-                                          windowSize: config.slidingWindow, dtype: dtype))
+            full: Self.attentionBlocks(queryLen: tq, keyLen: full.length, offset: offset,
+                                       keyBase: full.base, windowSize: nil, dtype: dtype),
+            sliding: Self.attentionBlocks(queryLen: tq, keyLen: sliding.length, offset: offset,
+                                          keyBase: sliding.base, windowSize: config.slidingWindow,
+                                          dtype: dtype))
     }
 
     /// Run one layer under the pass's plan.
     private func run(_ layer: Gemma4Layer, _ h: MLXArray, plan: AttentionPlan, isFull: Bool,
                      perLayerInput: MLXArray, sharedKV: (MLXArray, MLXArray)?,
-                     pastKV: (MLXArray, MLXArray)?, offset: Int)
+                     cache: Gemma4KVCache?, offset: Int)
         -> (MLXArray, (MLXArray, MLXArray)) {
         switch plan {
         case .blocks(let full, let sliding):
             return layer(h, blocks: isFull ? full : sliding, perLayerInput: perLayerInput,
-                         sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+                         sharedKV: sharedKV, cache: cache, offset: offset)
         case .referenceMasks(let full, let sliding):
             return layer(h, mask: isFull ? full : sliding, perLayerInput: perLayerInput,
-                         sharedKV: sharedKV, pastKV: pastKV, offset: offset)
+                         sharedKV: sharedKV, cache: cache, offset: offset)
         }
     }
 
     /// Build an additive float mask [1,1,Tq,Tk]: the `Tq` new queries live at absolute positions
-    /// `offset ..< offset+Tq`; the `Tk` keys at `0 ..< Tk` (`Tk == offset + Tq` for a contiguous
-    /// cache). Causal, with an optional sliding window. Reference geometry only — see `AttentionPlan`.
-    static func makeMask(queryLen tq: Int, keyLen tk: Int, offset: Int,
+    /// `offset ..< offset+Tq`; the `Tk` keys at `keyBase ..< keyBase+Tk`, `keyBase` being where the
+    /// cache starts once a sliding layer has dropped what it cannot read. Causal, with an optional
+    /// sliding window. Reference geometry only — see `AttentionPlan`.
+    static func makeMask(queryLen tq: Int, keyLen tk: Int, offset: Int, keyBase: Int = 0,
                          windowSize: Int?, dtype: DType) -> MLXArray {
-        // query absolute pos qi = offset + i ; key absolute pos kj = j.
+        // query absolute pos qi = offset + i ; key absolute pos kj = keyBase + j.
         let qInds = (MLXArray(Int32(0)..<Int32(tq)) + Int32(offset)).reshaped(tq, 1)
-        let kInds = MLXArray(Int32(0)..<Int32(tk)).reshaped(1, tk)
+        let kInds = (MLXArray(Int32(0)..<Int32(tk)) + Int32(keyBase)).reshaped(1, tk)
         var keep = qInds .>= kInds                       // causal
         if let w = windowSize {
             keep = logicalAnd(keep, qInds .< (kInds + w))  // sliding window
@@ -730,7 +909,10 @@ public final class Gemma4Model: Module {
         stat("ple_proj", perLayer)
 
         // Attention geometry per layer type — planned once and shared by every layer of that type.
-        let plan = attentionPlan(queryLen: t, keyLen: t, offset: 0, dtype: dtype)
+        // Nothing is cached on this path, so both types' keys are this pass's own tokens.
+        let plan = attentionPlan(queryLen: t, offset: 0, dtype: dtype,
+                                 full: Gemma4KeyAxis(base: 0, length: t),
+                                 sliding: Gemma4KeyAxis(base: 0, length: t))
 
         let prevKVs = config.previousKVs
         var produced: [(MLXArray, MLXArray)?] = Array(repeating: nil, count: layers.count)
@@ -740,7 +922,7 @@ public final class Gemma4Model: Module {
             let perLayerInput = perLayer[0..., 0..., i, 0...]    // [B,T,256]
             let shared = (prevKVs[i] == i) ? nil : produced[prevKVs[i]]
             let (nh, kv) = run(layer, h, plan: plan, isFull: isFull, perLayerInput: perLayerInput,
-                               sharedKV: shared, pastKV: nil, offset: 0)
+                               sharedKV: shared, cache: nil, offset: 0)
             h = nh
             produced[i] = kv
             if Gemma4Model.debugStats, i < 3 || i == 14 || i == 15 || i == 34 {
@@ -769,9 +951,13 @@ public final class Gemma4Model: Module {
     /// Per-conversation decode state. We keep a KV cache only for the M = (num_layers −
     /// num_kv_shared_layers) *producing* layers (slots for shared layers stay nil); each
     /// shared layer attends over the cache of its mapped producing layer (`previousKVs`).
-    /// `position` is the number of cached token positions (== the RoPE offset for the next step).
+    /// `position` is the number of token positions seen (== the RoPE offset for the next step).
+    ///
+    /// The caches are reference types that a step writes into, so this is a handle to them rather
+    /// than a snapshot of them: copy it and both copies drive the same buffers. Start a second
+    /// conversation with `initial` instead.
     public struct InferenceState {
-        public var kvCaches: [(MLXArray, MLXArray)?]   // indexed by layer; nil on shared layers
+        public var kvCaches: [Gemma4KVCache?]   // indexed by layer; nil on shared layers
         public var position: Int
 
         public static func initial(config c: Gemma4DenseConfig) -> InferenceState {
@@ -784,10 +970,6 @@ public final class Gemma4Model: Module {
     /// Prompt prefill passes the whole prompt (T = prompt length, position 0); each decode step
     /// passes a single token (T = 1). Producing layers append their post-RoPE K/V to their cache;
     /// shared layers read the producing layer's (now-updated) cache read-only.
-    ///
-    /// NOTE: sliding-window layers keep a simple growing cache (no eviction). Their attention only
-    /// ever *reads* the newest `slidingWindow` entries of it — see `attentionBlocks` — so eviction
-    /// would save cache memory at long contexts but change no result.
     public func forward(inputIds: MLXArray, state: inout InferenceState) -> MLXArray {
         softcapped(embedTokens.asLinear(hidden(inputIds: inputIds, state: &state)))  // tied lm_head
     }
@@ -819,9 +1001,22 @@ public final class Gemma4Model: Module {
         let pleRaw = getPerLayerInputs(inputIds)
         let perLayer = projectPerLayerInputs(h, pleRaw)        // [B,T,L,256]
 
-        // Keys span [0, offset+t) — a contiguous growing cache. Tq = t, Tk = offset+t.
-        let tk = offset + t
-        let plan = attentionPlan(queryLen: t, keyLen: tk, offset: offset, dtype: dtype)
+        // A sliding layer's next query reaches `slidingWindow - 1` tokens behind itself, so that is
+        // all its cache has to keep; a global layer keeps everything.
+        for i in producingLayers where state.kvCaches[i] == nil {
+            state.kvCaches[i] = Gemma4KVCache(
+                retention: config.layerTypes[i] == "full_attention"
+                    ? nil : config.slidingWindow - 1,
+                startingAt: offset)
+        }
+
+        // Every producing layer of one type appends the same tokens and drops by the same rule, so
+        // one of them answers for all of them — and for the KV-shared layers reading their buffers.
+        // Asked before anything is appended, because one geometry has to serve the whole pass.
+        let plan = attentionPlan(
+            queryLen: t, offset: offset, dtype: dtype,
+            full: keyAxis(of: fullProducer, in: state, appending: t),
+            sliding: keyAxis(of: slidingProducer, in: state, appending: t))
 
         let prevKVs = config.previousKVs
         for (i, layer) in layers.enumerated() {
@@ -829,15 +1024,33 @@ public final class Gemma4Model: Module {
             let perLayerInput = perLayer[0..., 0..., i, 0...]    // [B,T,256]
 
             let isProducing = (prevKVs[i] == i)
-            let shared = isProducing ? nil : state.kvCaches[prevKVs[i]]
-            let past = isProducing ? state.kvCaches[i] : nil
-            let (nh, kv) = run(layer, h, plan: plan, isFull: isFull, perLayerInput: perLayerInput,
-                               sharedKV: shared, pastKV: past, offset: offset)
+            let shared = isProducing ? nil : state.kvCaches[prevKVs[i]]?.window()
+            let (nh, _) = run(layer, h, plan: plan, isFull: isFull, perLayerInput: perLayerInput,
+                              sharedKV: shared, cache: isProducing ? state.kvCaches[i] : nil,
+                              offset: offset)
             h = nh
-            if isProducing { state.kvCaches[i] = kv }
         }
 
-        state.position = tk
+        // Drop what the sliding layers can no longer read, now that every layer that could still
+        // read it has run — a KV-shared layer's queries are this pass's queries and reach exactly
+        // as far back, so nothing may be dropped before the last of them.
+        //
+        // Trimming each producing layer the moment its own layer finished, which needs the two
+        // whose cache is shared held back to the end anyway, was tried and measured at a 17k
+        // prefill to change peak memory by nothing at all (7.10 GB either way). The peak is set by
+        // the activations mid-stack, not by the caches at the end of it, so the extra state that
+        // variant needed bought a rounding error.
+        for i in producingLayers { state.kvCaches[i]?.trim() }
+
+        state.position = offset + t
         return norm(h)
+    }
+
+    /// The key axis a layer type's caches will all present. A config with no producing layer of a
+    /// type has no layer that would read the answer, so any axis will do.
+    private func keyAxis(of producer: Int?, in state: InferenceState,
+                         appending t: Int) -> Gemma4KeyAxis {
+        producer.flatMap { state.kvCaches[$0]?.keyAxis(appending: t) }
+            ?? Gemma4KeyAxis(base: 0, length: t)
     }
 }

--- a/Tests/Qwen3ChatTests/E2EGemma4KVCacheTests.swift
+++ b/Tests/Qwen3ChatTests/E2EGemma4KVCacheTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+import Foundation
+import MLX
+import AudioCommon
+@testable import Qwen3Chat
+
+/// Gemma 4's KV cache appends in place and drops what a sliding layer can no longer read, so the
+/// map from a cache index to an absolute token position is no longer the identity. Every mask and
+/// key range in `attentionBlocks` is stated in absolute positions and translated through the
+/// cache's `base`; get that translation wrong and attention reads the wrong keys, which produces
+/// fluent, confidently wrong text and no crash at all.
+///
+/// So the cache is checked against implementations that cannot share the mistake:
+///   • `testDecodeMatchesCachelessForward` — greedy decode against re-running the whole prompt
+///     through the no-cache forward at every step. That path has no cache, no eviction and no base,
+///     so agreeing with it over a prompt already past the window is a direct check of the mapping.
+///   • `testPrefillAndDecodeAgree` — one prefill against the same tokens fed one at a time, at
+///     lengths either side of the 512 window. The two drive eviction completely differently: a
+///     prefill stores the whole prompt and trims once, a token-at-a-time run trims repeatedly.
+///
+/// `testGreedyParityAgainstBaseline` is the harness that compares a long greedy run against another
+/// revision's token ids; it needs a file from that other revision, so it stays opt-in.
+final class E2EGemma4KVCacheTests: XCTestCase {
+    private static let modelDir: URL? = {
+        if let p = ProcessInfo.processInfo.environment["GEMMA4_MODEL_DIR"] {
+            return URL(fileURLWithPath: p)
+        }
+        return try? HuggingFaceDownloader.getCacheDirectory(for: "aufklarer/gemma-4-E4B-it-MLX-4bit")
+    }()
+
+    private func loadChat() throws -> Gemma4Chat {
+        guard let dir = Self.modelDir,
+              FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.json").path)
+        else { throw XCTSkip("Gemma 4 model dir unavailable") }
+        do { return try Gemma4Chat.fromDirectory(dir) }
+        catch { throw XCTSkip("model load failed (weights/metallib): \(error)") }
+    }
+
+    // MARK: - Helpers
+
+    private func array(_ tokens: [Int]) -> MLXArray {
+        MLXArray(tokens.map { Int32($0) }).expandedDimensions(axis: 0)
+    }
+
+    /// Greedy argmax of the final row, read off the GPU as one index rather than as 262k floats.
+    private func argmax(_ logits: MLXArray) -> Int {
+        let last = logits[0, logits.dim(1) - 1]
+        let best = MLX.argMax(last, axis: -1)
+        eval(best)
+        return best.item(Int.self)
+    }
+
+    /// Greedy continuation through the incremental cache: one prefill, then one token per step.
+    private func decodeThroughCache(_ chat: Gemma4Chat, prompt: [Int], count: Int) -> [Int] {
+        var state = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+        var next = argmax(chat.model.lastTokenLogits(inputIds: array(prompt), state: &state))
+        var produced = [next]
+        for _ in 1..<count {
+            next = argmax(chat.model.lastTokenLogits(inputIds: array([next]), state: &state))
+            produced.append(next)
+        }
+        return produced
+    }
+
+    // MARK: - Tests
+
+    /// The cache against no cache at all. Every step re-runs the whole sequence through the
+    /// single-pass forward, which knows nothing about eviction — so if a decode step reads keys
+    /// from the wrong absolute positions, the two continuations diverge.
+    ///
+    /// One prompt sits under the 512-token window (nothing is ever evicted) and one well past it
+    /// (every sliding layer is evicting from the first step), because those are different states.
+    func testDecodeMatchesCachelessForward() throws {
+        let chat = try loadChat()
+        for promptLength in [300, 700] {
+            let prompt = E2EGemma4SlidingWindowTests.promptTokens(promptLength, chat.gemmaTokenizer)
+            let steps = 12
+
+            var reference: [Int] = []
+            var sequence = prompt
+            for _ in 0..<steps {
+                let next = argmax(chat.model.forward(inputIds: array(sequence)))
+                reference.append(next)
+                sequence.append(next)
+                Memory.clearCache()
+            }
+
+            let cached = decodeThroughCache(chat, prompt: prompt, count: steps)
+            print("[gemma4-kv] prompt=\(promptLength) cacheless=\(reference) cached=\(cached)")
+            XCTAssertEqual(cached, reference,
+                           "cached decode diverged from the no-cache forward at \(promptLength) tokens")
+            Memory.clearCache()
+        }
+    }
+
+    /// Prefill against one-token-at-a-time, at lengths either side of the window. A prefill writes
+    /// the whole prompt into the cache and trims once; the same tokens fed singly trim over and
+    /// over, so the two arrive at the same cache contents by different routes and must agree on
+    /// what comes next.
+    func testPrefillAndDecodeAgree() throws {
+        let chat = try loadChat()
+        for n in [400, 520, 700] {
+            let tokens = E2EGemma4SlidingWindowTests.promptTokens(n, chat.gemmaTokenizer)
+
+            var prefillState = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+            let prefilled = argmax(chat.model.lastTokenLogits(
+                inputIds: array(tokens), state: &prefillState))
+
+            var stepState = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+            var stepped = -1
+            for token in tokens {
+                stepped = argmax(chat.model.lastTokenLogits(
+                    inputIds: array([token]), state: &stepState))
+            }
+
+            print("[gemma4-kv] tokens=\(n) prefill=\(prefilled) oneAtATime=\(stepped)")
+            XCTAssertEqual(stepped, prefilled,
+                           "prefill and token-at-a-time disagree at \(n) tokens")
+            Memory.clearCache()
+        }
+    }
+
+    /// A prompt prefilled in two chunks must match the same prompt prefilled in one. The split is
+    /// placed so the second chunk starts mid-window, which is the case a cache that tracked its
+    /// contents by count rather than by absolute position would get wrong.
+    func testSplitPrefillMatchesWholePrefill() throws {
+        let chat = try loadChat()
+        let tokens = E2EGemma4SlidingWindowTests.promptTokens(900, chat.gemmaTokenizer)
+        for split in [200, 600] {
+            var whole = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+            let once = argmax(chat.model.lastTokenLogits(inputIds: array(tokens), state: &whole))
+
+            var chunked = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+            eval(chat.model.lastTokenLogits(inputIds: array(Array(tokens.prefix(split))),
+                                            state: &chunked))
+            let twice = argmax(chat.model.lastTokenLogits(
+                inputIds: array(Array(tokens.dropFirst(split))), state: &chunked))
+
+            print("[gemma4-kv] split=\(split) whole=\(once) chunked=\(twice)")
+            XCTAssertEqual(twice, once, "split prefill at \(split) changed the next token")
+            Memory.clearCache()
+        }
+    }
+
+    /// Long greedy runs recorded as token ids, for comparison against another revision.
+    ///
+    /// `GEMMA4_KV_TOKENS` names a JSON file: written when it does not exist, asserted against when
+    /// it does. Greedy decoding is deterministic, so a single differing id is a real defect rather
+    /// than sampling noise. Opt-in because it needs a file produced by a different checkout — the
+    /// two tests above are the ones that stand on their own.
+    func testGreedyParityAgainstBaseline() throws {
+        guard let path = ProcessInfo.processInfo.environment["GEMMA4_KV_TOKENS"] else {
+            throw XCTSkip("set GEMMA4_KV_TOKENS=<file> to record or compare greedy token ids")
+        }
+        let chat = try loadChat()
+        // Under the window, past it, and one long enough that 600 generated tokens cross the
+        // window boundary many times over.
+        let cases: [(prompt: Int, generate: Int)] = [(300, 64), (1_536, 600), (2_048, 200)]
+
+        var produced: [String: [Int]] = [:]
+        for c in cases {
+            let prompt = E2EGemma4SlidingWindowTests.promptTokens(c.prompt, chat.gemmaTokenizer)
+            let tokens = decodeThroughCache(chat, prompt: prompt, count: c.generate)
+            produced["\(c.prompt)x\(c.generate)"] = tokens
+            print("[gemma4-kv] prompt=\(c.prompt) generated=\(tokens.count) head=\(tokens.prefix(8))")
+            Memory.clearCache()
+        }
+
+        let url = URL(fileURLWithPath: path)
+        guard let data = try? Data(contentsOf: url),
+              let baseline = try? JSONDecoder().decode([String: [Int]].self, from: data)
+        else {
+            try JSONEncoder().encode(produced).write(to: url)
+            print("[gemma4-kv] wrote baseline token ids to \(path)")
+            return
+        }
+        XCTAssertEqual(Set(produced.keys), Set(baseline.keys))
+        for (key, expected) in baseline {
+            let actual = produced[key] ?? []
+            if actual != expected {
+                let firstDiff = zip(actual, expected).enumerated().first { $0.element.0 != $0.element.1 }
+                XCTFail("greedy tokens differ for \(key) at index "
+                        + "\(firstDiff?.offset.description ?? "length") "
+                        + "(\(actual.count) vs \(expected.count) tokens)")
+            } else {
+                print("[gemma4-kv] \(key): \(expected.count) tokens identical")
+            }
+        }
+    }
+
+    /// Decode cost and cache residency against context length. Gated on `GEMMA4_DECODE_BENCH` — it
+    /// loads the 4.2 GB checkpoint and prefills 17k tokens, so it is a measurement harness rather
+    /// than a test.
+    func testDecodeScaling() throws {
+        guard ProcessInfo.processInfo.environment["GEMMA4_DECODE_BENCH"] != nil else {
+            throw XCTSkip("set GEMMA4_DECODE_BENCH=1 to measure decode cost")
+        }
+        let chat = try loadChat()
+        // Warm up prefill *and* decode before anything is timed. The first pass after a load pays
+        // for paging 4.2 GB of weights in and for every kernel that has yet to be specialised, and
+        // decode uses kernels prefill never touches — measured, that one-time cost is large enough
+        // to make a 24-step average of the first context look slower than the last one, which is
+        // not a thing decode can do.
+        var warm = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+        let warmPrompt = E2EGemma4SlidingWindowTests.promptTokens(2_048, chat.gemmaTokenizer)
+        eval(chat.model.lastTokenLogits(inputIds: array(warmPrompt), state: &warm))
+        for _ in 0..<16 {
+            eval(chat.model.lastTokenLogits(inputIds: array([warmPrompt[0]]), state: &warm))
+        }
+
+        for n in [512, 2_560, 10_240, 17_408] {
+            let tokens = E2EGemma4SlidingWindowTests.promptTokens(n, chat.gemmaTokenizer)
+            Memory.clearCache()
+            GPU.resetPeakMemory()
+
+            var state = Gemma4Model.InferenceState.initial(config: chat.denseConfig)
+            eval(chat.model.lastTokenLogits(inputIds: array(tokens), state: &state))
+            let afterPrefill = Double(Memory.peakMemory) / 1_073_741_824
+
+            let step = array([tokens[0]])
+            // A few unmeasured steps first: the first decode off a fresh prefill is the one that
+            // grows the global caches out of the buffer the prompt itself became.
+            for _ in 0..<8 { eval(chat.model.lastTokenLogits(inputIds: step, state: &state)) }
+
+            let steps = 64
+            let start = CFAbsoluteTimeGetCurrent()
+            for _ in 0..<steps { eval(chat.model.lastTokenLogits(inputIds: step, state: &state)) }
+            let msPerToken = (CFAbsoluteTimeGetCurrent() - start) / Double(steps) * 1000
+            let resident = Double(Memory.activeMemory) / 1_073_741_824
+
+            print(String(format: "[gemma4-kv-bench] context=%5d decode=%6.2f ms/tok "
+                         + "prefillPeak=%5.2fGB residentAfterDecode=%5.2fGB",
+                         n, msPerToken, afterPrefill, resident))
+        }
+    }
+}

--- a/docs/models/gemma4-chat.md
+++ b/docs/models/gemma4-chat.md
@@ -24,6 +24,7 @@ Gemma 4 text differs from Qwen-style dense chat models in several important ways
 | Attention | Sliding-attention and full-attention layers with different head dimensions |
 | RoPE | Standard sliding RoPE plus proportional RoPE for full attention |
 | KV sharing | Later layers reuse K/V from earlier producer layers of the same attention type |
+| KV cache | Per-producer buffers appended to in place; sliding layers bounded to their window |
 | MLP | Double-wide MLP on KV-shared layers when configured |
 | Logits | Tied LM head followed by final logit softcap |
 
@@ -143,6 +144,11 @@ The backend has both deterministic and E2E coverage:
 - `E2EGemma4ParityTests` verifies next-token argmax against the `mlx_lm` reference.
 - `E2EGemma4GenTests` verifies streaming generation, thought-channel suppression, and cache-path first-token parity.
 - `E2EGemma4SamplingParityTests` runs the previous host-sampling loop and the current one against the real weights and requires identical greedy token sequences; `GEMMA4_BENCH=1` additionally reports ms/token for both at short and long contexts.
+- `E2EGemma4KVCacheTests` holds the incremental KV cache against implementations that cannot share
+  its mistakes: greedy decode against re-running the whole prompt through the no-cache forward, one
+  prefill against the same tokens fed singly, and a split prefill against a whole one. Sliding
+  layers evict what they can no longer read, so a cache index is no longer an absolute token
+  position, and a wrong translation between the two reads the wrong keys without failing.
 
 Reference parity prompt:
 


### PR DESCRIPTION
## What changed

Two things about Gemma 4's KV cache, in one change because they share the same machinery.

**It is appended to, not rebuilt.** A decode step ran `concatenated([past, new])` once per producing layer, allocating a new array and copying the whole cache to add one token. At the checkpoint's 2 KV heads, 256/512 head dims and 20 sliding plus 4 global producing layers that is 57 KB per token of context per step — 975 MB copied to produce one token at 17k tokens, and O(n²) across a generation. Measured cache residency grows by 55.9 KB per token, so the figure is observed rather than projected. The caches now hold buffers with spare room and a step writes into it; MLX donates a slice assignment's input buffer when nothing else holds it, so the write lands in place.

**Sliding layers no longer keep what they cannot read.** The `NOTE` this removes said sliding layers keep a growing cache while attention only reads the newest 512 entries, and framed it as memory. It was bandwidth too — the copy above copied those unreadable entries as well. They are dropped now.

## The correctness risk, and what stands against it

Eviction breaks the identity between a cache index and an absolute token position, and `attentionPlan` derives every `keyStart`/`keyEnd` from absolute positions. The key axis is therefore stated explicitly as a `Gemma4KeyAxis` — where it starts, how long it is — and the plan **asks the cache** for the axis its append is about to leave behind rather than re-deriving the eviction rule beside it.

That question exists because the first version answered it by assumption: it planned against the cache as it stood and let `append` evict underneath the plan. A 900-token prompt split at 600 then handed attention an 811-key axis behind a mask built for 900. It failed loudly on a shape mismatch; it would not have if the two numbers had happened to agree.

Get the translation wrong and attention reads the wrong keys — fluent output, silently incorrect, no crash. So the cache is checked against implementations that cannot share its mistake:

- `testDecodeMatchesCachelessForward` — greedy decode against re-running the whole prompt through the no-cache forward at every step. That path has no cache, no eviction and no base.
- `testPrefillAndDecodeAgree` — one prefill against the same tokens fed singly, at 400/520/700. The two reach the same cache contents by routes that evict completely differently.
- `testSplitPrefillMatchesWholePrefill` — a prompt prefilled in two chunks against one, split so the second chunk starts mid-window.
- `testGreedyParityAgainstBaseline` — opt-in, compares long greedy runs against token ids recorded on another revision.

RoPE offsets are untouched: eviction does not move `state.position`, and K/V are cached post-RoPE. `num_kv_shared_layers` is handled by trimming only after every layer has run — a KV-shared layer's queries are the pass's queries and reach exactly as far back as its producer's.

## Results

**Greedy parity against 616a8b8: exact.** 864 tokens, identical one for one — 64 from a 300-token prompt (under the window), 600 from 1,536 (crossing the 512 boundary repeatedly), 200 from 2,048. `E2EGemma4SlidingWindowTests`'s logit diffs are unchanged to the last digit at every length it measures (0.0000 / 0.0000 / 0.4375 / 1.0625 / 0.6250).

**Decode, release build, median of interleaved runs:**

| Context | Before | After | |
|---:|---:|---:|---:|
| 512 | 14.5 ms/tok | 13.7 ms/tok | −6% |
| 2,560 | 16.0 | 14.2 | −12% |
| 10,240 | 20.0 | 15.3 | −24% |
| 17,408 | 24.8 | 16.6 | −33% |

**Memory**, deterministic run to run:

| Context | Resident after decode, before | after |
|---:|---:|---:|
| 512 | 4.06 GB | 4.05 GB |
| 17,408 | 4.96 GB | 4.30 GB |

The cache's own growth from 512 to 17,408 tokens falls from 0.90 GB to 0.25. Prefill peak is unchanged (7.10 GB at 17,408): it is set by the activations mid-stack, not by the caches at the end of it. A prompt that is prefilled and answered in a few tokens gains nothing here.

Measure this in release. A debug build spends enough per MLX graph node that the extra ones a slice assignment costs outweigh the copy it saves at short context, and shows a 5% regression at 512 tokens that release does not have.

## Trying and dropping the smaller half

Trimming each producing layer the moment its own layer finished — which needs the two layers whose cache is shared held back to the end anyway — was measured at a 17k prefill to change peak memory by nothing at all, 7.10 GB either way. The extra state bought a rounding error, so the pass trims once, after the loop, and the reason is recorded where someone would otherwise try it again.

## API

`InferenceState.kvCaches` changes type from `[(MLXArray, MLXArray)?]` to `[Gemma4KVCache?]`. `InferenceState` is public but nothing in or out of the package reads that property; `initial(config:)` and passing the state to `forward` are unaffected, so `Gemma4Chat` needed no change. `Gemma4Attention` and `Gemma4Layer` take `cache:` where they took `pastKV:`. The cache is a reference type deliberately — a step writes through it, and a value type would promise a copy it does not make.

## Tests

`swift test` unit phase (the CI skip list): **1205 tests, 35 skipped, 0 failures**, identical to 616a8b8 measured the same way.

One pre-existing failure, unrelated and unchanged: `E2EGemma4SlidingWindowTests.testBlockedAttentionMatchesFullMask` exceeds its 1.0 logit tolerance at 1,600 tokens with 1.0625, on 616a8b8 and on this branch alike, with byte-identical numbers. It is E2E-gated and so outside the CI phase above. The tolerance is 8 bfloat16 steps and the observation is 8.5, which reads as a bound set on different hardware rather than as a defect; either way it is not this change.
