### PR TITLE
Bound the MLX buffer pool in Qwen3TTS E2E suites

### DIFF
--- a/Tests/Qwen3TTSTests/E2ELocalModelLoadingTests.swift
+++ b/Tests/Qwen3TTSTests/E2ELocalModelLoadingTests.swift
@@ -8,7 +8,7 @@ import XCTest
 /// Set `QWEN3_TTS_LOCAL_MODEL_DIR` and `QWEN3_TTS_LOCAL_TOKENIZER_DIR` to override
 /// the standard cache locations. The test skips instead of downloading because `fromLocal`
 /// promises never to perform network or cache resolution.
-final class E2ELocalModelLoadingTests: XCTestCase {
+final class E2ELocalModelLoadingTests: E2ETestCase {
     func testLocalLoaderUsesBundleMetadataAndSynthesizes() throws {
         let modelDirectory = try localDirectory(
             environmentKey: "QWEN3_TTS_LOCAL_MODEL_DIR",

--- a/Tests/Qwen3TTSTests/E2ETestCase.swift
+++ b/Tests/Qwen3TTSTests/E2ETestCase.swift
@@ -1,0 +1,53 @@
+import MLX
+import XCTest
+
+/// Base class for E2E suites, which bounds MLX's buffer pool.
+///
+/// MLX does not return freed buffers to the system; it pools them for reuse,
+/// and the pool's default ceiling is a fraction of physical RAM (~0.95x). In a
+/// long-lived xctest process that ceiling is never reached in a useful sense —
+/// the pool simply grows for the length of the run and the machine runs out of
+/// memory first.
+///
+/// Measured on a 16 GB machine before this change, `E2ETTSTests` alone, one
+/// shared model, phys_footprint after each test:
+///
+///     testBaseModelNoDefaultInstruct   4029 MB   (mlx cache 2187 MB)
+///     testEnglishLatency               7094 MB   (mlx cache 5298 MB)
+///     testEnglishRoundTrip             8916 MB   (mlx cache 6359 MB)
+///     testEnglishSynthesis            10317 MB   (mlx cache 7763 MB)
+///
+/// The `active` figure — the models themselves — stayed flat at 1.6-2.3 GB
+/// throughout. All of the growth was pooled buffers. The full nine-test suite
+/// could not finish: it passed 9 GB five tests in and was still climbing.
+///
+/// With the cap below, the same nine tests peak at 3089 MB and complete in 32 s,
+/// the pool pinned at its limit and the footprint returning after every test.
+///
+/// This does not replace `scripts/test_e2e_isolated.sh`. That bounds memory
+/// across suites; this bounds it within one. Both are needed — the per-suite
+/// bound is only as good as the largest suite, and the largest suite was itself
+/// larger than the machine.
+class E2ETestCase: XCTestCase {
+
+    /// Enough for a decode step's working set on the largest model here, and
+    /// ~3% of a 16 GB machine. MLX's own guidance is that small caches usually
+    /// perform as well as large ones; the risk of going lower is extra trips to
+    /// the Metal allocator, not correctness.
+    ///
+    /// Override in a subclass that genuinely needs more.
+    class var mlxCacheLimitBytes: Int { 512 << 20 }
+
+    override class func setUp() {
+        super.setUp()
+        MLX.Memory.cacheLimit = mlxCacheLimitBytes
+    }
+
+    /// Hand the pool back between tests. The cap alone bounds the high-water
+    /// mark; this keeps the resident figure near what the suite is actually
+    /// using, which matters when several suites run back to back.
+    override func tearDown() {
+        super.tearDown()
+        MLX.Memory.clearCache()
+    }
+}

--- a/Tests/Qwen3TTSTests/E2ETestCase.swift
+++ b/Tests/Qwen3TTSTests/E2ETestCase.swift
@@ -1,53 +1,34 @@
 import MLX
 import XCTest
 
-/// Base class for E2E suites, which bounds MLX's buffer pool.
-///
-/// MLX does not return freed buffers to the system; it pools them for reuse,
-/// and the pool's default ceiling is a fraction of physical RAM (~0.95x). In a
-/// long-lived xctest process that ceiling is never reached in a useful sense —
-/// the pool simply grows for the length of the run and the machine runs out of
-/// memory first.
-///
-/// Measured on a 16 GB machine before this change, `E2ETTSTests` alone, one
-/// shared model, phys_footprint after each test:
-///
-///     testBaseModelNoDefaultInstruct   4029 MB   (mlx cache 2187 MB)
-///     testEnglishLatency               7094 MB   (mlx cache 5298 MB)
-///     testEnglishRoundTrip             8916 MB   (mlx cache 6359 MB)
-///     testEnglishSynthesis            10317 MB   (mlx cache 7763 MB)
-///
-/// The `active` figure — the models themselves — stayed flat at 1.6-2.3 GB
-/// throughout. All of the growth was pooled buffers. The full nine-test suite
-/// could not finish: it passed 9 GB five tests in and was still climbing.
-///
-/// With the cap below, the same nine tests peak at 3089 MB and complete in 32 s,
-/// the pool pinned at its limit and the footprint returning after every test.
-///
-/// This does not replace `scripts/test_e2e_isolated.sh`. That bounds memory
-/// across suites; this bounds it within one. Both are needed — the per-suite
-/// bound is only as good as the largest suite, and the largest suite was itself
-/// larger than the machine.
+/// Bounds reusable MLX buffers while a Qwen3-TTS E2E suite runs, then restores
+/// the process-wide cache policy for subsequent suites.
 class E2ETestCase: XCTestCase {
 
-    /// Enough for a decode step's working set on the largest model here, and
-    /// ~3% of a 16 GB machine. MLX's own guidance is that small caches usually
-    /// perform as well as large ones; the risk of going lower is extra trips to
-    /// the Metal allocator, not correctness.
-    ///
-    /// Override in a subclass that genuinely needs more.
+    /// Maximum cache allowance. An existing stricter limit is preserved.
     class var mlxCacheLimitBytes: Int { 512 << 20 }
+
+    private static var previousMLXCacheLimit: Int?
 
     override class func setUp() {
         super.setUp()
-        MLX.Memory.cacheLimit = mlxCacheLimitBytes
+        let previousLimit = MLX.Memory.cacheLimit
+        previousMLXCacheLimit = previousLimit
+        MLX.Memory.cacheLimit = min(previousLimit, max(0, mlxCacheLimitBytes))
+        MLX.Memory.clearCache()
     }
 
-    /// Hand the pool back between tests. The cap alone bounds the high-water
-    /// mark; this keeps the resident figure near what the suite is actually
-    /// using, which matters when several suites run back to back.
     override func tearDown() {
-        super.tearDown()
         MLX.Memory.clearCache()
+        super.tearDown()
+    }
+
+    override class func tearDown() {
+        MLX.Memory.clearCache()
+        if let previousLimit = previousMLXCacheLimit {
+            MLX.Memory.cacheLimit = previousLimit
+            previousMLXCacheLimit = nil
+        }
+        super.tearDown()
     }
 }

--- a/Tests/Qwen3TTSTests/EOSCapTests.swift
+++ b/Tests/Qwen3TTSTests/EOSCapTests.swift
@@ -28,7 +28,7 @@ final class EOSCapTests: XCTestCase {
 
 // MARK: - E2E Tests
 
-final class E2EEOSCapTests: XCTestCase {
+final class E2EEOSCapTests: E2ETestCase {
 
     func testXVectorShortEnglishEOS() async throws {
         // Short English text should stop well before maxTokens

--- a/Tests/Qwen3TTSTests/ICLVoiceCloningTests.swift
+++ b/Tests/Qwen3TTSTests/ICLVoiceCloningTests.swift
@@ -90,7 +90,7 @@ final class ICLVoiceCloningTests: XCTestCase {
 
 // MARK: - E2E Tests
 
-final class E2EICLVoiceCloningTests: XCTestCase {
+final class E2EICLVoiceCloningTests: E2ETestCase {
 
     func testE2EEncoderWeightLoading() async throws {
         // Load model with encoder

--- a/Tests/Qwen3TTSTests/MLXCacheLimitPolicyTests.swift
+++ b/Tests/Qwen3TTSTests/MLXCacheLimitPolicyTests.swift
@@ -1,0 +1,50 @@
+import MLX
+import XCTest
+
+private final class CacheLimitProbeCase: E2ETestCase {
+    override class var mlxCacheLimitBytes: Int { 512 << 20 }
+}
+
+final class MLXCacheLimitPolicyTests: XCTestCase {
+    func testAppliesBoundAndRestoresPreviousLimit() {
+        exercisePolicy(
+            initialLimit: 1 << 30,
+            expectedAppliedLimit: 512 << 20)
+    }
+
+    func testPreservesStricterExistingLimit() {
+        exercisePolicy(
+            initialLimit: 256 << 20,
+            expectedAppliedLimit: 256 << 20)
+    }
+
+    private func exercisePolicy(
+        initialLimit: Int,
+        expectedAppliedLimit: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let processLimit = MLX.Memory.cacheLimit
+        defer {
+            MLX.Memory.cacheLimit = processLimit
+            MLX.Memory.clearCache()
+        }
+
+        MLX.Memory.cacheLimit = initialLimit
+        CacheLimitProbeCase.setUp()
+
+        XCTAssertEqual(
+            MLX.Memory.cacheLimit,
+            expectedAppliedLimit,
+            file: file,
+            line: line)
+
+        CacheLimitProbeCase.tearDown()
+
+        XCTAssertEqual(
+            MLX.Memory.cacheLimit,
+            initialLimit,
+            file: file,
+            line: line)
+    }
+}

--- a/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
+++ b/Tests/Qwen3TTSTests/Qwen3TTSTests.swift
@@ -299,7 +299,7 @@ final class SpeakerConfigTests: XCTestCase {
 
 // MARK: - Instruct Token Tests
 
-final class E2EInstructTokenTests: XCTestCase {
+final class E2EInstructTokenTests: E2ETestCase {
 
     static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     private static var _sharedModel: Qwen3TTSModel?
@@ -380,7 +380,7 @@ final class E2EInstructTokenTests: XCTestCase {
 
 /// End-to-end tests for CustomVoice model with instruct-based style control.
 /// Requires CustomVoice model weights (~1.2 GB download).
-final class E2ECustomVoiceInstructTests: XCTestCase {
+final class E2ECustomVoiceInstructTests: E2ETestCase {
 
     static let customVoiceModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
@@ -393,13 +393,6 @@ final class E2ECustomVoiceInstructTests: XCTestCase {
         try XCTSkipUnless(
             ProcessInfo.processInfo.environment["QWEN3_CUSTOMVOICE_INSTRUCT_E2E"] == "1",
             "Set QWEN3_CUSTOMVOICE_INSTRUCT_E2E=1 to run CustomVoice instruct E2E tests")
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        // Release accumulated MLX buffer pool between tests to prevent
-        // memory pressure from cascading across sequential synthesis calls.
-        Memory.clearCache()
     }
 
     /// CustomVoice + instruct should produce valid audio
@@ -641,16 +634,11 @@ final class E2ECustomVoiceInstructTests: XCTestCase {
 
 /// Verifies that speaker token position in codec prefix produces correct voice identity.
 /// Regression test for #105: speaker token must come BEFORE pad+bos.
-final class E2ESpeakerTokenPositionTests: XCTestCase {
+final class E2ESpeakerTokenPositionTests: E2ETestCase {
 
     static let customVoiceModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX-bf16"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     private static var _sharedModel: Qwen3TTSModel?
-
-    override func tearDown() {
-        super.tearDown()
-        Memory.clearCache()
-    }
 
     /// Two different speakers should produce distinct audio for the same text.
     /// With the old wrong token position, all speakers sounded the same.
@@ -748,7 +736,7 @@ final class E2ESpeakerTokenPositionTests: XCTestCase {
 
 /// End-to-end tests for TTS synthesis with latency measurement.
 /// Requires TTS model weights (~1.7 GB). Tests are grouped by language.
-final class E2ETTSTests: XCTestCase {
+final class E2ETTSTests: E2ETestCase {
 
     static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
@@ -1045,7 +1033,7 @@ final class E2ETTSTests: XCTestCase {
 // MARK: - TTS 8-bit E2E Tests
 
 /// End-to-end tests for 8-bit TTS model variant.
-final class E2ETTS8bitTests: XCTestCase {
+final class E2ETTS8bitTests: E2ETestCase {
 
     static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
@@ -1131,7 +1119,7 @@ final class E2ETTS8bitTests: XCTestCase {
 
 // MARK: - 1.7B TTS Tests
 
-final class E2ETTS17BTests: XCTestCase {
+final class E2ETTS17BTests: E2ETestCase {
 
     static let ttsModelIdBf16 = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"
     static let ttsModelId8bit = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-8bit"
@@ -1300,7 +1288,7 @@ final class E2ETTS17BTests: XCTestCase {
 
 // MARK: - Long Text Memory Regression
 
-final class E2ETTSLongTextTests: XCTestCase {
+final class E2ETTSLongTextTests: E2ETestCase {
 
     /// Verify long text synthesis completes without OOM.
     /// Before the chunkedDecode eval fix, this peaked at 17+ GB and crashed on 16 GB Macs.
@@ -1327,7 +1315,7 @@ final class E2ETTSLongTextTests: XCTestCase {
 
 // MARK: - Batch TTS Tests
 
-final class E2ETTSBatchTests: XCTestCase {
+final class E2ETTSBatchTests: E2ETestCase {
 
     static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
@@ -1524,7 +1512,7 @@ final class E2ETTSBatchTests: XCTestCase {
 
 /// End-to-end tests for streaming TTS synthesis.
 /// Requires TTS model weights (~1.7 GB).
-final class E2ETTSStreamingTests: XCTestCase {
+final class E2ETTSStreamingTests: E2ETestCase {
 
     static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-0.6B-Base-MLX-8bit"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"

--- a/Tests/Qwen3TTSTests/VoiceCloningTests.swift
+++ b/Tests/Qwen3TTSTests/VoiceCloningTests.swift
@@ -120,7 +120,7 @@ final class SpeakerEncoderUnitTests: XCTestCase {
 
 // MARK: - E2E Tests (require model download + GPU)
 
-final class E2EVoiceCloningTests: XCTestCase {
+final class E2EVoiceCloningTests: E2ETestCase {
 
     static let ttsModelId = "aufklarer/Qwen3-TTS-12Hz-1.7B-Base-MLX-bf16"
     static let ttsTokenizerModelId = "Qwen/Qwen3-TTS-Tokenizer-12Hz"


### PR DESCRIPTION
## What changed

`E2ETestCase` bounds the MLX buffer pool at 512 MB for all 13 Qwen3-TTS E2E suites. It preserves an existing stricter limit, clears reusable buffers between tests, and restores the previous process-wide policy after each suite.

This complements `scripts/test_e2e_isolated.sh`: the runner isolates test classes, while this change bounds memory within the largest class.

## Result

The nine-test `E2ETTSTests` suite now completes with real model weights at 2.71 GB maximum RSS and zero swaps. Before the buffer-pool bound, the suite exceeded 10 GB and did not complete on a 16 GB machine.

## Scope

Test infrastructure only. No production inference, public API, CLI, or documentation changes.

## Tests

- Hosted `build-and-test`: passed
- `MLXCacheLimitPolicyTests`: 2 passed
- Qwen3-TTS unit slice: 93 passed
- `E2ETTSTests`: 9 passed in 34.3 seconds, 2.71 GB maximum RSS, zero swaps