### PR TITLE
Add embeddable Qwen3-TTS runtime controls

### DIFF
--- a/Sources/Qwen3TTS/GenerationCancellation.swift
+++ b/Sources/Qwen3TTS/GenerationCancellation.swift
@@ -1,0 +1,18 @@
+/// Runs an autoregressive generation range with a cancellation checkpoint
+/// before every token step.
+///
+/// The body returns `false` when generation has reached its natural terminal
+/// condition. A throwing checkpoint stops the loop before the next token step
+/// begins, bounding cooperative cancellation latency to at most one in-flight
+/// token step.
+@inline(__always)
+func runQwen3TTSGenerationLoop(
+    _ steps: Range<Int>,
+    checkCancellation: () throws -> Void,
+    body: (Int) throws -> Bool
+) rethrows {
+    for step in steps {
+        try checkCancellation()
+        guard try body(step) else { return }
+    }
+}

--- a/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS+ICL.swift
@@ -5,15 +5,6 @@ import MLXFast
 import MLXCommon
 import AudioCommon
 
-/// Synthesis progress logs go to stderr so they don't corrupt a stdout-based
-/// IPC channel (e.g. speech-studio sidecar's NDJSON protocol). Swift's stdio
-/// `print()` is line-buffered and may flush at unexpected boundaries; routing
-/// to stderr keeps the stdout pipe clean for JSON responses.
-@inline(__always)
-private func iclLog(_ message: String) {
-    FileHandle.standardError.write(Data((message + "\n").utf8))
-}
-
 // MARK: - ICL Voice Cloning
 
 extension Qwen3TTSModel {
@@ -96,7 +87,8 @@ extension Qwen3TTSModel {
         } else if let id = CodecTokens.languageId(for: language) {
             langId = id
         } else {
-            iclLog("Warning: Unknown language '\(language)', falling back to auto")
+            AudioLog.inference.warning(
+                "Unknown language '\(language)', falling back to auto")
             return synthesizeWithVoiceCloneICL(
                 text: text, referenceAudio: referenceAudio,
                 referenceSampleRate: referenceSampleRate,
@@ -111,7 +103,8 @@ extension Qwen3TTSModel {
         let refCodes: MLXArray
         if let cached = referenceAudioCache.codecRefCodes(for: referenceAudio, sampleRate: referenceSampleRate) {
             refCodes = cached
-            iclLog("  ICL: codec tokens cache hit (\(cached.dim(2)) frames)")
+            AudioLog.inference.debug(
+                "ICL: codec tokens cache hit (\(cached.dim(2)) frames)")
         } else {
             let audio24k = referenceSampleRate == 24000
                 ? referenceAudio
@@ -120,7 +113,8 @@ extension Qwen3TTSModel {
             eval(codes)
             referenceAudioCache.storeCodecRefCodes(codes, audio: referenceAudio, sampleRate: referenceSampleRate)
             refCodes = codes
-            iclLog("  ICL: encoded \(audio24k.count) samples → \(codes.dim(2)) codec frames")
+            AudioLog.inference.debug(
+                "ICL: encoded \(audio24k.count) samples → \(codes.dim(2)) codec frames")
         }
 
         // Step 3: Extract speaker embedding (ICL still uses x-vector for speaker conditioning; cached)
@@ -175,7 +169,7 @@ extension Qwen3TTSModel {
         let t2 = CFAbsoluteTimeGetCurrent()
 
         guard numFrames > 0 else {
-            iclLog("Warning: ICL generation produced no tokens")
+            AudioLog.inference.warning("ICL generation produced no tokens")
             return []
         }
 
@@ -193,7 +187,8 @@ extension Qwen3TTSModel {
             ? concatenated([refCodes, allCodebooks], axis: 2)   // [1, 16, refFrames + numFrames]
             : allCodebooks
         let totalFrames = codesForDecode.dim(2)
-        iclLog("  ICL: decoding \(numFrames) target frames (+ \(trimReference ? refFrames : 0) ref ctx) → \(totalFrames) frames...")
+        AudioLog.inference.debug(
+            "ICL: decoding \(numFrames) target frames (+ \(trimReference ? refFrames : 0) ref ctx) → \(totalFrames) frames")
         let fullWaveform = codecDecoder.decode(codes: codesForDecode)
         let t3 = CFAbsoluteTimeGetCurrent()
 
@@ -202,7 +197,8 @@ extension Qwen3TTSModel {
             let cut = refFrames * fullWaveform.count / totalFrames
             trimmedWaveform = (cut > 0 && cut < fullWaveform.count)
                 ? Array(fullWaveform.dropFirst(cut)) : fullWaveform
-            iclLog("  ICL: cut \(cut) reference samples (~\(String(format: "%.2f", Double(cut)/24000.0))s, \(refFrames)/\(totalFrames) frames) from output start")
+            AudioLog.inference.debug(
+                "ICL: cut \(cut) reference samples (~\(String(format: "%.2f", Double(cut)/24000.0))s, \(refFrames)/\(totalFrames) frames) from output start")
         } else {
             trimmedWaveform = fullWaveform
         }
@@ -215,7 +211,8 @@ extension Qwen3TTSModel {
         let totTime = String(format: "%.3f", t3-t0)
         let audDur = String(format: "%.2f", audioDur)
         let rtf = String(format: "%.2f", (t3-t0)/max(audioDur, 0.001))
-        iclLog("  ICL timing: encode=\(encTime)s | generate=\(genTime)s (\(numFrames) steps, \(msPerStep)ms/step) | decode=\(decTime)s | total=\(totTime)s | audio=\(audDur)s | RTF=\(rtf)")
+        AudioLog.inference.info(
+            "ICL timing: encode=\(encTime)s | generate=\(genTime)s (\(numFrames) steps, \(msPerStep)ms/step) | decode=\(decTime)s | total=\(totTime)s | audio=\(audDur)s | RTF=\(rtf)")
 
         return trimmedWaveform
     }

--- a/Sources/Qwen3TTS/Qwen3TTS+Protocols.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS+Protocols.swift
@@ -8,7 +8,10 @@ extension Qwen3TTSModel: SpeechGenerationModel {
     public func generate(text: String, language: String?) async throws -> [Float] {
         let lang = language ?? "english"
         let speaker = speakerForLanguage(lang)
-        return synthesize(text: text, language: lang, speaker: speaker)
+        return try synthesizeCheckingCancellation(
+            text: text,
+            language: lang,
+            speaker: speaker)
     }
 
     public func generateStream(text: String, language: String?) -> AsyncThrowingStream<AudioChunk, Error> {

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -1610,6 +1610,53 @@ public class Qwen3TTSModel {
 
 // MARK: - Model Loading
 
+/// Controls whether loading a Qwen3-TTS model changes the process-wide Metal wired-memory limit.
+public enum Qwen3TTSWiredMemoryPolicy: Equatable, Sendable {
+    /// Leave the process-wide wired-memory limit unchanged.
+    case none
+
+    /// Pin a fraction of Metal's recommended working set after the model is loaded.
+    case pin(fraction: Double)
+}
+
+/// Errors raised before a Qwen3-TTS model is loaded from caller-provided files.
+public enum Qwen3TTSLoadingError: Error, Equatable, LocalizedError, Sendable {
+    /// A local-loader URL did not use the `file` scheme.
+    case nonFileURL(URL)
+
+    /// A required local directory does not exist.
+    case directoryNotFound(URL)
+
+    /// A required local directory URL resolves to a non-directory item.
+    case pathIsNotDirectory(URL)
+
+    /// A required file is missing or does not resolve to a regular file.
+    case requiredFileUnavailable(URL)
+
+    /// A model directory has no complete safetensors checkpoint.
+    case weightsUnavailable(URL)
+
+    /// The requested Metal wired-memory fraction is not finite or is outside `(0, 1]`.
+    case invalidWiredMemoryFraction(Double)
+
+    public var errorDescription: String? {
+        switch self {
+        case .nonFileURL(let url):
+            return "Qwen3-TTS local loading requires a file URL, got: \(url.absoluteString)"
+        case .directoryNotFound(let url):
+            return "Required Qwen3-TTS directory does not exist: \(url.path)"
+        case .pathIsNotDirectory(let url):
+            return "Required Qwen3-TTS path is not a directory: \(url.path)"
+        case .requiredFileUnavailable(let url):
+            return "Required Qwen3-TTS file is missing or is not a regular file: \(url.path)"
+        case .weightsUnavailable(let url):
+            return "No complete Qwen3-TTS safetensors checkpoint found in: \(url.path)"
+        case .invalidWiredMemoryFraction(let fraction):
+            return "Qwen3-TTS wired-memory fraction must be finite and in (0, 1], got: \(fraction)"
+        }
+    }
+}
+
 public extension Qwen3TTSModel {
     /// Load model from HuggingFace hub.
     ///
@@ -1622,7 +1669,9 @@ public extension Qwen3TTSModel {
         modelId: String = Qwen3TTSModel.defaultModelId,
         tokenizerModelId: String = "Qwen/Qwen3-TTS-Tokenizer-12Hz",
         cacheDir: URL? = nil,
+        tokenizerCacheDir: URL? = nil,
         offlineMode: Bool = false,
+        wiredMemoryPolicy: Qwen3TTSWiredMemoryPolicy = .pin(fraction: 0.9),
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> Qwen3TTSModel {
         progressHandler?(0.05, "Preparing download...")
@@ -1633,7 +1682,13 @@ public extension Qwen3TTSModel {
 
         // Download main model weights
         let mainCacheDir = try cacheDir ?? HuggingFaceDownloader.getCacheDirectory(for: modelId)
-        if !HuggingFaceDownloader.weightsExist(in: mainCacheDir) {
+        let requiredMainFiles = ["config.json", "vocab.json"]
+        if !HuggingFaceDownloader.weightsExist(in: mainCacheDir)
+            || requiredMainFiles.contains(where: {
+                !FileManager.default.fileExists(
+                    atPath: mainCacheDir.appendingPathComponent($0).path)
+            })
+        {
             progressHandler?(0.1, "Resolving TTS model files...")
             try await HuggingFaceDownloader.downloadWeights(
                 modelId: modelId,
@@ -1646,12 +1701,13 @@ public extension Qwen3TTSModel {
         }
 
         // Download tokenizer/codec weights
-        let tokenizerCacheDir = try HuggingFaceDownloader.getCacheDirectory(for: tokenizerModelId)
-        if !HuggingFaceDownloader.weightsExist(in: tokenizerCacheDir) {
+        let resolvedTokenizerCacheDir = try tokenizerCacheDir
+            ?? HuggingFaceDownloader.getCacheDirectory(for: tokenizerModelId)
+        if !HuggingFaceDownloader.weightsExist(in: resolvedTokenizerCacheDir) {
             progressHandler?(0.4, "Downloading speech tokenizer...")
             try await HuggingFaceDownloader.downloadWeights(
                 modelId: tokenizerModelId,
-                to: tokenizerCacheDir,
+                to: resolvedTokenizerCacheDir,
                 offlineMode: offlineMode,
                 progressHandler: { progress in
                     progressHandler?(0.4 + progress * 0.2, "Downloading speech tokenizer...")
@@ -1669,43 +1725,146 @@ public extension Qwen3TTSModel {
             }
         }
 
-        // Create model with detected config
         let ttsConfig = Qwen3TTSConfig.config(for: detectedSize, bits: detectedBits)
-        let model = Qwen3TTSModel(config: ttsConfig)
+        return try fromLocal(
+            modelDirectory: mainCacheDir,
+            tokenizerDirectory: resolvedTokenizerCacheDir,
+            configuration: ttsConfig,
+            wiredMemoryPolicy: wiredMemoryPolicy,
+            progressHandler: { progress, message in
+                progressHandler?(0.6 + progress * 0.4, message)
+            })
+    }
 
-        // Parse speaker config
-        if FileManager.default.fileExists(atPath: configPath.path) {
-            model.speakerConfig = try? parseSpeakerConfig(from: configPath)
-        }
+    /// Load a Qwen3-TTS model from two explicit local directories without resolving a cache,
+    /// contacting a remote endpoint, or downloading files.
+    ///
+    /// The main model directory must contain `config.json`, `vocab.json`, and a complete
+    /// safetensors checkpoint. The tokenizer directory must contain its own complete
+    /// safetensors checkpoint.
+    ///
+    /// - Parameters:
+    ///   - modelDirectory: Directory containing the talker, code predictor, speaker encoder,
+    ///     text tokenizer, and model configuration.
+    ///   - tokenizerDirectory: Directory containing the speech-tokenizer codec weights.
+    ///   - configuration: Architecture and quantization configuration for the local checkpoint.
+    ///   - wiredMemoryPolicy: Whether loading may change the process-wide Metal wired limit.
+    ///   - progressHandler: Optional loading progress callback.
+    static func fromLocal(
+        modelDirectory: URL,
+        tokenizerDirectory: URL,
+        configuration: Qwen3TTSConfig,
+        wiredMemoryPolicy: Qwen3TTSWiredMemoryPolicy = .none,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) throws -> Qwen3TTSModel {
+        progressHandler?(0.05, "Validating local model bundles...")
+        try validateLocalBundle(
+            modelDirectory: modelDirectory,
+            tokenizerDirectory: tokenizerDirectory)
+        try validateWiredMemoryPolicy(wiredMemoryPolicy)
 
-        // Load tokenizer
-        progressHandler?(0.6, "Loading tokenizer...")
-        let vocabPath = mainCacheDir.appendingPathComponent("vocab.json")
-        if FileManager.default.fileExists(atPath: vocabPath.path) {
-            let tokenizer = Qwen3Tokenizer()
-            try tokenizer.load(from: vocabPath)
-            model.setTokenizer(tokenizer)
-        }
+        let configPath = modelDirectory.appendingPathComponent("config.json")
+        let vocabPath = modelDirectory.appendingPathComponent("vocab.json")
+        let model = Qwen3TTSModel(config: configuration)
+        model.speakerConfig = try? parseSpeakerConfig(from: configPath)
 
-        // Load Talker + Code Predictor + Speaker Encoder weights (single safetensors load)
-        progressHandler?(0.7, "Loading TTS model weights...")
+        progressHandler?(0.15, "Loading tokenizer...")
+        let tokenizer = Qwen3Tokenizer()
+        try tokenizer.load(from: vocabPath)
+        model.setTokenizer(tokenizer)
+
+        progressHandler?(0.35, "Loading TTS model weights...")
         try TTSWeightLoader.loadTalkerAndCodePredictorWeights(
-            talker: model.talker, codePredictor: model.codePredictor, from: mainCacheDir,
-            castFloat16ToBFloat16: detectedBits == 0)
+            talker: model.talker,
+            codePredictor: model.codePredictor,
+            from: modelDirectory,
+            castFloat16ToBFloat16: configuration.talker.bits == 0)
         try TTSWeightLoader.loadSpeakerEncoderWeights(
-            into: model.speakerEncoder, from: mainCacheDir)
+            into: model.speakerEncoder, from: modelDirectory)
 
-        // Load Speech Tokenizer Decoder weights
-        progressHandler?(0.85, "Loading speech tokenizer decoder...")
+        progressHandler?(0.7, "Loading speech tokenizer decoder...")
         try TTSWeightLoader.loadSpeechTokenizerDecoderWeights(
-            into: model.codecDecoder, from: tokenizerCacheDir)
+            into: model.codecDecoder, from: tokenizerDirectory)
 
-        progressHandler?(0.95, "Warming up model...")
+        progressHandler?(0.9, "Warming up model...")
         model.warmUp()
 
-        MetalBudget.pinMemory()
+        try applyWiredMemoryPolicy(wiredMemoryPolicy)
         progressHandler?(1.0, "Ready")
         return model
+    }
+
+    internal static func validateLocalBundle(
+        modelDirectory: URL,
+        tokenizerDirectory: URL
+    ) throws {
+        try validateDirectory(modelDirectory)
+        try validateDirectory(tokenizerDirectory)
+        try validateRegularFile(modelDirectory.appendingPathComponent("config.json"))
+        try validateRegularFile(modelDirectory.appendingPathComponent("vocab.json"))
+        try validateWeights(in: modelDirectory)
+        try validateWeights(in: tokenizerDirectory)
+    }
+
+    internal static func applyWiredMemoryPolicy(
+        _ policy: Qwen3TTSWiredMemoryPolicy,
+        pinMemory: (Double) -> Void = { fraction in
+            MetalBudget.pinMemory(fraction: fraction)
+        }
+    ) throws {
+        try validateWiredMemoryPolicy(policy)
+        if case .pin(let fraction) = policy {
+            pinMemory(fraction)
+        }
+    }
+
+    private static func validateWiredMemoryPolicy(
+        _ policy: Qwen3TTSWiredMemoryPolicy
+    ) throws {
+        guard case .pin(let fraction) = policy else { return }
+        guard fraction.isFinite, fraction > 0, fraction <= 1 else {
+            throw Qwen3TTSLoadingError.invalidWiredMemoryFraction(fraction)
+        }
+    }
+
+    private static func validateDirectory(_ directory: URL) throws {
+        guard directory.isFileURL else {
+            throw Qwen3TTSLoadingError.nonFileURL(directory)
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+            atPath: directory.path, isDirectory: &isDirectory)
+        else {
+            throw Qwen3TTSLoadingError.directoryNotFound(directory)
+        }
+        guard isDirectory.boolValue else {
+            throw Qwen3TTSLoadingError.pathIsNotDirectory(directory)
+        }
+    }
+
+    private static func validateRegularFile(_ file: URL) throws {
+        let values = try? file.resourceValues(forKeys: [.isRegularFileKey])
+        guard values?.isRegularFile == true else {
+            throw Qwen3TTSLoadingError.requiredFileUnavailable(file)
+        }
+    }
+
+    private static func validateWeights(in directory: URL) throws {
+        let contents: [URL]
+        do {
+            contents = try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.isRegularFileKey])
+        } catch {
+            throw Qwen3TTSLoadingError.weightsUnavailable(directory)
+        }
+        let hasRegularSafetensors = contents.contains { file in
+            guard file.pathExtension == "safetensors" else { return false }
+            return (try? file.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+        }
+        guard hasRegularSafetensors, HuggingFaceDownloader.weightsExist(in: directory) else {
+            throw Qwen3TTSLoadingError.weightsUnavailable(directory)
+        }
     }
 
     /// Parse speaker configuration from model config.json

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -120,6 +120,48 @@ public class Qwen3TTSModel {
         sampling: SamplingConfig = .default,
         languageExplicit: Bool = false
     ) -> [Float] {
+        synthesize(
+            text: text,
+            language: language,
+            speaker: speaker,
+            instruct: instruct,
+            sampling: sampling,
+            languageExplicit: languageExplicit,
+            checkCancellation: {})
+    }
+
+    /// Cancellation-aware implementation used by the async generation
+    /// contract. The synchronous public API remains source-compatible and
+    /// deliberately supplies a no-op checkpoint.
+    func synthesizeCheckingCancellation(
+        text: String,
+        language: String = "english",
+        speaker: String? = nil,
+        instruct: String? = nil,
+        sampling: SamplingConfig = .default,
+        languageExplicit: Bool = false
+    ) throws -> [Float] {
+        try synthesize(
+            text: text,
+            language: language,
+            speaker: speaker,
+            instruct: instruct,
+            sampling: sampling,
+            languageExplicit: languageExplicit,
+            checkCancellation: { try Task.checkCancellation() })
+    }
+
+    private func synthesize(
+        text: String,
+        language: String,
+        speaker: String?,
+        instruct: String?,
+        sampling: SamplingConfig,
+        languageExplicit: Bool,
+        checkCancellation: () throws -> Void
+    ) rethrows -> [Float] {
+        try checkCancellation()
+
         guard let tokenizer = tokenizer else {
             fatalError("Tokenizer not loaded. Call setTokenizer() first.")
         }
@@ -131,8 +173,16 @@ public class Qwen3TTSModel {
         let effectiveInstruct = instruct ?? (speakerConfig != nil ? Self.defaultInstruct : nil)
 
         guard let langId = CodecTokens.languageId(for: effectiveLanguage) else {
-            print("Warning: Unknown language '\(effectiveLanguage)', defaulting to English")
-            return synthesize(text: text, language: "english", speaker: speaker, sampling: sampling)
+            AudioLog.inference.warning(
+                "Unknown language '\(effectiveLanguage)', defaulting to English")
+            return try synthesize(
+                text: text,
+                language: "english",
+                speaker: speaker,
+                instruct: nil,
+                sampling: sampling,
+                languageExplicit: false,
+                checkCancellation: checkCancellation)
         }
 
         let t0 = CFAbsoluteTimeGetCurrent()
@@ -147,6 +197,7 @@ public class Qwen3TTSModel {
             textTokens: textTokens, codecPrefixTokens: codecPrefixTokens, instructTokens: instructTokens)
 
         eval(prefillEmbeds, trailingTextHidden, ttsPadEmbed)
+        try checkCancellation()
         let t1 = CFAbsoluteTimeGetCurrent()
 
         // Stage 3: Autoregressive generation with per-step code predictor
@@ -154,34 +205,41 @@ public class Qwen3TTSModel {
         var cappedSampling = sampling
         cappedSampling.maxTokens = maxTokenCap(for: [text], tokenizer: tokenizer, sampling: sampling)
 
-        let (allCodebooks, numFrames) = generateWithCodePredictor(
+        let (allCodebooks, numFrames) = try generateWithCodePredictor(
             prefillEmbeds: prefillEmbeds,
             trailingTextHidden: trailingTextHidden,
             ttsPadEmbed: ttsPadEmbed,
-            sampling: cappedSampling)
+            sampling: cappedSampling,
+            checkCancellation: checkCancellation)
 
         eval(allCodebooks)
+        try checkCancellation()
         let t2 = CFAbsoluteTimeGetCurrent()
 
         guard numFrames > 0 else {
-            print("Warning: Talker generated no tokens")
+            AudioLog.inference.warning("Talker generated no tokens")
             return []
         }
 
         // Stage 4: Codec decode to waveform
         let outputSamples = numFrames * 1920
-        print("  Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)...")
+        AudioLog.inference.debug(
+            "Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)")
         let waveform = codecDecoder.decode(codes: allCodebooks)
+        try checkCancellation()
         let t3 = CFAbsoluteTimeGetCurrent()
 
         let audioDur = Double(waveform.count) / 24000.0
-        print("  Timing: embed=\(String(format: "%.3f", t1-t0))s | " +
-              "generate=\(String(format: "%.3f", t2-t1))s (\(numFrames) steps, " +
-              "\(String(format: "%.0f", (t2-t1)/Double(numFrames)*1000))ms/step) | " +
-              "decode=\(String(format: "%.3f", t3-t2))s | " +
-              "total=\(String(format: "%.3f", t3-t0))s | " +
-              "audio=\(String(format: "%.2f", audioDur))s | " +
-              "RTF=\(String(format: "%.2f", (t3-t0)/audioDur))")
+        let embedTime = String(format: "%.3f", t1-t0)
+        let generateTime = String(format: "%.3f", t2-t1)
+        let millisecondsPerStep = String(
+            format: "%.0f", (t2-t1)/Double(numFrames)*1000)
+        let decodeTime = String(format: "%.3f", t3-t2)
+        let totalTime = String(format: "%.3f", t3-t0)
+        let audioDuration = String(format: "%.2f", audioDur)
+        let realTimeFactor = String(format: "%.2f", (t3-t0)/audioDur)
+        AudioLog.inference.info(
+            "TTS timing: embed=\(embedTime)s | generate=\(generateTime)s (\(numFrames) steps, \(millisecondsPerStep)ms/step) | decode=\(decodeTime)s | total=\(totalTime)s | audio=\(audioDuration)s | RTF=\(realTimeFactor)")
 
         return waveform
     }
@@ -212,7 +270,8 @@ public class Qwen3TTSModel {
         }
 
         guard let langId = CodecTokens.languageId(for: language) else {
-            print("Warning: Unknown language '\(language)', defaulting to English")
+            AudioLog.inference.warning(
+                "Unknown language '\(language)', defaulting to English")
             return synthesizeWithVoiceClone(
                 text: text, referenceAudio: referenceAudio,
                 referenceSampleRate: referenceSampleRate, language: "english", sampling: sampling)
@@ -224,14 +283,14 @@ public class Qwen3TTSModel {
         let speakerEmbed: MLXArray
         if let cached = referenceAudioCache.speakerEmbed(for: referenceAudio, sampleRate: referenceSampleRate) {
             speakerEmbed = cached
-            print("  Speaker embedding: cache hit \(cached.shape)")
+            AudioLog.inference.debug("Speaker embedding: cache hit \(cached.shape)")
         } else {
             let mels = SpeakerMel.compute(audio: referenceAudio, sampleRate: referenceSampleRate)
             let embed = speakerEncoder(mels)  // [1, 1024]
             eval(embed)
             referenceAudioCache.storeSpeakerEmbed(embed, audio: referenceAudio, sampleRate: referenceSampleRate)
             speakerEmbed = embed
-            print("  Speaker embedding extracted: \(speakerEmbed.shape)")
+            AudioLog.inference.debug("Speaker embedding extracted: \(speakerEmbed.shape)")
         }
 
         // Stage 1: Prepare text tokens and codec prefix (no speaker token ID — using embedding)
@@ -263,24 +322,28 @@ public class Qwen3TTSModel {
         let t2 = CFAbsoluteTimeGetCurrent()
 
         guard numFrames > 0 else {
-            print("Warning: Talker generated no tokens")
+            AudioLog.inference.warning("Talker generated no tokens")
             return []
         }
 
         // Stage 4: Codec decode to waveform
         let outputSamples = numFrames * 1920
-        print("  Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)...")
+        AudioLog.inference.debug(
+            "Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)")
         let waveform = codecDecoder.decode(codes: allCodebooks)
         let t3 = CFAbsoluteTimeGetCurrent()
 
         let audioDur = Double(waveform.count) / 24000.0
-        print("  Voice clone timing: embed=\(String(format: "%.3f", t1-t0))s | " +
-              "generate=\(String(format: "%.3f", t2-t1))s (\(numFrames) steps, " +
-              "\(String(format: "%.0f", (t2-t1)/Double(numFrames)*1000))ms/step) | " +
-              "decode=\(String(format: "%.3f", t3-t2))s | " +
-              "total=\(String(format: "%.3f", t3-t0))s | " +
-              "audio=\(String(format: "%.2f", audioDur))s | " +
-              "RTF=\(String(format: "%.2f", (t3-t0)/audioDur))")
+        let embedTime = String(format: "%.3f", t1-t0)
+        let generateTime = String(format: "%.3f", t2-t1)
+        let millisecondsPerStep = String(
+            format: "%.0f", (t2-t1)/Double(numFrames)*1000)
+        let decodeTime = String(format: "%.3f", t3-t2)
+        let totalTime = String(format: "%.3f", t3-t0)
+        let audioDuration = String(format: "%.2f", audioDur)
+        let realTimeFactor = String(format: "%.2f", (t3-t0)/audioDur)
+        AudioLog.inference.info(
+            "Voice clone timing: embed=\(embedTime)s | generate=\(generateTime)s (\(numFrames) steps, \(millisecondsPerStep)ms/step) | decode=\(decodeTime)s | total=\(totalTime)s | audio=\(audioDuration)s | RTF=\(realTimeFactor)")
 
         return waveform
     }
@@ -342,6 +405,8 @@ public class Qwen3TTSModel {
         languageExplicit: Bool = false,
         continuation: AsyncThrowingStream<AudioChunk, Error>.Continuation
     ) throws {
+        try Task.checkCancellation()
+
         guard let tokenizer = tokenizer else {
             throw TTSError.tokenizerNotLoaded
         }
@@ -368,6 +433,7 @@ public class Qwen3TTSModel {
         let (prefillEmbeds, trailingTextHidden, ttsPadEmbed) = buildPrefillEmbeddings(
             textTokens: textTokens, codecPrefixTokens: codecPrefixTokens, instructTokens: instructTokens)
         eval(prefillEmbeds, trailingTextHidden, ttsPadEmbed)
+        try Task.checkCancellation()
 
         // Stage 2: Autoregressive generation with chunked decode + emit
         let cpSamplingConfig = SamplingConfig(temperature: sampling.temperature, topK: sampling.topK)
@@ -379,6 +445,7 @@ public class Qwen3TTSModel {
             offset: MLXArray(Int32(0)),
             cache: nil)
         var talkerCache = newCache
+        try Task.checkCancellation()
 
         // Sample first token
         let lastLogits = logits[0..., (prefillLen - 1)..<prefillLen, 0...]
@@ -388,6 +455,7 @@ public class Qwen3TTSModel {
             generatedTokens: [],
             suppressRange: (2048, 3072),
             eosTokenId: CodecTokens.codecEos)
+        try Task.checkCancellation()
 
         if nextToken == Int32(CodecTokens.codecEos) {
             let chunk = AudioChunk(
@@ -408,6 +476,7 @@ public class Qwen3TTSModel {
             hiddenState: lastHidden,
             firstCodebookToken: nextToken,
             cpSamplingConfig: cpSamplingConfig)
+        try Task.checkCancellation()
         for (i, token) in codeTokens.enumerated() {
             generatedAllCodebooks[i + 1].append(token)
         }
@@ -421,12 +490,14 @@ public class Qwen3TTSModel {
 
         // Emit immediately if prefill already produced enough frames (e.g., firstChunkFrames=1)
         if generatedFirstCodebook.count >= nextEmitThreshold {
+            try Task.checkCancellation()
             let chunk = decodeAndEmitChunk(
                 allCodebooks: generatedAllCodebooks,
                 chunkStart: 0,
                 chunkEnd: generatedFirstCodebook.count,
                 decoderLeftContext: streaming.decoderLeftContext,
                 samplesPerFrame: samplesPerFrame)
+            try Task.checkCancellation()
             let audioChunk = AudioChunk(
                 samples: chunk,
                 sampleRate: 24000,
@@ -439,7 +510,10 @@ public class Qwen3TTSModel {
         }
 
         // Autoregressive generation loop
-        for iterIdx in 1..<safeMaxTokens {
+        try runQwen3TTSGenerationLoop(
+            1..<safeMaxTokens,
+            checkCancellation: { try Task.checkCancellation() }
+        ) { iterIdx in
             // Text side
             let textEmbed: MLXArray
             let trailingLen = trailingTextHidden.dim(1)
@@ -479,6 +553,7 @@ public class Qwen3TTSModel {
                     hiddenState: stepHidden,
                     firstCodebookToken: nextToken,
                     cpSamplingConfig: cpSamplingConfig)
+                try Task.checkCancellation()
                 for (i, token) in codeTokens.enumerated() {
                     generatedAllCodebooks[i + 1].append(token)
                 }
@@ -493,12 +568,14 @@ public class Qwen3TTSModel {
                 let chunkFrameStart = emittedFrames
                 let chunkFrameEnd = totalFrames
 
+                try Task.checkCancellation()
                 let chunk = decodeAndEmitChunk(
                     allCodebooks: generatedAllCodebooks,
                     chunkStart: chunkFrameStart,
                     chunkEnd: chunkFrameEnd,
                     decoderLeftContext: streaming.decoderLeftContext,
                     samplesPerFrame: samplesPerFrame)
+                try Task.checkCancellation()
 
                 let isFinalChunk = isEos || iterIdx == safeMaxTokens - 1
                 let audioChunk = AudioChunk(
@@ -515,28 +592,34 @@ public class Qwen3TTSModel {
                 nextEmitThreshold = emittedFrames + streaming.chunkFrames
             }
 
-            if isEos { break }
+            if isEos { return false }
 
             if iterIdx % 50 == 0 {
                 let estSec = Double(generatedFirstCodebook.count) / 12.5
-                print("  Streaming: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)...")
+                AudioLog.inference.debug(
+                    "Streaming: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)")
             }
+
+            return true
         }
 
         let numFrames = generatedFirstCodebook.count
         if numFrames >= safeMaxTokens && nextToken != Int32(CodecTokens.codecEos) {
             let estSec = Double(numFrames) / 12.5
-            print("Warning: Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio).")
+            AudioLog.inference.warning(
+                "Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio)")
         }
 
         // Emit remaining frames if any
         if emittedFrames < numFrames {
+            try Task.checkCancellation()
             let chunk = decodeAndEmitChunk(
                 allCodebooks: generatedAllCodebooks,
                 chunkStart: emittedFrames,
                 chunkEnd: numFrames,
                 decoderLeftContext: streaming.decoderLeftContext,
                 samplesPerFrame: samplesPerFrame)
+            try Task.checkCancellation()
             let audioChunk = AudioChunk(
                 samples: chunk,
                 sampleRate: 24000,
@@ -549,6 +632,7 @@ public class Qwen3TTSModel {
 
         // If EOS arrived with no new frames, emit a final sentinel
         if !emittedFinal {
+            try Task.checkCancellation()
             let audioChunk = AudioChunk(
                 samples: [],
                 sampleRate: 24000,
@@ -660,7 +744,8 @@ public class Qwen3TTSModel {
         let effectiveInstruct = instruct ?? (speakerConfig != nil ? Self.defaultInstruct : nil)
 
         guard let langId = CodecTokens.languageId(for: language) else {
-            print("Warning: Unknown language '\(language)', defaulting to English")
+            AudioLog.inference.warning(
+                "Unknown language '\(language)', defaulting to English")
             return synthesizeBatch(texts: texts, language: "english", instruct: instruct, sampling: sampling, maxBatchSize: maxBatchSize)
         }
 
@@ -761,9 +846,9 @@ public class Qwen3TTSModel {
             let totalWaste = wastedSteps.reduce(0, +)
             let wasteRatio = Double(totalWaste) / Double(maxFrames * batchSize)
             if wasteRatio > 0.3 {
-                print("  Warning: \(Int(wasteRatio * 100))% padding waste " +
-                      "(items finished at: \(frameCounts.map { String($0) }.joined(separator: ", ")) steps). " +
-                      "Batch similar-length texts for better efficiency.")
+                let finishedSteps = frameCounts.map { String($0) }.joined(separator: ", ")
+                AudioLog.inference.warning(
+                    "\(Int(wasteRatio * 100))% padding waste (items finished at: \(finishedSteps) steps). Batch similar-length texts for better efficiency")
             }
         }
 
@@ -772,13 +857,14 @@ public class Qwen3TTSModel {
         for i in 0..<batchSize {
             let numFrames = frameCounts[i]
             if numFrames == 0 {
-                print("  Item \(i): no tokens generated")
+                AudioLog.inference.warning("Batch item \(i): no tokens generated")
                 results.append([])
                 continue
             }
             let codes = allCodebooksList[i]  // [1, 16, Ti]
             let outputSamples = numFrames * 1920
-            print("  Item \(i): decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)...")
+            AudioLog.inference.debug(
+                "Batch item \(i): decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)")
             let waveform = codecDecoder.decode(codes: codes)
             results.append(waveform)
         }
@@ -786,13 +872,14 @@ public class Qwen3TTSModel {
 
         let totalAudio = results.reduce(0.0) { $0 + Double($1.count) / 24000.0 }
         let totalFrames = frameCounts.reduce(0, +)
-        print("  Batch timing: embed=\(String(format: "%.3f", t1-t0))s | " +
-              "generate=\(String(format: "%.3f", t2-t1))s (\(totalFrames) total steps, " +
-              "\(batchSize) items) | " +
-              "decode=\(String(format: "%.3f", t3-t2))s | " +
-              "total=\(String(format: "%.3f", t3-t0))s | " +
-              "audio=\(String(format: "%.2f", totalAudio))s | " +
-              "RTF=\(String(format: "%.2f", (t3-t0)/max(totalAudio, 0.001)))")
+        let embedTime = String(format: "%.3f", t1-t0)
+        let generateTime = String(format: "%.3f", t2-t1)
+        let decodeTime = String(format: "%.3f", t3-t2)
+        let totalTime = String(format: "%.3f", t3-t0)
+        let audioDuration = String(format: "%.2f", totalAudio)
+        let realTimeFactor = String(format: "%.2f", (t3-t0)/max(totalAudio, 0.001))
+        AudioLog.inference.info(
+            "Batch timing: embed=\(embedTime)s | generate=\(generateTime)s (\(totalFrames) total steps, \(batchSize) items) | decode=\(decodeTime)s | total=\(totalTime)s | audio=\(audioDuration)s | RTF=\(realTimeFactor)")
 
         return results
     }
@@ -911,12 +998,14 @@ public class Qwen3TTSModel {
             if iterIdx % 50 == 0 {
                 let estSec = Double(iterIdx) / 12.5
                 let doneCount = finishedArray.filter { $0 }.count
-                print("  Batch: \(iterIdx) steps (~\(String(format: "%.1f", estSec))s), \(doneCount)/\(batchSize) done...")
+                AudioLog.inference.debug(
+                    "Batch: \(iterIdx) steps (~\(String(format: "%.1f", estSec))s), \(doneCount)/\(batchSize) done")
             }
         }
 
         let totalSteps = allCBSteps.count
-        print("  Batch generation done: \(totalSteps) steps, \(batchSize) items")
+        AudioLog.inference.debug(
+            "Batch generation done: \(totalSteps) steps, \(batchSize) items")
 
         // Stack all timesteps: [B, 16, T]
         let stepsStacked = stacked(allCBSteps, axis: 0)  // [T, B, 16]
@@ -1220,15 +1309,16 @@ public class Qwen3TTSModel {
         }
 
         guard let config = speakerConfig else {
-            print("Warning: Speaker '\(speakerName)' requested but model has no speaker support. " +
-                  "Use the CustomVoice model variant for speaker selection.")
+            AudioLog.inference.warning(
+                "Speaker '\(speakerName)' requested but model has no speaker support. Use the CustomVoice model variant for speaker selection")
             return (nil, language)
         }
 
         let normalizedName = speakerName.lowercased()
         guard let tokenId = config.speakerIds[normalizedName] else {
             let available = config.availableSpeakers.joined(separator: ", ")
-            print("Warning: Unknown speaker '\(speakerName)'. Available speakers: \(available)")
+            AudioLog.inference.warning(
+                "Unknown speaker '\(speakerName)'. Available speakers: \(available)")
             return (nil, language)
         }
 
@@ -1426,6 +1516,23 @@ public class Qwen3TTSModel {
         ttsPadEmbed: MLXArray,
         sampling: SamplingConfig
     ) -> (allCodebooks: MLXArray, numFrames: Int) {
+        generateWithCodePredictor(
+            prefillEmbeds: prefillEmbeds,
+            trailingTextHidden: trailingTextHidden,
+            ttsPadEmbed: ttsPadEmbed,
+            sampling: sampling,
+            checkCancellation: {})
+    }
+
+    private func generateWithCodePredictor(
+        prefillEmbeds: MLXArray,
+        trailingTextHidden: MLXArray,
+        ttsPadEmbed: MLXArray,
+        sampling: SamplingConfig,
+        checkCancellation: () throws -> Void
+    ) rethrows -> (allCodebooks: MLXArray, numFrames: Int) {
+        try checkCancellation()
+
         // Reference (QwenLM + mlx-audio) uses 2048 here. Earlier 500 cap clipped
         // long lines mid-word and produced hard-cut endings.
         let safeMaxTokens = min(sampling.maxTokens, 2048)
@@ -1445,6 +1552,7 @@ public class Qwen3TTSModel {
             offset: MLXArray(Int32(0)),
             cache: talkerCache)
         talkerCache = newCache
+        try checkCancellation()
 
         // Sample first token from last position
         let lastLogits = logits[0..., (prefillLen - 1)..<prefillLen, 0...]
@@ -1454,6 +1562,7 @@ public class Qwen3TTSModel {
             generatedTokens: generatedFirstCodebook,
             suppressRange: (2048, 3072),
             eosTokenId: CodecTokens.codecEos)
+        try checkCancellation()
 
         if nextToken == Int32(CodecTokens.codecEos) {
             return (MLXArray.zeros([1, 16, 0]), 0)
@@ -1470,6 +1579,7 @@ public class Qwen3TTSModel {
             hiddenState: lastHidden,
             firstCodebookToken: nextToken,
             cpSamplingConfig: cpSamplingConfig)
+        try checkCancellation()
         for (i, token) in codeTokens.enumerated() {
             generatedAllCodebooks[i + 1].append(token)
         }
@@ -1478,7 +1588,10 @@ public class Qwen3TTSModel {
         var step = prefillLen
 
         // Autoregressive generation
-        for iterIdx in 1..<safeMaxTokens {
+        try runQwen3TTSGenerationLoop(
+            1..<safeMaxTokens,
+            checkCancellation: checkCancellation
+        ) { iterIdx in
             // Text side: next trailing text embed or tts_pad
             let textEmbed: MLXArray
             let trailingLen = trailingTextHidden.dim(1)
@@ -1508,7 +1621,7 @@ public class Qwen3TTSModel {
                 suppressRange: (2048, 3072),
                 eosTokenId: CodecTokens.codecEos)
 
-            if nextToken == Int32(CodecTokens.codecEos) { break }
+            if nextToken == Int32(CodecTokens.codecEos) { return false }
 
             generatedFirstCodebook.append(nextToken)
             generatedAllCodebooks[0].append(nextToken)
@@ -1519,6 +1632,7 @@ public class Qwen3TTSModel {
                 hiddenState: stepHidden,
                 firstCodebookToken: nextToken,
                 cpSamplingConfig: cpSamplingConfig)
+            try checkCancellation()
             for (i, token) in codeTokens.enumerated() {
                 generatedAllCodebooks[i + 1].append(token)
             }
@@ -1527,20 +1641,24 @@ public class Qwen3TTSModel {
 
             if iterIdx % 50 == 0 {
                 let estSec = Double(generatedFirstCodebook.count) / 12.5
-                print("  Talker: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)...")
+                AudioLog.inference.debug(
+                    "Talker: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)")
             }
+
+            return true
         }
 
         let numFrames = generatedFirstCodebook.count
 
         if numFrames >= safeMaxTokens && nextToken != Int32(CodecTokens.codecEos) {
             let estSec = Double(numFrames) / 12.5
-            print("Warning: Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio). "
-                + "Increase SamplingConfig.maxTokens if you need longer output.")
+            AudioLog.inference.warning(
+                "Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio). Increase SamplingConfig.maxTokens if you need longer output")
         }
 
         let estAudioSec = Double(numFrames) / 12.5
-        print("  Talker done: \(numFrames) codec tokens (~\(String(format: "%.1f", estAudioSec))s audio)")
+        AudioLog.inference.debug(
+            "Talker done: \(numFrames) codec tokens (~\(String(format: "%.1f", estAudioSec))s audio)")
 
         // Stack all codebooks: [1, 16, T]
         let codebookArrays = generatedAllCodebooks.map { tokens in

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -131,7 +131,8 @@ public class Qwen3TTSModel {
         let effectiveInstruct = instruct ?? (speakerConfig != nil ? Self.defaultInstruct : nil)
 
         guard let langId = CodecTokens.languageId(for: effectiveLanguage) else {
-            print("Warning: Unknown language '\(effectiveLanguage)', defaulting to English")
+            AudioLog.inference.warning(
+                "Unknown language '\(effectiveLanguage)', defaulting to English")
             return synthesize(text: text, language: "english", speaker: speaker, sampling: sampling)
         }
 
@@ -164,24 +165,28 @@ public class Qwen3TTSModel {
         let t2 = CFAbsoluteTimeGetCurrent()
 
         guard numFrames > 0 else {
-            print("Warning: Talker generated no tokens")
+            AudioLog.inference.warning("Talker generated no tokens")
             return []
         }
 
         // Stage 4: Codec decode to waveform
         let outputSamples = numFrames * 1920
-        print("  Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)...")
+        AudioLog.inference.debug(
+            "Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)")
         let waveform = codecDecoder.decode(codes: allCodebooks)
         let t3 = CFAbsoluteTimeGetCurrent()
 
         let audioDur = Double(waveform.count) / 24000.0
-        print("  Timing: embed=\(String(format: "%.3f", t1-t0))s | " +
-              "generate=\(String(format: "%.3f", t2-t1))s (\(numFrames) steps, " +
-              "\(String(format: "%.0f", (t2-t1)/Double(numFrames)*1000))ms/step) | " +
-              "decode=\(String(format: "%.3f", t3-t2))s | " +
-              "total=\(String(format: "%.3f", t3-t0))s | " +
-              "audio=\(String(format: "%.2f", audioDur))s | " +
-              "RTF=\(String(format: "%.2f", (t3-t0)/audioDur))")
+        let embedTime = String(format: "%.3f", t1-t0)
+        let generateTime = String(format: "%.3f", t2-t1)
+        let millisecondsPerStep = String(
+            format: "%.0f", (t2-t1)/Double(numFrames)*1000)
+        let decodeTime = String(format: "%.3f", t3-t2)
+        let totalTime = String(format: "%.3f", t3-t0)
+        let audioDuration = String(format: "%.2f", audioDur)
+        let realTimeFactor = String(format: "%.2f", (t3-t0)/audioDur)
+        AudioLog.inference.info(
+            "TTS timing: embed=\(embedTime)s | generate=\(generateTime)s (\(numFrames) steps, \(millisecondsPerStep)ms/step) | decode=\(decodeTime)s | total=\(totalTime)s | audio=\(audioDuration)s | RTF=\(realTimeFactor)")
 
         return waveform
     }
@@ -212,7 +217,8 @@ public class Qwen3TTSModel {
         }
 
         guard let langId = CodecTokens.languageId(for: language) else {
-            print("Warning: Unknown language '\(language)', defaulting to English")
+            AudioLog.inference.warning(
+                "Unknown language '\(language)', defaulting to English")
             return synthesizeWithVoiceClone(
                 text: text, referenceAudio: referenceAudio,
                 referenceSampleRate: referenceSampleRate, language: "english", sampling: sampling)
@@ -224,14 +230,14 @@ public class Qwen3TTSModel {
         let speakerEmbed: MLXArray
         if let cached = referenceAudioCache.speakerEmbed(for: referenceAudio, sampleRate: referenceSampleRate) {
             speakerEmbed = cached
-            print("  Speaker embedding: cache hit \(cached.shape)")
+            AudioLog.inference.debug("Speaker embedding: cache hit \(cached.shape)")
         } else {
             let mels = SpeakerMel.compute(audio: referenceAudio, sampleRate: referenceSampleRate)
             let embed = speakerEncoder(mels)  // [1, 1024]
             eval(embed)
             referenceAudioCache.storeSpeakerEmbed(embed, audio: referenceAudio, sampleRate: referenceSampleRate)
             speakerEmbed = embed
-            print("  Speaker embedding extracted: \(speakerEmbed.shape)")
+            AudioLog.inference.debug("Speaker embedding extracted: \(speakerEmbed.shape)")
         }
 
         // Stage 1: Prepare text tokens and codec prefix (no speaker token ID — using embedding)
@@ -263,24 +269,28 @@ public class Qwen3TTSModel {
         let t2 = CFAbsoluteTimeGetCurrent()
 
         guard numFrames > 0 else {
-            print("Warning: Talker generated no tokens")
+            AudioLog.inference.warning("Talker generated no tokens")
             return []
         }
 
         // Stage 4: Codec decode to waveform
         let outputSamples = numFrames * 1920
-        print("  Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)...")
+        AudioLog.inference.debug(
+            "Decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)")
         let waveform = codecDecoder.decode(codes: allCodebooks)
         let t3 = CFAbsoluteTimeGetCurrent()
 
         let audioDur = Double(waveform.count) / 24000.0
-        print("  Voice clone timing: embed=\(String(format: "%.3f", t1-t0))s | " +
-              "generate=\(String(format: "%.3f", t2-t1))s (\(numFrames) steps, " +
-              "\(String(format: "%.0f", (t2-t1)/Double(numFrames)*1000))ms/step) | " +
-              "decode=\(String(format: "%.3f", t3-t2))s | " +
-              "total=\(String(format: "%.3f", t3-t0))s | " +
-              "audio=\(String(format: "%.2f", audioDur))s | " +
-              "RTF=\(String(format: "%.2f", (t3-t0)/audioDur))")
+        let embedTime = String(format: "%.3f", t1-t0)
+        let generateTime = String(format: "%.3f", t2-t1)
+        let millisecondsPerStep = String(
+            format: "%.0f", (t2-t1)/Double(numFrames)*1000)
+        let decodeTime = String(format: "%.3f", t3-t2)
+        let totalTime = String(format: "%.3f", t3-t0)
+        let audioDuration = String(format: "%.2f", audioDur)
+        let realTimeFactor = String(format: "%.2f", (t3-t0)/audioDur)
+        AudioLog.inference.info(
+            "Voice clone timing: embed=\(embedTime)s | generate=\(generateTime)s (\(numFrames) steps, \(millisecondsPerStep)ms/step) | decode=\(decodeTime)s | total=\(totalTime)s | audio=\(audioDuration)s | RTF=\(realTimeFactor)")
 
         return waveform
     }
@@ -519,14 +529,16 @@ public class Qwen3TTSModel {
 
             if iterIdx % 50 == 0 {
                 let estSec = Double(generatedFirstCodebook.count) / 12.5
-                print("  Streaming: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)...")
+                AudioLog.inference.debug(
+                    "Streaming: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)")
             }
         }
 
         let numFrames = generatedFirstCodebook.count
         if numFrames >= safeMaxTokens && nextToken != Int32(CodecTokens.codecEos) {
             let estSec = Double(numFrames) / 12.5
-            print("Warning: Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio).")
+            AudioLog.inference.warning(
+                "Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio)")
         }
 
         // Emit remaining frames if any
@@ -660,7 +672,8 @@ public class Qwen3TTSModel {
         let effectiveInstruct = instruct ?? (speakerConfig != nil ? Self.defaultInstruct : nil)
 
         guard let langId = CodecTokens.languageId(for: language) else {
-            print("Warning: Unknown language '\(language)', defaulting to English")
+            AudioLog.inference.warning(
+                "Unknown language '\(language)', defaulting to English")
             return synthesizeBatch(texts: texts, language: "english", instruct: instruct, sampling: sampling, maxBatchSize: maxBatchSize)
         }
 
@@ -761,9 +774,9 @@ public class Qwen3TTSModel {
             let totalWaste = wastedSteps.reduce(0, +)
             let wasteRatio = Double(totalWaste) / Double(maxFrames * batchSize)
             if wasteRatio > 0.3 {
-                print("  Warning: \(Int(wasteRatio * 100))% padding waste " +
-                      "(items finished at: \(frameCounts.map { String($0) }.joined(separator: ", ")) steps). " +
-                      "Batch similar-length texts for better efficiency.")
+                let finishedSteps = frameCounts.map { String($0) }.joined(separator: ", ")
+                AudioLog.inference.warning(
+                    "\(Int(wasteRatio * 100))% padding waste (items finished at: \(finishedSteps) steps). Batch similar-length texts for better efficiency")
             }
         }
 
@@ -772,13 +785,14 @@ public class Qwen3TTSModel {
         for i in 0..<batchSize {
             let numFrames = frameCounts[i]
             if numFrames == 0 {
-                print("  Item \(i): no tokens generated")
+                AudioLog.inference.warning("Batch item \(i): no tokens generated")
                 results.append([])
                 continue
             }
             let codes = allCodebooksList[i]  // [1, 16, Ti]
             let outputSamples = numFrames * 1920
-            print("  Item \(i): decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)...")
+            AudioLog.inference.debug(
+                "Batch item \(i): decoding \(numFrames) frames -> \(outputSamples) samples (\(String(format: "%.1f", Double(outputSamples) / 24000.0))s)")
             let waveform = codecDecoder.decode(codes: codes)
             results.append(waveform)
         }
@@ -786,13 +800,14 @@ public class Qwen3TTSModel {
 
         let totalAudio = results.reduce(0.0) { $0 + Double($1.count) / 24000.0 }
         let totalFrames = frameCounts.reduce(0, +)
-        print("  Batch timing: embed=\(String(format: "%.3f", t1-t0))s | " +
-              "generate=\(String(format: "%.3f", t2-t1))s (\(totalFrames) total steps, " +
-              "\(batchSize) items) | " +
-              "decode=\(String(format: "%.3f", t3-t2))s | " +
-              "total=\(String(format: "%.3f", t3-t0))s | " +
-              "audio=\(String(format: "%.2f", totalAudio))s | " +
-              "RTF=\(String(format: "%.2f", (t3-t0)/max(totalAudio, 0.001)))")
+        let embedTime = String(format: "%.3f", t1-t0)
+        let generateTime = String(format: "%.3f", t2-t1)
+        let decodeTime = String(format: "%.3f", t3-t2)
+        let totalTime = String(format: "%.3f", t3-t0)
+        let audioDuration = String(format: "%.2f", totalAudio)
+        let realTimeFactor = String(format: "%.2f", (t3-t0)/max(totalAudio, 0.001))
+        AudioLog.inference.info(
+            "Batch timing: embed=\(embedTime)s | generate=\(generateTime)s (\(totalFrames) total steps, \(batchSize) items) | decode=\(decodeTime)s | total=\(totalTime)s | audio=\(audioDuration)s | RTF=\(realTimeFactor)")
 
         return results
     }
@@ -911,12 +926,14 @@ public class Qwen3TTSModel {
             if iterIdx % 50 == 0 {
                 let estSec = Double(iterIdx) / 12.5
                 let doneCount = finishedArray.filter { $0 }.count
-                print("  Batch: \(iterIdx) steps (~\(String(format: "%.1f", estSec))s), \(doneCount)/\(batchSize) done...")
+                AudioLog.inference.debug(
+                    "Batch: \(iterIdx) steps (~\(String(format: "%.1f", estSec))s), \(doneCount)/\(batchSize) done")
             }
         }
 
         let totalSteps = allCBSteps.count
-        print("  Batch generation done: \(totalSteps) steps, \(batchSize) items")
+        AudioLog.inference.debug(
+            "Batch generation done: \(totalSteps) steps, \(batchSize) items")
 
         // Stack all timesteps: [B, 16, T]
         let stepsStacked = stacked(allCBSteps, axis: 0)  // [T, B, 16]
@@ -1220,15 +1237,16 @@ public class Qwen3TTSModel {
         }
 
         guard let config = speakerConfig else {
-            print("Warning: Speaker '\(speakerName)' requested but model has no speaker support. " +
-                  "Use the CustomVoice model variant for speaker selection.")
+            AudioLog.inference.warning(
+                "Speaker '\(speakerName)' requested but model has no speaker support. Use the CustomVoice model variant for speaker selection")
             return (nil, language)
         }
 
         let normalizedName = speakerName.lowercased()
         guard let tokenId = config.speakerIds[normalizedName] else {
             let available = config.availableSpeakers.joined(separator: ", ")
-            print("Warning: Unknown speaker '\(speakerName)'. Available speakers: \(available)")
+            AudioLog.inference.warning(
+                "Unknown speaker '\(speakerName)'. Available speakers: \(available)")
             return (nil, language)
         }
 
@@ -1527,7 +1545,8 @@ public class Qwen3TTSModel {
 
             if iterIdx % 50 == 0 {
                 let estSec = Double(generatedFirstCodebook.count) / 12.5
-                print("  Talker: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)...")
+                AudioLog.inference.debug(
+                    "Talker: \(generatedFirstCodebook.count) tokens (~\(String(format: "%.1f", estSec))s audio)")
             }
         }
 
@@ -1535,12 +1554,13 @@ public class Qwen3TTSModel {
 
         if numFrames >= safeMaxTokens && nextToken != Int32(CodecTokens.codecEos) {
             let estSec = Double(numFrames) / 12.5
-            print("Warning: Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio). "
-                + "Increase SamplingConfig.maxTokens if you need longer output.")
+            AudioLog.inference.warning(
+                "Hit safety limit of \(safeMaxTokens) tokens (~\(String(format: "%.1f", estSec))s audio). Increase SamplingConfig.maxTokens if you need longer output")
         }
 
         let estAudioSec = Double(numFrames) / 12.5
-        print("  Talker done: \(numFrames) codec tokens (~\(String(format: "%.1f", estAudioSec))s audio)")
+        AudioLog.inference.debug(
+            "Talker done: \(numFrames) codec tokens (~\(String(format: "%.1f", estAudioSec))s audio)")
 
         // Stack all codebooks: [1, 16, T]
         let codebookArrays = generatedAllCodebooks.map { tokens in

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -137,13 +137,16 @@ public class Qwen3TTSModel {
     /// Cancellation is checked before generation, between codec-token steps,
     /// and around the final codec decode. An already-running MLX or Metal kernel
     /// completes before the next checkpoint can throw `CancellationError`.
+    /// The operation inherits `isolation` so callers can keep a non-Sendable
+    /// model on their actor or serial executor for the complete generation.
     public func synthesizeCancellable(
         text: String,
         language: String = "english",
         speaker: String? = nil,
         instruct: String? = nil,
         sampling: SamplingConfig = .default,
-        languageExplicit: Bool = false
+        languageExplicit: Bool = false,
+        isolation _: isolated (any Actor) = #isolation
     ) async throws -> [Float] {
         try synthesizeCheckingCancellation(
             text: text,

--- a/Sources/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/Qwen3TTS/Qwen3TTS.swift
@@ -130,6 +130,30 @@ public class Qwen3TTSModel {
             checkCancellation: {})
     }
 
+    /// Synthesize speech while cooperatively observing Swift task cancellation.
+    ///
+    /// This preserves the exact speaker, instruction, sampling, and
+    /// whole-waveform decode behavior of ``synthesize(text:language:speaker:instruct:sampling:languageExplicit:)``.
+    /// Cancellation is checked before generation, between codec-token steps,
+    /// and around the final codec decode. An already-running MLX or Metal kernel
+    /// completes before the next checkpoint can throw `CancellationError`.
+    public func synthesizeCancellable(
+        text: String,
+        language: String = "english",
+        speaker: String? = nil,
+        instruct: String? = nil,
+        sampling: SamplingConfig = .default,
+        languageExplicit: Bool = false
+    ) async throws -> [Float] {
+        try synthesizeCheckingCancellation(
+            text: text,
+            language: language,
+            speaker: speaker,
+            instruct: instruct,
+            sampling: sampling,
+            languageExplicit: languageExplicit)
+    }
+
     /// Cancellation-aware implementation used by the async generation
     /// contract. The synchronous public API remains source-compatible and
     /// deliberately supplies a no-op checkpoint.

--- a/Sources/Qwen3TTS/TTSWeightLoading.swift
+++ b/Sources/Qwen3TTS/TTSWeightLoading.swift
@@ -4,11 +4,10 @@ import MLX
 import MLXNN
 import AudioCommon
 
-/// Weight-loading progress logs go to stderr so they don't corrupt a stdout-based
-/// IPC channel (e.g. the speech-studio sidecar's NDJSON protocol).
+/// Route weight-loading progress through the package's model-loading category.
 @inline(__always)
 internal func logLoad(_ message: String) {
-    FileHandle.standardError.write(Data((message + "\n").utf8))
+    AudioLog.modelLoading.debug("\(message)")
 }
 
 /// Weight loading for TTS components

--- a/Tests/Qwen3TTSTests/DiagnosticsContractTests.swift
+++ b/Tests/Qwen3TTSTests/DiagnosticsContractTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import XCTest
+
+final class DiagnosticsContractTests: XCTestCase {
+
+    func testLibraryDiagnosticsUseCentralizedLoggingWithoutDirectStandardIO() throws {
+        let sourceDirectory = packageRoot
+            .appendingPathComponent("Sources", isDirectory: true)
+            .appendingPathComponent("Qwen3TTS", isDirectory: true)
+        let sourceFiles = try FileManager.default.contentsOfDirectory(
+            at: sourceDirectory,
+            includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "swift" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        XCTAssertFalse(sourceFiles.isEmpty)
+
+        let forbiddenPatterns = [
+            #"\bprint\s*\("#,
+            #"\bdebugPrint\s*\("#,
+            #"\bdump\s*\("#,
+            #"FileHandle\s*\.\s*standard(?:Output|Error)"#,
+            #"\bfputs\s*\("#,
+            #"\bputs\s*\("#,
+        ].map { try! NSRegularExpression(pattern: $0) }
+        var violations: [String] = []
+        var combinedSource = ""
+
+        for file in sourceFiles {
+            let source = try String(contentsOf: file, encoding: .utf8)
+            combinedSource += source
+            for (index, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+                let text = String(line)
+                guard !text.trimmingCharacters(in: .whitespaces).hasPrefix("//") else {
+                    continue
+                }
+                let range = NSRange(text.startIndex..., in: text)
+                if forbiddenPatterns.contains(where: {
+                    $0.firstMatch(in: text, range: range) != nil
+                }) {
+                    violations.append("\(file.lastPathComponent):\(index + 1): \(text)")
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "Qwen3TTS library diagnostics must not write directly to stdout or stderr:\n"
+                + violations.joined(separator: "\n"))
+        XCTAssertTrue(combinedSource.contains("AudioLog.inference."))
+        XCTAssertTrue(combinedSource.contains("AudioLog.modelLoading."))
+    }
+
+    private var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}

--- a/Tests/Qwen3TTSTests/GenerationCancellationTests.swift
+++ b/Tests/Qwen3TTSTests/GenerationCancellationTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import XCTest
+@testable import Qwen3TTS
+
+final class GenerationCancellationTests: XCTestCase {
+
+    func testCancellationStopsBeforeTheNextTokenStep() {
+        var checkpointCount = 0
+        var completedSteps: [Int] = []
+
+        XCTAssertThrowsError(
+            try runQwen3TTSGenerationLoop(
+                0..<10,
+                checkCancellation: {
+                    checkpointCount += 1
+                    if checkpointCount == 4 {
+                        throw CancellationError()
+                    }
+                },
+                body: { step in
+                    completedSteps.append(step)
+                    return true
+                })
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+
+        XCTAssertEqual(checkpointCount, 4)
+        XCTAssertEqual(completedSteps, [0, 1, 2])
+    }
+
+    func testNaturalTerminationDoesNotRunAnExtraCheckpoint() {
+        var checkpointCount = 0
+        var completedSteps: [Int] = []
+
+        runQwen3TTSGenerationLoop(
+            0..<10,
+            checkCancellation: { checkpointCount += 1 },
+            body: { step in
+                completedSteps.append(step)
+                return step < 2
+            })
+
+        XCTAssertEqual(checkpointCount, 3)
+        XCTAssertEqual(completedSteps, [0, 1, 2])
+    }
+
+    func testSwiftTaskCancellationPropagatesAsCancellationError() async {
+        let gate = SuspensionGate()
+        let task = Task<Int, Error> {
+            await gate.wait()
+            var completedSteps = 0
+            try runQwen3TTSGenerationLoop(
+                0..<10,
+                checkCancellation: { try Task.checkCancellation() },
+                body: { _ in
+                    completedSteps += 1
+                    return true
+                })
+            return completedSteps
+        }
+
+        await gate.waitUntilEntered()
+        task.cancel()
+        await gate.open()
+
+        do {
+            _ = try await task.value
+            XCTFail("A cancelled generation task must not begin another token step")
+        } catch is CancellationError {
+            // Expected cooperative cancellation.
+        } catch {
+            XCTFail("Expected CancellationError, received \(error)")
+        }
+    }
+
+    func testPublicAsyncGenerateRejectsPrecancelledTaskBeforeTokenizerAccess() async {
+        let gate = SuspensionGate()
+        let task = Task<[Float], Error> {
+            await gate.wait()
+            let model = Qwen3TTSModel()
+            return try await model.generate(
+                text: "Cancellation must win before tokenizer access.",
+                language: "english")
+        }
+
+        await gate.waitUntilEntered()
+        task.cancel()
+        await gate.open()
+
+        do {
+            _ = try await task.value
+            XCTFail("A pre-cancelled async generation must not access the unset tokenizer")
+        } catch is CancellationError {
+            // Expected before the unset tokenizer can be accessed.
+        } catch {
+            XCTFail("Expected CancellationError, received \(error)")
+        }
+    }
+
+    func testAsyncGenerationPathsUseTheCooperativeLoop() throws {
+        let sourceDirectory = packageRoot
+            .appendingPathComponent("Sources", isDirectory: true)
+            .appendingPathComponent("Qwen3TTS", isDirectory: true)
+        let modelSource = try String(
+            contentsOf: sourceDirectory.appendingPathComponent("Qwen3TTS.swift"),
+            encoding: .utf8)
+        let protocolSource = try String(
+            contentsOf: sourceDirectory.appendingPathComponent("Qwen3TTS+Protocols.swift"),
+            encoding: .utf8)
+
+        XCTAssertEqual(
+            occurrences(of: "runQwen3TTSGenerationLoop(", in: modelSource),
+            2,
+            "Single-item and streaming token loops must use the cooperative runner")
+        XCTAssertEqual(
+            occurrences(of: "for iterIdx in 1..<safeMaxTokens", in: modelSource),
+            1,
+            "Only the synchronous batch loop may remain outside the async cancellation contract")
+        XCTAssertTrue(protocolSource.contains("return try synthesizeCheckingCancellation("))
+        XCTAssertTrue(modelSource.contains("continuation.onTermination = { @Sendable _ in task.cancel() }"))
+    }
+
+    private func occurrences(of needle: String, in source: String) -> Int {
+        source.components(separatedBy: needle).count - 1
+    }
+
+    private var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}
+
+private actor SuspensionGate {
+    private var entered = false
+    private var isOpen = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        entered = true
+        let entryWaiters = self.entryWaiters
+        self.entryWaiters.removeAll()
+        for waiter in entryWaiters { waiter.resume() }
+
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            openWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let openWaiters = self.openWaiters
+        self.openWaiters.removeAll()
+        for waiter in openWaiters { waiter.resume() }
+    }
+}

--- a/Tests/Qwen3TTSTests/LocalModelLoadingTests.swift
+++ b/Tests/Qwen3TTSTests/LocalModelLoadingTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import XCTest
+@testable import Qwen3TTS
+
+final class LocalModelLoadingTests: XCTestCase {
+
+    func testLocalBundleValidationAcceptsSeparateCompleteDirectories() throws {
+        let fixture = try LocalBundleFixture()
+        defer { fixture.remove() }
+
+        XCTAssertNoThrow(
+            try Qwen3TTSModel.validateLocalBundle(
+                modelDirectory: fixture.modelDirectory,
+                tokenizerDirectory: fixture.tokenizerDirectory))
+    }
+
+    func testLocalBundleValidationRejectsNonFileURLBeforeFileSystemAccess() throws {
+        let fixture = try LocalBundleFixture()
+        defer { fixture.remove() }
+        let remoteURL = try XCTUnwrap(URL(string: "https://example.com/model"))
+
+        XCTAssertThrowsError(
+            try Qwen3TTSModel.validateLocalBundle(
+                modelDirectory: remoteURL,
+                tokenizerDirectory: fixture.tokenizerDirectory)
+        ) { error in
+            XCTAssertEqual(error as? Qwen3TTSLoadingError, .nonFileURL(remoteURL))
+        }
+    }
+
+    func testLocalBundleValidationRejectsMissingDirectory() throws {
+        let fixture = try LocalBundleFixture()
+        defer { fixture.remove() }
+        let missing = fixture.root.appendingPathComponent("missing", isDirectory: true)
+
+        XCTAssertThrowsError(
+            try Qwen3TTSModel.validateLocalBundle(
+                modelDirectory: missing,
+                tokenizerDirectory: fixture.tokenizerDirectory)
+        ) { error in
+            XCTAssertEqual(error as? Qwen3TTSLoadingError, .directoryNotFound(missing))
+        }
+    }
+
+    func testLocalBundleValidationRejectsRegularFileAsDirectory() throws {
+        let fixture = try LocalBundleFixture()
+        defer { fixture.remove() }
+        let file = fixture.root.appendingPathComponent("not-a-directory")
+        try Data().write(to: file)
+
+        XCTAssertThrowsError(
+            try Qwen3TTSModel.validateLocalBundle(
+                modelDirectory: fixture.modelDirectory,
+                tokenizerDirectory: file)
+        ) { error in
+            XCTAssertEqual(error as? Qwen3TTSLoadingError, .pathIsNotDirectory(file))
+        }
+    }
+
+    func testLocalBundleValidationRejectsMissingRequiredFiles() throws {
+        for fileName in ["config.json", "vocab.json"] {
+            let fixture = try LocalBundleFixture()
+            defer { fixture.remove() }
+            let file = fixture.modelDirectory.appendingPathComponent(fileName)
+            try FileManager.default.removeItem(at: file)
+
+            XCTAssertThrowsError(
+                try Qwen3TTSModel.validateLocalBundle(
+                    modelDirectory: fixture.modelDirectory,
+                    tokenizerDirectory: fixture.tokenizerDirectory)
+            ) { error in
+                XCTAssertEqual(
+                    error as? Qwen3TTSLoadingError,
+                    .requiredFileUnavailable(file))
+            }
+        }
+    }
+
+    func testLocalBundleValidationRejectsMissingModelWeights() throws {
+        let fixture = try LocalBundleFixture()
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.modelWeights)
+
+        XCTAssertThrowsError(
+            try Qwen3TTSModel.validateLocalBundle(
+                modelDirectory: fixture.modelDirectory,
+                tokenizerDirectory: fixture.tokenizerDirectory)
+        ) { error in
+            XCTAssertEqual(
+                error as? Qwen3TTSLoadingError,
+                .weightsUnavailable(fixture.modelDirectory))
+        }
+    }
+
+    func testLocalBundleValidationRejectsMissingTokenizerWeights() throws {
+        let fixture = try LocalBundleFixture()
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.tokenizerWeights)
+
+        XCTAssertThrowsError(
+            try Qwen3TTSModel.validateLocalBundle(
+                modelDirectory: fixture.modelDirectory,
+                tokenizerDirectory: fixture.tokenizerDirectory)
+        ) { error in
+            XCTAssertEqual(
+                error as? Qwen3TTSLoadingError,
+                .weightsUnavailable(fixture.tokenizerDirectory))
+        }
+    }
+
+    func testLocalBundleValidationRejectsIncompleteShardedCheckpoint() throws {
+        let fixture = try LocalBundleFixture()
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.modelWeights)
+        let firstShard = "model-00001-of-00002.safetensors"
+        try Data().write(
+            to: fixture.modelDirectory.appendingPathComponent(firstShard))
+        let index = """
+            {
+              "weight_map": {
+                "talker.weight": "\(firstShard)",
+                "predictor.weight": "model-00002-of-00002.safetensors"
+              }
+            }
+            """
+        try Data(index.utf8).write(
+            to: fixture.modelDirectory.appendingPathComponent(
+                "model.safetensors.index.json"))
+
+        XCTAssertThrowsError(
+            try Qwen3TTSModel.validateLocalBundle(
+                modelDirectory: fixture.modelDirectory,
+                tokenizerDirectory: fixture.tokenizerDirectory)
+        ) { error in
+            XCTAssertEqual(
+                error as? Qwen3TTSLoadingError,
+                .weightsUnavailable(fixture.modelDirectory))
+        }
+    }
+
+    func testNoneWiredMemoryPolicyLeavesProcessStateUntouched() throws {
+        var requestedFractions: [Double] = []
+
+        try Qwen3TTSModel.applyWiredMemoryPolicy(.none) { fraction in
+            requestedFractions.append(fraction)
+        }
+
+        XCTAssertTrue(requestedFractions.isEmpty)
+    }
+
+    func testPinWiredMemoryPolicyForwardsValidatedFraction() throws {
+        var requestedFractions: [Double] = []
+
+        try Qwen3TTSModel.applyWiredMemoryPolicy(.pin(fraction: 0.75)) { fraction in
+            requestedFractions.append(fraction)
+        }
+
+        XCTAssertEqual(requestedFractions, [0.75])
+    }
+
+    func testPinWiredMemoryPolicyRejectsInvalidFractionsWithoutMutation() {
+        for fraction in [0, -0.1, 1.1, .infinity, .nan] {
+            var didPin = false
+
+            XCTAssertThrowsError(
+                try Qwen3TTSModel.applyWiredMemoryPolicy(.pin(fraction: fraction)) { _ in
+                    didPin = true
+                }
+            ) { error in
+                guard let loadingError = error as? Qwen3TTSLoadingError,
+                    case .invalidWiredMemoryFraction(let actual) = loadingError
+                else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+                if fraction.isNaN {
+                    XCTAssertTrue(actual.isNaN)
+                } else {
+                    XCTAssertEqual(actual, fraction)
+                }
+            }
+            XCTAssertFalse(didPin)
+        }
+    }
+}
+
+private final class LocalBundleFixture {
+    let root: URL
+    let modelDirectory: URL
+    let tokenizerDirectory: URL
+    let modelWeights: URL
+    let tokenizerWeights: URL
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("qwen-local-loader-\(UUID().uuidString)", isDirectory: true)
+        modelDirectory = root.appendingPathComponent("model", isDirectory: true)
+        tokenizerDirectory = root.appendingPathComponent("tokenizer", isDirectory: true)
+        modelWeights = modelDirectory.appendingPathComponent("model.safetensors")
+        tokenizerWeights = tokenizerDirectory.appendingPathComponent("tokenizer.safetensors")
+
+        try FileManager.default.createDirectory(
+            at: modelDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: tokenizerDirectory, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(
+            to: modelDirectory.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(
+            to: modelDirectory.appendingPathComponent("vocab.json"))
+        try Data().write(to: modelWeights)
+        try Data().write(to: tokenizerWeights)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}

--- a/Tests/Qwen3TTSTests/PublicGenerationCancellationAPITests.swift
+++ b/Tests/Qwen3TTSTests/PublicGenerationCancellationAPITests.swift
@@ -4,7 +4,19 @@ import XCTest
 final class PublicGenerationCancellationAPITests: XCTestCase {
     func testExactCancellableSynthesisIsPublic() {
         let publicMethod = Qwen3TTSModel.synthesizeCancellable
+        let callerIsolatedUse = Self.synthesizeOnCallerExecutor
         XCTAssertFalse(
             String(reflecting: type(of: publicMethod)).isEmpty)
+        XCTAssertFalse(
+            String(reflecting: type(of: callerIsolatedUse)).isEmpty)
+    }
+
+    private static func synthesizeOnCallerExecutor(
+        model: Qwen3TTSModel,
+        isolation: isolated (any Actor)
+    ) async throws -> [Float] {
+        try await model.synthesizeCancellable(
+            text: "Public API compile contract",
+            isolation: isolation)
     }
 }

--- a/Tests/Qwen3TTSTests/PublicGenerationCancellationAPITests.swift
+++ b/Tests/Qwen3TTSTests/PublicGenerationCancellationAPITests.swift
@@ -1,0 +1,10 @@
+import Qwen3TTS
+import XCTest
+
+final class PublicGenerationCancellationAPITests: XCTestCase {
+    func testExactCancellableSynthesisIsPublic() {
+        let publicMethod = Qwen3TTSModel.synthesizeCancellable
+        XCTAssertFalse(
+            String(reflecting: type(of: publicMethod)).isEmpty)
+    }
+}

--- a/Tests/Qwen3TTSTests/PublicLocalModelLoadingAPITests.swift
+++ b/Tests/Qwen3TTSTests/PublicLocalModelLoadingAPITests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Qwen3TTS
+import XCTest
+
+final class PublicLocalModelLoadingAPITests: XCTestCase {
+
+    func testPublicLocalAndPretrainedLoaderSignatures() {
+        let localLoader: (URL, URL, Qwen3TTSConfig) throws -> Qwen3TTSModel = {
+            modelDirectory, tokenizerDirectory, configuration in
+            try Qwen3TTSModel.fromLocal(
+                modelDirectory: modelDirectory,
+                tokenizerDirectory: tokenizerDirectory,
+                configuration: configuration)
+        }
+        let governedLocalLoader: (URL, URL, Qwen3TTSConfig) throws -> Qwen3TTSModel = {
+            modelDirectory, tokenizerDirectory, configuration in
+            try Qwen3TTSModel.fromLocal(
+                modelDirectory: modelDirectory,
+                tokenizerDirectory: tokenizerDirectory,
+                configuration: configuration,
+                wiredMemoryPolicy: .none)
+        }
+        let pretrainedLoader: (URL, URL) async throws -> Qwen3TTSModel = {
+            modelDirectory, tokenizerDirectory in
+            try await Qwen3TTSModel.fromPretrained(
+                cacheDir: modelDirectory,
+                tokenizerCacheDir: tokenizerDirectory)
+        }
+
+        _ = localLoader
+        _ = governedLocalLoader
+        _ = pretrainedLoader
+    }
+}

--- a/docs/inference/cache-and-offline.md
+++ b/docs/inference/cache-and-offline.md
@@ -165,7 +165,7 @@ All models support both parameters:
 | `ParakeetASRModel` | `cacheDir`, `offlineMode` |
 | `CoreMLASRModel` | `cacheDir`, `offlineMode` |
 | `KokoroTTSModel` | `cacheDir`, `offlineMode` |
-| `Qwen3TTSModel` | `cacheDir`, `offlineMode` |
+| `Qwen3TTSModel` | `cacheDir`, `tokenizerCacheDir`, `offlineMode`; or explicit `fromLocal` directories |
 | `Qwen3TTSCoreMLModel` | `cacheDir`, `offlineMode` |
 | `CosyVoiceTTSModel` | `cacheDir`, `offlineMode` |
 | `PersonaPlexModel` | `cacheDir`, `offlineMode` |

--- a/docs/inference/qwen3-tts-inference.md
+++ b/docs/inference/qwen3-tts-inference.md
@@ -163,6 +163,30 @@ Audio waveform [1, T*1920, 1] at 24kHz
 | On-device | Yes (MLX) | Yes (AVFoundation) |
 | Model size | ~1.7 GB | Built-in |
 
+## Loading Local Model Bundles
+
+Use `fromLocal` when model acquisition and storage are owned by the calling app. It accepts
+separate directories for the main TTS model and the speech-tokenizer codec, validates both
+before model allocation, and never resolves a cache, contacts an endpoint, or downloads files.
+
+```swift
+let model = try Qwen3TTSModel.fromLocal(
+    modelDirectory: ttsDirectory,
+    tokenizerDirectory: speechTokenizerDirectory,
+    configuration: .config(for: .large, bits: 0),
+    wiredMemoryPolicy: .none
+)
+```
+
+The main directory must contain `config.json`, `vocab.json`, and a complete safetensors
+checkpoint. The speech-tokenizer directory must contain its own complete safetensors
+checkpoint. Validation failures are reported as `Qwen3TTSLoadingError` values.
+
+`fromLocal` defaults to `.none`, leaving the process-wide Metal wired-memory limit unchanged.
+`fromPretrained` retains its existing `.pin(fraction: 0.9)` default for source compatibility.
+Apps with a shared resource governor should use `.none` and manage any Metal memory policy
+themselves.
+
 ### Implementation Notes
 
 - **Chunked codec decoding** — Codec frames processed in overlapping chunks (`chunkSize=25, leftContext=10`), reducing O(T²) attention to O(chunk²)

--- a/docs/inference/qwen3-tts-inference.md
+++ b/docs/inference/qwen3-tts-inference.md
@@ -196,6 +196,18 @@ themselves.
 - **Lazy code predictor chain** — 15 sequential codebook predictions use lazy MLXArray (Gumbel-max trick) with a single `eval()` at the end, reducing 15 GPU sync barriers to 1 per timestep
 - **Compiled talker + code predictor** — `compile(shapeless: true)` for the 28-layer talker (growing KV cache); `compile(shapeless: false)` for the 5-layer code predictor (14 fixed cache sizes)
 
+## Diagnostics
+
+Qwen3-TTS routes model-loading and inference diagnostics through the package's
+`AudioLog.modelLoading` and `AudioLog.inference` unified-log categories. Its
+diagnostic paths do not write directly to stdout or stderr, leaving those
+streams under the control of the embedding application or command-line tool.
+
+Warnings report fallbacks, empty generations, safety limits, and inefficient
+batches. Per-generation timing summaries use the `info` level; periodic token,
+decode, cache, and weight-loading progress uses `debug` so normal operation is
+bounded to completion summaries and actionable conditions.
+
 ## Streaming Synthesis
 
 The Talker, Code Predictor, and Mimi decoder are all fully causal, enabling chunk-by-chunk audio emission during generation.
@@ -210,6 +222,20 @@ The Talker, Code Predictor, and Mimi decoder are all fully causal, enabling chun
 1. **First chunk** — emitted after `firstChunkFrames` tokens (default 3, or 1 for low-latency)
 2. **Subsequent chunks** — emitted every `chunkFrames` tokens (default 25 = 2s audio)
 3. **Codec decode** — each chunk runs the Mimi decoder with left-context overlap for quality
+
+### Cooperative Cancellation
+
+The async `SpeechGenerationModel.generate()` path and `synthesizeStream()`
+cooperate with Swift task cancellation. Autoregressive inference checks for
+cancellation before every codec-token step and again before and after codec
+decode. Once cancellation is observed at a checkpoint, generation throws
+`CancellationError` instead of yielding or returning a successful final
+result.
+
+Cancellation latency is bounded to the currently executing token step or
+codec decode; MLX and Metal kernels already in flight cannot be preempted.
+The synchronous `synthesize()` and `synthesizeBatch()` APIs retain their
+existing non-throwing behavior and are not task-cancellation entry points.
 
 ### Zero-Pad Decode
 

--- a/docs/inference/qwen3-tts-inference.md
+++ b/docs/inference/qwen3-tts-inference.md
@@ -172,6 +172,18 @@ Audio waveform [1, T*1920, 1] at 24kHz
 - **Lazy code predictor chain** — 15 sequential codebook predictions use lazy MLXArray (Gumbel-max trick) with a single `eval()` at the end, reducing 15 GPU sync barriers to 1 per timestep
 - **Compiled talker + code predictor** — `compile(shapeless: true)` for the 28-layer talker (growing KV cache); `compile(shapeless: false)` for the 5-layer code predictor (14 fixed cache sizes)
 
+## Diagnostics
+
+Qwen3-TTS routes model-loading and inference diagnostics through the package's
+`AudioLog.modelLoading` and `AudioLog.inference` unified-log categories. Its
+diagnostic paths do not write directly to stdout or stderr, leaving those
+streams under the control of the embedding application or command-line tool.
+
+Warnings report fallbacks, empty generations, safety limits, and inefficient
+batches. Per-generation timing summaries use the `info` level; periodic token,
+decode, cache, and weight-loading progress uses `debug` so normal operation is
+bounded to completion summaries and actionable conditions.
+
 ## Streaming Synthesis
 
 The Talker, Code Predictor, and Mimi decoder are all fully causal, enabling chunk-by-chunk audio emission during generation.


### PR DESCRIPTION
## Summary

- add a validated local-only Qwen3-TTS loader with separate model and tokenizer roots
- make wired-memory mutation an explicit opt-in policy while preserving pretrained-loader defaults
- route Qwen3-TTS diagnostics through the package logging categories instead of direct stdout or stderr writes
- add cooperative cancellation checkpoints to async single-item and streaming generation

This combines the package-scoped changes proposed independently in #442, #443, and #444 so their overlapping generation and documentation edits can be reviewed and tested together.

## Architecture and compatibility

The synchronous synthesis and batch APIs remain non-throwing and source-compatible. Existing pretrained loading retains its download and wired-memory defaults. The new local loader performs no network access, validates both artifact roots before loading, and allows an embedding client to leave process-wide wired-memory state untouched.

Async generation now checks cancellation before each autoregressive token step and around codec decode. MLX and Metal kernels already in flight remain non-preemptible, so cancellation latency is bounded by the current token step or decode operation.

Library diagnostics use `AudioLog.modelLoading` and `AudioLog.inference`, leaving stdout and stderr under the control of the embedding application or command-line tool.

## Validation

```sh
DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
  xcrun swift test \
  --build-system native \
  --scratch-path /private/tmp/speech-swift-ss-0003a-build-native \
  --no-parallel \
  --filter 'LocalModelLoadingTests|PublicLocalModelLoadingAPITests|DiagnosticsContractTests|GenerationCancellationTests' \
  --skip 'GenerationCancellationTests/testPublicAsyncGenerateRejectsPrecancelledTaskBeforeTokenizerAccess'
```

Result: 17 tests passed with no failures.

The excluded public cancellation probe initializes MLX and requires the compiled metallib; it passed on the isolated cancellation branch in #444. The default Swift Build lane is currently blocked locally by an Xcode 27 beta Metal component build mismatch, while the native SwiftPM package build and model-free contract suite above pass.
