### PR TITLE
Fix Parakeet digit token filtering

### DIFF
--- a/Sources/ParakeetASR/ParakeetASR.swift
+++ b/Sources/ParakeetASR/ParakeetASR.swift
@@ -170,7 +170,13 @@ public class ParakeetASRModel {
         let encoderOutput = try runEncoder(mel: paddedMel, length: effectiveLength)
         let encoded = encoderOutput.featureValue(for: "encoded")!.multiArrayValue!
         let encodedLength = encoderOutput.featureValue(for: "encoded_length")!.multiArrayValue![0].intValue
-        let tdtDecoder = TDTGreedyDecoder(config: config, decoder: decoder!, joint: joint!, maskedTokenIds: maskedTokenIds)
+        let tdtDecoder = TDTGreedyDecoder(
+            config: config,
+            decoder: decoder!,
+            joint: joint!,
+            vocabulary: vocabulary,
+            maskedTokenIds: maskedTokenIds
+        )
         return try tdtDecoder.decode(encoded: encoded, encodedLength: encodedLength)
     }
 

--- a/Sources/ParakeetASR/TDTGreedyDecoder.swift
+++ b/Sources/ParakeetASR/TDTGreedyDecoder.swift
@@ -35,14 +35,23 @@ struct TDTGreedyDecoder {
     let config: ParakeetConfig
     let decoder: MLModel
     let joint: MLModel
+    /// Vocabulary-owned classification of transcript text versus model-control tokens.
+    let vocabulary: ParakeetVocabulary
     /// Language-tag token IDs to suppress during argmax, so the decoder can only emit an allowed
     /// language and the transcription follows it. Empty = no steering (native auto-detect).
     let maskedTokenIds: Set<Int>
 
-    init(config: ParakeetConfig, decoder: MLModel, joint: MLModel, maskedTokenIds: Set<Int> = []) {
+    init(
+        config: ParakeetConfig,
+        decoder: MLModel,
+        joint: MLModel,
+        vocabulary: ParakeetVocabulary,
+        maskedTokenIds: Set<Int> = []
+    ) {
         self.config = config
         self.decoder = decoder
         self.joint = joint
+        self.vocabulary = vocabulary
         self.maskedTokenIds = maskedTokenIds
     }
 
@@ -91,11 +100,6 @@ struct TDTGreedyDecoder {
         decoderProvider.update("h", hState)
         decoderProvider.update("c", cState)
 
-        // Special tokens (0..273) are filtered from output — they include
-        // language tags, speaker tags, control tokens from SentencePiece training.
-        // Text tokens start at index 274.
-        let firstTextTokenId = 274
-
         var t = 0
         while t < encodedLength {
             // Extract encoder frame at position t (mutates encSlice data in-place)
@@ -112,7 +116,10 @@ struct TDTGreedyDecoder {
             if tokenId == config.blankTokenId {
                 t += 1
             } else {
-                if tokenId >= firstTextTokenId {
+                // Keep model-control emissions out of the transcript, but still feed them into
+                // the decoder state below. Token ordering is not a valid classifier: plain digit
+                // tokens 0...9 occupy IDs 234...243 between special-token ranges.
+                if vocabulary.isTextToken(tokenId) {
                     tokens.append(tokenId)
                     // Compute log-softmax: log_prob = logit[id] - log(sum(exp(logits)))
                     let logProb = logSoftmax(tokenLogits, tokenId: tokenId, count: config.vocabSize + 1, floatBuf: argmaxBuf)

--- a/Sources/ParakeetASR/Vocabulary.swift
+++ b/Sources/ParakeetASR/Vocabulary.swift
@@ -9,6 +9,13 @@ public struct ParakeetVocabulary: Sendable {
     /// Mapping from token ID to token string.
     private let idToToken: [Int: String]
 
+    /// Token IDs used for model control rather than transcript text.
+    ///
+    /// Parakeet's tokenizer interleaves plain digit tokens with control tokens, so token IDs
+    /// cannot be classified using a numeric boundary. Special tokens use angle-bracket syntax
+    /// (`<unk>`, `<pad>`, `<|pnc|>`, `<|en|>`, and similar).
+    private let specialTokenIds: Set<Int>
+
     /// Number of tokens in the vocabulary (excluding blank).
     public var count: Int { idToToken.count }
 
@@ -21,7 +28,22 @@ public struct ParakeetVocabulary: Sendable {
     /// Initialize from a pre-loaded dictionary.
     public init(idToToken: [Int: String]) {
         self.idToToken = idToToken
+        self.specialTokenIds = Self.extractSpecialTokenIds(from: idToToken)
         self.languageTagIds = Self.extractLanguageTags(from: idToToken)
+    }
+
+    /// Whether an emitted token belongs in transcript text.
+    ///
+    /// Unknown IDs are excluded as well: a model/vocabulary mismatch should not contribute an
+    /// undecodable token or confidence score to the returned transcription.
+    func isTextToken(_ id: Int) -> Bool {
+        idToToken[id] != nil && !specialTokenIds.contains(id)
+    }
+
+    private static func extractSpecialTokenIds(from idToToken: [Int: String]) -> Set<Int> {
+        Set(idToToken.compactMap { id, token in
+            token.hasPrefix("<") && token.hasSuffix(">") ? id : nil
+        })
     }
 
     /// Pull `<|xx|>` language tags out of the vocab. Control tokens (`<|pnc|>`, `<|emo:...|>`,

--- a/Tests/ParakeetASRTests/ParakeetASRTests.swift
+++ b/Tests/ParakeetASRTests/ParakeetASRTests.swift
@@ -95,6 +95,48 @@ final class ParakeetASRTests: XCTestCase {
         XCTAssertEqual(text, "unbelievable")
     }
 
+    func testVocabularyClassifiesTextByTokenSyntaxRatherThanIdRange() {
+        let vocab = ParakeetVocabulary(idToToken: [
+            0: "<unk>",
+            5: "<|pnc|>",
+            64: "<|en|>",
+            233: "<|spk15|>",
+            234: "0",
+            235: "1",
+            243: "9",
+            244: "<|spltoken0|>",
+            273: "<|spltoken29|>",
+            274: "en",
+            8_000: "<|future_control|>",
+        ])
+
+        // Digit tokens are interleaved with special-token ranges in the shipped vocabulary.
+        XCTAssertTrue(vocab.isTextToken(234))
+        XCTAssertTrue(vocab.isTextToken(235))
+        XCTAssertTrue(vocab.isTextToken(243))
+        XCTAssertTrue(vocab.isTextToken(274))
+
+        for id in [0, 5, 64, 233, 244, 273, 8_000] {
+            XCTAssertFalse(vocab.isTextToken(id), "Token ID \(id) should be special")
+        }
+        XCTAssertFalse(vocab.isTextToken(9_999), "Unknown IDs should not be emitted")
+    }
+
+    func testVocabularyDecodesDigitTokensBelowFormerTextBoundary() {
+        let vocab = ParakeetVocabulary(idToToken: [
+            234: "0",
+            235: "1",
+            236: "2",
+            237: "3",
+            7_863: "\u{2581}",
+        ])
+
+        let textTokenIds = [7_863, 235, 7_863, 236, 7_863, 237]
+            .filter(vocab.isTextToken)
+
+        XCTAssertEqual(vocab.decode(textTokenIds), "1 2 3")
+    }
+
     func testVocabularyEmpty() {
         let vocab = ParakeetVocabulary(idToToken: [:])
         let text = vocab.decode([0, 1, 2])

--- a/docs/inference/parakeet-asr-inference.md
+++ b/docs/inference/parakeet-asr-inference.md
@@ -27,6 +27,11 @@ Token-and-Duration Transducer (TDT) decoding interprets the encoder output. Unli
 
 Greedy decoding selects the highest-probability token and duration at each step. No beam search or language model rescoring is applied.
 
+The vocabulary classifies angle-bracket entries as model-control tokens and omits them from the
+returned transcript without suppressing them during decoding. Ordinary tokens are not classified
+by ID range, so model-emitted digits `0`–`9` are preserved even though their IDs sit between
+control-token ranges. Hidden control tokens still update the recurrent decoder state.
+
 ### 4. Confidence Score
 
 The pipeline returns an overall confidence score (0.0 to 1.0) computed as the sigmoid-scaled mean of token logits. This provides a rough estimate of transcription reliability — useful for deciding whether to retry with a different model or prompt the user.

--- a/docs/models/parakeet-asr.md
+++ b/docs/models/parakeet-asr.md
@@ -25,13 +25,18 @@ while t < encoded_length:
     if token == blank:
         t += 1
     else:
-        emit(token)
+        if vocabulary.is_text_token(token):
+            emit(token)
         duration = duration_bins[argmax(dur_logits)]
         t += max(duration, 1)
         decoder_state = lstm(token, decoder_state)
 ```
 
-This variable-rate alignment is more accurate and efficient than fixed-rate RNN-T.
+Transcript filtering is derived from the vocabulary: angle-bracket control tokens are hidden,
+while ordinary text tokens are emitted regardless of their numeric ID. This preserves the digit
+tokens `0`–`9` at IDs 234–243. Every non-blank token still updates the prediction-network state,
+including hidden control tokens. This variable-rate alignment is more accurate and efficient than
+fixed-rate RNN-T.
 
 ## CoreML Models
 


### PR DESCRIPTION
## Summary

- replace the hard-coded Parakeet text-token cutoff with vocabulary-derived special-token classification
- preserve model-emitted digit tokens at IDs 234–243 while keeping language, speaker, and control tokens out of transcripts
- continue feeding hidden control tokens through TDT duration handling and recurrent decoder state
- add regression tests and update the local Parakeet architecture and inference documentation

## Architecture fit

Token semantics now live in `ParakeetVocabulary`, while `TDTGreedyDecoder` remains responsible for emission and state progression. Unknown vocabulary IDs are excluded from returned text and confidence scoring.

## Regression risk

Low. The shipped vocabulary identifies model-control entries with angle-bracket syntax. Real text tokens are no longer coupled to an assumed numeric range.

## Validation

- `swift test --filter ParakeetASRTests.ParakeetASRTests` — 10 passed
- `swift test --skip E2E --no-parallel` — 1,876 passed, 48 expected skips, 0 failures
- real Parakeet Core ML transcription preserved `35` and `20` in the Barcelona weather sample
- `git diff --check`

## Documentation

- https://github.com/ivan-digital/soniqo-web/pull/44

Closes #462