### PR TITLE
Make VoiceChat INT5 faster than real time

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On-device speech recognition, synthesis, and understanding for Mac and iOS. Runs
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Streaming speech-to-speech translation (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi stack, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/guides/respond)** — Full-duplex speech-to-speech (7B, audio in → audio out, 18 voice presets)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — Native MLX duplex speech-to-speech with continuous speech input, text/function channels, direct EAR-TTS speech output, and a neural codec (INT5/INT8; not yet real-time)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — Native MLX duplex speech-to-speech with continuous speech input, text/function channels, direct EAR-TTS speech output, and a neural codec (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Speech-driven facial animation for avatars (NVIDIA Audio2Face-3D v2.3 Mark, 301 facial coefficients, MLX)
 
 **Enhancement, Separation & Audio Generation**

--- a/README_ar.md
+++ b/README_ar.md
@@ -88,7 +88,7 @@
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — ترجمة تدفقية من كلام إلى كلام (FR/ES/PT/DE → EN، MLX INT4 + INT8، حزمة Kyutai Moshi/Mimi، CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/ar/guides/respond)** — تحويل صوت إلى صوت ثنائي الاتجاه الكامل (7B، صوت داخل → صوت خارج، 18 إعداداً صوتياً مسبقاً)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — نموذج speech-to-speech ثنائي الاتجاه أصلي عبر MLX بمدخل كلام مستمر وقناتي نص/وظيفة وإخراج كلام مباشر عبر EAR-TTS والترميز العصبي (INT5/INT8؛ ليس آنيًا بعد)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — نموذج speech-to-speech ثنائي الاتجاه أصلي عبر MLX بمدخل كلام مستمر وقناتي نص/وظيفة وإخراج كلام مباشر عبر EAR-TTS والترميز العصبي (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — تحريك وجه الأفاتار انطلاقًا من الكلام (NVIDIA Audio2Face-3D v2.3 Mark, 301 معامل وجه, MLX)
 
 **التحسين والفصل وتوليد الصوت**

--- a/README_de.md
+++ b/README_de.md
@@ -78,7 +78,7 @@ Spracherkennung, -synthese und -verständnis auf dem Gerät für Mac und iOS. L�
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Streaming-Sprache-zu-Sprache-Übersetzung (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi-Stack, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/de/guides/respond)** — Vollduplex-Sprache-zu-Sprache (7B, Audio rein → Audio raus, 18 Stimmvoreinstellungen)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — Natives MLX-Duplex-Speech-to-Speech mit kontinuierlicher Spracheingabe, Text-/Funktionskanälen und direkter Sprachausgabe über EAR-TTS und neuronalen Codec (INT5/INT8; noch nicht echtzeitfähig)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — Natives MLX-Duplex-Speech-to-Speech mit kontinuierlicher Spracheingabe, Text-/Funktionskanälen und direkter Sprachausgabe über EAR-TTS und neuronalen Codec (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Sprachgesteuerte Gesichtsanimation für Avatare (NVIDIA Audio2Face-3D v2.3 Mark, 301 Gesichtskoeffizienten, MLX)
 
 **Verbesserung, Trennung und Audiogenerierung**

--- a/README_es.md
+++ b/README_es.md
@@ -78,7 +78,7 @@ Reconocimiento, síntesis y comprensión de voz en el dispositivo para Mac e iOS
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Traducción voz a voz en streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, pila Kyutai Moshi/Mimi, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/es/guides/respond)** — Voz a voz full-duplex (7B, audio de entrada → audio de salida, 18 presets de voz)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — Speech-to-speech dúplex nativo en MLX con entrada de voz continua, canales de texto/función y voz directa mediante EAR-TTS y códec neuronal (INT5/INT8; aún no funciona en tiempo real)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — Speech-to-speech dúplex nativo en MLX con entrada de voz continua, canales de texto/función y voz directa mediante EAR-TTS y códec neuronal (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Animación facial de avatares impulsada por voz (NVIDIA Audio2Face-3D v2.3 Mark, 301 coeficientes faciales, MLX)
 
 **Mejora, separación y generación de audio**

--- a/README_fr.md
+++ b/README_fr.md
@@ -78,7 +78,7 @@ Reconnaissance, synthese et comprehension vocale embarquees pour Mac et iOS. S'e
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Traduction parole-a-parole en streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, pile Kyutai Moshi/Mimi, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/fr/guides/respond)** -- Parole-a-parole en full-duplex (7B, audio entrant → audio sortant, 18 preselections de voix)
-- **[VoiceChat 11B](docs/models/voicechat.md)** -- Speech-to-speech duplex natif MLX avec entrée vocale continue, canaux texte/fonction et parole directe via EAR-TTS et codec neuronal (INT5/INT8 ; pas encore en temps réel)
+- **[VoiceChat 11B](docs/models/voicechat.md)** -- Speech-to-speech duplex natif MLX avec entrée vocale continue, canaux texte/fonction et parole directe via EAR-TTS et codec neuronal (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Animation faciale d'avatar pilotée par la voix (NVIDIA Audio2Face-3D v2.3 Mark, 301 coefficients faciaux, MLX)
 
 **Amélioration, séparation et génération audio**

--- a/README_hi.md
+++ b/README_hi.md
@@ -78,7 +78,7 @@ Speech Swift पैकेज के सत्यापन योग्य सं
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — स्ट्रीमिंग स्पीच-टू-स्पीच अनुवाद (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi स्टैक, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/hi/guides/respond)** — फुल-डुप्लेक्स स्पीच-टू-स्पीच (7B, ऑडियो इन → ऑडियो आउट, 18 वॉयस प्रीसेट)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — continuous speech input, duplex text/function channels और EAR-TTS + neural codec से direct speech output वाला native MLX speech-to-speech (INT5/INT8; अभी real-time नहीं)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — continuous speech input, duplex text/function channels और EAR-TTS + neural codec से direct speech output वाला native MLX speech-to-speech (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — वाक्-चालित अवतार चेहरा एनीमेशन (NVIDIA Audio2Face-3D v2.3 Mark, 301 फेशियल कोएफ़िशिएंट, MLX)
 
 **एन्हांसमेंट, सेपरेशन और ऑडियो जनरेशन**

--- a/README_ja.md
+++ b/README_ja.md
@@ -78,7 +78,7 @@ Speech Swift パッケージへの参照を公開ソースで確認できる 16 
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — ストリーミング音声間翻訳（FR/ES/PT/DE → EN、MLX INT4 + INT8、Kyutai Moshi/Mimi スタック、CC-BY-4.0）
 - **[PersonaPlex](https://soniqo.audio/ja/guides/respond)** — 全二重音声間会話（7B、音声入力 → 音声出力、18種類のボイスプリセット）
-- **[VoiceChat 11B](docs/models/voicechat.md)** — 音声を連続入力し、テキスト/関数チャンネルと EAR-TTS からニューラルコーデック音声を直接生成するネイティブ MLX 全二重 speech-to-speech（INT5/INT8、現時点ではリアルタイム未達）
+- **[VoiceChat 11B](docs/models/voicechat.md)** — 音声を連続入力し、テキスト/関数チャンネルと EAR-TTS からニューラルコーデック音声を直接生成するネイティブ MLX 全二重 speech-to-speech（INT5/INT8）
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — 音声駆動のアバター表情アニメーション（NVIDIA Audio2Face-3D v2.3 Mark、顔係数 301 次元、MLX）
 
 **強化、分離、オーディオ生成**

--- a/README_ko.md
+++ b/README_ko.md
@@ -78,7 +78,7 @@ Speech Swift 패키지 참조를 공개 소스에서 확인할 수 있는 저장
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — 스트리밍 음성-음성 번역 (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi 스택, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/ko/guides/respond)** — 전이중 음성-음성 대화 (7B, 오디오 입력 → 오디오 출력, 18개 음색 프리셋)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — 음성을 연속 입력받아 텍스트/함수 채널과 EAR-TTS에서 신경 코덱 음성을 직접 생성하는 네이티브 MLX 전이중 speech-to-speech (INT5/INT8, 현재 실시간 미달)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — 음성을 연속 입력받아 텍스트/함수 채널과 EAR-TTS에서 신경 코덱 음성을 직접 생성하는 네이티브 MLX 전이중 speech-to-speech (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — 음성 기반 아바타 얼굴 애니메이션 (NVIDIA Audio2Face-3D v2.3 Mark, 얼굴 계수 301개, MLX)
 
 **향상, 분리 및 오디오 생성**

--- a/README_pt.md
+++ b/README_pt.md
@@ -78,7 +78,7 @@ Reconhecimento, sintese e compreensao de fala no dispositivo para Mac e iOS. Exe
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Tradução de fala para fala em streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, stack Kyutai Moshi/Mimi, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/pt/guides/respond)** — Fala-a-fala full-duplex (7B, audio de entrada → audio de saida, 18 presets de voz)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — Speech-to-speech duplex nativo em MLX com entrada contínua de fala, canais de texto/função e fala direta via EAR-TTS e codec neural (INT5/INT8; ainda não em tempo real)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — Speech-to-speech duplex nativo em MLX com entrada contínua de fala, canais de texto/função e fala direta via EAR-TTS e codec neural (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Animação facial de avatares guiada por fala (NVIDIA Audio2Face-3D v2.3 Mark, 301 coeficientes faciais, MLX)
 
 **Aprimoramento, separação e geração de áudio**

--- a/README_ru.md
+++ b/README_ru.md
@@ -78,7 +78,7 @@
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Потоковый перевод речи в речь (FR/ES/PT/DE → EN, MLX INT4 + INT8, стек Kyutai Moshi/Mimi, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/ru/guides/respond)** — Полнодуплексная генерация речи из речи (7B, аудио на входе → аудио на выходе, 18 голосовых пресетов)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — Нативная MLX-модель дуплексного speech-to-speech с непрерывным речевым входом, каналами текста/функций и прямым речевым выходом через EAR-TTS и нейрокодек (INT5/INT8; пока не в реальном времени)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — Нативная MLX-модель дуплексного speech-to-speech с непрерывным речевым входом, каналами текста/функций и прямым речевым выходом через EAR-TTS и нейрокодек (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Анимация лица аватара по речи (NVIDIA Audio2Face-3D v2.3 Mark, 301 лицевой коэффициент, MLX)
 
 **Улучшение, разделение и генерация аудио**

--- a/README_th.md
+++ b/README_th.md
@@ -78,7 +78,7 @@
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — การแปลเสียงพูดสู่เสียงพูดแบบสตรีมมิ่ง (FR/ES/PT/DE → EN, MLX INT4 + INT8, สแต็ก Kyutai Moshi/Mimi, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/guides/respond)** — เสียงพูดสู่เสียงพูดแบบ full-duplex (7B, เสียงเข้า → เสียงออก, 18 พรีเซ็ตเสียง)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — speech-to-speech แบบ duplex บน MLX ที่รับเสียงพูดต่อเนื่อง ใช้ช่องข้อความ/ฟังก์ชัน และส่งเสียงพูดโดยตรงผ่าน EAR-TTS กับ neural codec (INT5/INT8; ยังไม่ทำงานแบบเรียลไทม์)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — speech-to-speech แบบ duplex บน MLX ที่รับเสียงพูดต่อเนื่อง ใช้ช่องข้อความ/ฟังก์ชัน และส่งเสียงพูดโดยตรงผ่าน EAR-TTS กับ neural codec (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — แอนิเมชันใบหน้าอวาตาร์ขับเคลื่อนด้วยเสียงพูด (NVIDIA Audio2Face-3D v2.3 Mark, ค่าสัมประสิทธิ์ใบหน้า 301 ค่า, MLX)
 
 **การปรับปรุง การแยก และการสร้างเสียง**

--- a/README_tr.md
+++ b/README_tr.md
@@ -78,7 +78,7 @@ Speech Swift paketine doğrulanabilir biçimde başvuran 16 açık depo.
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Akışlı konuşmadan konuşmaya çeviri (FR/ES/PT/DE → EN, MLX INT4 + INT8, Kyutai Moshi/Mimi yığını, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/guides/respond)** — Tam çift yönlü (full-duplex) konuşmadan konuşmaya (7B, ses girişi → ses çıkışı, 18 ses ön ayarı)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — Sürekli konuşma girişi, duplex metin/işlev kanalları ve EAR-TTS + nöral codec üzerinden doğrudan konuşma çıkışı sunan native MLX duplex speech-to-speech (INT5/INT8; henüz gerçek zamanlı değil)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — Sürekli konuşma girişi, duplex metin/işlev kanalları ve EAR-TTS + nöral codec üzerinden doğrudan konuşma çıkışı sunan native MLX duplex speech-to-speech (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Konuşmayla sürülen avatar yüz animasyonu (NVIDIA Audio2Face-3D v2.3 Mark, 301 yüz katsayısı, MLX)
 
 **İyileştirme, ayırma ve ses üretimi**

--- a/README_vi.md
+++ b/README_vi.md
@@ -78,7 +78,7 @@ Nhận dạng, tổng hợp và hiểu giọng nói trên thiết bị cho Mac v
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — Dịch giọng nói sang giọng nói streaming (FR/ES/PT/DE → EN, MLX INT4 + INT8, stack Kyutai Moshi/Mimi, CC-BY-4.0)
 - **[PersonaPlex](https://soniqo.audio/guides/respond)** — Giọng nói sang giọng nói full-duplex (7B, audio vào → audio ra, 18 preset giọng nói)
-- **[VoiceChat 11B](docs/models/voicechat.md)** — Speech-to-speech duplex MLX native với đầu vào giọng nói liên tục, kênh văn bản/chức năng và đầu ra giọng nói trực tiếp qua EAR-TTS cùng neural codec (INT5/INT8; chưa đạt thời gian thực)
+- **[VoiceChat 11B](docs/models/voicechat.md)** — Speech-to-speech duplex MLX native với đầu vào giọng nói liên tục, kênh văn bản/chức năng và đầu ra giọng nói trực tiếp qua EAR-TTS cùng neural codec (INT5/INT8)
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — Hoạt ảnh khuôn mặt avatar điều khiển bằng giọng nói (NVIDIA Audio2Face-3D v2.3 Mark, 301 hệ số khuôn mặt, MLX)
 
 **Nâng cấp, tách nguồn và tạo âm thanh**

--- a/README_zh.md
+++ b/README_zh.md
@@ -78,7 +78,7 @@
 
 - **[Hibiki Zero-3B](https://soniqo.audio/guides/audio-translate)** — 流式语音到语音翻译（FR/ES/PT/DE → EN，MLX INT4 + INT8，Kyutai Moshi/Mimi 技术栈，CC-BY-4.0）
 - **[PersonaPlex](https://soniqo.audio/zh/guides/respond)** — 全双工语音到语音（7B，音频输入 → 音频输出，18 种预设音色）
-- **[VoiceChat 11B](docs/models/voicechat.md)** — 原生 MLX 双工语音到语音（speech-to-speech），持续接收语音，通过文本/函数通道和 EAR-TTS 直接生成神经编解码器语音（INT5/INT8；目前尚未达到实时）
+- **[VoiceChat 11B](docs/models/voicechat.md)** — 原生 MLX 双工语音到语音（speech-to-speech），持续接收语音，通过文本/函数通道和 EAR-TTS 直接生成神经编解码器语音（INT5/INT8）
 - **[Audio2Face-3D](docs/models/audio2face3d.md)** — 语音驱动的虚拟形象面部动画（NVIDIA Audio2Face-3D v2.3 Mark，301 个面部系数，MLX）
 
 **增强、分离与音频生成**

--- a/Sources/VoiceChat/VoiceChatCodec.swift
+++ b/Sources/VoiceChat/VoiceChatCodec.swift
@@ -24,6 +24,7 @@ public final class VoiceChatCodec {
 
     private let weights: [String: MLXArray]
     private let codebooks: [MLXArray]
+    private var compiledLiveDecode: (@Sendable (MLXArray) -> MLXArray)?
     public let silenceCodes: MLXArray
 
     public init(weights: [String: MLXArray]) throws {
@@ -119,6 +120,28 @@ public final class VoiceChatCodec {
 
     /// Decode `(B, T, 512)` dequantized latents.
     public func decode(latents: MLXArray) -> MLXArray {
+        if latents.dim(1) == VoiceChatSession.codecContextFrames,
+           let compiledLiveDecode {
+            return compiledLiveDecode(latents.asType(.float32))
+        }
+        return decodeUncompiled(latents: latents)
+    }
+
+    /// Compile the steady-state eight-frame live window once. Short startup
+    /// windows and arbitrary offline lengths keep the general eager path.
+    func warmUpLiveDecoding() {
+        if compiledLiveDecode == nil {
+            compiledLiveDecode = compile(shapeless: false) { [unowned self] in
+                self.decodeUncompiled(latents: $0)
+            }
+        }
+        let input = MLXArray.zeros(
+            [1, VoiceChatSession.codecContextFrames, Self.latentSize],
+            dtype: .float32)
+        eval(compiledLiveDecode!(input))
+    }
+
+    private func decodeUncompiled(latents: MLXArray) -> MLXArray {
         var x = latents.asType(.float32)
         for index in 0 ..< 13 {
             x = decoderLayer(index, x)

--- a/Sources/VoiceChat/VoiceChatEncoder.swift
+++ b/Sources/VoiceChat/VoiceChatEncoder.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import MLX
+import MLXFast
 import MLXNN
 
 // MARK: - Causal subsampling
@@ -130,7 +131,9 @@ final class RelPositionalEncoding {
         self.maxLen = maxLen
     }
 
-    func callAsFunction(_ x: MLXArray) -> MLXArray { encode(x) }
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        embedding(length: x.shape[1], dtype: x.dtype)
+    }
 
     /// Symmetric relative positions from +(T-1) down to -(T-1).
     private func buildTable(length: Int, dtype: DType) -> MLXArray {
@@ -146,13 +149,79 @@ final class RelPositionalEncoding {
         return table.expandedDimensions(axis: 0).asType(dtype)
     }
 
-    private func encode(_ x: MLXArray) -> MLXArray {
-        let length = x.shape[1]
+    func embedding(length: Int, dtype: DType) -> MLXArray {
         if pe == nil || pe!.shape[1] < 2 * length - 1 {
-            pe = buildTable(length: max(length, maxLen / 2), dtype: x.dtype)
+            pe = buildTable(length: max(length, maxLen / 2), dtype: dtype)
         }
         let centre = pe!.shape[1] / 2
         return pe![0..., (centre - length + 1) ..< (centre + length), 0...]
+    }
+}
+
+// MARK: - Streaming encoder state
+
+/// Per-layer state for exact causal FastConformer streaming.
+///
+/// Attention retains the 70 preceding projected keys/values. Convolution
+/// retains its eight post-GLU inputs, matching the zero-left-padding batch
+/// path without recomputing prior encoder frames.
+final class VoiceChatEncoderLayerCache {
+    var key: MLXArray?
+    var value: MLXArray?
+    var convolution: MLXArray?
+
+    func append(
+        key newKey: MLXArray,
+        value newValue: MLXArray,
+        leftContext: Int
+    ) -> (MLXArray, MLXArray) {
+        var combinedKey = key.map {
+            MLX.concatenated([$0, newKey], axis: 2)
+        } ?? newKey
+        var combinedValue = value.map {
+            MLX.concatenated([$0, newValue], axis: 2)
+        } ?? newValue
+
+        let retained = leftContext + newKey.dim(2)
+        if combinedKey.dim(2) > retained {
+            let start = combinedKey.dim(2) - retained
+            combinedKey = combinedKey[0..., 0..., start..., 0...]
+            combinedValue = combinedValue[0..., 0..., start..., 0...]
+        }
+        key = combinedKey
+        value = combinedValue
+        return (key!, value!)
+    }
+
+    func prependConvolution(_ input: MLXArray, cacheSize: Int) -> MLXArray {
+        if convolution == nil {
+            convolution = MLXArray.zeros(
+                [input.dim(0), cacheSize, input.dim(2)], dtype: input.dtype)
+        }
+        let combined = MLX.concatenated([convolution!, input], axis: 1)
+        convolution = combined[
+            0..., (combined.dim(1) - cacheSize)..., 0...
+        ]
+        return combined
+    }
+
+    var evaluatedArrays: [MLXArray] {
+        [key, value, convolution].compactMap { $0 }
+    }
+
+}
+
+/// Conversation-owned FastConformer state. Model weights remain shareable;
+/// only these bounded activation caches are session-specific.
+final class VoiceChatEncoderStreamState {
+    let layers: [VoiceChatEncoderLayerCache]
+
+    init(layerCount: Int) {
+        layers = (0 ..< layerCount).map { _ in VoiceChatEncoderLayerCache() }
+    }
+
+    var evaluatedArrays: [MLXArray] {
+        layers.flatMap(\.evaluatedArrays)
     }
 }
 
@@ -199,11 +268,22 @@ final class CausalConformerConvolution: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        var h = pointwiseConv1(x)
-        let parts = MLX.split(h, parts: 2, axis: -1)
-        h = parts[0] * sigmoid(parts[1])
+        var h = MLXNN.glu(pointwiseConv1(x), axis: 2)
         // Causal: all padding on the left, nothing on the right.
         h = MLX.padded(h, widths: [IntOrPair(0), IntOrPair((leftPad, 0)), IntOrPair(0)])
+        h = depthwiseConv(h)
+        h = batchNorm(h)
+        h = silu(h)
+        return pointwiseConv2(h)
+    }
+
+    /// Exact one-frame causal convolution using the preceding post-GLU inputs.
+    func stream(
+        _ x: MLXArray,
+        cache: VoiceChatEncoderLayerCache
+    ) -> MLXArray {
+        var h = MLXNN.glu(pointwiseConv1(x), axis: 2)
+        h = cache.prependConvolution(h, cacheSize: leftPad)
         h = depthwiseConv(h)
         h = batchNorm(h)
         h = silu(h)
@@ -276,6 +356,40 @@ final class RelPositionMultiHeadAttention: Module {
         let output = MLX.matmul(attn, v).transposed(0, 2, 1, 3).reshaped(b, -1, nHead * dK)
         return linearOut(output)
     }
+
+    /// Exact one-query attention over the current frame and bounded cached keys.
+    func stream(
+        _ x: MLXArray,
+        posEmb: MLXArray,
+        cache: VoiceChatEncoderLayerCache,
+        leftContext: Int
+    ) -> MLXArray {
+        precondition(x.dim(1) == 1, "streaming attention accepts one frame")
+        let b = x.dim(0)
+        let q = linearQ(x).reshaped(b, 1, nHead, dK).transposed(0, 2, 1, 3)
+        let newKey = linearK(x).reshaped(b, 1, nHead, dK).transposed(0, 2, 1, 3)
+        let newValue = linearV(x).reshaped(b, 1, nHead, dK).transposed(0, 2, 1, 3)
+        let (key, value) = cache.append(
+            key: newKey, value: newValue, leftContext: leftContext)
+
+        let posInput = (posEmb.dim(0) == 1 && b > 1)
+            ? MLX.repeated(posEmb, count: b, axis: 0) : posEmb
+        let p = linearPos(posInput).reshaped(b, -1, nHead, dK)
+            .transposed(0, 2, 1, 3)
+
+        let qU = q + posBiasU.expandedDimensions(axes: [0, 2])
+        let qV = q + posBiasV.expandedDimensions(axes: [0, 2])
+        // For a one-frame query the relative shift is an identity.
+        var matrixBD = MLX.matmul(qV, p.transposed(0, 1, 3, 2))
+        matrixBD = matrixBD[0..., 0..., 0..., ..<key.dim(2)] * MLXArray(scale)
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: qU, keys: key, values: value,
+            scale: scale, mask: matrixBD)
+            .transposed(0, 2, 1, 3)
+            .reshaped(b, 1, nHead * dK)
+        return linearOut(output)
+    }
 }
 
 final class ConformerLayer: Module {
@@ -309,6 +423,21 @@ final class ConformerLayer: Module {
         var h = x + 0.5 * feedForward1(normFeedForward1(x))
         h = h + selfAttn(normSelfAtt(h), posEmb: posEmb, mask: mask)
         h = h + conv(normConv(h))
+        h = h + 0.5 * feedForward2(normFeedForward2(h))
+        return normOut(h)
+    }
+
+    func stream(
+        _ x: MLXArray,
+        posEmb: MLXArray,
+        cache: VoiceChatEncoderLayerCache,
+        leftContext: Int
+    ) -> MLXArray {
+        var h = x + 0.5 * feedForward1(normFeedForward1(x))
+        h = h + selfAttn.stream(
+            normSelfAtt(h), posEmb: posEmb, cache: cache,
+            leftContext: leftContext)
+        h = h + conv.stream(normConv(h), cache: cache)
         h = h + 0.5 * feedForward2(normFeedForward2(h))
         return normOut(h)
     }
@@ -369,6 +498,32 @@ public final class VoiceChatEncoder: Module {
             rightContext: config.rightContext)
         for layer in layers {
             h = layer(h, posEmb: posEmb, mask: mask)
+        }
+        return h
+    }
+
+    /// Create session-local state for exact incremental conformer inference.
+    func newStreamState() -> VoiceChatEncoderStreamState {
+        VoiceChatEncoderStreamState(layerCount: layers.count)
+    }
+
+    /// Process one newly subsampled frame without recomputing prior layers.
+    func stream(
+        _ subsampled: MLXArray,
+        state: VoiceChatEncoderStreamState
+    ) -> MLXArray {
+        precondition(subsampled.dim(1) == 1, "streaming encoder accepts one frame")
+        precondition(state.layers.count == layers.count, "encoder state does not match model")
+
+        let seen = state.layers.first?.key?.dim(2) ?? 0
+        let keyFrames = min(config.leftContext, seen) + 1
+        let posEmb = posEnc.embedding(length: keyFrames, dtype: subsampled.dtype)
+
+        var h = subsampled
+        for (layer, cache) in zip(layers, state.layers) {
+            h = layer.stream(
+                h, posEmb: posEmb, cache: cache,
+                leftContext: config.leftContext)
         }
         return h
     }

--- a/Sources/VoiceChat/VoiceChatModel.swift
+++ b/Sources/VoiceChat/VoiceChatModel.swift
@@ -77,6 +77,7 @@ public final class VoiceChatModel {
             throw VoiceChatGenerationError.invalidSpeechConfiguration(
                 "canonical silence decoded to RMS \(silence.rms), peak \(silence.peak)")
         }
+        codec.warmUpLiveDecoding()
 
         return VoiceChatModel(
             perception: perception,

--- a/Sources/VoiceChat/VoiceChatSession.swift
+++ b/Sources/VoiceChat/VoiceChatSession.swift
@@ -77,14 +77,18 @@ public actor VoiceChatSession {
     public static let greetingSystemPrompt =
         baseSystemPrompt + " Start the conversation by greeting the user."
 
-    // 70 attention frames + 24 causal convolutions of reach 8 + a safety margin.
-    static let encoderLeftContextFrames = 70 + 24 * (9 - 1) + 16
+    // Three stride-2 causal subsampling stages have a 15-mel-frame receptive
+    // field (140 ms of history). The conformer now owns its longer history in
+    // bounded per-layer caches, so two preceding 80 ms input frames are enough
+    // for the recomputed frontend window.
+    static let frontendContextFrames = 2
     static let codecContextFrames = 8
 
     private let model: VoiceChatModel
     private let sampling: VoiceChatTextSamplingParameters
     private let speechParameters: VoiceChatSpeechGenerationParameters
     private var languageCache: [KVCache]
+    private var encoderState: VoiceChatEncoderStreamState
     private var inputAudio: [Float] = []
     private var completedFrames = 0
     private var previousText: Int
@@ -105,6 +109,7 @@ public actor VoiceChatSession {
         self.sampling = sampling
         self.speechParameters = speechParameters
         self.languageCache = model.languageModel.newCache()
+        self.encoderState = model.perception.encoder.newStreamState()
         self.previousText = model.tokenizer.padID
         self.previousFunction = model.tokenizer.padID
     }
@@ -189,27 +194,36 @@ public actor VoiceChatSession {
 
         let perceptionStart = DispatchTime.now().uptimeNanoseconds
         let contextStart = max(
-            0, completedFrames - Self.encoderLeftContextFrames)
+            0, completedFrames - Self.frontendContextFrames)
         let startSample = contextStart * Self.inputSamplesPerFrame
         let window = Array(inputAudio[startSample...])
         // NeMo's centred STFT needs enough signal to reveal a stable mel frame.
         guard window.count >= Self.inputSampleRate / 10 else { return [] }
 
         let mel = model.transcriber.logMel(window)
-        let embeddings = model.perception(mel).asType(.float32)
-        eval(embeddings)
-
+        let subsampled = model.perception.encoder.preEncode(mel)
         let alreadyProduced = completedFrames - contextStart
         let complete = inputAudio.count / Self.inputSamplesPerFrame
-        let limit = min(embeddings.dim(1), complete - contextStart)
+        let limit = min(subsampled.dim(1), complete - contextStart)
         guard limit > alreadyProduced else { return [] }
+
+        var embeddings: [MLXArray] = []
+        embeddings.reserveCapacity(limit - alreadyProduced)
+        for offset in alreadyProduced ..< limit {
+            let hidden = model.perception.encoder.stream(
+                subsampled[0..., offset..<(offset + 1), 0...],
+                state: encoderState)
+            let embedding = model.perception.modalityProj(hidden).asType(.float32)
+            MLX.eval([embedding] + encoderState.evaluatedArrays)
+            embeddings.append(embedding)
+        }
         let perceptionPerFrame = milliseconds(since: perceptionStart)
             / Double(limit - alreadyProduced)
 
         var events: [VoiceChatFrameEvent] = []
-        for offset in alreadyProduced ..< limit {
+        for embedding in embeddings {
             let event = try advance(
-                audioEmbedding: embeddings[0..., offset..<(offset + 1), 0...],
+                audioEmbedding: embedding,
                 record: true,
                 forceSilent: completedFrames == 0,
                 audioMilliseconds: Double(completedFrames * Self.frameMilliseconds),

--- a/Sources/VoiceChat/VoiceChatSpeechDecoder.swift
+++ b/Sources/VoiceChat/VoiceChatSpeechDecoder.swift
@@ -220,7 +220,14 @@ public final class VoiceChatSpeechDecoder {
             promptLatents: speakerPrompt,
             beginningAt: configuration.promptFrames - 1,
             conditioning: warmupConditioning(state: state))
-        _ = backbone(fused, cache: state.attention)
+        let promptHidden = backbone(fused, cache: state.attention)
+        let promptState = state.attention.flatMap { cache in
+            [cache.keys, cache.values].compactMap { $0 }
+        }
+        // MLX is lazy. Evaluating only the returned previous code leaves the
+        // 37-frame prompt prefill attached to the first live synthesis step,
+        // incorrectly charging session warmup to end-to-end streaming RTF.
+        MLX.eval([promptHidden] + promptState)
         return (
             state,
             codes[0..., (configuration.promptFrames - 1)..., 0...])

--- a/Sources/VoiceChat/VoiceChatSpeechLayers.swift
+++ b/Sources/VoiceChat/VoiceChatSpeechLayers.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MLX
+import MLXFast
 import MLXNN
 import MLXRandom
 
@@ -159,6 +160,18 @@ final class VoiceChatSpeechAttention {
             }
             cache.keys = k
             cache.values = v
+        }
+
+        // Generation advances one cached frame at a time. With no softcap or
+        // explicit mask, fused SDPA is the same attention computation with far
+        // fewer Metal dispatches across the 28-layer speech backbone.
+        if length == 1, softcap == nil, additiveMask == nil {
+            let attended = MLXFast.scaledDotProductAttention(
+                queries: q, keys: k, values: v,
+                scale: 1 / Float(16), mask: nil)
+                .transposed(0, 2, 1, 3)
+                .reshaped([batch, length, heads * headDimension])
+            return output(attended)
         }
 
         var scores = MLX.matmul(q, k.transposed(0, 1, 3, 2)) / MLXArray(Float(16))

--- a/Tests/VoiceChatTests/VoiceChatTests.swift
+++ b/Tests/VoiceChatTests/VoiceChatTests.swift
@@ -72,6 +72,56 @@ final class VoiceChatTests: XCTestCase {
         }
     }
 
+    /// Stateful inference must be the same causal computation as the batch
+    /// stack, not merely close enough to produce plausible speech.
+    func testStreamingConformerMatchesBatchAndBoundsCaches() {
+        let config = VoiceChatEncoderConfig(
+            dModel: 16,
+            nLayers: 2,
+            nHeads: 4,
+            featIn: 8,
+            ffExpansionFactor: 2,
+            convKernelSize: 3,
+            subsamplingFactor: 8,
+            subsamplingConvChannels: 4,
+            preEncodeFreqOut: 1,
+            causalConvIndices: [0, 2, 5],
+            convNormType: "layer_norm",
+            selfAttentionModel: "rel_pos",
+            attContextSize: [4, 0],
+            attContextStyle: "chunked_limited",
+            posEmbMaxLen: 64,
+            useBias: false,
+            xscaling: false)
+        let encoder = VoiceChatEncoder(config)
+        MLXRandom.seed(7)
+        let input = MLXRandom.normal([1, 12, config.dModel]).asType(.float32)
+
+        let batch = encoder.conformerStack(input)
+        let state = encoder.newStreamState()
+        var frames: [MLXArray] = []
+        for index in 0 ..< input.dim(1) {
+            let frame = encoder.stream(
+                input[0..., index..<(index + 1), 0...], state: state)
+            MLX.eval([frame] + state.evaluatedArrays)
+            frames.append(frame)
+        }
+        let streamed = MLX.concatenated(frames, axis: 1)
+        eval(batch, streamed)
+
+        let deviation = mean(abs(batch - streamed)).item(Float.self)
+        let scale = mean(abs(batch)).item(Float.self)
+        // MLX selects shape-dependent kernels for a 12-frame matrix and a
+        // sequence of one-frame matrices. They are not bit-identical, but the
+        // normalized drift must remain below one tenth of one percent.
+        XCTAssertLessThan(deviation / max(scale, 1e-7), 1e-3)
+        for cache in state.layers {
+            XCTAssertLessThanOrEqual(cache.key?.dim(2) ?? 0, config.leftContext + 1)
+            XCTAssertLessThanOrEqual(cache.value?.dim(2) ?? 0, config.leftContext + 1)
+            XCTAssertEqual(cache.convolution?.dim(1), config.convKernelSize - 1)
+        }
+    }
+
     // MARK: - Weights required
 
     func testPerceptionEncodesIntoLanguageModelSpace() throws {

--- a/docs/inference/voicechat.md
+++ b/docs/inference/voicechat.md
@@ -13,8 +13,10 @@ input frame. The upstream architecture reference is
 - The `VoiceChat` package product.
 - A complete VoiceChat MLX bundle with `encoder/`, `llm/`, and `tts/`.
 - Enough unified memory for the selected export (about 12.11 GB on disk for
-  INT8 or 8.56 GB for INT5, plus runtime allocations). The controlled full
-  streaming run peaked at 12.21 GB RSS for INT8 and 8.73 GB for INT5.
+  INT8 or 8.56 GB for INT5, plus runtime allocations). The optimized controlled
+  INT5 run peaked at about 8.70 GB RSS and 15.61–15.64 GB macOS physical
+  footprint; the latter includes file-backed MLX mappings that RSS can
+  undercount.
 
 An older bundle containing only `encoder/` and `llm/` can still be loaded by
 the low-level perception/language APIs, but `VoiceChatModel.load` rejects it
@@ -177,23 +179,26 @@ speaker-prompt warmup. Startup latency and bundle download time are therefore
 reported separately from per-frame inference.
 
 For reference, release builds on an M5 Pro (48 GB), using the controlled
-120-frame fixture and the default one-frame/80 ms live chunks, measured:
+120-frame fixture and the default one-frame/80 ms live chunks, completed three
+independent protected-head INT5 runs in 9.183 s, 9.197 s, and 9.497 s for a
+9.600 s model timeline. Their whole-pipeline RTF values were `0.96`, `0.96`,
+and `0.99`. Typical perception/decision/synthesis p50 values were about
+9/36/31–32 ms, and total/frame p50 was 76–79 ms. Peak RSS was about 8.70 GB,
+the physical-footprint peak was 15.61–15.64 GB, and MLX reported 9.50 GB peak
+GPU allocation. A final source-matched confirmation measured RTF 0.96, first
+spoken text at 44.4 ms, and first playable audio at 77.5 ms.
 
-| Variant | Peak RSS | First spoken text token | First playable audio | Total/frame p50 / p95 | Whole-pipeline RTF |
-|---|---:|---:|---:|---:|---:|
-| INT8 | 12.21 GB | 68.8 ms | 105.1 ms | 104.6 / 114.0 ms | 1.34 |
-| INT5 | 8.73 GB | 57.5 ms | 91.4 ms | 93.0 / 104.7 ms | 1.17 |
+Whole-pipeline RTF below `1` establishes sustained throughput, while the
+session's `realTime` flag deliberately requires the stricter total/frame p95
+to remain below `80 ms`. Two of those runs met that p95 deadline; the slowest
+reached 83.8 ms. Measure on the deployment machine and avoid concurrent GPU
+work when comparing results. Current INT8 correctness is verified, but its
+post-optimization release performance has not yet been remeasured.
 
-The first-token/audio values are hot compute latency after the controlled turn
-opens, not learned turn-taking latency. Both variants remain slower than real
-time once perception cost is included. `--chunk-frames` can test larger input
-batches, but those amortize encoder work and are not the default 80 ms live
-cadence.
-
-Sustained real-time operation requires whole-pipeline RTF < 1; INT8 at 1.34
-and INT5 at 1.17 do not yet meet that threshold. Stateful FastConformer
-caching, replacing bounded encoder recomputation, is the next optimization
-target.
+The first-token/audio values printed by the command are hot compute latency
+after the controlled turn opens, not learned turn-taking latency.
+`--chunk-frames` can test larger input batches, but those are not the default
+80 ms live cadence.
 
 `--force-turn-at-end` injects BOS at the end of the input. It exists for
 controlled regression tests; do not use its onset as a natural turn-taking

--- a/docs/models/voicechat.md
+++ b/docs/models/voicechat.md
@@ -54,8 +54,11 @@ The perception path applies the checkpoint's own centred-STFT frontend, a
 24-layer FastConformer at 1,024 hidden dimensions, and an `IdentityConnector`
 whose single 1,024 → 4,480 linear projection places audio in the language
 model's embedding space. The encoder attends to 70 frames on the left and none
-on the right. Streaming uses bounded recomputation over that attention window,
-the causal-convolution receptive field, and a small safety margin.
+on the right. Each streaming layer retains those projected keys/values plus its
+eight-frame causal-convolution state, so only the newly subsampled frame crosses
+the FastConformer stack. The frontend keeps two 80 ms input frames, which cover
+the centred STFT and the three causal stride-2 subsampling stages without
+recomputing the encoder's longer history.
 
 Each language-model position is the sum of three channels:
 
@@ -99,7 +102,10 @@ requires RMS below `1e-5`.
 The implementation also preserves causal left-only ConvNeXt padding, a
 periodic Hann window, real-valued DC and Nyquist bins, and the six-sample ISTFT
 trim. Codec weights remain dense fp16 in quantized bundles and are promoted to
-fp32 for decoding, matching the verified Python path.
+fp32 for decoding, matching the verified Python path. Live playback uses a
+bounded eight-frame decoder window whose fixed-shape graph is compiled during
+model warmup; short startup windows and arbitrary-length offline rendering keep
+the general decoder path.
 
 ## Quiet failure modes kept under test
 
@@ -152,33 +158,42 @@ text-token agreement for a substantially smaller bundle.
 
 ## Runtime status and latency
 
-The current implementation is functionally streaming but does not yet sustain
-the model's 80 ms frame clock on the tested M5 Pro. `VoiceChatSessionSummary`
-reports perception, language-decision, speech-synthesis, and total per-frame
-latency separately. `realTime` is true only when the p95 of the complete
-per-frame path is below 80 ms; omitting encoder cost can incorrectly classify
-the smaller variant as real-time.
+Stateful FastConformer caches and the compiled live codec path let the INT5
+bundle sustain the model's 80 ms frame clock on the tested M5 Pro.
+`VoiceChatSessionSummary` reports perception, language-decision,
+speech-synthesis, and total per-frame latency separately. Two thresholds remain
+deliberately distinct:
+
+- whole-pipeline RTF below `1` means aggregate inference keeps pace with live
+  audio; and
+- total per-frame p95 below `80 ms` means nearly every individual frame meets
+  its playback deadline. `realTime` reports this stricter p95 condition.
 
 Release builds on an M5 Pro (48 GB), over the 120-frame controlled E2E fixture
-with one 80 ms frame per live input push, measured:
+with one 80 ms frame per live input push, produced these three independent INT5
+runs after model loading and prompt warmup:
 
-| Variant | Peak RSS | First spoken text token | First playable audio | Total/frame p50 / p95 | Whole-pipeline RTF |
-|---|---:|---:|---:|---:|---:|
-| INT8 | 12.21 GB | 68.8 ms | 105.1 ms | 104.6 / 114.0 ms | 1.34 |
-| INT5 | 8.73 GB | 57.5 ms | 91.4 ms | 93.0 / 104.7 ms | 1.17 |
+| Run | Wall time | Model timeline | Whole-pipeline RTF |
+|---:|---:|---:|---:|
+| 1 | 9.183 s | 9.600 s | 0.96 |
+| 2 | 9.197 s | 9.600 s | 0.96 |
+| 3 | 9.497 s | 9.600 s | 0.99 |
 
-The corresponding macOS physical-footprint peaks were 24.42 GB for INT8 and
-20.94 GB for INT5; physical footprint includes file-backed MLX mappings that
-RSS can undercount. Both variants remain outside the 80 ms frame budget.
-Sustained real-time operation also requires whole-pipeline RTF < 1; INT8 at
-1.34 and INT5 at 1.17 do not yet meet that threshold. Stateful FastConformer
-caching, replacing bounded encoder recomputation, is the next optimization
-target.
+All three runs produced the same transcript and generated response. Typical
+perception, decision, and synthesis p50 values were about 9 ms, 36 ms, and
+31–32 ms; total/frame p50 was 76–79 ms. Peak RSS was about 8.70 GB, MLX
+reported 9.50 GB peak GPU allocation, and the macOS physical-footprint peak was
+15.61–15.64 GB. Physical footprint includes file-backed MLX mappings that RSS
+can undercount. A final source-matched confirmation measured RTF 0.96, first
+spoken text at 44.4 ms, and first playable audio at 77.5 ms.
 
-For INT8, perception/decision/synthesis p50/p95 were 23.4/28.8,
-47.0/50.8, and 33.1/36.9 ms. For INT5 they were 22.0/30.3, 36.3/39.5,
-and 33.4/36.1 ms. The whole 9.60 s model timeline took 12.86 s for INT8
-and 11.20 s for INT5.
+This establishes sustained whole-pipeline RTF below `1` for the tested INT5
+configuration, not unlimited deadline headroom: two runs had total/frame p95
+below 80 ms, while the slowest reached 83.8 ms. Current INT8 correctness gates
+pass, but release performance has not been remeasured after this optimization,
+so no updated INT8 real-time claim is made here. Run the benchmark on the target
+machine because thermal state and concurrent GPU work materially affect this
+margin.
 
 Model turn onset and hardware compute latency are different measurements. The
 default prompt is intentionally neutral because adding “greet the user” or


### PR DESCRIPTION
## Summary

- replace bounded FastConformer recomputation with session-local attention and convolution caches
- fuse one-frame attention, evaluate speech prompt warmup eagerly, and compile the steady-state codec window
- document three controlled M5 Pro INT5 runs at 0.96, 0.96, and 0.99 whole-pipeline RTF
- keep README coverage concise across all 14 languages and add a streaming parity/cache-bounds regression test

## Validation

- release build
- 1,710 non-E2E tests passed, 41 fixture-dependent skips, 0 failures
- isolated VoiceChat speech-generation E2E passed
- isolated VoiceChat conversation E2E passed
- exact 1,364-code speech output and verified conversation response remain unchanged

## Performance scope

Measured with the controlled 120-frame fixture, 80 ms live input pushes, VoiceChat 11B INT5, release build, and an M5 Pro with 48 GB unified memory. Whole-pipeline RTF below 1 establishes aggregate sustained throughput. Per-frame p95 has narrower headroom: two runs stayed below 80 ms and the slowest reached 83.8 ms, so the docs explicitly avoid a universal real-time claim under contention. INT8 correctness remains verified but post-optimization release performance has not been remeasured.