### PR TITLE
Make Qwen async generation cooperatively cancellable

### DIFF
--- a/Sources/Qwen3TTS/GenerationCancellation.swift
+++ b/Sources/Qwen3TTS/GenerationCancellation.swift
@@ -1,0 +1,18 @@
+/// Runs an autoregressive generation range with a cancellation checkpoint
+/// before every token step.
+///
+/// The body returns `false` when generation has reached its natural terminal
+/// condition. A throwing checkpoint stops the loop before the next token step
+/// begins, bounding cooperative cancellation latency to at most one in-flight
+/// token step.
+@inline(__always)
+func runQwen3TTSGenerationLoop(
+    _ steps: Range<Int>,
+    checkCancellation: () throws -> Void,
+    body: (Int) throws -> Bool
+) rethrows {
+    for step in steps {
+        try checkCancellation()
+        guard try body(step) else { return }
+    }
+}

--- a/Sources/Qwen3TTS/Qwen3TTS+Protocols.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS+Protocols.swift
@@ -8,7 +8,10 @@ extension Qwen3TTSModel: SpeechGenerationModel {
     public func generate(text: String, language: String?) async throws -> [Float] {
         let lang = language ?? "english"
         let speaker = speakerForLanguage(lang)
-        return synthesize(text: text, language: lang, speaker: speaker)
+        return try synthesizeCheckingCancellation(
+            text: text,
+            language: lang,
+            speaker: speaker)
     }
 
     public func generateStream(text: String, language: String?) -> AsyncThrowingStream<AudioChunk, Error> {

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -120,6 +120,48 @@ public class Qwen3TTSModel {
         sampling: SamplingConfig = .default,
         languageExplicit: Bool = false
     ) -> [Float] {
+        synthesize(
+            text: text,
+            language: language,
+            speaker: speaker,
+            instruct: instruct,
+            sampling: sampling,
+            languageExplicit: languageExplicit,
+            checkCancellation: {})
+    }
+
+    /// Cancellation-aware implementation used by the async generation
+    /// contract. The synchronous public API remains source-compatible and
+    /// deliberately supplies a no-op checkpoint.
+    func synthesizeCheckingCancellation(
+        text: String,
+        language: String = "english",
+        speaker: String? = nil,
+        instruct: String? = nil,
+        sampling: SamplingConfig = .default,
+        languageExplicit: Bool = false
+    ) throws -> [Float] {
+        try synthesize(
+            text: text,
+            language: language,
+            speaker: speaker,
+            instruct: instruct,
+            sampling: sampling,
+            languageExplicit: languageExplicit,
+            checkCancellation: { try Task.checkCancellation() })
+    }
+
+    private func synthesize(
+        text: String,
+        language: String,
+        speaker: String?,
+        instruct: String?,
+        sampling: SamplingConfig,
+        languageExplicit: Bool,
+        checkCancellation: () throws -> Void
+    ) rethrows -> [Float] {
+        try checkCancellation()
+
         guard let tokenizer = tokenizer else {
             fatalError("Tokenizer not loaded. Call setTokenizer() first.")
         }
@@ -132,7 +174,14 @@ public class Qwen3TTSModel {
 
         guard let langId = CodecTokens.languageId(for: effectiveLanguage) else {
             print("Warning: Unknown language '\(effectiveLanguage)', defaulting to English")
-            return synthesize(text: text, language: "english", speaker: speaker, sampling: sampling)
+            return try synthesize(
+                text: text,
+                language: "english",
+                speaker: speaker,
+                instruct: nil,
+                sampling: sampling,
+                languageExplicit: false,
+                checkCancellation: checkCancellation)
         }
 
         let t0 = CFAbsoluteTimeGetCurrent()
@@ -147,6 +196,7 @@ public class Qwen3TTSModel {
             textTokens: textTokens, codecPrefixTokens: codecPrefixTokens, instructTokens: instructTokens)
 
         eval(prefillEmbeds, trailingTextHidden, ttsPadEmbed)
+        try checkCancellation()
         let t1 = CFAbsoluteTimeGetCurrent()
 
         // Stage 3: Autoregressive generation with per-step code predictor
@@ -154,13 +204,15 @@ public class Qwen3TTSModel {
         var cappedSampling = sampling
         cappedSampling.maxTokens = maxTokenCap(for: [text], tokenizer: tokenizer, sampling: sampling)
 
-        let (allCodebooks, numFrames) = generateWithCodePredictor(
+        let (allCodebooks, numFrames) = try generateWithCodePredictor(
             prefillEmbeds: prefillEmbeds,
             trailingTextHidden: trailingTextHidden,
             ttsPadEmbed: ttsPadEmbed,
-            sampling: cappedSampling)
+            sampling: cappedSampling,
+            checkCancellation: checkCancellation)
 
         eval(allCodebooks)
+        try checkCancellation()
         let t2 = CFAbsoluteTimeGetCurrent()
 
         guard numFrames > 0 else {
@@ -172,6 +224,7 @@ public class Qwen3TTSModel {
         let outputSamples = numFrames * 1920
         print("  Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)...")
         let waveform = codecDecoder.decode(codes: allCodebooks)
+        try checkCancellation()
         let t3 = CFAbsoluteTimeGetCurrent()
 
         let audioDur = Double(waveform.count) / 24000.0
@@ -342,6 +395,8 @@ public class Qwen3TTSModel {
         languageExplicit: Bool = false,
         continuation: AsyncThrowingStream<AudioChunk, Error>.Continuation
     ) throws {
+        try Task.checkCancellation()
+
         guard let tokenizer = tokenizer else {
             throw TTSError.tokenizerNotLoaded
         }
@@ -368,6 +423,7 @@ public class Qwen3TTSModel {
         let (prefillEmbeds, trailingTextHidden, ttsPadEmbed) = buildPrefillEmbeddings(
             textTokens: textTokens, codecPrefixTokens: codecPrefixTokens, instructTokens: instructTokens)
         eval(prefillEmbeds, trailingTextHidden, ttsPadEmbed)
+        try Task.checkCancellation()
 
         // Stage 2: Autoregressive generation with chunked decode + emit
         let cpSamplingConfig = SamplingConfig(temperature: sampling.temperature, topK: sampling.topK)
@@ -379,6 +435,7 @@ public class Qwen3TTSModel {
             offset: MLXArray(Int32(0)),
             cache: nil)
         var talkerCache = newCache
+        try Task.checkCancellation()
 
         // Sample first token
         let lastLogits = logits[0..., (prefillLen - 1)..<prefillLen, 0...]
@@ -388,6 +445,7 @@ public class Qwen3TTSModel {
             generatedTokens: [],
             suppressRange: (2048, 3072),
             eosTokenId: CodecTokens.codecEos)
+        try Task.checkCancellation()
 
         if nextToken == Int32(CodecTokens.codecEos) {
             let chunk = AudioChunk(
@@ -408,6 +466,7 @@ public class Qwen3TTSModel {
             hiddenState: lastHidden,
             firstCodebookToken: nextToken,
             cpSamplingConfig: cpSamplingConfig)
+        try Task.checkCancellation()
         for (i, token) in codeTokens.enumerated() {
             generatedAllCodebooks[i + 1].append(token)
         }
@@ -421,12 +480,14 @@ public class Qwen3TTSModel {
 
         // Emit immediately if prefill already produced enough frames (e.g., firstChunkFrames=1)
         if generatedFirstCodebook.count >= nextEmitThreshold {
+            try Task.checkCancellation()
             let chunk = decodeAndEmitChunk(
                 allCodebooks: generatedAllCodebooks,
                 chunkStart: 0,
                 chunkEnd: generatedFirstCodebook.count,
                 decoderLeftContext: streaming.decoderLeftContext,
                 samplesPerFrame: samplesPerFrame)
+            try Task.checkCancellation()
             let audioChunk = AudioChunk(
                 samples: chunk,
                 sampleRate: 24000,
@@ -439,7 +500,10 @@ public class Qwen3TTSModel {
         }
 
         // Autoregressive generation loop
-        for iterIdx in 1..<safeMaxTokens {
+        try runQwen3TTSGenerationLoop(
+            1..<safeMaxTokens,
+            checkCancellation: { try Task.checkCancellation() }
+        ) { iterIdx in
             // Text side
             let textEmbed: MLXArray
             let trailingLen = trailingTextHidden.dim(1)
@@ -479,6 +543,7 @@ public class Qwen3TTSModel {
                     hiddenState: stepHidden,
                     firstCodebookToken: nextToken,
                     cpSamplingConfig: cpSamplingConfig)
+                try Task.checkCancellation()
                 for (i, token) in codeTokens.enumerated() {
                     generatedAllCodebooks[i + 1].append(token)
                 }
@@ -493,12 +558,14 @@ public class Qwen3TTSModel {
                 let chunkFrameStart = emittedFrames
                 let chunkFrameEnd = totalFrames
 
+                try Task.checkCancellation()
                 let chunk = decodeAndEmitChunk(
                     allCodebooks: generatedAllCodebooks,
                     chunkStart: chunkFrameStart,
                     chunkEnd: chunkFrameEnd,
                     decoderLeftContext: streaming.decoderLeftContext,
                     samplesPerFrame: samplesPerFrame)
+                try Task.checkCancellation()
 
                 let isFinalChunk = isEos || iterIdx == safeMaxTokens - 1
                 let audioChunk = AudioChunk(
@@ -515,12 +582,14 @@ public class Qwen3TTSModel {
                 nextEmitThreshold = emittedFrames + streaming.chunkFrames
             }
 
-            if isEos { break }
+            if isEos { return false }
 
             if iterIdx % 50 == 0 {
                 let estSec = Double(generatedFirstCodebook.count) / 12.5
                 print("  Streaming: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)...")
             }
+
+            return true
         }
 
         let numFrames = generatedFirstCodebook.count
@@ -531,12 +600,14 @@ public class Qwen3TTSModel {
 
         // Emit remaining frames if any
         if emittedFrames < numFrames {
+            try Task.checkCancellation()
             let chunk = decodeAndEmitChunk(
                 allCodebooks: generatedAllCodebooks,
                 chunkStart: emittedFrames,
                 chunkEnd: numFrames,
                 decoderLeftContext: streaming.decoderLeftContext,
                 samplesPerFrame: samplesPerFrame)
+            try Task.checkCancellation()
             let audioChunk = AudioChunk(
                 samples: chunk,
                 sampleRate: 24000,
@@ -549,6 +620,7 @@ public class Qwen3TTSModel {
 
         // If EOS arrived with no new frames, emit a final sentinel
         if !emittedFinal {
+            try Task.checkCancellation()
             let audioChunk = AudioChunk(
                 samples: [],
                 sampleRate: 24000,
@@ -1426,6 +1498,23 @@ public class Qwen3TTSModel {
         ttsPadEmbed: MLXArray,
         sampling: SamplingConfig
     ) -> (allCodebooks: MLXArray, numFrames: Int) {
+        generateWithCodePredictor(
+            prefillEmbeds: prefillEmbeds,
+            trailingTextHidden: trailingTextHidden,
+            ttsPadEmbed: ttsPadEmbed,
+            sampling: sampling,
+            checkCancellation: {})
+    }
+
+    private func generateWithCodePredictor(
+        prefillEmbeds: MLXArray,
+        trailingTextHidden: MLXArray,
+        ttsPadEmbed: MLXArray,
+        sampling: SamplingConfig,
+        checkCancellation: () throws -> Void
+    ) rethrows -> (allCodebooks: MLXArray, numFrames: Int) {
+        try checkCancellation()
+
         // Reference (QwenLM + mlx-audio) uses 2048 here. Earlier 500 cap clipped
         // long lines mid-word and produced hard-cut endings.
         let safeMaxTokens = min(sampling.maxTokens, 2048)
@@ -1445,6 +1534,7 @@ public class Qwen3TTSModel {
             offset: MLXArray(Int32(0)),
             cache: talkerCache)
         talkerCache = newCache
+        try checkCancellation()
 
         // Sample first token from last position
         let lastLogits = logits[0..., (prefillLen - 1)..<prefillLen, 0...]
@@ -1454,6 +1544,7 @@ public class Qwen3TTSModel {
             generatedTokens: generatedFirstCodebook,
             suppressRange: (2048, 3072),
             eosTokenId: CodecTokens.codecEos)
+        try checkCancellation()
 
         if nextToken == Int32(CodecTokens.codecEos) {
             return (MLXArray.zeros([1, 16, 0]), 0)
@@ -1470,6 +1561,7 @@ public class Qwen3TTSModel {
             hiddenState: lastHidden,
             firstCodebookToken: nextToken,
             cpSamplingConfig: cpSamplingConfig)
+        try checkCancellation()
         for (i, token) in codeTokens.enumerated() {
             generatedAllCodebooks[i + 1].append(token)
         }
@@ -1478,7 +1570,10 @@ public class Qwen3TTSModel {
         var step = prefillLen
 
         // Autoregressive generation
-        for iterIdx in 1..<safeMaxTokens {
+        try runQwen3TTSGenerationLoop(
+            1..<safeMaxTokens,
+            checkCancellation: checkCancellation
+        ) { iterIdx in
             // Text side: next trailing text embed or tts_pad
             let textEmbed: MLXArray
             let trailingLen = trailingTextHidden.dim(1)
@@ -1508,7 +1603,7 @@ public class Qwen3TTSModel {
                 suppressRange: (2048, 3072),
                 eosTokenId: CodecTokens.codecEos)
 
-            if nextToken == Int32(CodecTokens.codecEos) { break }
+            if nextToken == Int32(CodecTokens.codecEos) { return false }
 
             generatedFirstCodebook.append(nextToken)
             generatedAllCodebooks[0].append(nextToken)
@@ -1519,6 +1614,7 @@ public class Qwen3TTSModel {
                 hiddenState: stepHidden,
                 firstCodebookToken: nextToken,
                 cpSamplingConfig: cpSamplingConfig)
+            try checkCancellation()
             for (i, token) in codeTokens.enumerated() {
                 generatedAllCodebooks[i + 1].append(token)
             }
@@ -1529,6 +1625,8 @@ public class Qwen3TTSModel {
                 let estSec = Double(generatedFirstCodebook.count) / 12.5
                 print("  Talker: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)...")
             }
+
+            return true
         }
 
         let numFrames = generatedFirstCodebook.count

--- a/Tests/Qwen3TTSTests/GenerationCancellationTests.swift
+++ b/Tests/Qwen3TTSTests/GenerationCancellationTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import XCTest
+@testable import Qwen3TTS
+
+final class GenerationCancellationTests: XCTestCase {
+
+    func testCancellationStopsBeforeTheNextTokenStep() {
+        var checkpointCount = 0
+        var completedSteps: [Int] = []
+
+        XCTAssertThrowsError(
+            try runQwen3TTSGenerationLoop(
+                0..<10,
+                checkCancellation: {
+                    checkpointCount += 1
+                    if checkpointCount == 4 {
+                        throw CancellationError()
+                    }
+                },
+                body: { step in
+                    completedSteps.append(step)
+                    return true
+                })
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+
+        XCTAssertEqual(checkpointCount, 4)
+        XCTAssertEqual(completedSteps, [0, 1, 2])
+    }
+
+    func testNaturalTerminationDoesNotRunAnExtraCheckpoint() {
+        var checkpointCount = 0
+        var completedSteps: [Int] = []
+
+        runQwen3TTSGenerationLoop(
+            0..<10,
+            checkCancellation: { checkpointCount += 1 },
+            body: { step in
+                completedSteps.append(step)
+                return step < 2
+            })
+
+        XCTAssertEqual(checkpointCount, 3)
+        XCTAssertEqual(completedSteps, [0, 1, 2])
+    }
+
+    func testSwiftTaskCancellationPropagatesAsCancellationError() async {
+        let gate = SuspensionGate()
+        let task = Task<Int, Error> {
+            await gate.wait()
+            var completedSteps = 0
+            try runQwen3TTSGenerationLoop(
+                0..<10,
+                checkCancellation: { try Task.checkCancellation() },
+                body: { _ in
+                    completedSteps += 1
+                    return true
+                })
+            return completedSteps
+        }
+
+        await gate.waitUntilEntered()
+        task.cancel()
+        await gate.open()
+
+        do {
+            _ = try await task.value
+            XCTFail("A cancelled generation task must not begin another token step")
+        } catch is CancellationError {
+            // Expected cooperative cancellation.
+        } catch {
+            XCTFail("Expected CancellationError, received \(error)")
+        }
+    }
+
+    func testPublicAsyncGenerateRejectsPrecancelledTaskBeforeTokenizerAccess() async {
+        let gate = SuspensionGate()
+        let task = Task<[Float], Error> {
+            await gate.wait()
+            let model = Qwen3TTSModel()
+            return try await model.generate(
+                text: "Cancellation must win before tokenizer access.",
+                language: "english")
+        }
+
+        await gate.waitUntilEntered()
+        task.cancel()
+        await gate.open()
+
+        do {
+            _ = try await task.value
+            XCTFail("A pre-cancelled async generation must not access the unset tokenizer")
+        } catch is CancellationError {
+            // Expected before the unset tokenizer can be accessed.
+        } catch {
+            XCTFail("Expected CancellationError, received \(error)")
+        }
+    }
+
+    func testAsyncGenerationPathsUseTheCooperativeLoop() throws {
+        let sourceDirectory = packageRoot
+            .appendingPathComponent("Sources", isDirectory: true)
+            .appendingPathComponent("Qwen3TTS", isDirectory: true)
+        let modelSource = try String(
+            contentsOf: sourceDirectory.appendingPathComponent("Qwen3TTS.swift"),
+            encoding: .utf8)
+        let protocolSource = try String(
+            contentsOf: sourceDirectory.appendingPathComponent("Qwen3TTS+Protocols.swift"),
+            encoding: .utf8)
+
+        XCTAssertEqual(
+            occurrences(of: "runQwen3TTSGenerationLoop(", in: modelSource),
+            2,
+            "Single-item and streaming token loops must use the cooperative runner")
+        XCTAssertEqual(
+            occurrences(of: "for iterIdx in 1..<safeMaxTokens", in: modelSource),
+            1,
+            "Only the synchronous batch loop may remain outside the async cancellation contract")
+        XCTAssertTrue(protocolSource.contains("return try synthesizeCheckingCancellation("))
+        XCTAssertTrue(modelSource.contains("continuation.onTermination = { @Sendable _ in task.cancel() }"))
+    }
+
+    private func occurrences(of needle: String, in source: String) -> Int {
+        source.components(separatedBy: needle).count - 1
+    }
+
+    private var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}
+
+private actor SuspensionGate {
+    private var entered = false
+    private var isOpen = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        entered = true
+        let entryWaiters = self.entryWaiters
+        self.entryWaiters.removeAll()
+        for waiter in entryWaiters { waiter.resume() }
+
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            openWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let openWaiters = self.openWaiters
+        self.openWaiters.removeAll()
+        for waiter in openWaiters { waiter.resume() }
+    }
+}

--- a/docs/inference/qwen3-tts-inference.md
+++ b/docs/inference/qwen3-tts-inference.md
@@ -187,6 +187,20 @@ The Talker, Code Predictor, and Mimi decoder are all fully causal, enabling chun
 2. **Subsequent chunks** — emitted every `chunkFrames` tokens (default 25 = 2s audio)
 3. **Codec decode** — each chunk runs the Mimi decoder with left-context overlap for quality
 
+### Cooperative Cancellation
+
+The async `SpeechGenerationModel.generate()` path and `synthesizeStream()`
+cooperate with Swift task cancellation. Autoregressive inference checks for
+cancellation before every codec-token step and again before and after codec
+decode. Once cancellation is observed at a checkpoint, generation throws
+`CancellationError` instead of yielding or returning a successful final
+result.
+
+Cancellation latency is bounded to the currently executing token step or
+codec decode; MLX and Metal kernels already in flight cannot be preempted.
+The synchronous `synthesize()` and `synthesizeBatch()` APIs retain their
+existing non-throwing behavior and are not task-cancellation entry points.
+
 ### Zero-Pad Decode
 
 When `firstChunkFrames < 4` (the codec's minimum input size due to ConvNeXt kernel=7 after 2x pre-upsample), the decoder input is zero-padded on the left. The decoder is fully causal, so zero frames produce silence. Output is trimmed from the right to keep exactly `realChunkFrames × 1920` samples.


### PR DESCRIPTION
## Summary

- make Qwen's async `SpeechGenerationModel.generate` path observe Swift task
  cancellation throughout synthesis
- poll streaming and full-waveform autoregressive generation before every
  codec-token step and before and after codec decode
- preserve the existing synchronous synthesis signatures and behavior
- add deterministic model-free cancellation tests and document the latency
  boundary

## Motivation

`synthesizeStream` already cancelled its child task when a consumer terminated,
but the synchronous generation loop did not inspect that cancellation state.
Inference could therefore continue running after the stream was no longer
consumed. The shared loop runner now bounds cooperative polling to one
in-flight token step, while surrounding decode checkpoints prevent observed
cancellation from being reported as successful completion.

MLX and Metal work already in flight remains non-preemptible, so cancellation
latency is bounded by the active token step or codec decode rather than by a
wall-clock deadline.

## Testing

- `GenerationCancellationTests`: 5 tests passed
- model-free Qwen compatibility matrix: 50 tests passed
- cold sequential SwiftPM test-product build completed
- `git diff --check`
- Swift parser check for every changed Swift source and test file

## Documentation

- updated `docs/inference/qwen3-tts-inference.md`
- the corresponding public-site update requires maintainer access to the
  private `soniqo-web` repository
