### PR TITLE
Make release builds reproducible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to rebuild
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -10,10 +16,16 @@ permissions:
 jobs:
   build:
     runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: main
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Select Xcode 16.4
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Build release binary
         run: swift build -c release --disable-sandbox
@@ -36,11 +48,12 @@ jobs:
           # Globbing keeps future modules from silently shipping broken.
           cp -R .build/release/*.bundle dist/
           cd dist
-          tar czf speech-macos-arm64.tar.gz speech speech-server audio audio-server mlx.metallib *.bundle
+          tar czf speech-macos-arm64.tar.gz speech speech-server audio audio-server mlx.metallib ./*.bundle
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: dist/speech-macos-arm64.tar.gz
 
       # Mint a short-lived installation token for soniqo/homebrew-tap via the
@@ -61,7 +74,7 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}
         run: |
           SHA=$(shasum -a 256 dist/speech-macos-arm64.tar.gz | awk '{print $1}')
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${RELEASE_TAG}"
           VERSION="${TAG#v}"
           URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/speech-macos-arm64.tar.gz"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           path: .build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
-          restore-keys: spm-${{ runner.os }}-
 
       - name: Build debug
         run: swift build --build-tests --disable-sandbox
@@ -39,7 +38,7 @@ jobs:
       - name: Copy metallib to test bundle
         run: |
           ARCH="$(uname -m)-apple-macosx"
-          for BUNDLE in .build/$ARCH/debug/*.xctest/Contents/MacOS; do
+          for BUNDLE in .build/"$ARCH"/debug/*.xctest/Contents/MacOS; do
             [ -d "$BUNDLE" ] && cp .build/debug/mlx.metallib "$BUNDLE/" 2>/dev/null || true
           done
 

--- a/Package.swift
+++ b/Package.swift
@@ -231,12 +231,9 @@ let package = Package(
         // Generic LLM runtime (loads standard HF MLX models: Qwen3, Gemma, Llama, …) — backs the
         // larger on-device chat model. The MLXLLM/MLXLMCommon libraries moved here from
         // mlx-swift-examples. Pins mlx-swift .upToNextMinor(0.31.4), compatible with ours.
-        // Pin the verified Swift 6.1-compatible revision. Tracking the upstream
+        // Pin the stable release matched to MLX Swift 0.31.4. Tracking the upstream
         // main branch made clean release and Homebrew builds non-reproducible.
-        .package(
-            url: "https://github.com/ml-explore/mlx-swift-lm",
-            revision: "c97539da0e8554d2fad90cc79692381eab1c7906"
-        ),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", exact: "3.31.4"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.12.1"),
         .package(url: "https://github.com/apple/swift-system.git", from: "1.8.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -231,7 +231,12 @@ let package = Package(
         // Generic LLM runtime (loads standard HF MLX models: Qwen3, Gemma, Llama, …) — backs the
         // larger on-device chat model. The MLXLLM/MLXLMCommon libraries moved here from
         // mlx-swift-examples. Pins mlx-swift .upToNextMinor(0.31.4), compatible with ours.
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm", branch: "main"),
+        // Pin the verified Swift 6.1-compatible revision. Tracking the upstream
+        // main branch made clean release and Homebrew builds non-reproducible.
+        .package(
+            url: "https://github.com/ml-explore/mlx-swift-lm",
+            revision: "c97539da0e8554d2fad90cc79692381eab1c7906"
+        ),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.12.1"),
         .package(url: "https://github.com/apple/swift-system.git", from: "1.8.0"),


### PR DESCRIPTION
## What changed

- replace the moving `mlx-swift-lm` main branch with stable release 3.31.4, matched to MLX Swift 0.31.4
- build release artifacts from the requested tag
- add a tag-scoped manual retry path for partially failed releases
- select Xcode 16.4 explicitly and bound release runtime
- stop restoring broad SwiftPM caches across dependency-manifest changes

## Why

The v0.0.24 release resolved the moving upstream `main` branch to a new Swift 6.2-only commit, while CI had reused older dependency build products. The broad cache fallback also preserved stale upstream Git refs. Stable matching versions and isolated cache keys make clean GitHub and Homebrew builds deterministic.

## Validation

- `swift package dump-package`
- `actionlint .github/workflows/tests.yml .github/workflows/release.yml`
- `git diff --check`
- clean hosted build and unit suite pending