### PR TITLE
Add SpeechBrain ECAPA language identification

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,6 +77,10 @@ let package = Package(
             targets: ["SpeechVAD"]
         ),
         .library(
+            name: "SpeechLanguageID",
+            targets: ["SpeechLanguageID"]
+        ),
+        .library(
             name: "SpeechEnhancement",
             targets: ["SpeechEnhancement"]
         ),
@@ -470,6 +474,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "SpeechLanguageID",
+            dependencies: [
+                "AudioCommon",
+                "MLXCommon",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+            ]
+        ),
+        .target(
             name: "LocalVQEAECFrontend",
             path: "Sources/LocalVQEAECFrontend",
             publicHeadersPath: "include",
@@ -723,6 +736,7 @@ let package = Package(
                 "CSM",
                 "HibikiTranslate",
                 "SpeechVAD",
+                "SpeechLanguageID",
                 "SpeechEnhancement",
                 "SpeechRestoration",
                 "SourceSeparation",
@@ -978,6 +992,14 @@ let package = Package(
             name: "SpeechVADTests",
             dependencies: [
                 "SpeechVAD",
+                "AudioCommon",
+                .product(name: "MLX", package: "mlx-swift"),
+            ]
+        ),
+        .testTarget(
+            name: "SpeechLanguageIDTests",
+            dependencies: [
+                "SpeechLanguageID",
                 "AudioCommon",
                 .product(name: "MLX", package: "mlx-swift"),
             ]

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ struct DictateView: View {
 
 `SpeechUI` ships only `TranscriptionView` (finals + partials) and `TranscriptionStore` (streaming ASR adapter). Use AVFoundation for audio visualization and playback.
 
-Available SPM products: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Available SPM products: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Models
 
@@ -227,6 +227,7 @@ Compact view below. **[Full model catalogue with sizes, quantisations, download 
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | Audio super-resolution (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnostic |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Speaker Embedding | MLX, CoreML | 6.6M | Agnostic |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/guides/language-id) | Language Identification | MLX, CoreML | 21.25M | 107 languages |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Named Voice Identity | CoreML | 12.3M | Agnostic |
 
 ## Installation

--- a/README_ar.md
+++ b/README_ar.md
@@ -203,7 +203,7 @@ struct DictateView: View {
 
 تشحن `SpeechUI` فقط `TranscriptionView` (النهائيات + الجزئيات) و `TranscriptionStore` (محول ASR تدفقي). استخدم AVFoundation لتصور الصوت وتشغيله.
 
-منتجات SPM المتاحة: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+منتجات SPM المتاحة: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 </div>
 
@@ -267,6 +267,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ar/guides/upsample) | رفع دقة الصوت (48 كيلوهرتز) | MLX | 363 ميغابايت / 720 ميغابايت (int4/int8) | محايد للغة |
 | [WeSpeaker](https://soniqo.audio/ar/guides/embed-speaker) | تضمين المتحدث | MLX, CoreML | 6.6M | محايد للغة |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/ar/guides/language-id) | تحديد اللغة | MLX, CoreML | 21.25M | 107 لغة |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | هوية صوتية مسماة | CoreML | 12.3M | محايد للغة |
 
 ## التثبيت

--- a/README_de.md
+++ b/README_de.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` liefert nur `TranscriptionView` (finale + partielle Ergebnisse) und `TranscriptionStore` (Streaming-ASR-Adapter). Verwende AVFoundation für Audio-Visualisierung und Wiedergabe.
 
-Verfügbare SPM-Produkte: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Verfügbare SPM-Produkte: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modelle
 
@@ -223,6 +223,7 @@ Kompakte Übersicht unten. **[Vollständiger Modellkatalog mit Größen, Quantis
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/de/guides/upsample) | Audio-Super-Resolution (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnostisch |
 | [WeSpeaker](https://soniqo.audio/de/guides/embed-speaker) | Sprechereinbettung | MLX, CoreML | 6.6M | Sprachunabhängig |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/de/guides/language-id) | Sprachidentifikation | MLX, CoreML | 21.25M | 107 Sprachen |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Benannte Stimmidentität | CoreML | 12.3M | Sprachunabhängig |
 
 ## Installation

--- a/README_es.md
+++ b/README_es.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` solo incluye `TranscriptionView` (finales + parciales) y `TranscriptionStore` (adaptador de ASR en streaming). Usa AVFoundation para la visualización y reproducción de audio.
 
-Productos SPM disponibles: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Productos SPM disponibles: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modelos
 
@@ -223,6 +223,7 @@ Vista compacta a continuación. **[Catálogo completo de modelos con tamaños, c
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/es/guides/upsample) | Super-resolución de audio (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnóstico |
 | [WeSpeaker](https://soniqo.audio/es/guides/embed-speaker) | Embedding de hablante | MLX, CoreML | 6.6M | Agnóstico |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/es/guides/language-id) | Identificación de idioma | MLX, CoreML | 21.25M | 107 idiomas |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Identidad de voz con nombre | CoreML | 12.3M | Agnóstico |
 
 ## Instalación

--- a/README_fr.md
+++ b/README_fr.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` ne fournit que `TranscriptionView` (finaux + partiels) et `TranscriptionStore` (adaptateur ASR en streaming). Utilisez AVFoundation pour la visualisation et la lecture audio.
 
-Produits SPM disponibles : `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Produits SPM disponibles : `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modeles
 
@@ -223,6 +223,7 @@ Vue compacte ci-dessous. **[Catalogue complet des modeles avec tailles, quantifi
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/fr/guides/upsample) | Super-résolution audio (48 kHz) | MLX | 363 Mo / 720 Mo (int4/int8) | Agnostique |
 | [WeSpeaker](https://soniqo.audio/fr/guides/embed-speaker) | Empreinte de locuteur | MLX, CoreML | 6.6M | Agnostique |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/fr/guides/language-id) | Identification de langue | MLX, CoreML | 21.25M | 107 langues |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Identité vocale nommée | CoreML | 12.3M | Agnostique |
 
 ## Installation

--- a/README_hi.md
+++ b/README_hi.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` केवल `TranscriptionView` (finals + partials) और `TranscriptionStore` (स्ट्रीमिंग ASR एडाप्टर) प्रदान करता है। ऑडियो विज़ुअलाइज़ेशन और प्लेबैक के लिए AVFoundation का उपयोग करें।
 
-उपलब्ध SPM उत्पाद: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+उपलब्ध SPM उत्पाद: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## मॉडल
 
@@ -223,6 +223,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/hi/guides/upsample) | ऑडियो सुपर-रेज़ोल्यूशन (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | भाषा-निरपेक्ष |
 | [WeSpeaker](https://soniqo.audio/hi/guides/embed-speaker) | स्पीकर एम्बेडिंग | MLX, CoreML | 6.6M | भाषा-तटस्थ |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/hi/guides/language-id) | भाषा पहचान | MLX, CoreML | 21.25M | 107 भाषाएँ |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | नामित आवाज़ पहचान | CoreML | 12.3M | भाषा-तटस्थ |
 
 ## इंस्टॉलेशन

--- a/README_ja.md
+++ b/README_ja.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` には `TranscriptionView`（確定 + 部分）と `TranscriptionStore`（ストリーミングASRアダプター）のみが含まれます。音声の可視化や再生には AVFoundation をお使いください。
 
-利用可能なSPMプロダクト：`Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`。
+利用可能なSPMプロダクト：`Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`。
 
 ## モデル
 
@@ -223,6 +223,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ja/guides/upsample) | オーディオ超解像 (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | 言語非依存 |
 | [WeSpeaker](https://soniqo.audio/ja/guides/embed-speaker) | 話者埋め込み | MLX、CoreML | 6.6M | 言語非依存 |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/ja/guides/language-id) | 言語識別 | MLX、CoreML | 21.25M | 107言語 |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | 名前付き音声識別 | CoreML | 12.3M | 言語非依存 |
 
 ## インストール

--- a/README_ko.md
+++ b/README_ko.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI`에는 `TranscriptionView`(파이널 + 파셜)와 `TranscriptionStore`(스트리밍 ASR 어댑터)만 포함됩니다. 오디오 시각화와 재생에는 AVFoundation을 사용하세요.
 
-사용 가능한 SPM 프로덕트: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+사용 가능한 SPM 프로덕트: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## 모델
 
@@ -223,6 +223,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ko/guides/upsample) | 오디오 초고해상도 (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | 언어 무관 |
 | [WeSpeaker](https://soniqo.audio/ko/guides/embed-speaker) | 화자 임베딩 | MLX, CoreML | 6.6M | 언어 무관 |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/ko/guides/language-id) | 언어 식별 | MLX, CoreML | 21.25M | 107개 언어 |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | 이름 지정 음성 식별 | CoreML | 12.3M | 언어 무관 |
 
 ## 설치

--- a/README_pt.md
+++ b/README_pt.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` inclui apenas `TranscriptionView` (finais + parciais) e `TranscriptionStore` (adaptador de ASR em streaming). Use AVFoundation para visualizacao e reproducao de audio.
 
-Produtos SPM disponiveis: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Produtos SPM disponiveis: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modelos
 
@@ -223,6 +223,7 @@ Vista compacta abaixo. **[Catalogo completo de modelos com tamanhos, quantizacoe
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/pt/guides/upsample) | Super-resolução de áudio (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Agnóstico |
 | [WeSpeaker](https://soniqo.audio/pt/guides/embed-speaker) | Embedding de falante | MLX, CoreML | 6.6M | Agnostico |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/pt/guides/language-id) | Identificação de idioma | MLX, CoreML | 21.25M | 107 idiomas |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Identidade de voz nomeada | CoreML | 12.3M | Agnostico |
 
 ## Instalacao

--- a/README_ru.md
+++ b/README_ru.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` предоставляет только `TranscriptionView` (финальные + частичные результаты) и `TranscriptionStore` (адаптер для потокового ASR). Для визуализации и воспроизведения аудио используйте AVFoundation.
 
-Доступные SPM-продукты: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Доступные SPM-продукты: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Модели
 
@@ -223,6 +223,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/ru/guides/upsample) | Аудио супер-разрешение (48 кГц) | MLX | 363 МБ / 720 МБ (int4/int8) | Языконезависимое |
 | [WeSpeaker](https://soniqo.audio/ru/guides/embed-speaker) | Эмбеддинги спикеров | MLX, CoreML | 6.6M | Универсальный |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/ru/guides/language-id) | Определение языка | MLX, CoreML | 21.25M | 107 языков |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Именованная идентификация голоса | CoreML | 12.3M | Универсальный |
 
 ## Установка

--- a/README_th.md
+++ b/README_th.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` มาพร้อมเพียง `TranscriptionView` (ผลลัพธ์สุดท้าย + บางส่วน) และ `TranscriptionStore` (อะแดปเตอร์สำหรับ ASR แบบสตรีมมิ่ง) ใช้ AVFoundation สำหรับการแสดงผลภาพเสียงและการเล่นเสียง
 
-ผลิตภัณฑ์ SPM ที่มีให้: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`
+ผลิตภัณฑ์ SPM ที่มีให้: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`
 
 ## โมเดล
 
@@ -223,6 +223,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | การเพิ่มความละเอียดเสียง (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | ไม่จำกัดภาษา |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Embedding ของผู้พูด | MLX, CoreML | 6.6M | ไม่จำกัดภาษา |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/th/guides/language-id) | การระบุภาษา | MLX, CoreML | 21.25M | 107 ภาษา |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | การระบุตัวตนเสียงแบบตั้งชื่อ | CoreML | 12.3M | ไม่จำกัดภาษา |
 
 ## การติดตั้ง

--- a/README_tr.md
+++ b/README_tr.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` yalnızca `TranscriptionView` (kesin sonuçlar + kısmi sonuçlar) ve `TranscriptionStore` (akış ASR adaptörü) sunar. Ses görselleştirme ve oynatma için AVFoundation kullanın.
 
-Mevcut SPM ürünleri: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Mevcut SPM ürünleri: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Modeller
 
@@ -223,6 +223,7 @@ Aşağıda kompakt bir görünüm. **[Boyutlar, kuantizasyonlar, indirme URL'ler
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | Ses süper çözünürlük (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Bağımsız |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Konuşmacı Gömme | MLX, CoreML | 6.6M | Bağımsız |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/tr/guides/language-id) | Dil tanımlama | MLX, CoreML | 21.25M | 107 dil |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Adlandırılmış Ses Kimliği | CoreML | 12.3M | Bağımsız |
 
 ## Kurulum

--- a/README_vi.md
+++ b/README_vi.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` chỉ cung cấp `TranscriptionView` (kết quả cuối + tạm thời) và `TranscriptionStore` (adapter ASR streaming). Hãy dùng AVFoundation để hiển thị trực quan và phát lại âm thanh.
 
-Các sản phẩm SPM có sẵn: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
+Các sản phẩm SPM có sẵn: `Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`.
 
 ## Mô hình
 
@@ -223,6 +223,7 @@ Xem tổng quan gọn bên dưới. **[Danh mục mô hình đầy đủ với k
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/guides/upsample) | Siêu phân giải âm thanh (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | Không phụ thuộc ngôn ngữ |
 | [WeSpeaker](https://soniqo.audio/guides/embed-speaker) | Embedding người nói | MLX, CoreML | 6.6M | Không phụ thuộc ngôn ngữ |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/vi/guides/language-id) | Nhận dạng ngôn ngữ | MLX, CoreML | 21.25M | 107 ngôn ngữ |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | Nhận dạng giọng nói có tên | CoreML | 12.3M | Không phụ thuộc ngôn ngữ |
 
 ## Cài đặt

--- a/README_zh.md
+++ b/README_zh.md
@@ -165,7 +165,7 @@ struct DictateView: View {
 
 `SpeechUI` 只提供 `TranscriptionView`（最终结果 + 部分结果）与 `TranscriptionStore`（流式 ASR 适配器）。音频可视化和播放请使用 AVFoundation。
 
-可用的 SPM products：`Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`。
+可用的 SPM products：`Qwen3ASR`, `WhisperASR`, `MossTranscribe`, `Qwen3TTS`, `Qwen3TTSCoreML`, `ParakeetASR`, `ParakeetStreamingASR`, `NemotronStreamingASR`, `OmnilingualASR`, `CohereTranscribeASR`, `VoxtralASR`, `KokoroTTS`, `SupertonicTTS`, `VibeVoiceTTS`, `CosyVoiceTTS`, `VoxCPM2TTS`, `IndexTTS2TTS`, `F5TTS`, `HiggsTTS`, `ChatterboxTTS`, `OmniVoiceTTS`, `IndicMioTTS`, `FishAudioTTS`, `MagpieTTS`, `MagpieTTSCoreML`, `MAGNeTMusicGen`, `StableAudio3MusicGen`, `FlashSR`, `PersonaPlex`, `VoiceChat`, `CSM`, `Audio2Face3D`, `HibikiTranslate`, `MADLADTranslation`, `SpeechVAD`, `SpeechLanguageID`, `SpeechWakeWord`, `SpeechEnhancement`, `SpeechRestoration`, `SourceSeparation`, `Qwen3Chat`, `FunctionGemma`, `SpeechCore`, `SpeechUI`, `AudioCommon`。
 
 ## 模型
 
@@ -223,6 +223,7 @@ struct DictateView: View {
 | [Stable Audio 3](docs/models/stable-audio-3.md) | Text → Music/audio (44.1 kHz stereo) | MLX | Medium 1.4B (int4/int8) | EN prompts |
 | [FlashSR](https://soniqo.audio/zh/guides/upsample) | 音频超分辨率 (48 kHz) | MLX | 363 MB / 720 MB (int4/int8) | 通用 |
 | [WeSpeaker](https://soniqo.audio/zh/guides/embed-speaker) | 说话人嵌入向量 | MLX、CoreML | 6.6M | 语言无关 |
+| [SpeechBrain ECAPA VoxLingua107](https://soniqo.audio/zh/guides/language-id) | 语言识别 | MLX、CoreML | 21.25M | 107 种语言 |
 | [ReDimNet2-B6](https://huggingface.co/aufklarer/ReDimNet2-B6-CoreML) | 命名语音身份 | CoreML | 12.3M | 语言无关 |
 
 ## 安装

--- a/Sources/AudioCLILib/AudioCLI.swift
+++ b/Sources/AudioCLILib/AudioCLI.swift
@@ -16,6 +16,7 @@ public struct AudioCLI: ParsableCommand {
             VadStreamCommand.self,
             DiarizeCommand.self,
             EmbedSpeakerCommand.self,
+            LanguageIDCommand.self,
             DenoiseCommand.self,
             RestoreCommand.self,
             SeparateCommand.self,

--- a/Sources/AudioCLILib/LanguageIDCommand.swift
+++ b/Sources/AudioCLILib/LanguageIDCommand.swift
@@ -1,0 +1,95 @@
+import ArgumentParser
+import AudioCommon
+import Foundation
+import SpeechLanguageID
+
+public struct LanguageIDCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "language-id",
+        abstract: "Identify the spoken language in an audio file"
+    )
+
+    @Argument(help: "Audio file to classify (WAV, FLAC, or another supported format)")
+    public var audioFile: String
+
+    @Option(name: .long, help: "Inference engine: mlx or coreml")
+    public var engine: String = LanguageIDEngine.mlx.rawValue
+
+    @Option(name: .long, help: "Override the Hugging Face model ID")
+    public var model: String?
+
+    @Option(name: .long, help: "Number of ranked language candidates to show")
+    public var top: Int = 5
+
+    @Flag(name: .long, help: "Emit the result as JSON")
+    public var json: Bool = false
+
+    public init() {}
+
+    public func validate() throws {
+        guard LanguageIDEngine(rawValue: engine) != nil else {
+            throw ValidationError("--engine must be 'mlx' or 'coreml'")
+        }
+        guard (1...107).contains(top) else {
+            throw ValidationError("--top must be between 1 and 107")
+        }
+    }
+
+    public func run() throws {
+        try runAsync {
+            guard let selectedEngine = LanguageIDEngine(rawValue: engine) else {
+                throw ValidationError("--engine must be 'mlx' or 'coreml'")
+            }
+            let audio = try AudioFileLoader.load(
+                url: URL(fileURLWithPath: audioFile),
+                targetSampleRate: SpeechBrainFbank.sampleRate
+            )
+            let identifier = try await SpeechLanguageIdentifier.fromPretrained(
+                modelID: model,
+                engine: selectedEngine,
+                progressHandler: json ? nil : reportProgress
+            )
+
+            let started = Date()
+            let result = try identifier.identify(
+                audio: audio,
+                sampleRate: SpeechBrainFbank.sampleRate,
+                topK: top
+            )
+            let elapsed = Date().timeIntervalSince(started)
+
+            if json {
+                struct Output: Encodable {
+                    let predictions: [LanguageIDPrediction]
+                    let analyzedDuration: TimeInterval
+                    let windowCount: Int
+                    let inferenceSeconds: TimeInterval
+                }
+                let output = Output(
+                    predictions: result.predictions,
+                    analyzedDuration: result.analyzedDuration,
+                    windowCount: result.windowCount,
+                    inferenceSeconds: elapsed
+                )
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                print(String(decoding: try encoder.encode(output), as: UTF8.self))
+                return
+            }
+
+            for (rank, prediction) in result.predictions.enumerated() {
+                let percent = prediction.probability * 100
+                print(
+                    "\(rank + 1). \(prediction.label.name) "
+                        + "[\(prediction.label.code)] "
+                        + "\(String(format: "%.2f", percent))%"
+                )
+            }
+            print(
+                "Analyzed \(String(format: "%.2f", result.analyzedDuration))s "
+                    + "in \(result.windowCount) window(s); "
+                    + "inference \(String(format: "%.3f", elapsed))s"
+            )
+        }
+    }
+}

--- a/Sources/SpeechLanguageID/LanguageIDTypes.swift
+++ b/Sources/SpeechLanguageID/LanguageIDTypes.swift
@@ -1,0 +1,219 @@
+import AudioCommon
+import Foundation
+
+public enum SpeechLanguageIDError: Error, LocalizedError, Sendable {
+    case invalidAudio(String)
+    case invalidConfiguration(String)
+    case invalidLabels(String)
+    case unsupportedEngine(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidAudio(let reason):
+            return "Invalid language-identification audio: \(reason)"
+        case .invalidConfiguration(let reason):
+            return "Invalid language-identification model configuration: \(reason)"
+        case .invalidLabels(let reason):
+            return "Invalid language-identification labels: \(reason)"
+        case .unsupportedEngine(let reason):
+            return "Unsupported language-identification engine: \(reason)"
+        }
+    }
+}
+
+/// Execution backend for SpeechBrain ECAPA language identification.
+public enum LanguageIDEngine: String, Codable, Sendable, CaseIterable {
+    /// MLX on Apple Silicon GPU.
+    case mlx
+    /// Compiled Core ML model using all available Apple compute units.
+    case coreML = "coreml"
+}
+
+/// One label in the exact upstream VoxLingua107 classifier order.
+public struct SpokenLanguageLabel: Codable, Sendable, Equatable, Hashable {
+    public let id: Int
+    public let code: String
+    public let name: String
+    public let upstreamLabel: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case code
+        case name
+        case upstreamLabel = "upstream_label"
+    }
+
+    public init(id: Int, code: String, name: String, upstreamLabel: String) {
+        self.id = id
+        self.code = code
+        self.name = name
+        self.upstreamLabel = upstreamLabel
+    }
+}
+
+/// Ranked closed-set prediction from the 107-language classifier.
+public struct LanguageIDPrediction: Codable, Sendable, Equatable {
+    public let label: SpokenLanguageLabel
+    public let probability: Float
+    public let logProbability: Float
+
+    public init(
+        label: SpokenLanguageLabel,
+        probability: Float,
+        logProbability: Float
+    ) {
+        self.label = label
+        self.probability = probability
+        self.logProbability = logProbability
+    }
+}
+
+/// Language-ID output, including how a long recording was aggregated.
+public struct LanguageIDResult: Codable, Sendable, Equatable {
+    public let predictions: [LanguageIDPrediction]
+    public let analyzedDuration: TimeInterval
+    public let windowCount: Int
+
+    public var best: LanguageIDPrediction? { predictions.first }
+
+    public init(
+        predictions: [LanguageIDPrediction],
+        analyzedDuration: TimeInterval,
+        windowCount: Int
+    ) {
+        self.predictions = predictions
+        self.analyzedDuration = analyzedDuration
+        self.windowCount = windowCount
+    }
+}
+
+/// Minimal subset of the reproducible export contract consumed by the runtime.
+public struct LanguageIDModelConfiguration: Codable, Sendable, Equatable {
+    public let modelType: String
+    public let task: String
+    public let format: String
+    public let sampleRate: Int
+    public let nFFT: Int
+    public let winLength: Int
+    public let hopLength: Int
+    public let nMels: Int
+    public let minimumMelFrames: Int
+    public let maximumMelFrames: Int
+    public let embeddingDimension: Int
+    public let classCount: Int
+    public let outputName: String
+    public let artifact: String
+    public let sourceModel: String
+    public let sourceRevision: String
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case task
+        case format
+        case sampleRate = "sample_rate"
+        case nFFT = "n_fft"
+        case winLength = "win_length"
+        case hopLength = "hop_length"
+        case nMels = "n_mels"
+        case minimumMelFrames = "minimum_mel_frames"
+        case maximumMelFrames = "maximum_mel_frames"
+        case embeddingDimension = "embedding_dimension"
+        case classCount = "class_count"
+        case outputName = "output_name"
+        case artifact
+        case sourceModel = "source_model"
+        case sourceRevision = "source_revision"
+    }
+
+    public func validate(for engine: LanguageIDEngine) throws {
+        guard modelType == "speechbrain-ecapa-voxlingua107-language-id" else {
+            throw SpeechLanguageIDError.invalidConfiguration(
+                "unexpected model_type '\(modelType)'"
+            )
+        }
+        guard task == "audio-classification" else {
+            throw SpeechLanguageIDError.invalidConfiguration(
+                "unexpected task '\(task)'"
+            )
+        }
+        guard format == engine.rawValue else {
+            throw SpeechLanguageIDError.invalidConfiguration(
+                "artifact format '\(format)' does not match engine '\(engine.rawValue)'"
+            )
+        }
+        guard sampleRate == SpeechBrainFbank.sampleRate,
+              nFFT == SpeechBrainFbank.fftSize,
+              winLength == SpeechBrainFbank.windowLength,
+              hopLength == SpeechBrainFbank.hopLength,
+              nMels == 60,
+              embeddingDimension == 256,
+              classCount == 107,
+              outputName == "log_probabilities",
+              minimumMelFrames == 10,
+              maximumMelFrames == 3_001,
+              !artifact.isEmpty,
+              !sourceModel.isEmpty,
+              !sourceRevision.isEmpty
+        else {
+            throw SpeechLanguageIDError.invalidConfiguration(
+                "frontend or classifier dimensions do not match VoxLingua107 ECAPA"
+            )
+        }
+    }
+
+    public static func load(from directory: URL) throws -> Self {
+        let url = directory.appendingPathComponent("config.json")
+        do {
+            return try JSONDecoder().decode(Self.self, from: Data(contentsOf: url))
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: directory.path,
+                reason: "could not decode config.json",
+                underlying: error
+            )
+        }
+    }
+}
+
+enum SpokenLanguageLabelLoader {
+    static func load(from directory: URL, expectedCount: Int) throws -> [SpokenLanguageLabel] {
+        let url = directory.appendingPathComponent("labels.json")
+        let labels: [SpokenLanguageLabel]
+        do {
+            labels = try JSONDecoder().decode(
+                [SpokenLanguageLabel].self,
+                from: Data(contentsOf: url)
+            )
+        } catch {
+            throw AudioModelError.modelLoadFailed(
+                modelId: directory.path,
+                reason: "could not decode labels.json",
+                underlying: error
+            )
+        }
+
+        guard labels.count == expectedCount else {
+            throw SpeechLanguageIDError.invalidLabels(
+                "expected \(expectedCount), found \(labels.count)"
+            )
+        }
+        guard labels.map(\.id) == Array(0..<expectedCount) else {
+            throw SpeechLanguageIDError.invalidLabels(
+                "ids must be contiguous and preserve the upstream classifier order"
+            )
+        }
+        guard Set(labels.map(\.code)).count == expectedCount else {
+            throw SpeechLanguageIDError.invalidLabels("language codes are not unique")
+        }
+        guard labels.allSatisfy({ label in
+            !label.code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !label.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !label.upstreamLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) else {
+            throw SpeechLanguageIDError.invalidLabels(
+                "language code, name, and upstream label must not be empty"
+            )
+        }
+        return labels
+    }
+}

--- a/Sources/SpeechLanguageID/SpeechBrainECAPA.swift
+++ b/Sources/SpeechLanguageID/SpeechBrainECAPA.swift
@@ -1,0 +1,374 @@
+import MLX
+import MLXNN
+
+private func speechBrainLeakyReLU(
+    _ values: MLXArray,
+    negativeSlope: Float = 0.01
+) -> MLXArray {
+    MLX.maximum(values, MLXArray(negativeSlope) * values)
+}
+
+func speechBrainReflectPad(_ values: MLXArray, padding: Int) -> MLXArray {
+    guard padding > 0 else { return values }
+    precondition(
+        values.dim(1) > padding,
+        "reflection padding requires more input frames than padding"
+    )
+    let frameCount = values.dim(1)
+    let leftIndexes = MLXArray((1...padding).reversed().map(Int32.init))
+    let rightIndexes = MLXArray(
+        (0..<padding).map { Int32(frameCount - 2 - $0) }
+    )
+    return concatenated(
+        [
+            take(values, leftIndexes, axis: 1),
+            values,
+            take(values, rightIndexes, axis: 1),
+        ],
+        axis: 1
+    )
+}
+
+final class SpeechBrainTDNNBlock: Module {
+    @ModuleInfo(key: "conv") var conv: Conv1d
+    @ModuleInfo(key: "norm") var norm: BatchNorm
+    let padding: Int
+
+    init(
+        inputChannels: Int,
+        outputChannels: Int,
+        kernelSize: Int,
+        dilation: Int = 1,
+        groups: Int = 1
+    ) {
+        self.padding = (kernelSize - 1) * dilation / 2
+        _conv.wrappedValue = Conv1d(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: kernelSize,
+            padding: 0,
+            dilation: dilation,
+            groups: groups,
+            bias: true
+        )
+        _norm.wrappedValue = BatchNorm(featureCount: outputChannels)
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        norm(relu(conv(speechBrainReflectPad(values, padding: padding))))
+    }
+}
+
+final class SpeechBrainRes2NetBlock: Module {
+    @ModuleInfo(key: "blocks") var blocks: [SpeechBrainTDNNBlock]
+    let scale: Int
+
+    init(channels: Int, kernelSize: Int, dilation: Int, scale: Int = 8) {
+        precondition(channels.isMultiple(of: scale))
+        self.scale = scale
+        let width = channels / scale
+        _blocks.wrappedValue = (0..<(scale - 1)).map { _ in
+            SpeechBrainTDNNBlock(
+                inputChannels: width,
+                outputChannels: width,
+                kernelSize: kernelSize,
+                dilation: dilation
+            )
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        let chunks = MLX.split(values, parts: scale, axis: -1)
+        var outputs = [chunks[0]]
+        for index in blocks.indices {
+            let input = index == 0
+                ? chunks[index + 1]
+                : chunks[index + 1] + outputs[index]
+            outputs.append(blocks[index](input))
+        }
+        return concatenated(outputs, axis: -1)
+    }
+}
+
+final class SpeechBrainSEBlock: Module {
+    @ModuleInfo(key: "conv1") var conv1: Conv1d
+    @ModuleInfo(key: "conv2") var conv2: Conv1d
+
+    init(channels: Int, seChannels: Int = 128) {
+        _conv1.wrappedValue = Conv1d(
+            inputChannels: channels,
+            outputChannels: seChannels,
+            kernelSize: 1,
+            bias: true
+        )
+        _conv2.wrappedValue = Conv1d(
+            inputChannels: seChannels,
+            outputChannels: channels,
+            kernelSize: 1,
+            bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        let pooled = values.mean(axis: 1, keepDims: true)
+        let scale = sigmoid(conv2(relu(conv1(pooled))))
+        return values * scale
+    }
+}
+
+final class SpeechBrainSERes2NetBlock: Module {
+    @ModuleInfo(key: "tdnn1") var tdnn1: SpeechBrainTDNNBlock
+    @ModuleInfo(key: "res2net_block") var res2netBlock: SpeechBrainRes2NetBlock
+    @ModuleInfo(key: "tdnn2") var tdnn2: SpeechBrainTDNNBlock
+    @ModuleInfo(key: "se_block") var seBlock: SpeechBrainSEBlock
+
+    init(channels: Int, kernelSize: Int, dilation: Int) {
+        _tdnn1.wrappedValue = SpeechBrainTDNNBlock(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: 1
+        )
+        _res2netBlock.wrappedValue = SpeechBrainRes2NetBlock(
+            channels: channels,
+            kernelSize: kernelSize,
+            dilation: dilation
+        )
+        _tdnn2.wrappedValue = SpeechBrainTDNNBlock(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: 1
+        )
+        _seBlock.wrappedValue = SpeechBrainSEBlock(channels: channels)
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        var hidden = tdnn1(values)
+        hidden = res2netBlock(hidden)
+        hidden = tdnn2(hidden)
+        return seBlock(hidden) + values
+    }
+}
+
+final class SpeechBrainECAPABlocks: Module {
+    @ModuleInfo(key: "block0") var block0: SpeechBrainTDNNBlock
+    @ModuleInfo(key: "block1") var block1: SpeechBrainSERes2NetBlock
+    @ModuleInfo(key: "block2") var block2: SpeechBrainSERes2NetBlock
+    @ModuleInfo(key: "block3") var block3: SpeechBrainSERes2NetBlock
+
+    init(melBinCount: Int, channels: Int) {
+        _block0.wrappedValue = SpeechBrainTDNNBlock(
+            inputChannels: melBinCount,
+            outputChannels: channels,
+            kernelSize: 5
+        )
+        _block1.wrappedValue = SpeechBrainSERes2NetBlock(
+            channels: channels,
+            kernelSize: 3,
+            dilation: 2
+        )
+        _block2.wrappedValue = SpeechBrainSERes2NetBlock(
+            channels: channels,
+            kernelSize: 3,
+            dilation: 3
+        )
+        _block3.wrappedValue = SpeechBrainSERes2NetBlock(
+            channels: channels,
+            kernelSize: 3,
+            dilation: 4
+        )
+        super.init()
+    }
+}
+
+final class SpeechBrainAttentiveStatisticsPooling: Module {
+    @ModuleInfo(key: "tdnn") var tdnn: SpeechBrainTDNNBlock
+    @ModuleInfo(key: "conv") var conv: Conv1d
+
+    init(channels: Int, attentionChannels: Int = 128) {
+        _tdnn.wrappedValue = SpeechBrainTDNNBlock(
+            inputChannels: channels * 3,
+            outputChannels: attentionChannels,
+            kernelSize: 1
+        )
+        _conv.wrappedValue = Conv1d(
+            inputChannels: attentionChannels,
+            outputChannels: channels,
+            kernelSize: 1,
+            bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        let mean = values.mean(axis: 1, keepDims: true)
+        let centered = values - mean
+        let standardDeviation = sqrt(
+            MLX.maximum(
+                (centered * centered).mean(axis: 1, keepDims: true),
+                MLXArray(Float(1e-12))
+            )
+        )
+        let context = concatenated(
+            [
+                values,
+                MLX.broadcast(mean, to: values.shape),
+                MLX.broadcast(standardDeviation, to: values.shape),
+            ],
+            axis: -1
+        )
+        let attention = softmax(conv(tanh(tdnn(context))), axis: 1)
+        let weightedMean = (attention * values).sum(axis: 1)
+        let weightedCentered = values - weightedMean.expandedDimensions(axis: 1)
+        let weightedStandardDeviation = sqrt(
+            MLX.maximum(
+                (attention * weightedCentered * weightedCentered).sum(axis: 1),
+                MLXArray(Float(1e-12))
+            )
+        )
+        return concatenated(
+            [weightedMean, weightedStandardDeviation],
+            axis: -1
+        )
+    }
+}
+
+final class SpeechBrainECAPAEmbedding: Module {
+    @ModuleInfo(key: "blocks") var blocks: SpeechBrainECAPABlocks
+    @ModuleInfo(key: "mfa") var mfa: SpeechBrainTDNNBlock
+    @ModuleInfo(key: "asp") var asp: SpeechBrainAttentiveStatisticsPooling
+    @ModuleInfo(key: "asp_bn") var aspBN: BatchNorm
+    @ModuleInfo(key: "fc") var fc: Conv1d
+
+    init(melBinCount: Int = 60, embeddingDimension: Int = 256) {
+        let channels = 1_024
+        _blocks.wrappedValue = SpeechBrainECAPABlocks(
+            melBinCount: melBinCount,
+            channels: channels
+        )
+        _mfa.wrappedValue = SpeechBrainTDNNBlock(
+            inputChannels: channels * 3,
+            outputChannels: channels * 3,
+            kernelSize: 1
+        )
+        _asp.wrappedValue = SpeechBrainAttentiveStatisticsPooling(
+            channels: channels * 3
+        )
+        _aspBN.wrappedValue = BatchNorm(featureCount: channels * 6)
+        _fc.wrappedValue = Conv1d(
+            inputChannels: channels * 6,
+            outputChannels: embeddingDimension,
+            kernelSize: 1,
+            bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        let initial = blocks.block0(values)
+        let output1 = blocks.block1(initial)
+        let output2 = blocks.block2(output1)
+        let output3 = blocks.block3(output2)
+        var hidden = mfa(concatenated([output1, output2, output3], axis: -1))
+        hidden = aspBN(asp(hidden))
+        return fc(hidden.expandedDimensions(axis: 1))
+    }
+}
+
+final class SpeechBrainWrappedLinear: Module {
+    @ModuleInfo(key: "w") var linear: Linear
+
+    init(inputDimension: Int, outputDimension: Int) {
+        _linear.wrappedValue = Linear(inputDimension, outputDimension, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        linear(values)
+    }
+}
+
+final class SpeechBrainClassifierBlock: Module {
+    @ModuleInfo(key: "linear") var linear: SpeechBrainWrappedLinear
+    @ModuleInfo(key: "norm") var norm: BatchNorm
+
+    init(inputDimension: Int, outputDimension: Int) {
+        _linear.wrappedValue = SpeechBrainWrappedLinear(
+            inputDimension: inputDimension,
+            outputDimension: outputDimension
+        )
+        _norm.wrappedValue = BatchNorm(featureCount: outputDimension)
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        norm(speechBrainLeakyReLU(linear(values)))
+    }
+}
+
+final class SpeechBrainClassifierDNN: Module {
+    @ModuleInfo(key: "block_0") var block0: SpeechBrainClassifierBlock
+
+    init(inputDimension: Int, outputDimension: Int) {
+        _block0.wrappedValue = SpeechBrainClassifierBlock(
+            inputDimension: inputDimension,
+            outputDimension: outputDimension
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ values: MLXArray) -> MLXArray {
+        block0(values)
+    }
+}
+
+final class SpeechBrainLanguageClassifier: Module {
+    @ModuleInfo(key: "norm") var norm: BatchNorm
+    @ModuleInfo(key: "DNN") var dnn: SpeechBrainClassifierDNN
+    @ModuleInfo(key: "out") var out: SpeechBrainWrappedLinear
+
+    init(
+        embeddingDimension: Int = 256,
+        hiddenDimension: Int = 512,
+        classCount: Int = 107
+    ) {
+        _norm.wrappedValue = BatchNorm(featureCount: embeddingDimension)
+        _dnn.wrappedValue = SpeechBrainClassifierDNN(
+            inputDimension: embeddingDimension,
+            outputDimension: hiddenDimension
+        )
+        _out.wrappedValue = SpeechBrainWrappedLinear(
+            inputDimension: hiddenDimension,
+            outputDimension: classCount
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ embeddings: MLXArray) -> MLXArray {
+        var values = embeddings.squeezed(axis: 1)
+        values = norm(speechBrainLeakyReLU(values))
+        values = dnn(values)
+        let logits = out(values)
+        return logits - MLX.logSumExp(logits, axis: -1, keepDims: true)
+    }
+}
+
+final class SpeechBrainLanguageIDNetwork: Module {
+    @ModuleInfo(key: "embedding_model") var embeddingModel: SpeechBrainECAPAEmbedding
+    @ModuleInfo(key: "classifier") var classifier: SpeechBrainLanguageClassifier
+
+    override init() {
+        _embeddingModel.wrappedValue = SpeechBrainECAPAEmbedding()
+        _classifier.wrappedValue = SpeechBrainLanguageClassifier()
+        super.init()
+    }
+
+    func callAsFunction(_ melFeatures: MLXArray) -> MLXArray {
+        let centered = melFeatures
+            - melFeatures.mean(axis: 1, keepDims: true)
+        return classifier(embeddingModel(centered))
+    }
+}

--- a/Sources/SpeechLanguageID/SpeechBrainFbank.swift
+++ b/Sources/SpeechLanguageID/SpeechBrainFbank.swift
@@ -1,0 +1,250 @@
+import Accelerate
+import Foundation
+
+/// Time-major SpeechBrain log-mel features.
+public struct SpeechBrainLogMelFeatures: Sendable, Equatable {
+    public let values: [Float]
+    public let frameCount: Int
+    public let melBinCount: Int
+
+    public init(values: [Float], frameCount: Int, melBinCount: Int) {
+        self.values = values
+        self.frameCount = frameCount
+        self.melBinCount = melBinCount
+    }
+}
+
+/// CPU frontend matching `speechbrain.lobes.features.Fbank` for the published
+/// ECAPA VoxCeleb and VoxLingua107 checkpoints.
+///
+/// The 400-point DFT is evaluated as a pair of BLAS matrix multiplies. Using a
+/// power-of-two FFT would change the frequency grid from 201 to 257 bins and
+/// produce materially different embeddings.
+public final class SpeechBrainFbank: @unchecked Sendable {
+    public static let sampleRate = 16_000
+    public static let fftSize = 400
+    public static let windowLength = 400
+    public static let hopLength = 160
+    public static let frequencyBinCount = 201
+
+    public let melBinCount: Int
+
+    private let window: [Float]
+    /// Row-major `[fftSize, frequencyBinCount]`.
+    private let dftRealBasis: [Float]
+    /// Row-major `[fftSize, frequencyBinCount]`.
+    private let dftImaginaryBasis: [Float]
+    /// Row-major `[frequencyBinCount, melBinCount]`.
+    private let melFilterbank: [Float]
+
+    public init(melBinCount: Int) {
+        precondition(melBinCount > 0, "melBinCount must be positive")
+        self.melBinCount = melBinCount
+
+        window = (0..<Self.windowLength).map { index in
+            0.54 - 0.46
+                * cos(2 * Float.pi * Float(index) / Float(Self.windowLength))
+        }
+
+        var real = [Float](
+            repeating: 0,
+            count: Self.fftSize * Self.frequencyBinCount
+        )
+        var imaginary = real
+        for sample in 0..<Self.fftSize {
+            for bin in 0..<Self.frequencyBinCount {
+                let angle = -2 * Double.pi * Double(sample * bin)
+                    / Double(Self.fftSize)
+                let offset = sample * Self.frequencyBinCount + bin
+                real[offset] = Float(cos(angle))
+                imaginary[offset] = Float(sin(angle))
+            }
+        }
+        dftRealBasis = real
+        dftImaginaryBasis = imaginary
+        melFilterbank = Self.makeFilterbank(melBinCount: melBinCount)
+    }
+
+    /// Extract `[frames, melBinCount]` log-mel values from 16 kHz mono PCM.
+    ///
+    /// The centered STFT uses constant-zero padding, a periodic Hamming window,
+    /// power spectrum, SpeechBrain's symmetric triangular mel filters, dB
+    /// conversion, and an 80 dB global dynamic-range floor.
+    public func extract(_ audio: [Float]) throws -> SpeechBrainLogMelFeatures {
+        guard !audio.isEmpty else {
+            throw SpeechLanguageIDError.invalidAudio("audio is empty")
+        }
+
+        let centerPadding = Self.fftSize / 2
+        var padded = [Float](
+            repeating: 0,
+            count: audio.count + 2 * centerPadding
+        )
+        padded.replaceSubrange(
+            centerPadding..<(centerPadding + audio.count),
+            with: audio
+        )
+
+        let frameCount = (padded.count - Self.fftSize) / Self.hopLength + 1
+        var frames = [Float](
+            repeating: 0,
+            count: frameCount * Self.fftSize
+        )
+        padded.withUnsafeBufferPointer { source in
+            frames.withUnsafeMutableBufferPointer { destination in
+                for frame in 0..<frameCount {
+                    vDSP_vmul(
+                        source.baseAddress! + frame * Self.hopLength,
+                        1,
+                        window,
+                        1,
+                        destination.baseAddress! + frame * Self.fftSize,
+                        1,
+                        vDSP_Length(Self.fftSize)
+                    )
+                }
+            }
+        }
+
+        let spectrumCount = frameCount * Self.frequencyBinCount
+        var real = [Float](repeating: 0, count: spectrumCount)
+        var imaginary = real
+        vDSP_mmul(
+            frames,
+            1,
+            dftRealBasis,
+            1,
+            &real,
+            1,
+            vDSP_Length(frameCount),
+            vDSP_Length(Self.frequencyBinCount),
+            vDSP_Length(Self.fftSize)
+        )
+        vDSP_mmul(
+            frames,
+            1,
+            dftImaginaryBasis,
+            1,
+            &imaginary,
+            1,
+            vDSP_Length(frameCount),
+            vDSP_Length(Self.frequencyBinCount),
+            vDSP_Length(Self.fftSize)
+        )
+
+        var power = [Float](repeating: 0, count: spectrumCount)
+        real.withUnsafeMutableBufferPointer { realBuffer in
+            imaginary.withUnsafeMutableBufferPointer { imaginaryBuffer in
+                var split = DSPSplitComplex(
+                    realp: realBuffer.baseAddress!,
+                    imagp: imaginaryBuffer.baseAddress!
+                )
+                vDSP_zvmags(
+                    &split,
+                    1,
+                    &power,
+                    1,
+                    vDSP_Length(spectrumCount)
+                )
+            }
+        }
+
+        var mel = [Float](
+            repeating: 0,
+            count: frameCount * melBinCount
+        )
+        vDSP_mmul(
+            power,
+            1,
+            melFilterbank,
+            1,
+            &mel,
+            1,
+            vDSP_Length(frameCount),
+            vDSP_Length(melBinCount),
+            vDSP_Length(Self.frequencyBinCount)
+        )
+
+        var lowerBound: Float = 1e-10
+        var upperBound = Float.greatestFiniteMagnitude
+        vDSP_vclip(
+            mel,
+            1,
+            &lowerBound,
+            &upperBound,
+            &mel,
+            1,
+            vDSP_Length(mel.count)
+        )
+        var count = Int32(mel.count)
+        vvlog10f(&mel, mel, &count)
+        var decibelScale: Float = 10
+        vDSP_vsmul(
+            mel,
+            1,
+            &decibelScale,
+            &mel,
+            1,
+            vDSP_Length(mel.count)
+        )
+
+        var peak = -Float.infinity
+        vDSP_maxv(mel, 1, &peak, vDSP_Length(mel.count))
+        var dynamicRangeFloor = peak - 80
+        vDSP_vclip(
+            mel,
+            1,
+            &dynamicRangeFloor,
+            &upperBound,
+            &mel,
+            1,
+            vDSP_Length(mel.count)
+        )
+
+        return SpeechBrainLogMelFeatures(
+            values: mel,
+            frameCount: frameCount,
+            melBinCount: melBinCount
+        )
+    }
+
+    private static func makeFilterbank(melBinCount: Int) -> [Float] {
+        func hertzToMel(_ hertz: Float) -> Float {
+            2_595 * log10(1 + hertz / 700)
+        }
+
+        func melToHertz(_ mel: Float) -> Float {
+            700 * (pow(10, mel / 2_595) - 1)
+        }
+
+        let melMinimum = hertzToMel(0)
+        let melMaximum = hertzToMel(Float(sampleRate) / 2)
+        let points = (0..<(melBinCount + 2)).map { index -> Float in
+            let mel = melMinimum
+                + Float(index) * (melMaximum - melMinimum)
+                    / Float(melBinCount + 1)
+            return melToHertz(mel)
+        }
+        let centers = Array(points[1...melBinCount])
+        // SpeechBrain uses each filter's lower band on both sides. This is
+        // intentionally different from the usual asymmetric HTK triangle.
+        let bands = (0..<melBinCount).map { points[$0 + 1] - points[$0] }
+
+        var filters = [Float](
+            repeating: 0,
+            count: frequencyBinCount * melBinCount
+        )
+        for bin in 0..<frequencyBinCount {
+            let frequency = Float(bin) * Float(sampleRate / 2)
+                / Float(frequencyBinCount - 1)
+            for mel in 0..<melBinCount {
+                let slope = (frequency - centers[mel]) / bands[mel]
+                filters[bin * melBinCount + mel] = max(
+                    0,
+                    min(slope + 1, -slope + 1)
+                )
+            }
+        }
+        return filters
+    }
+}

--- a/Sources/SpeechLanguageID/SpeechLanguageIdentifier.swift
+++ b/Sources/SpeechLanguageID/SpeechLanguageIdentifier.swift
@@ -1,0 +1,343 @@
+import AudioCommon
+import CoreML
+import Foundation
+import MLX
+import MLXCommon
+import MLXNN
+
+/// Native Apple runtime for SpeechBrain's ECAPA VoxLingua107 classifier.
+///
+/// This is a closed-set model. A high-ranked result is not proof that the
+/// language belongs to the 107-label inventory; applications should calibrate
+/// their own unknown-language rejection policy.
+public final class SpeechLanguageIdentifier {
+    public static let defaultMLXModelID =
+        "aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-MLX"
+    public static let defaultCoreMLModelID =
+        "aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML"
+
+    public let engine: LanguageIDEngine
+    public let configuration: LanguageIDModelConfiguration
+    public let labels: [SpokenLanguageLabel]
+
+    private let frontend: SpeechBrainFbank
+    private let network: SpeechBrainLanguageIDNetwork?
+
+    private let coreMLModel: MLModel?
+
+    private init(
+        engine: LanguageIDEngine,
+        configuration: LanguageIDModelConfiguration,
+        labels: [SpokenLanguageLabel],
+        network: SpeechBrainLanguageIDNetwork?,
+        coreMLModel: MLModel?
+    ) {
+        self.engine = engine
+        self.configuration = configuration
+        self.labels = labels
+        self.frontend = SpeechBrainFbank(melBinCount: configuration.nMels)
+        self.network = network
+        self.coreMLModel = coreMLModel
+    }
+
+    /// Download and load a published `aufklarer` export.
+    public static func fromPretrained(
+        modelID: String? = nil,
+        engine: LanguageIDEngine = .mlx,
+        cacheDir: URL? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> SpeechLanguageIdentifier {
+        let resolvedModelID = modelID ?? {
+            switch engine {
+            case .mlx: return defaultMLXModelID
+            case .coreML: return defaultCoreMLModelID
+            }
+        }()
+        let directory = try cacheDir
+            ?? HuggingFaceDownloader.getCacheDirectory(for: resolvedModelID)
+
+        let additionalFiles: [String]
+        switch engine {
+        case .mlx:
+            additionalFiles = ["labels.json"]
+        case .coreML:
+            additionalFiles = [
+                "SpeechBrainECAPAVoxLingua107.mlmodelc/**",
+                "labels.json",
+            ]
+        }
+
+        progressHandler?(0, "Downloading language-identification model...")
+        try await HuggingFaceDownloader.downloadWeights(
+            modelId: resolvedModelID,
+            to: directory,
+            additionalFiles: additionalFiles,
+            offlineMode: offlineMode,
+            progressHandler: { progress in
+                progressHandler?(progress * 0.85, "Downloading model files...")
+            }
+        )
+        progressHandler?(0.85, "Loading language-identification model...")
+        let model = try fromLocal(directory: directory, engine: engine)
+        progressHandler?(1, "Ready")
+        return model
+    }
+
+    /// Load a complete local export directory containing config, labels, and
+    /// either MLX safetensors or a compiled Core ML bundle.
+    public static func fromLocal(
+        directory: URL,
+        engine: LanguageIDEngine
+    ) throws -> SpeechLanguageIdentifier {
+        let configuration = try LanguageIDModelConfiguration.load(from: directory)
+        try configuration.validate(for: engine)
+        let labels = try SpokenLanguageLabelLoader.load(
+            from: directory,
+            expectedCount: configuration.classCount
+        )
+        let artifactURL = try validatedArtifactURL(
+            configuration.artifact,
+            in: directory,
+            engine: engine
+        )
+
+        switch engine {
+        case .mlx:
+            let network = SpeechBrainLanguageIDNetwork()
+            do {
+                let weights = try MLX.loadArrays(url: artifactURL)
+                try network.update(
+                    parameters: ModuleParameters.unflattened(weights),
+                    verify: .all
+                )
+                network.train(false)
+                MLX.eval(network.parameters())
+            } catch {
+                throw AudioModelError.weightLoadingFailed(
+                    path: artifactURL.path,
+                    underlying: error
+                )
+            }
+            return SpeechLanguageIdentifier(
+                engine: engine,
+                configuration: configuration,
+                labels: labels,
+                network: network,
+                coreMLModel: nil
+            )
+
+        case .coreML:
+            let model: MLModel
+            do {
+                model = try CoreMLLoader.load(
+                    url: artifactURL,
+                    computeUnits: .all,
+                    name: "speechbrain-voxlingua107"
+                )
+            } catch {
+                throw AudioModelError.modelLoadFailed(
+                    modelId: directory.path,
+                    reason: "failed to load compiled Core ML model",
+                    underlying: error
+                )
+            }
+            return SpeechLanguageIdentifier(
+                engine: engine,
+                configuration: configuration,
+                labels: labels,
+                network: nil,
+                coreMLModel: model
+            )
+        }
+    }
+
+    /// Rank the model's known labels. Recordings longer than the artifact's
+    /// maximum frame count are classified in non-overlapping windows and their
+    /// probabilities are duration-weighted.
+    public func identify(
+        audio: [Float],
+        sampleRate: Int,
+        topK: Int = 5
+    ) throws -> LanguageIDResult {
+        guard sampleRate > 0 else {
+            throw SpeechLanguageIDError.invalidAudio("sample rate must be positive")
+        }
+        guard (1...labels.count).contains(topK) else {
+            throw SpeechLanguageIDError.invalidConfiguration(
+                "topK must be between 1 and \(labels.count)"
+            )
+        }
+
+        let samples = sampleRate == configuration.sampleRate
+            ? audio
+            : AudioFileLoader.resample(
+                audio,
+                from: sampleRate,
+                to: configuration.sampleRate
+            )
+        guard samples.allSatisfy(\.isFinite) else {
+            throw SpeechLanguageIDError.invalidAudio("samples contain NaN or infinity")
+        }
+
+        let minimumSamples = max(
+            1,
+            (configuration.minimumMelFrames - 1) * configuration.hopLength
+        )
+        let maximumSamples = max(
+            minimumSamples,
+            (configuration.maximumMelFrames - 1) * configuration.hopLength
+        )
+        guard samples.count >= minimumSamples else {
+            throw SpeechLanguageIDError.invalidAudio(
+                "at least \(minimumSamples) samples "
+                    + "(\(String(format: "%.2f", Double(minimumSamples) / Double(configuration.sampleRate))) s) are required"
+            )
+        }
+
+        var weightedProbabilities = [Double](
+            repeating: 0,
+            count: labels.count
+        )
+        var analyzedSamples = 0
+        var windowCount = 0
+        var start = 0
+        while start < samples.count {
+            let end = min(start + maximumSamples, samples.count)
+            let count = end - start
+            if count < minimumSamples { break }
+
+            let chunk = Array(samples[start..<end])
+            let logProbabilities = try inferLogProbabilities(chunk)
+            guard logProbabilities.count == labels.count else {
+                throw AudioModelError.inferenceFailed(
+                    operation: "LanguageIdentification",
+                    reason: "expected \(labels.count) scores, found \(logProbabilities.count)"
+                )
+            }
+            guard logProbabilities.allSatisfy(\.isFinite) else {
+                throw AudioModelError.inferenceFailed(
+                    operation: "LanguageIdentification",
+                    reason: "model returned NaN or infinite scores"
+                )
+            }
+            for index in weightedProbabilities.indices {
+                weightedProbabilities[index] += Double(count)
+                    * exp(Double(logProbabilities[index]))
+            }
+            analyzedSamples += count
+            windowCount += 1
+            start = end
+        }
+
+        guard analyzedSamples > 0 else {
+            throw SpeechLanguageIDError.invalidAudio("no complete inference window")
+        }
+        let denominator = Double(analyzedSamples)
+        let probabilities = weightedProbabilities.map { Float($0 / denominator) }
+        let ranked = probabilities.indices.sorted {
+            if probabilities[$0] == probabilities[$1] { return $0 < $1 }
+            return probabilities[$0] > probabilities[$1]
+        }
+        let predictions = ranked.prefix(topK).map { index in
+            let probability = probabilities[index]
+            return LanguageIDPrediction(
+                label: labels[index],
+                probability: probability,
+                logProbability: log(max(probability, Float.leastNonzeroMagnitude))
+            )
+        }
+        return LanguageIDResult(
+            predictions: predictions,
+            analyzedDuration: Double(analyzedSamples) / Double(configuration.sampleRate),
+            windowCount: windowCount
+        )
+    }
+
+    private func inferLogProbabilities(_ samples: [Float]) throws -> [Float] {
+        let features = try frontend.extract(samples)
+        guard features.frameCount >= configuration.minimumMelFrames,
+              features.frameCount <= configuration.maximumMelFrames
+        else {
+            throw SpeechLanguageIDError.invalidAudio(
+                "frontend produced unsupported frame count \(features.frameCount)"
+            )
+        }
+
+        switch engine {
+        case .mlx:
+            guard let network else {
+                throw AudioModelError.inferenceFailed(
+                    operation: "LanguageIdentification",
+                    reason: "MLX network is not loaded"
+                )
+            }
+            let input = MLXArray(
+                features.values,
+                [1, features.frameCount, features.melBinCount]
+            )
+            let output = network(input)
+            MLX.eval(output)
+            return output[0].asArray(Float.self)
+
+        case .coreML:
+            guard let coreMLModel else {
+                throw AudioModelError.inferenceFailed(
+                    operation: "LanguageIdentification",
+                    reason: "Core ML model is not loaded"
+                )
+            }
+            let input = try MLMultiArray(
+                shape: [1, NSNumber(value: features.frameCount), 60],
+                dataType: .float32
+            )
+            let pointer = input.dataPointer.assumingMemoryBound(to: Float.self)
+            features.values.withUnsafeBufferPointer { source in
+                pointer.update(from: source.baseAddress!, count: source.count)
+            }
+            let provider = try MLDictionaryFeatureProvider(dictionary: [
+                "mel_features": MLFeatureValue(multiArray: input),
+            ])
+            let prediction = try coreMLModel.prediction(from: provider)
+            guard let output = prediction.featureValue(
+                for: configuration.outputName
+            )?.multiArrayValue else {
+                throw AudioModelError.inferenceFailed(
+                    operation: "LanguageIdentification",
+                    reason: "missing '\(configuration.outputName)' output"
+                )
+            }
+            return (0..<configuration.classCount).map { output[$0].floatValue }
+        }
+    }
+
+    private static func validatedArtifactURL(
+        _ artifact: String,
+        in directory: URL,
+        engine: LanguageIDEngine
+    ) throws -> URL {
+        guard !artifact.isEmpty,
+              (artifact as NSString).lastPathComponent == artifact,
+              artifact != ".",
+              artifact != ".."
+        else {
+            throw SpeechLanguageIDError.invalidConfiguration(
+                "artifact must be a safe top-level file name"
+            )
+        }
+        let expectedExtension = engine == .mlx ? "safetensors" : "mlmodelc"
+        guard (artifact as NSString).pathExtension == expectedExtension else {
+            throw SpeechLanguageIDError.invalidConfiguration(
+                "artifact '\(artifact)' is not a .\(expectedExtension) bundle"
+            )
+        }
+        let url = directory.appendingPathComponent(artifact)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw AudioModelError.modelLoadFailed(
+                modelId: directory.path,
+                reason: "missing artifact \(artifact)"
+            )
+        }
+        return url
+    }
+}

--- a/Tests/AudioCLITests/AudioCLITests.swift
+++ b/Tests/AudioCLITests/AudioCLITests.swift
@@ -21,6 +21,7 @@ final class AudioCLIRootTests: XCTestCase {
         XCTAssertTrue(help.contains("align"))
         XCTAssertTrue(help.contains("speak"))
         XCTAssertTrue(help.contains("respond"))
+        XCTAssertTrue(help.contains("language-id"))
     }
 
     func testHelpContainsAbstract() {

--- a/Tests/AudioCLITests/LanguageIDCommandTests.swift
+++ b/Tests/AudioCLITests/LanguageIDCommandTests.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import XCTest
+@testable import AudioCLILib
+
+final class LanguageIDCommandTests: XCTestCase {
+    func testParsesDefaults() throws {
+        let root = try AudioCLI.parseAsRoot(["language-id", "recording.wav"])
+        let command = try XCTUnwrap(root as? LanguageIDCommand)
+        XCTAssertEqual(command.audioFile, "recording.wav")
+        XCTAssertEqual(command.engine, "mlx")
+        XCTAssertEqual(command.top, 5)
+        XCTAssertNil(command.model)
+        XCTAssertFalse(command.json)
+    }
+
+    func testParsesCoreMLOptions() throws {
+        let root = try AudioCLI.parseAsRoot([
+            "language-id", "recording.wav",
+            "--engine", "coreml",
+            "--model", "org/custom-lid",
+            "--top", "3",
+            "--json",
+        ])
+        let command = try XCTUnwrap(root as? LanguageIDCommand)
+        XCTAssertEqual(command.engine, "coreml")
+        XCTAssertEqual(command.model, "org/custom-lid")
+        XCTAssertEqual(command.top, 3)
+        XCTAssertTrue(command.json)
+    }
+
+    func testRejectsUnknownEngine() {
+        XCTAssertThrowsError(
+            try AudioCLI.parseAsRoot([
+                "language-id", "recording.wav", "--engine", "onnx",
+            ])
+        ) { error in
+            XCTAssertEqual(AudioCLI.exitCode(for: error), .validationFailure)
+        }
+    }
+
+    func testRejectsInvalidTopK() {
+        XCTAssertThrowsError(
+            try AudioCLI.parseAsRoot([
+                "language-id", "recording.wav", "--top", "0",
+            ])
+        ) { error in
+            XCTAssertEqual(AudioCLI.exitCode(for: error), .validationFailure)
+        }
+    }
+}
+
+final class E2ELanguageIDCommandTests: XCTestCase {
+    func testPublishedMLXModelRunsThroughCLICommand() throws {
+        guard let audioPath = ProcessInfo.processInfo.environment[
+            "SPEECH_LANGUAGE_ID_TEST_AUDIO"
+        ] else {
+            throw XCTSkip("Set SPEECH_LANGUAGE_ID_TEST_AUDIO")
+        }
+
+        let root = try AudioCLI.parseAsRoot([
+            "language-id", audioPath,
+            "--model", "aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-MLX",
+            "--top", "1",
+            "--json",
+        ])
+        let command = try XCTUnwrap(root as? LanguageIDCommand)
+        XCTAssertNoThrow(try command.run())
+    }
+}

--- a/Tests/SpeechLanguageIDTests/SpeechLanguageIDTests.swift
+++ b/Tests/SpeechLanguageIDTests/SpeechLanguageIDTests.swift
@@ -1,0 +1,302 @@
+import AudioCommon
+import Foundation
+import MLX
+import XCTest
+@testable import SpeechLanguageID
+
+final class SpeechLanguageIDTests: XCTestCase {
+    func testSpeechBrainFrontendMatchesPinnedPythonReference() throws {
+        let sampleCount = 1_600
+        let audio = (0..<sampleCount).map { index -> Float in
+            let position = Float(index)
+            return 0.1 * sin(2 * Float.pi * 440 * position / 16_000)
+                + 0.03 * cos(2 * Float.pi * 997 * position / 16_000)
+        }
+
+        let features = try SpeechBrainFbank(melBinCount: 60).extract(audio)
+        XCTAssertEqual(features.frameCount, 11)
+        XCTAssertEqual(features.melBinCount, 60)
+        XCTAssertEqual(features.values.count, 660)
+
+        let firstFrameReference: [Float] = [
+            -7.054196358, -5.820843697, -4.971723080, -5.359392643,
+            -2.733277798, -3.522770643, -1.269868374, -0.520141542,
+            2.369039297, 6.836628437, 13.425397873, 14.531822205,
+        ]
+        for (actual, expected) in zip(
+            features.values.prefix(firstFrameReference.count),
+            firstFrameReference
+        ) {
+            XCTAssertEqual(actual, expected, accuracy: 0.01)
+        }
+        XCTAssertEqual(features.values[1 * 60 + 17], -26.001571655, accuracy: 0.01)
+        XCTAssertEqual(features.values[5 * 60 + 31], -50.083141327, accuracy: 0.01)
+        XCTAssertEqual(features.values[10 * 60 + 59], -29.250514984, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(features.values.min()), -59.967133, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(features.values.max()), 20.032866, accuracy: 0.01)
+    }
+
+    func testFrontendRejectsEmptyAudio() {
+        XCTAssertThrowsError(try SpeechBrainFbank(melBinCount: 60).extract([]))
+    }
+
+    func testSpeechBrainConvolutionUsesReflectionPadding() {
+        let values = MLXArray([Float(1), 2, 3, 4, 5], [1, 5, 1])
+        let actual = speechBrainReflectPad(values, padding: 2)
+        eval(actual)
+        XCTAssertEqual(actual.asArray(Float.self), [3, 2, 1, 2, 3, 4, 5, 4, 3])
+    }
+
+    func testConfigurationDecodesAndValidates() throws {
+        let configuration = try JSONDecoder().decode(
+            LanguageIDModelConfiguration.self,
+            from: Data(Self.configurationJSON.utf8)
+        )
+        XCTAssertEqual(configuration.nMels, 60)
+        XCTAssertEqual(configuration.classCount, 107)
+        XCTAssertNoThrow(try configuration.validate(for: .mlx))
+        XCTAssertThrowsError(try configuration.validate(for: .coreML))
+    }
+
+    func testConfigurationRejectsMissingSourceRevision() throws {
+        let invalidJSON = Self.configurationJSON.replacingOccurrences(
+            of: #""source_revision": "0253049ae131d6a4be1c4f0d8b0ff483a0f8c8e9""#,
+            with: #""source_revision": """#
+        )
+        let configuration = try JSONDecoder().decode(
+            LanguageIDModelConfiguration.self,
+            from: Data(invalidJSON.utf8)
+        )
+        XCTAssertThrowsError(try configuration.validate(for: .mlx))
+    }
+
+    func testConfigurationRejectsUnsafeFrameLimits() throws {
+        let invalidJSON = Self.configurationJSON.replacingOccurrences(
+            of: #""maximum_mel_frames": 3001"#,
+            with: #""maximum_mel_frames": 9223372036854775807"#
+        )
+        let configuration = try JSONDecoder().decode(
+            LanguageIDModelConfiguration.self,
+            from: Data(invalidJSON.utf8)
+        )
+        XCTAssertThrowsError(try configuration.validate(for: .mlx))
+    }
+
+    func testLabelLoaderRequiresStableContiguousIndexes() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let labels = [
+            SpokenLanguageLabel(
+                id: 0,
+                code: "iw",
+                name: "Hebrew",
+                upstreamLabel: "iw: Hebrew"
+            ),
+            SpokenLanguageLabel(
+                id: 1,
+                code: "jw",
+                name: "Javanese",
+                upstreamLabel: "jw: Javanese"
+            ),
+        ]
+        try JSONEncoder().encode(labels).write(
+            to: directory.appendingPathComponent("labels.json")
+        )
+        XCTAssertEqual(
+            try SpokenLanguageLabelLoader.load(from: directory, expectedCount: 2),
+            labels
+        )
+
+        let reordered = [labels[1], labels[0]]
+        try JSONEncoder().encode(reordered).write(
+            to: directory.appendingPathComponent("labels.json"),
+            options: .atomic
+        )
+        XCTAssertThrowsError(
+            try SpokenLanguageLabelLoader.load(from: directory, expectedCount: 2)
+        )
+    }
+
+    func testLabelLoaderRejectsEmptyPublicCode() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let labels = [
+            SpokenLanguageLabel(id: 0, code: "", name: "Hebrew", upstreamLabel: "iw: Hebrew"),
+        ]
+        try JSONEncoder().encode(labels).write(
+            to: directory.appendingPathComponent("labels.json")
+        )
+        XCTAssertThrowsError(
+            try SpokenLanguageLabelLoader.load(from: directory, expectedCount: 1)
+        )
+    }
+
+    func testLocalLoaderRejectsArtifactPathTraversal() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let invalidJSON = Self.configurationJSON.replacingOccurrences(
+            of: #""artifact": "model.safetensors""#,
+            with: #""artifact": "../model.safetensors""#
+        )
+        try Data(invalidJSON.utf8).write(
+            to: directory.appendingPathComponent("config.json")
+        )
+        let labels = (0..<107).map { index in
+            SpokenLanguageLabel(
+                id: index,
+                code: "language-\(index)",
+                name: "Language \(index)",
+                upstreamLabel: "language-\(index): Language \(index)"
+            )
+        }
+        try JSONEncoder().encode(labels).write(
+            to: directory.appendingPathComponent("labels.json")
+        )
+
+        XCTAssertThrowsError(
+            try SpeechLanguageIdentifier.fromLocal(directory: directory, engine: .mlx)
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("safe top-level"))
+        }
+    }
+
+    func testResultBestIsFirstRankedPrediction() {
+        let prediction = LanguageIDPrediction(
+            label: SpokenLanguageLabel(
+                id: 94,
+                code: "th",
+                name: "Thai",
+                upstreamLabel: "th: Thai"
+            ),
+            probability: 0.9,
+            logProbability: log(0.9)
+        )
+        let result = LanguageIDResult(
+            predictions: [prediction],
+            analyzedDuration: 3,
+            windowCount: 1
+        )
+        XCTAssertEqual(result.best, prediction)
+    }
+
+    private static let configurationJSON = #"""
+    {
+      "model_type": "speechbrain-ecapa-voxlingua107-language-id",
+      "task": "audio-classification",
+      "format": "mlx",
+      "sample_rate": 16000,
+      "n_fft": 400,
+      "win_length": 400,
+      "hop_length": 160,
+      "n_mels": 60,
+      "minimum_mel_frames": 10,
+      "maximum_mel_frames": 3001,
+      "embedding_dimension": 256,
+      "class_count": 107,
+      "output_name": "log_probabilities",
+      "artifact": "model.safetensors",
+      "source_model": "speechbrain/lang-id-voxlingua107-ecapa",
+      "source_revision": "0253049ae131d6a4be1c4f0d8b0ff483a0f8c8e9"
+    }
+    """#
+}
+
+final class E2ELanguageIDTests: XCTestCase {
+    func testThaiUpstreamExampleMatchesOfficialClassifierIndex() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let modelPath = environment["SPEECH_LANGUAGE_ID_MODEL_DIR"],
+              let audioPath = environment["SPEECH_LANGUAGE_ID_TEST_AUDIO"]
+        else {
+            throw XCTSkip(
+                "Set SPEECH_LANGUAGE_ID_MODEL_DIR and SPEECH_LANGUAGE_ID_TEST_AUDIO"
+            )
+        }
+
+        let model = try SpeechLanguageIdentifier.fromLocal(
+            directory: URL(fileURLWithPath: modelPath),
+            engine: .mlx
+        )
+        let audio = try AudioFileLoader.load(
+            url: URL(fileURLWithPath: audioPath),
+            targetSampleRate: 16_000
+        )
+        let result = try model.identify(audio: audio, sampleRate: 16_000, topK: 3)
+        XCTAssertEqual(result.best?.label.id, 94)
+        XCTAssertEqual(result.best?.label.code, "th")
+        XCTAssertGreaterThan(result.best?.probability ?? 0, 0.95)
+    }
+
+    func testThaiUpstreamExampleMatchesOfficialClassifierIndexCoreML() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let modelPath = environment["SPEECH_LANGUAGE_ID_COREML_MODEL_DIR"],
+              let audioPath = environment["SPEECH_LANGUAGE_ID_TEST_AUDIO"]
+        else {
+            throw XCTSkip(
+                "Set SPEECH_LANGUAGE_ID_COREML_MODEL_DIR and SPEECH_LANGUAGE_ID_TEST_AUDIO"
+            )
+        }
+
+        let model = try SpeechLanguageIdentifier.fromLocal(
+            directory: URL(fileURLWithPath: modelPath),
+            engine: .coreML
+        )
+        let audio = try AudioFileLoader.load(
+            url: URL(fileURLWithPath: audioPath),
+            targetSampleRate: 16_000
+        )
+        let result = try model.identify(audio: audio, sampleRate: 16_000, topK: 3)
+        XCTAssertEqual(result.best?.label.id, 94)
+        XCTAssertEqual(result.best?.label.code, "th")
+        XCTAssertGreaterThan(result.best?.probability ?? 0, 0.95)
+    }
+
+    func testLongRecordingUsesMultipleDurationWeightedWindows() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let modelPath = environment["SPEECH_LANGUAGE_ID_MODEL_DIR"],
+              let audioPath = environment["SPEECH_LANGUAGE_ID_TEST_AUDIO"]
+        else {
+            throw XCTSkip(
+                "Set SPEECH_LANGUAGE_ID_MODEL_DIR and SPEECH_LANGUAGE_ID_TEST_AUDIO"
+            )
+        }
+
+        let model = try SpeechLanguageIdentifier.fromLocal(
+            directory: URL(fileURLWithPath: modelPath),
+            engine: .mlx
+        )
+        let clip = try AudioFileLoader.load(
+            url: URL(fileURLWithPath: audioPath),
+            targetSampleRate: 16_000
+        )
+        let audio = clip + clip + clip
+        let result = try model.identify(audio: audio, sampleRate: 16_000, topK: 1)
+
+        XCTAssertEqual(result.windowCount, 2)
+        XCTAssertEqual(result.analyzedDuration, Double(audio.count) / 16_000, accuracy: 0.001)
+        XCTAssertEqual(result.best?.label.code, "th")
+    }
+}

--- a/docs/inference/language-identification.md
+++ b/docs/inference/language-identification.md
@@ -1,0 +1,65 @@
+# Language Identification
+
+## CLI
+
+```bash
+speech language-id recording.wav
+speech language-id recording.wav --engine coreml --top 3
+speech language-id recording.wav --json
+speech language-id recording.wav --model organization/custom-export
+```
+
+The default backend is MLX. `--model` can override the Hugging Face model ID,
+and `--top` selects how many of the 107 closed-set labels are returned.
+Human-readable output includes ranked language names, upstream codes,
+probabilities, analyzed duration, window count, and inference time. `--json`
+emits the same result as structured JSON.
+
+## Swift API
+
+```swift
+import SpeechLanguageID
+
+let identifier = try await SpeechLanguageIdentifier.fromPretrained(
+    engine: .mlx
+)
+let result = try identifier.identify(
+    audio: samples,
+    sampleRate: sampleRate,
+    topK: 5
+)
+
+if let best = result.best {
+    print("\(best.label.name) [\(best.label.code)]: \(best.probability)")
+}
+```
+
+Use `.coreML` to load the compiled Core ML export instead. For local artifacts,
+`SpeechLanguageIdentifier.fromLocal(directory:engine:)` strictly validates the
+configuration, label order, artifact name, and complete MLX parameter set.
+
+`fromPretrained` downloads the selected export on first use and accepts
+`cacheDir:`, `offlineMode:`, and a progress callback. The default public models
+are:
+
+- MLX: [`aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-MLX`](https://huggingface.co/aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-MLX)
+- Core ML: [`aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML`](https://huggingface.co/aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML)
+
+## Long recordings
+
+The runtime analyzes up to roughly 30 seconds per model call. Longer audio is
+split into non-overlapping windows; class probabilities are averaged with each
+window's analyzed duration as its weight. The result exposes both
+`analyzedDuration` and `windowCount`.
+
+## Interpreting results
+
+Probabilities only compare labels inside the model's fixed inventory. They are
+not calibrated evidence that the recording contains a supported language.
+Applications that may receive silence, music, unknown languages, non-native
+speech, or code-switching should add VAD and an independently evaluated reject
+policy before presenting a definitive label.
+
+Do not compare confidence thresholds across backends without calibration. FP16
+conversion preserves all representative top-1 outputs, but small probability
+differences remain and can matter near a product rejection threshold.

--- a/docs/models/language-identification.md
+++ b/docs/models/language-identification.md
@@ -1,0 +1,60 @@
+# SpeechBrain ECAPA Language Identification
+
+`SpeechLanguageID` runs the compact 21.25M-parameter SpeechBrain VoxLingua107
+classifier with either native MLX or compiled Core ML. Both FP16 exports come
+from the same pinned upstream checkpoint, preserve its classifier order, and
+ship source hashes plus byte-level artifact manifests.
+
+## Architecture
+
+```
+16 kHz mono audio
+  → SpeechBrain-compatible 60-bin log-mel frontend
+  → temporal mean normalization
+  → ECAPA-TDNN encoder (256-dimensional embedding)
+  → BatchNorm / LeakyReLU classifier
+  → 107 log probabilities
+```
+
+The ECAPA encoder contains an initial TDNN block, three SE-Res2Net blocks,
+multi-layer feature aggregation, and attentive statistics pooling. Temporal
+convolutions use SpeechBrain's reflected edge padding. The native frontend also
+matches SpeechBrain's centered 400-sample DFT, periodic Hamming window,
+160-sample hop, symmetric triangular filters, and 80 dB log-mel clipping.
+
+## Model files
+
+| Backend | Model | Artifact | Minimum output cosine |
+|---------|-------|---------:|----------------------:|
+| MLX | [`aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-MLX`](https://huggingface.co/aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-MLX) | 40.6 MiB | 0.99999987 |
+| Core ML | [`aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML`](https://huggingface.co/aufklarer/SpeechBrain-ECAPA-VoxLingua107-21M-CoreML) | 40.8 MiB | 0.99996739 |
+
+Each export includes `config.json`, the exact 107-label `labels.json`, license,
+conversion validation, a runnable reference frontend, and an artifact manifest.
+The Core ML repository contains a compiled `.mlmodelc` bundle; the MLX
+repository contains safetensors and the reference MLX graph.
+
+The source checkpoint is pinned to
+`speechbrain/lang-id-voxlingua107-ecapa@0253049ae131d6a4be1c4f0d8b0ff483a0f8c8e9`.
+Export validation compares 10, 101, 301, 1,001, and 3,001 mel-frame inputs
+against the official PyTorch graph. All representative top-1 predictions match.
+
+## Constraints
+
+- Input is mono audio and is resampled to 16 kHz when needed.
+- The minimum accepted input is approximately 90 ms, but very short clips are
+  not expected to classify reliably. Prefer several seconds of voiced speech.
+- A single inference window supports up to approximately 30 seconds.
+- Longer recordings are split into non-overlapping windows and probabilities
+  are combined with duration weighting.
+- This is a closed-set classifier. It always ranks one of its 107 labels and
+  does not provide calibrated unknown-language or code-switch detection.
+- The upstream label codes are preserved exactly, including legacy `iw` for
+  Hebrew and `jw` for Javanese.
+
+The upstream model card reports 6.7% error on a manually verified development
+set containing 1,609 clips from only 33 of the 107 languages. That result is
+not a complete 107-language benchmark.
+
+Product thresholds and unknown-language rejection should be calibrated with
+representative accents, noise, short clips, and out-of-inventory languages.


### PR DESCRIPTION
## What changed
- add the SpeechLanguageID Swift package product and a language-id CLI command
- run the 21.25M SpeechBrain VoxLingua107 ECAPA classifier through native MLX or compiled Core ML
- reproduce the pinned SpeechBrain log-mel frontend, validate model metadata and label order, and aggregate long recordings with duration-weighted windows
- add unit, CLI, MLX/Core ML E2E, and long-recording regression coverage
- document the API, model contract, limitations, and all README translations

## Architecture fit
The feature is an additive audio-analysis module built on AudioCommon and MLXCommon. It keeps the MLX graph, Core ML loader, frontend, and public result types isolated from existing ASR, VAD, and speaker-embedding paths. Defaults point to the matching published Aufklarer exports.

## Regression risk
Existing targets and commands are unchanged apart from registering the new product and subcommand. Configuration, artifact paths, frame limits, output dimensions, and label ordering are validated before inference. The model is explicitly documented as closed-set and not an unknown-language detector.

## Validation
- release build and MLX metallib: passed
- hosted-CI-equivalent suite: 1,268 tests, 41 skipped, 0 failures
- curated make test suite: 233 tests, 0 failures
- targeted language-ID suite: 18 tests, 4 environment-gated E2E skips, 0 failures
- local MLX and Core ML Thai E2E, including long-window aggregation: 3 tests, 0 failures
- published MLX and Core ML French smoke test: both returned fr at about 99.59% confidence
- diff and README translation checks: clean