### PR TITLE
Heal corrupt SwiftPM caches in CI

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -172,15 +172,27 @@ jobs:
       - uses: actions/checkout@v5
         if: steps.shard-filter.outputs.selected == 'true'
 
+      # Package.resolved is gitignored, so it never exists in the checkout and
+      # never contributed to this key — hash the manifest alone.
+      #
+      # The restore-keys fallbacks are kept deliberately: 13 shards each need a
+      # warm .build, and a manifest edit would otherwise cold-build all of them
+      # inside the 30-minute shard cap. The risk they carry — restoring a stale
+      # or corrupt archive — is handled by the resolve step below rather than by
+      # giving up the warm start.
       - name: Cache SwiftPM build
         if: steps.shard-filter.outputs.selected == 'true'
         uses: actions/cache@v5
         with:
           path: .build
-          key: spm-nightly-${{ runner.os }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          key: spm-nightly-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: |
             spm-nightly-${{ runner.os }}-
             spm-${{ runner.os }}-
+
+      - name: Resolve dependencies (heals a corrupt cache)
+        if: steps.shard-filter.outputs.selected == 'true'
+        run: ./scripts/ci_resolve.sh
 
       - name: Build debug + tests
         if: steps.shard-filter.outputs.selected == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,9 @@ jobs:
           path: .build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
 
+      - name: Resolve dependencies (heals a corrupt cache)
+        run: ./scripts/ci_resolve.sh
+
       - name: Build debug
         run: swift build --build-tests --disable-sandbox
 

--- a/scripts/ci_resolve.sh
+++ b/scripts/ci_resolve.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve SwiftPM dependencies, healing a corrupt restored build cache.
+#
+# CI restores `.build` from an actions/cache archive. That archive carries
+# SwiftPM's dependency git state: bare mirrors under `.build/repositories`,
+# working copies under `.build/checkouts`, and the resolved pins in
+# `.build/workspace-state.json`. A mirror can come back unusable — e.g. a
+# remote-tracking ref naming an object the archive does not contain:
+#
+#   error: 'mlx-swift-lm': Couldn't check out revision '<sha>':
+#       fatal: bad object refs/remotes/origin/<branch>
+#
+# git then aborts on any operation that scans refs in that mirror, so
+# resolution can never succeed no matter what the manifest asks for. The
+# failure is also self-perpetuating: the job dies before actions/cache's post
+# step runs, so the bad archive is never replaced and every later run restores
+# it again. (Observed 2026-08-16: all 13 Nightly E2E shards failed this way on
+# an archive saved 2026-08-09.)
+#
+# Recovery is to discard the dependency git state and resolve from scratch.
+# Compiled build products under `.build/<triple>/` are left alone, so a healed
+# run still gets the incremental-build value the cache exists for.
+
+if swift package resolve --disable-sandbox; then
+  exit 0
+fi
+
+echo "::warning::SwiftPM resolve failed — discarding cached dependency git state and retrying"
+rm -rf .build/repositories .build/checkouts .build/workspace-state.json
+swift package resolve --disable-sandbox


### PR DESCRIPTION
## Problem

Last night's Nightly E2E failed 13/13 shards, all at `Build debug + tests`, ~90 s in:

```
error: 'mlx-swift-lm': Couldn't check out revision 'bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57':
    fatal: bad object refs/remotes/origin/materialized-array
```

No test ran, so the night produced no coverage signal at all.

Every shard restored the same archive — `spm-nightly-macOS-2b240e13…`, **saved 2026-08-09** and
never rewritten since. Its `.build/repositories` mirror of `mlx-swift-lm` is corrupt: a
remote-tracking ref names an object the archive doesn't contain. git aborts on any operation
that scans refs in that mirror, so resolution can't succeed no matter what the manifest asks for.

Two things turned a one-off bad archive into a permanent outage:

- **The nightly still had `restore-keys`.** #456 dropped them from `tests.yml`, which is why PR CI
  is green. Nightly kept them, so when #455/#456 changed `Package.swift` and invalidated the exact
  key, the fallback walked straight back to the 8-day-old poisoned archive.
- **The failure is self-perpetuating.** The job dies before `actions/cache`'s post step, so a good
  archive is never saved. Every subsequent run restores the same corrupt one.

Worth noting the revision in the error is not stale: `bd4b7434` *is* tag `3.31.4`, the pin #456
introduced. The pin is correct — only the cached mirror was broken.

## Change

`scripts/ci_resolve.sh` resolves dependencies and, if that fails, discards the cached dependency
git state (`.build/repositories`, `.build/checkouts`, `.build/workspace-state.json`) and resolves
again. Compiled products under `.build/<triple>/` are untouched, so a healed run keeps the
incremental-build value the cache exists for.

Wired into both `nightly-e2e.yml` and `tests.yml` ahead of the build step.

The nightly `restore-keys` are kept on purpose: 13 shards each need a warm `.build`, and a manifest
edit would otherwise cold-build all of them inside the 30-minute shard cap. Healing the restored
archive is the better trade than giving up the warm start.

Also drops `Package.resolved` from the nightly cache key. It's gitignored, so it never existed in
the checkout and never contributed — confirmed empirically: on 2026-08-09 the nightly key and the
`tests.yml` key (which hashes `Package.swift` alone) produced the identical hash `2b240e13…`.

## Verification

- Happy path: `./scripts/ci_resolve.sh` on a clean tree resolves in ~55 s, rc=0.
- Healing action: after clearing the dependency git state, resolve succeeds and pins exactly to
  `bd4b7434` / `3.31.4` — the revision the failing shards were reaching for.
- Fallback control flow: with a stub `swift` that fails the first call, the script emits the
  warning, clears the git state, retries, and exits 0. A sentinel `.o` under `.build/<triple>/`
  survives, confirming build products are preserved.
- `swift build --build-tests --disable-sandbox` and the `tests.yml` unit filter both pass.
- Both workflows parse and the new step lands in the right position.

The runner's exact git abort can't be reproduced on a local Swift 6.3.3 toolchain — it re-clones a
broken mirror by itself — which is consistent with this only ever being seen on the macos-15 image.

No Swift source changes.
